### PR TITLE
feat: launcher version compatiblity check

### DIFF
--- a/cmd/exasol/compatibility.go
+++ b/cmd/exasol/compatibility.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"fmt"
+
+	deploymentcompatibility "github.com/exasol/exasol-personal/internal/compatibility"
+	"github.com/spf13/cobra"
+)
+
+const (
+	annotationRequiresDeploymentCompatibility = "exasol.requiresDeploymentCompatibility"
+	annotationMinSupportedDeploymentVersion   = "exasol.minSupportedDeploymentVersion"
+	annotationRequiresInitializedDeployment   = "exasol.requiresInitializedDeploymentDir"
+
+	annotationEnabledValue = "true"
+
+	errMissingMinSupportedFmt = "internal error: command %q requires deployment" +
+		"compatibility but is missing annotation %q"
+)
+
+// nolint: unparam
+func requireDeploymentCompatibility(cmd *cobra.Command, minSupportedDeploymentVersion string) {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations[annotationRequiresDeploymentCompatibility] = annotationEnabledValue
+	cmd.Annotations[annotationMinSupportedDeploymentVersion] = minSupportedDeploymentVersion
+}
+
+// requireInitializedDeploymentDir declares that a command expects an existing,
+// initialized deployment directory.
+//
+// Commands like init/install that can create the deployment directory should not
+// set this.
+func requireInitializedDeploymentDir(cmd *cobra.Command) {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations[annotationRequiresInitializedDeployment] = annotationEnabledValue
+}
+
+func deploymentCompatibilityIsRequired(cmd *cobra.Command) bool {
+	v, ok := cmd.Annotations[annotationRequiresDeploymentCompatibility]
+	return ok && v == annotationEnabledValue
+}
+
+func minSupportedDeploymentVersionFromAnnotations(cmd *cobra.Command) string {
+	return cmd.Annotations[annotationMinSupportedDeploymentVersion]
+}
+
+func deploymentDirMustBeInitialized(cmd *cobra.Command) bool {
+	v, ok := cmd.Annotations[annotationRequiresInitializedDeployment]
+	return ok && v == annotationEnabledValue
+}
+
+// enforceDeploymentDirectoryCompatibility is a thin orchestration wrapper.
+//
+// It interprets command annotations (cmd-layer concern) and delegates the actual
+// compatibility enforcement (including logging) to internal packages.
+func enforceDeploymentDirectoryCompatibility(cmd *cobra.Command, deploymentDir string) error {
+	if !deploymentCompatibilityIsRequired(cmd) {
+		return nil
+	}
+
+	minSupported := minSupportedDeploymentVersionFromAnnotations(cmd)
+	if minSupported == "" {
+		return fmt.Errorf(
+			errMissingMinSupportedFmt,
+			cmd.Name(),
+			annotationMinSupportedDeploymentVersion,
+		)
+	}
+
+	req := deploymentcompatibility.Requirement{
+		CommandName:                   cmd.Name(),
+		MinSupportedDeploymentVersion: minSupported,
+	}
+
+	initReq := deploymentcompatibility.DeploymentDirMayBeUninitialized
+	if deploymentDirMustBeInitialized(cmd) {
+		initReq = deploymentcompatibility.DeploymentDirMustBeInitialized
+	}
+
+	return deploymentcompatibility.EnforceDeploymentDirectoryCompatibility(
+		deploymentDir,
+		version,
+		req,
+		initReq,
+	)
+}

--- a/cmd/exasol/compatibility_test.go
+++ b/cmd/exasol/compatibility_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestEnforceDeploymentDirectoryCompatibility_FailsEarlyWhenNotInitialized(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+
+	cmd := &cobra.Command{Use: "deploy"}
+	requireDeploymentCompatibility(cmd, minSupportedDeploymentVersionBaseline)
+	requireInitializedDeploymentDir(cmd)
+
+	err := enforceDeploymentDirectoryCompatibility(cmd, tmp)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	msg := err.Error()
+	if !strings.Contains(msg, "deployment directory is not initialized") {
+		t.Fatalf("unexpected error message: %q", msg)
+	}
+	if !strings.Contains(msg, ".exasolLauncherState.json") {
+		t.Fatalf("expected error to mention state file, got: %q", msg)
+	}
+	if !strings.Contains(msg, "exasol init") || !strings.Contains(msg, "exasol install") {
+		t.Fatalf("expected error to mention init/install guidance, got: %q", msg)
+	}
+}
+
+func TestEnforceDeploymentDirectoryCompatibility_HintsLegacyWorkflowStateLayout(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+
+	// Simulate legacy deployment directories created before state file
+	// .exasolLauncherState.json existed.
+	err := os.WriteFile(filepath.Join(tmp, ".workflowState.json"), []byte("{}"), 0o600)
+	if err != nil {
+		t.Fatalf("failed to create legacy workflow state file: %v", err)
+	}
+
+	cmd := &cobra.Command{Use: "some_init_like_command"}
+	requireDeploymentCompatibility(cmd, minSupportedDeploymentVersionBaseline)
+	// Note: init/install must NOT require an initialized deployment dir.
+	err = enforceDeploymentDirectoryCompatibility(cmd, tmp)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	msg := err.Error()
+	if !strings.Contains(msg, "deployment directory appears to be from an older version") {
+		t.Fatalf("expected legacy version hint, got: %q", msg)
+	}
+	if !strings.Contains(msg, ".workflowState.json") {
+		t.Fatalf("expected message to mention legacy file, got: %q", msg)
+	}
+	if !strings.Contains(msg, "1.0.0") {
+		t.Fatalf("expected message to suggest older launcher version, got: %q", msg)
+	}
+}

--- a/cmd/exasol/compatibility_versions.go
+++ b/cmd/exasol/compatibility_versions.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+// This file centralizes deployment compatibility version constants.
+//
+// Why this exists:
+// - Many commands co-evolve in what deployment versions they can safely operate on.
+// - We want to avoid sprinkling raw semver literals (e.g. "0.0.0") across the cmd layer.
+// - When we introduce a breaking change in deployment directory semantics, we add a
+//   new constant here (named after the change) and switch affected commands to it.
+//
+// Rules of thumb for maintainers:
+// - Bump minimum supported deployment versions only when a command would be unsafe
+//   or misleading on older deployments.
+// - Prefer introducing a new constant with a comment explaining the breaking change
+//   (what changed and why older deployments are incompatible).
+// - Do not include prerelease/build suffixes in these constants. Compatibility
+//   comparisons ignore suffixes like "-rc1" and compare only the base version.
+
+const (
+	// minSupportedDeploymentVersionBaseline is the default minimum supported deployment version.
+	//
+	// It is intentionally set to "0.0.0" so that development builds (which commonly
+	// report version "0.0.0") can create and operate on deployments without tripping
+	// compatibility checks.
+	//
+	// When a real breaking change is introduced, define a new constant below and use
+	// it for the affected commands.
+	minSupportedDeploymentVersionBaseline = "0.0.0"
+
+	// Example for the next breaking change:
+	//	// minSupportedDeploymentVersion_<featureName> is the first deployment version
+	//	// that includes <featureName> changes (explain the incompatibility here).
+	//	minSupportedDeploymentVersion_<featureName> = "X.Y.Z"
+)

--- a/cmd/exasol/connect.go
+++ b/cmd/exasol/connect.go
@@ -52,6 +52,8 @@ func registerConnectFlags() {
 
 // nolint: gochecknoinits
 func init() {
+	requireDeploymentCompatibility(connectCmd, minSupportedDeploymentVersionBaseline)
+	requireInitializedDeploymentDir(connectCmd)
 	registerConnectFlags()
 	registerDeploymentDirFlag(connectCmd, commonFlags)
 	rootCmd.AddCommand(connectCmd)

--- a/cmd/exasol/deploy.go
+++ b/cmd/exasol/deploy.go
@@ -46,6 +46,8 @@ var deployCmd = &cobra.Command{
 
 // nolint: gochecknoinits
 func init() {
+	requireDeploymentCompatibility(deployCmd, minSupportedDeploymentVersionBaseline)
+	requireInitializedDeploymentDir(deployCmd)
 	registerDeploymentDirFlag(deployCmd, commonFlags)
 	registerVerboseFlag(deployCmd, commonFlags)
 	registerDeployFlags(deployCmd, commonFlags)

--- a/cmd/exasol/deploymentControl.go
+++ b/cmd/exasol/deploymentControl.go
@@ -83,11 +83,15 @@ func registerStartFlags() {
 
 // nolint: gochecknoinits
 func init() {
+	requireDeploymentCompatibility(startCmd, minSupportedDeploymentVersionBaseline)
+	requireInitializedDeploymentDir(startCmd)
 	registerStartFlags()
 	registerVerboseFlag(startCmd, commonFlags)
 	registerDeploymentDirFlag(startCmd, commonFlags)
 	rootCmd.AddCommand(startCmd)
 
+	requireDeploymentCompatibility(stopCmd, minSupportedDeploymentVersionBaseline)
+	requireInitializedDeploymentDir(stopCmd)
 	registerVerboseFlag(stopCmd, commonFlags)
 	registerDeploymentDirFlag(stopCmd, commonFlags)
 	rootCmd.AddCommand(stopCmd)

--- a/cmd/exasol/destroy.go
+++ b/cmd/exasol/destroy.go
@@ -60,6 +60,8 @@ var destroyCmd = &cobra.Command{
 
 // nolint: gochecknoinits
 func init() {
+	requireDeploymentCompatibility(destroyCmd, minSupportedDeploymentVersionBaseline)
+	requireInitializedDeploymentDir(destroyCmd)
 	registerDeploymentDirFlag(destroyCmd, commonFlags)
 	registerDestroyFlags(destroyCmd)
 	rootCmd.AddCommand(destroyCmd)

--- a/cmd/exasol/diagInfo.go
+++ b/cmd/exasol/diagInfo.go
@@ -30,6 +30,8 @@ var infoCmd = &cobra.Command{
 
 // nolint: gochecknoinits
 func init() {
+	requireDeploymentCompatibility(infoCmd, minSupportedDeploymentVersionBaseline)
+	requireInitializedDeploymentDir(infoCmd)
 	registerDeploymentDirFlag(infoCmd, commonFlags)
 	diagCmd.AddCommand(infoCmd)
 }

--- a/cmd/exasol/diagShell.go
+++ b/cmd/exasol/diagShell.go
@@ -42,6 +42,8 @@ func registerShellFlags() {
 
 // nolint: gochecknoinits
 func init() {
+	requireDeploymentCompatibility(shellCmd, minSupportedDeploymentVersionBaseline)
+	requireInitializedDeploymentDir(shellCmd)
 	registerShellFlags()
 	registerDeploymentDirFlag(shellCmd, commonFlags)
 	diagCmd.AddCommand(shellCmd)

--- a/cmd/exasol/hidden.go
+++ b/cmd/exasol/hidden.go
@@ -37,6 +37,11 @@ var printConnectionInstructions = &cobra.Command{
 
 // nolint: gochecknoinits
 func init() {
+	requireDeploymentCompatibility(
+		printConnectionInstructions,
+		minSupportedDeploymentVersionBaseline,
+	)
+	requireInitializedDeploymentDir(printConnectionInstructions)
 	registerDeploymentDirFlag(printConnectionInstructions, commonFlags)
 	rootCmd.AddCommand(printConnectionInstructions)
 }

--- a/cmd/exasol/info.go
+++ b/cmd/exasol/info.go
@@ -83,6 +83,8 @@ var deploymentInfoCmd = &cobra.Command{
 
 // nolint: gochecknoinits
 func init() {
+	requireDeploymentCompatibility(deploymentInfoCmd, minSupportedDeploymentVersionBaseline)
+	requireInitializedDeploymentDir(deploymentInfoCmd)
 	registerDeploymentDirFlag(deploymentInfoCmd, commonFlags)
 	registerOutputFlags(deploymentInfoCmd, commonFlags)
 	rootCmd.AddCommand(deploymentInfoCmd)

--- a/cmd/exasol/init.go
+++ b/cmd/exasol/init.go
@@ -47,6 +47,11 @@ var initCmd = &cobra.Command{
 
 // nolint: gochecknoinits
 func init() {
+	// Init creates the deployment directory state; if a deployment directory already
+	// exists, the compatibility check protects against operating on an incompatible
+	// deployment.
+	requireDeploymentCompatibility(initCmd, minSupportedDeploymentVersionBaseline)
+
 	// Augment long help with embedded preset names so users know what they can pass.
 	initCmd.Long = strings.TrimRight(initCmdLongDesc, "\n") +
 		"\n\t" + presetNamesForHelp(presets.PresetTypeInfrastructure,

--- a/cmd/exasol/install.go
+++ b/cmd/exasol/install.go
@@ -41,6 +41,9 @@ var installCmd = &cobra.Command{
 
 // nolint: gochecknoinits
 func init() {
+	// Install creates (init) and then operates on (deploy) the deployment directory.
+	requireDeploymentCompatibility(installCmd, minSupportedDeploymentVersionBaseline)
+
 	installCmd.Long = strings.TrimRight(installCmd.Long, "\n") +
 		"\n\t" + presetNamesForHelp(presets.PresetTypeInfrastructure,
 		presets.ListEmbeddedInfrastructuresPresets()) +

--- a/cmd/exasol/root.go
+++ b/cmd/exasol/root.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -58,22 +57,31 @@ var rootCmd = &cobra.Command{
 	Example:       rootCmdExample,
 	SilenceErrors: true,
 	PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-		if err := setuplogging(); err != nil {
+		// Root-level pre-run is the single place where we enforce cross-cutting concerns.
+		// Design decision: keep this centralized so individual commands don't have to
+		// remember to repeat it (and so user-visible behavior stays consistent).
+		if err := setupLogging(); err != nil {
 			return err
 		}
 
-		// Perform silent version check (non-blocking, only logs if update available)
-		// Skip for the version command itself and if disabled
-		// And if the directory isn't initialized
+		// Deployment-directory compatibility is enforced centrally and only for commands
+		// that declare it via annotations.
+		err := enforceDeploymentDirectoryCompatibility(cmd, commonFlags.DeploymentDir)
+		if err != nil {
+			return err
+		}
+
+		// Best-effort version update hint (non-blocking; logs only when an update is available).
+		// Design decision: never block commands on this.
 		if cmd.Name() != "version" {
-			printVersionUpdateHint(cmd.Context())
+			deploy.MaybeLogVersionUpdateHint(cmd.Context(), commonFlags.DeploymentDir, version)
 		}
 
 		return nil
 	},
 }
 
-func setuplogging() error {
+func setupLogging() error {
 	var logger *slog.Logger
 
 	selectedLevel, ok := logLevelMap[commonFlags.LogLevel]
@@ -83,7 +91,7 @@ func setuplogging() error {
 	if term.IsTerminal(int(os.Stdout.Fd())) {
 		levelVar := slog.LevelVar{}
 		levelVar.Set(selectedLevel)
-		// --log-level is not set and terminal is attached. Use pretty-printing for log messages
+		// Design decision: when attached to a terminal, prefer human-friendly logs.
 		logger = slog.New(tint.NewHandler(os.Stderr, &tint.Options{
 			Level: &levelVar, TimeFormat: time.DateTime,
 		}))
@@ -101,29 +109,6 @@ func setuplogging() error {
 	)
 
 	return nil
-}
-
-func printVersionUpdateHint(ctx context.Context) {
-	result, err := deploy.PerformSilentVersionCheck(
-		ctx,
-		commonFlags.DeploymentDir,
-		version,
-	)
-	if err != nil {
-		slog.Debug("launcher version update check failed", "error", err)
-		return
-	}
-	if !result.Checked {
-		return
-	}
-	if result.UpdateAvailable {
-		slog.Info(
-			"A new version of Exasol Personal is available",
-			"current", version,
-			"latest", result.LatestVersion,
-			"info", "Run 'exasol version --latest' for more details",
-		)
-	}
 }
 
 // addHelpFlag adds the help flag to the command and all its children.

--- a/cmd/exasol/status.go
+++ b/cmd/exasol/status.go
@@ -72,6 +72,8 @@ func registerStatusFlags() {
 
 // nolint: gochecknoinits
 func init() {
+	requireDeploymentCompatibility(statusCmd, minSupportedDeploymentVersionBaseline)
+	requireInitializedDeploymentDir(statusCmd)
 	registerStatusFlags()
 	registerDeploymentDirFlag(statusCmd, commonFlags)
 	registerOutputFlags(statusCmd, commonFlags)

--- a/cmd/exasol/unlock.go
+++ b/cmd/exasol/unlock.go
@@ -36,6 +36,8 @@ var unlockCmd = &cobra.Command{
 
 // nolint: gochecknoinits
 func init() {
+	requireDeploymentCompatibility(unlockCmd, minSupportedDeploymentVersionBaseline)
+	requireInitializedDeploymentDir(unlockCmd)
 	registerDeploymentDirFlag(unlockCmd, commonFlags)
 	diagCmd.AddCommand(unlockCmd)
 }

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -17,6 +17,7 @@ The Exasol Personal tool (`exasol`) is a command-line application that automates
 - [Main README](../README.md)
 - [Development Guide](development.md)
 - [Preset Development (contracts and schemas)](presets.md)
+- [Deployment directory compatibility](deployment_compatibility.md)
 - Installation preset documentation (see the README in `assets/installation/<preset>/`)
 - [AWS Infrastructure README](../assets/infrastructure/aws/README.md)
 - [Exasol Documentation](https://docs.exasol.com/db/latest/home.htm)
@@ -203,6 +204,12 @@ Each infrastructure preset documents:
 - Network topology
 
 ## State and Configuration Management
+
+### Deployment directory compatibility
+
+Because the deployment directory is long-lived while the launcher evolves over time, the launcher validates that a deployment directory is compatible with the current launcher version before executing any command that operates on that directory.
+
+For the compatibility contract and user-facing behavior, see [Deployment directory compatibility](deployment_compatibility.md).
 
 ### Deployment Directory
 

--- a/doc/deployment_compatibility.md
+++ b/doc/deployment_compatibility.md
@@ -1,0 +1,81 @@
+# Deployment directory compatibility
+
+The deployment directory is a long-lived artifact. To protect users from accidentally running an incompatible launcher against an existing deployment directory (which can corrupt state, break workflow guarantees, or leave infrastructure in an undefined state), the launcher enforces a **mandatory compatibility check** before executing any deployment-directory-dependent command.
+
+This compatibility mechanism is distinct from release/update notifications. For update checking, see [Version checking](version_checking.md).
+
+## Concepts
+
+### Deployment version
+
+When a deployment directory is created, the launcher persists the launcher version as part of the deployment’s persistent state.
+
+This stored version is the **deployment version**:
+
+- It is the authoritative version marker for that deployment directory.
+- It is treated as part of the deployment contract.
+- It is **immutable** for the lifetime of the deployment directory.
+
+### Launcher version
+
+The **launcher version** is the version of the currently running `exasol` binary.
+
+### Command compatibility range
+
+Each command that operates on a deployment directory defines the range of deployment versions it supports.
+
+At minimum, a command declares a **minimum supported deployment version**.
+
+This allows compatibility to evolve gradually:
+
+- Read-only commands can remain compatible with a wider range of deployments.
+- Lifecycle and mutating commands can require stricter compatibility.
+
+## Compatibility rules (enforced for every command)
+
+Before doing any mutation or external interaction, commands that operate on a deployment directory must validate compatibility using a centralized mechanism.
+
+This check is implemented in an abstract, generic fashion and is mandatory for **all commands** that interact with a deployment directory.
+
+The decision rules are:
+
+1. **Deployment newer than launcher:**
+   - If $\text{deployment version} > \text{launcher version}$, the command fails immediately.
+   - This is rejected **on principle**: an older launcher cannot reliably claim compatibility with a deployment created by a newer launcher, because future changes to state, contracts, or workflow semantics are not knowable to the older binary.
+   - The required action is to **upgrade** the launcher.
+
+2. **Deployment older than launcher:**
+   - If $\text{deployment version} < \text{command minimum supported deployment version}$, the command fails immediately.
+   - The required action is to **use a compatible launcher version** (typically by downgrading).
+
+3. **Supported:**
+   - Otherwise, the command is allowed to proceed.
+
+## Failure behavior and messaging
+
+On incompatibility, the launcher:
+
+- Exits with a non-zero status.
+- Produces a clear, actionable message that includes:
+  - Deployment version
+  - Current launcher version
+  - The reason execution is blocked
+  - The required action (upgrade or use a compatible older launcher)
+
+## Stability of the version marker
+
+The compatibility mechanism depends on being able to read the deployment version reliably.
+
+For that reason, the deployment version is recorded in a dedicated plain-text marker file (`.exasolLauncher.version`).
+
+This marker’s presence, identity, and location are treated as a long-term contract and must remain stable over time.
+
+This ensures that even as the launcher evolves, it can still detect an incompatible deployment directory early and fail fast rather than proceeding with undefined behavior.
+
+## Forward evolution
+
+This model supports safe evolution of the launcher and deployment contract:
+
+- Breaking changes can be introduced without silently corrupting existing deployments.
+- Individual commands can tighten their supported range over time.
+- A future migration workflow can be added explicitly (for example, a dedicated migration command), without weakening the “fail fast on incompatibility” guarantee.

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -11,6 +11,16 @@ A self-contained directory with all configuration, state, and credentials for ma
 
 See [Architecture: State and Configuration Management](architecture.md#state-and-configuration-management).
 
+### Deployment Version
+The launcher version that was persisted when a deployment directory was created. It is an immutable marker that defines the deployment’s compatibility contract.
+
+See [Deployment directory compatibility](deployment_compatibility.md).
+
+### Deployment Compatibility Check
+A mandatory validation performed before executing any command that operates on a deployment directory. It ensures the deployment version is compatible with the current launcher version and the command’s supported range.
+
+See [Deployment directory compatibility](deployment_compatibility.md).
+
 ### Infrastructure Preset
 The infrastructure template selected for deployment. It defines the infrastructure layout and provisioning approach. Infrastructure presets can target cloud or non-cloud environments.
 

--- a/doc/launcher_state.md
+++ b/doc/launcher_state.md
@@ -7,6 +7,8 @@ The launcher keeps this lifecycle consistent across command invocations using tw
 - A **persistent state file** (`.exasolLauncherState.json`) that records the deployment's current workflow state and additional launcher metadata.
 - A **temporary lock file** (`.exasolLock.json`) that prevents concurrent, conflicting operations.
 
+Deployment compatibility also relies on a stable, plain-text deployment-version marker file (`.exasolLauncher.version`).
+
 This document is an architecture guide for developers. It describes what is stored in these files, the invariants they must uphold, and the intended usage patterns.
 
 ## Persistent state: `.exasolLauncherState.json`
@@ -16,9 +18,11 @@ The persistent state file is the source of truth for the deployment's lifecycle.
 It has two responsibilities:
 
 - **Workflow coordination:** record the current workflow state so commands can enforce a consistent lifecycle across process invocations.
-- **Launcher metadata:** persist additional launcher-level information that must survive restarts (for example, version-check bookkeeping).
+- **Launcher metadata:** persist additional launcher-level information that must survive restarts (for example, version-check bookkeeping and deployment compatibility metadata).
 
 The version-checking feature stores its bookkeeping in this file; for details, see `doc/version_checking.md`.
+
+The deployment compatibility mechanism reads the deployment version from the marker file (`.exasolLauncher.version`); for details, see [Deployment directory compatibility](deployment_compatibility.md).
 
 ### Key invariants
 
@@ -27,6 +31,8 @@ These are the invariants the code must preserve (independent of implementation d
 - The file must remain readable/writable by the launcher throughout the workflow.
 - The workflow state is a **single, unambiguous value** at any point in time.
 - Commands must treat the persistent state as the contract for what operations are safe/allowed next.
+- The deployment version (used for compatibility checks) is written when the deployment directory is created and remains immutable for the lifetime of the deployment directory.
+- The deployment-version marker is a long-term contract: its presence, identity, and location must remain stable over time so that future launchers can always perform compatibility checks before doing any work.
 - Developers should avoid editing this file by hand; it is meant to be machine-managed.
 
 ## Workflow states (intended meaning)

--- a/doc/release.md
+++ b/doc/release.md
@@ -22,6 +22,11 @@ Tag governance controls (for example restricting who can create `v*` tags and wh
 
 ## Creating a Release
 
+Before tagging a release, ensure deployment directory compatibility constraints are up to date:
+
+- If the release introduces a breaking change in deployment directory semantics (state layout, workflow invariants, marker files, etc.), add a new minimum supported deployment version constant in the cmd layer (see `cmd/exasol/compatibility_versions.go`) and apply it to the affected commands.
+- Release-candidate versions (for example `1.2.0-rc1`) must not appear in those constants. Compatibility comparisons treat prerelease/build suffixes as irrelevant and compare only the base version (so `1.2.0-rc1` behaves like `1.2.0`).
+
 ### 1. Tag the Release
 
 ```bash

--- a/doc/version_checking.md
+++ b/doc/version_checking.md
@@ -1,5 +1,9 @@
 # Version checking
 
+This document describes how the launcher checks for newer launcher releases.
+
+It is **not** the deployment directory compatibility mechanism (which prevents running an incompatible launcher against an existing deployment directory). For that contract, see [Deployment directory compatibility](deployment_compatibility.md).
+
 Exasol personal makes calls to a REST API once per day, per repository.
 
 To determine if 24 hours has passed, the time of the last version check is written to the `.exasolLauncherState.json` file in the deployment directory.

--- a/internal/compatibility/compatibility.go
+++ b/internal/compatibility/compatibility.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+// Package deploymentcompatibility provides a centralized, generic compatibility
+// check between a deployment directory (created by some launcher version) and
+// the currently running launcher.
+//
+// The key safety rule is strict: if the deployment was created by a newer
+// launcher version than the current binary, commands must never proceed.
+package deploymentcompatibility
+
+import (
+	"fmt"
+
+	"github.com/blang/semver/v4"
+)
+
+// Requirement describes the minimum deployment version a command supports.
+//
+// The launcher version is not used as an upper bound for compatibility.
+// Instead, the framework enforces a strict rule: deployment versions newer than
+// the current launcher are always rejected.
+//
+// MinSupportedDeploymentVersion must be a valid semantic version.
+//
+// CommandName is optional and only used for diagnostics.
+type Requirement struct {
+	CommandName                   string
+	MinSupportedDeploymentVersion string
+}
+
+// Result is the outcome of a compatibility check.
+//
+// If Allowed is false, Err describes why execution must be blocked.
+type Result struct {
+	Allowed bool
+	Err     error
+}
+
+// Check validates whether a command is allowed to operate on a deployment
+// directory.
+//
+// Inputs:
+//   - deploymentVersion: version persisted in the deployment directory state
+//   - launcherVersion: version of the currently running launcher binary
+//   - req: command-specific compatibility requirement
+func Check(deploymentVersion, launcherVersion string, req Requirement) Result {
+	depV, err := parseRequiredVersion(deploymentVersion, "deployment version")
+	if err != nil {
+		return Result{Allowed: false, Err: err}
+	}
+	launchV, err := parseRequiredVersion(launcherVersion, "launcher version")
+	if err != nil {
+		return Result{Allowed: false, Err: err}
+	}
+	minV, err := parseRequiredVersion(
+		req.MinSupportedDeploymentVersion,
+		"minimum supported deployment version",
+	)
+	if err != nil {
+		return Result{Allowed: false, Err: err}
+	}
+
+	// Strict forward-incompatibility rule: an older launcher must never operate on
+	// a deployment created by a newer launcher.
+	if depV.GT(launchV) {
+		return Result{Allowed: false, Err: &IncompatibleError{
+			DeploymentVersion: depV,
+			LauncherVersion:   launchV,
+			MinSupported:      minV,
+			CommandName:       req.CommandName,
+			Reason:            ReasonDeploymentNewerThanLauncher,
+			RequiredAction:    ActionUpgradeLauncher,
+		}}
+	}
+
+	if depV.LT(minV) {
+		return Result{Allowed: false, Err: &IncompatibleError{
+			DeploymentVersion: depV,
+			LauncherVersion:   launchV,
+			MinSupported:      minV,
+			CommandName:       req.CommandName,
+			Reason:            ReasonDeploymentTooOld,
+			RequiredAction:    ActionUseCompatibleLauncher,
+		}}
+	}
+
+	return Result{Allowed: true, Err: nil}
+}
+
+func parseRequiredVersion(raw string, label string) (semver.Version, error) {
+	if raw == "" {
+		return semver.Version{}, &InvalidVersionError{
+			Label: label,
+			Raw:   raw,
+			Cause: fmt.Errorf("missing %s", label),
+		}
+	}
+	ver, err := semver.Parse(raw)
+	if err != nil {
+		return semver.Version{}, &InvalidVersionError{Label: label, Raw: raw, Cause: err}
+	}
+
+	// Design decision: compatibility comparisons ignore prerelease and build metadata.
+	//
+	// We publish release candidates like "1.2.0-rc1". For compatibility decisions we
+	// treat these as "1.2.0" to avoid artificial incompatibilities between a release
+	// and its RCs.
+	ver.Pre = nil
+	ver.Build = nil
+
+	return ver, nil
+}

--- a/internal/compatibility/compatibility_test.go
+++ b/internal/compatibility/compatibility_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploymentcompatibility
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestCheck_AllowsSupportedVersions(t *testing.T) {
+	t.Parallel()
+	res := Check(
+		"1.2.0",
+		"2.0.0",
+		Requirement{CommandName: "status", MinSupportedDeploymentVersion: "1.0.0"},
+	)
+	if !res.Allowed {
+		t.Fatalf("expected allowed, got disallowed error: %v", res.Err)
+	}
+	if res.Err != nil {
+		t.Fatalf("expected nil error when allowed, got: %v", res.Err)
+	}
+}
+
+func TestCheck_RejectsDeploymentNewerThanLauncher_OnPrinciple(t *testing.T) {
+	t.Parallel()
+	res := Check(
+		"2.0.0",
+		"1.9.0",
+		Requirement{CommandName: "deploy", MinSupportedDeploymentVersion: "1.0.0"},
+	)
+	if res.Allowed {
+		t.Fatal("expected disallowed")
+	}
+
+	var inc *IncompatibleError
+	if !errors.As(res.Err, &inc) {
+		t.Fatalf("expected IncompatibleError, got %T: %v", res.Err, res.Err)
+	}
+	if inc.Reason != ReasonDeploymentNewerThanLauncher {
+		t.Fatalf("expected reason %q, got %q", ReasonDeploymentNewerThanLauncher, inc.Reason)
+	}
+	if inc.RequiredAction != ActionUpgradeLauncher {
+		t.Fatalf("expected action %q, got %q", ActionUpgradeLauncher, inc.RequiredAction)
+	}
+	if !strings.Contains(inc.Error(), ">= 2.0.0") {
+		t.Fatalf(
+			"expected error to mention minimum upgrade version (>= deployment version), got: %q",
+			inc.Error(),
+		)
+	}
+}
+
+func TestCheck_IgnoresPrereleaseSuffixes(t *testing.T) {
+	t.Parallel()
+
+	req := Requirement{CommandName: "deploy", MinSupportedDeploymentVersion: "1.0.0"}
+
+	// Deployment created by release, launcher is an RC of the same version.
+	res := Check("1.2.0", "1.2.0-rc1", req)
+	if !res.Allowed {
+		t.Fatalf("expected allowed, got error: %v", res.Err)
+	}
+
+	// Deployment created by an RC, launcher is the final release.
+	res = Check("1.2.0-rc2", "1.2.0", req)
+	if !res.Allowed {
+		t.Fatalf("expected allowed, got error: %v", res.Err)
+	}
+}
+
+func TestCheck_RejectsDeploymentOlderThanCommandMinimum(t *testing.T) {
+	t.Parallel()
+	res := Check(
+		"1.0.0",
+		"2.0.0",
+		Requirement{CommandName: "deploy", MinSupportedDeploymentVersion: "1.5.0"},
+	)
+	if res.Allowed {
+		t.Fatal("expected disallowed")
+	}
+
+	var inc *IncompatibleError
+	if !errors.As(res.Err, &inc) {
+		t.Fatalf("expected IncompatibleError, got %T: %v", res.Err, res.Err)
+	}
+	if inc.Reason != ReasonDeploymentTooOld {
+		t.Fatalf("expected reason %q, got %q", ReasonDeploymentTooOld, inc.Reason)
+	}
+	if inc.RequiredAction != ActionUseCompatibleLauncher {
+		t.Fatalf("expected action %q, got %q", ActionUseCompatibleLauncher, inc.RequiredAction)
+	}
+}
+
+func TestCheck_RejectsInvalidVersions(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name         string
+		deployment   string
+		launcher     string
+		minSupported string
+	}{
+		{name: "missing deployment", deployment: "", launcher: "1.0.0", minSupported: "1.0.0"},
+		{
+			name:         "invalid deployment",
+			deployment:   "not-a-version",
+			launcher:     "1.0.0",
+			minSupported: "1.0.0",
+		},
+		{name: "invalid launcher", deployment: "1.0.0", launcher: "nope", minSupported: "1.0.0"},
+		{name: "invalid minimum", deployment: "1.0.0", launcher: "1.0.0", minSupported: "bad"},
+	}
+
+	for _, testcase := range cases {
+		t.Run(testcase.name, func(t *testing.T) {
+			t.Parallel()
+			res := Check(
+				testcase.deployment,
+				testcase.launcher,
+				Requirement{CommandName: "x", MinSupportedDeploymentVersion: testcase.minSupported},
+			)
+			if res.Allowed {
+				t.Fatal("expected disallowed")
+			}
+			var inv *InvalidVersionError
+			if !errors.As(res.Err, &inv) {
+				t.Fatalf("expected InvalidVersionError, got %T: %v", res.Err, res.Err)
+			}
+		})
+	}
+}

--- a/internal/compatibility/enforce.go
+++ b/internal/compatibility/enforce.go
@@ -1,0 +1,203 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploymentcompatibility
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/exasol/exasol-personal/internal/config"
+)
+
+const (
+	legacyWorkflowStateFileName = ".workflowState.json"
+
+	exampleLegacyLauncherVersion = "1.0.0"
+
+	errLegacyDeploymentLayoutFmt = "deployment directory appears to be from an older version " +
+		"(found %q but missing %q).\n" +
+		"This launcher cannot operate on it. " +
+		"Use a compatible older launcher (e.g. %s) or recreate the deployment directory"
+	errDeploymentNotInitializedFmt = "deployment directory is not initialized " +
+		"(missing %q in %q).\n" +
+		"Run 'exasol init' or 'exasol install' in that directory, " +
+		"or pass --deployment-dir pointing to an existing deployment directory"
+	errDeploymentVersionMarkerMissingFmt = "deployment directory is missing deployment " +
+		"version marker %q in %q.\n" +
+		"Recreate the deployment directory with this launcher " +
+		"(run 'exasol init' or 'exasol install') " +
+		"or ensure --deployment-dir points to the correct directory"
+	errDeploymentVersionMarkerEmptyFmt = "deployment version marker %q in %q is empty"
+)
+
+// DeploymentDirInitializationRequirement describes whether a command expects an
+// already-initialized deployment directory.
+type DeploymentDirInitializationRequirement int
+
+const (
+	DeploymentDirMayBeUninitialized DeploymentDirInitializationRequirement = iota
+	DeploymentDirMustBeInitialized
+)
+
+// EnforceDeploymentDirectoryCompatibility validates whether a command is allowed to
+// operate on the deployment directory.
+//
+// Design decision: this function performs logging internally so the cmd layer can
+// stay focused on orchestration and terminal output.
+//
+// If initReq is DeploymentDirMayBeUninitialized, the function allows truly
+// empty/uninitialized directories (for commands like init/install), but still
+// fails on known legacy layouts.
+func EnforceDeploymentDirectoryCompatibility(
+	deploymentDir string,
+	launcherVersion string,
+	req Requirement,
+	initReq DeploymentDirInitializationRequirement,
+) error {
+	initialized, err := config.IsDirectoryContainingStateFile(deploymentDir)
+	if err != nil {
+		return err
+	}
+	if !initialized {
+		return handleUninitializedDeploymentDir(req.CommandName, deploymentDir, initReq)
+	}
+
+	deploymentVersion, err := readDeploymentVersionMarker(deploymentDir)
+	if err != nil {
+		return err
+	}
+
+	result := Check(deploymentVersion, launcherVersion, req)
+	if result.Allowed {
+		return nil
+	}
+
+	logCompatibilityFailure(req.CommandName, result.Err)
+
+	return result.Err
+}
+
+func handleUninitializedDeploymentDir(
+	commandName string,
+	deploymentDir string,
+	initReq DeploymentDirInitializationRequirement,
+) error {
+	legacy, err := legacyWorkflowStateExists(deploymentDir)
+	if err != nil {
+		return err
+	}
+	if legacy {
+		err := fmt.Errorf(
+			errLegacyDeploymentLayoutFmt,
+			legacyWorkflowStateFileName,
+			config.ExasolPersonalStateFileName,
+			exampleLegacyLauncherVersion,
+		)
+		slog.Warn(
+			"legacy deployment directory detected",
+			"command", commandName,
+			"deployment_dir", deploymentDir,
+		)
+
+		return err
+	}
+
+	if initReq == DeploymentDirMayBeUninitialized {
+		return nil
+	}
+
+	err = fmt.Errorf(
+		errDeploymentNotInitializedFmt,
+		config.ExasolPersonalStateFileName,
+		deploymentDir,
+	)
+	slog.Error(
+		"deployment directory is not initialized",
+		"command", commandName,
+		"deployment_dir", deploymentDir,
+	)
+
+	return err
+}
+
+func legacyWorkflowStateExists(deploymentDir string) (bool, error) {
+	_, err := os.Stat(filepath.Join(deploymentDir, legacyWorkflowStateFileName))
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+
+	return false, err
+}
+
+func readDeploymentVersionMarker(deploymentDir string) (string, error) {
+	ver, ok, err := config.ReadDeploymentVersionMarker(deploymentDir)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		err := fmt.Errorf(
+			errDeploymentVersionMarkerMissingFmt,
+			config.DeploymentVersionMarkerFileName,
+			deploymentDir,
+		)
+		slog.Error(
+			"deployment version marker missing",
+			"deployment_dir", deploymentDir,
+			"marker", config.DeploymentVersionMarkerFileName,
+			"error", err.Error(),
+		)
+
+		return "", err
+	}
+	if ver == "" {
+		err := fmt.Errorf(
+			errDeploymentVersionMarkerEmptyFmt,
+			config.DeploymentVersionMarkerFileName,
+			deploymentDir,
+		)
+		slog.Error(
+			"deployment version marker empty",
+			"deployment_dir", deploymentDir,
+			"marker", config.DeploymentVersionMarkerFileName,
+			"error", err.Error(),
+		)
+
+		return "", err
+	}
+
+	return ver, nil
+}
+
+func logCompatibilityFailure(commandName string, err error) {
+	// Structured logging is useful for automation/diagnostics while keeping cmd output
+	// as just the returned error message.
+	var inc *IncompatibleError
+	if errors.As(err, &inc) {
+		slog.Error(
+			"deployment directory compatibility check failed",
+			"command", inc.CommandName,
+			"deployment_version", inc.DeploymentVersion.String(),
+			"launcher_version", inc.LauncherVersion.String(),
+			"min_supported_deployment_version", inc.MinSupported.String(),
+			"reason", string(inc.Reason),
+			"required_action", string(inc.RequiredAction),
+			"error", inc.Error(),
+		)
+
+		return
+	}
+	if err != nil {
+		slog.Error(
+			"deployment directory compatibility check failed",
+			"command", commandName,
+			"error", err,
+		)
+	}
+}

--- a/internal/compatibility/errors.go
+++ b/internal/compatibility/errors.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploymentcompatibility
+
+import (
+	"fmt"
+
+	"github.com/blang/semver/v4"
+)
+
+// Reason describes why a compatibility check failed.
+type Reason string
+
+const (
+	ReasonDeploymentNewerThanLauncher Reason = "deployment_newer_than_launcher"
+	ReasonDeploymentTooOld            Reason = "deployment_too_old_for_command"
+)
+
+// Action describes what the user needs to do to resolve an incompatibility.
+type Action string
+
+const (
+	ActionUpgradeLauncher       Action = "upgrade_launcher"
+	ActionUseCompatibleLauncher Action = "use_compatible_launcher"
+)
+
+// IncompatibleError is returned when a deployment directory is not compatible
+// with the currently running launcher for a given command.
+//
+// This error is designed to support actionable, user-facing messaging in the
+// cmd layer without printing from internal packages.
+type IncompatibleError struct {
+	DeploymentVersion semver.Version
+	LauncherVersion   semver.Version
+	MinSupported      semver.Version
+	CommandName       string
+	Reason            Reason
+	RequiredAction    Action
+}
+
+func (e *IncompatibleError) Error() string {
+	cmd := e.CommandName
+	if cmd == "" {
+		cmd = "(unspecified command)"
+	}
+
+	switch e.Reason {
+	case ReasonDeploymentNewerThanLauncher:
+		return fmt.Sprintf(
+			"deployment directory is incompatible with this launcher:\n"+
+				"Deployment version %s is newer than launcher version %s (command %s)\n"+
+				"Required action: upgrade the launcher to version >= %s",
+			e.DeploymentVersion,
+			e.LauncherVersion,
+			cmd,
+			e.DeploymentVersion,
+		)
+	case ReasonDeploymentTooOld:
+		return fmt.Sprintf(
+			"deployment directory is incompatible with this command:\n"+
+				"Deployment version %s is older than the minimum supported "+
+				"deployment version %s for launcher version %s (command %s)\n"+
+				"Required action: use a launcher version that supports this deployment",
+			e.DeploymentVersion,
+			e.MinSupported,
+			e.LauncherVersion,
+			cmd,
+		)
+	default:
+		return fmt.Sprintf(
+			"deployment directory is incompatible (command %s); required action: %s",
+			cmd,
+			e.RequiredAction,
+		)
+	}
+}
+
+// InvalidVersionError is returned when an input version string is missing or
+// not a valid semantic version.
+type InvalidVersionError struct {
+	Label string
+	Raw   string
+	Cause error
+}
+
+func (e *InvalidVersionError) Error() string {
+	if e.Raw == "" {
+		return fmt.Sprintf("invalid %s: missing", e.Label)
+	}
+
+	return fmt.Sprintf("invalid %s %q: %v", e.Label, e.Raw, e.Cause)
+}
+
+func (e *InvalidVersionError) Unwrap() error { return e.Cause }

--- a/internal/config/deployment_version_marker.go
+++ b/internal/config/deployment_version_marker.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DeploymentVersionMarkerFileName is a plain-text marker file which contains the
+// launcher version that created a deployment directory.
+//
+// Design decision: this file exists to provide a stable, low-coupling and
+// human-auditable source for deployment compatibility checks.
+const DeploymentVersionMarkerFileName = ".exasolLauncher.version"
+
+const deploymentVersionMarkerFileMode = 0o600
+
+// ReadDeploymentVersionMarker reads the deployment version marker from the deployment directory.
+// It returns (version, true, nil) if the marker exists, ("", false, nil) if it does not exist.
+func ReadDeploymentVersionMarker(deploymentDir string) (string, bool, error) {
+	path := filepath.Join(deploymentDir, DeploymentVersionMarkerFileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", false, nil
+		}
+
+		return "", false, err
+	}
+
+	return strings.TrimSpace(string(data)), true, nil
+}
+
+// WriteDeploymentVersionMarker writes the plain-text deployment version marker.
+func WriteDeploymentVersionMarker(deploymentDir string, deploymentVersion string) error {
+	path := filepath.Join(deploymentDir, DeploymentVersionMarkerFileName)
+
+	// Assumption: this file is written during init (under the deployment directory lock)
+	// and only read afterwards. We keep the implementation intentionally simple.
+	content := []byte(strings.TrimSpace(deploymentVersion))
+
+	return os.WriteFile(path, content, deploymentVersionMarkerFileMode)
+}

--- a/internal/config/exasol_launcher_state.go
+++ b/internal/config/exasol_launcher_state.go
@@ -10,7 +10,9 @@ import (
 	"time"
 )
 
-const exasolPersonalStateFileName = ".exasolLauncherState.json"
+// ExasolPersonalStateFileName is the persistent workflow/metadata state file stored
+// in a deployment directory.
+const ExasolPersonalStateFileName = ".exasolLauncherState.json"
 
 type (
 	WorkflowStateInitialized struct{}
@@ -50,13 +52,20 @@ type WorkflowState struct {
 
 type ExasolPersonalState struct {
 	CurrentWorkflowState WorkflowState `json:"currentWorkflowState"`
-	LastVersionCheck     time.Time     `json:"lastVersionCheck"`
-	VersionCheckEnabled  bool          `json:"versionCheckEnabled"`
+	// DeploymentVersion is the launcher version that created this deployment directory.
+	//
+	// Note: the long-term, stable deployment-version marker used for compatibility
+	// checks is the plain-text file ".exasolLauncher.version".
+	// This JSON field mirrors that marker for convenience, but compatibility checks
+	// should not depend on it.
+	DeploymentVersion   string    `json:"deploymentVersion"`
+	LastVersionCheck    time.Time `json:"lastVersionCheck"`
+	VersionCheckEnabled bool      `json:"versionCheckEnabled"`
 }
 
 // DirectoryExasolPersonalStatefile.
 func IsDirectoryContainingStateFile(directory string) (bool, error) {
-	path := filepath.Join(directory, exasolPersonalStateFileName)
+	path := filepath.Join(directory, ExasolPersonalStateFileName)
 
 	info, err := os.Stat(path)
 	if err != nil {
@@ -78,7 +87,7 @@ func IsDirectoryContainingStateFile(directory string) (bool, error) {
 // SetExasolPersonalState writes a new exasol personal state to permanent storage.
 func WriteExasolPersonalState(state *ExasolPersonalState, deploymentDir string) error {
 	return writeConfig(state,
-		filepath.Join(deploymentDir, exasolPersonalStateFileName),
+		filepath.Join(deploymentDir, ExasolPersonalStateFileName),
 		"exasol personal state")
 }
 
@@ -88,7 +97,7 @@ var ErrNoExasolPersonalStateSet = errors.New("no exasol-personal state is set")
 func ReadExasolPersonalState(deploymentDir string) (*ExasolPersonalState, error) {
 	slog.Debug("reading exasol personal state")
 	state, err := readConfig[ExasolPersonalState](
-		filepath.Join(deploymentDir, exasolPersonalStateFileName),
+		filepath.Join(deploymentDir, ExasolPersonalStateFileName),
 		"exasol personal state")
 	if err != nil {
 		return nil, err

--- a/internal/deploy/init.go
+++ b/internal/deploy/init.go
@@ -143,11 +143,11 @@ func InitDeployment(
 
 			slog.Debug("Initializing deployment state")
 			if versionCheckEnabled {
-				if err := writeInitializedStateWithVersionChecks(deploymentDir); err != nil {
+				if err := writeInitializedStateWithVersionChecks(deploymentDir, currentVersion); err != nil {
 					return err
 				}
 			} else {
-				if err := writeInitializedStateWithoutVersionChecks(deploymentDir); err != nil {
+				if err := writeInitializedStateWithoutVersionChecks(deploymentDir, currentVersion); err != nil {
 					return err
 				}
 			}
@@ -244,25 +244,40 @@ func ensureDirectoryIsEmpty(deploymentDir string) error {
 	return nil
 }
 
-func writeInitializedStateWithVersionChecks(deploymentDir string) error {
-	exasolState := newInitializedStateWithVersionChecks()
-	return exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateInitialized{}, deploymentDir)
+func writeInitializedStateWithVersionChecks(deploymentDir string, deploymentVersion string) error {
+	exasolState := newInitializedStateWithVersionChecks(deploymentVersion)
+	err := exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateInitialized{}, deploymentDir)
+	if err != nil {
+		return err
+	}
+
+	return config.WriteDeploymentVersionMarker(deploymentDir, deploymentVersion)
 }
 
-func writeInitializedStateWithoutVersionChecks(deploymentDir string) error {
-	exasolState := newInitializedStateWithoutVersionChecks()
-	return exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateInitialized{}, deploymentDir)
+func writeInitializedStateWithoutVersionChecks(
+	deploymentDir string,
+	deploymentVersion string,
+) error {
+	exasolState := newInitializedStateWithoutVersionChecks(deploymentVersion)
+	err := exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateInitialized{}, deploymentDir)
+	if err != nil {
+		return err
+	}
+
+	return config.WriteDeploymentVersionMarker(deploymentDir, deploymentVersion)
 }
 
-func newInitializedStateWithVersionChecks() *config.ExasolPersonalState {
+func newInitializedStateWithVersionChecks(deploymentVersion string) *config.ExasolPersonalState {
 	return &config.ExasolPersonalState{
+		DeploymentVersion:   deploymentVersion,
 		VersionCheckEnabled: true,
 		LastVersionCheck:    time.Now(),
 	}
 }
 
-func newInitializedStateWithoutVersionChecks() *config.ExasolPersonalState {
+func newInitializedStateWithoutVersionChecks(deploymentVersion string) *config.ExasolPersonalState {
 	return &config.ExasolPersonalState{
+		DeploymentVersion:   deploymentVersion,
 		VersionCheckEnabled: false,
 		LastVersionCheck:    time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC),
 	}

--- a/internal/deploy/init_test.go
+++ b/internal/deploy/init_test.go
@@ -40,6 +40,21 @@ func TestInitDeployment_CreatesTfVarsWhenTofuConfigured(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected workflow state to be readable, got error: %v", err)
 	}
+	if state.DeploymentVersion != "0.0.0" {
+		t.Fatalf(
+			"expected deployment version to be persisted as %q, got %q",
+			"0.0.0",
+			state.DeploymentVersion,
+		)
+	}
+	if ver, ok, err := config.ReadDeploymentVersionMarker(deploymentDir); err != nil {
+		t.Fatalf("expected deployment version marker to be readable, got error: %v", err)
+	} else if !ok {
+		t.Fatalf("expected deployment version marker %q to exist",
+			config.DeploymentVersionMarkerFileName)
+	} else if ver != "0.0.0" {
+		t.Fatalf("expected deployment version marker to be %q, got %q", "0.0.0", ver)
+	}
 	workflowState, err := state.GetWorkflowState()
 	if err != nil {
 		t.Fatalf("expected workflow state to be set, got error: %v", err)

--- a/internal/deploy/status.go
+++ b/internal/deploy/status.go
@@ -135,19 +135,6 @@ func GetStatus(
 	deploymentDir string,
 	checkConnection bool,
 ) (*StatusOutput, error) {
-	initialized, err := config.IsDirectoryContainingStateFile(deploymentDir)
-	if err != nil {
-		return nil, err
-	}
-
-	if !initialized {
-		return &StatusOutput{
-			Status: StatusNotInitialized,
-			Message: "No exasol personal state file was found. " +
-				"Run `init` or `install` to start a new deployment in this directory.",
-		}, nil
-	}
-
 	exasolState, err := config.ReadExasolPersonalState(deploymentDir)
 	if err != nil {
 		return nil, err

--- a/internal/deploy/version_update_hint.go
+++ b/internal/deploy/version_update_hint.go
@@ -1,0 +1,34 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"context"
+	"log/slog"
+)
+
+// MaybeLogVersionUpdateHint performs a best-effort silent version check and logs a
+// hint if an update is available.
+//
+// Design decision: this lives in the deploy package because it relies on the
+// version-checking mechanism and its locking semantics. The cmd layer should not
+// need to understand those details.
+func MaybeLogVersionUpdateHint(ctx context.Context, deploymentDir string, currentVersion string) {
+	result, err := PerformSilentVersionCheck(ctx, deploymentDir, currentVersion)
+	if err != nil {
+		slog.Debug("launcher version update check failed", "error", err)
+		return
+	}
+	if !result.Checked {
+		return
+	}
+	if result.UpdateAvailable {
+		slog.Info(
+			"A new version of Exasol Personal is available",
+			"current", currentVersion,
+			"latest", result.LatestVersion,
+			"info", "Run 'exasol version --latest' for more details",
+		)
+	}
+}


### PR DESCRIPTION
## Description

Introduce a centralized, fail-fast deployment directory compatibility mechanism that blocks unsafe command execution when a deployment directory is not compatible with the running launcher.

The main concern here was that people having made deployments with previous public releases of Exasol Personal would just get rather unhelpful error messages about `uninitialized deployments` rather than a hint to upgrade.

I've created some infrastructure to be able to track, document and maintain compatibility of future releases with past release where possible. In theory, a `status` of a new version could continue to work with older deployments while a new `install` one would not be able to.
This also added some new considerations for existing release process. These were documented too. 

This is how it what it looks like when you run any command interacting with the deployment directory in a legacy deployment.

Always, you might want to start with the documentation like `doc/deployment_compatibility.md` when reviewing.

```
> ../exasol status
2026-03-02 18:23:53 WRN legacy deployment directory detected command=status deployment_dir=/home/nh/ws/exasol-personal/bin/demo
Usage:
  exasol status [flags]

Global Flags:
  -h, --help               Help for status
      --log-level string   Set log level: debug, info, warn, error

Flags:
      --deployment-dir file-path   The directory to store deployment files (default /home/nh/ws/exasol-personal/bin/demo)
  -j, --json                       Output in JSON format
      --unsafe                     Try to read the deployment folder state even it is locked. May fail.


Error: deployment directory appears to be from an older version (found ".workflowState.json" but missing ".exasolLauncherState.json").
This launcher cannot operate on it. Use a compatible older launcher (e.g. 1.0.0) or recreate the deployment directory
```
and this is what it looks like in case of future incompatibilities in the opposite direction.
```
2026-03-02 18:25:55 ERR deployment directory compatibility check failed command=status deployment_version=1.4.0 launcher_version=1.2.0 min_supported_deployment_version=0.0.0 reason=deployment_newer_than_launcher required_action=upgrade_launcher error="deployment directory is incompatible with this launcher: deployment version 1.4.0 is new
...
Error: deployment directory is incompatible with this launcher: deployment version 1.4.0 is newer than launcher version 1.2.0 (command status); required action: upgrade the launcher to version >= 1.4.0
```

## Related Issue

Fixes SPOT-29563

## Type of Change

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [x] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [x] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Added deployment directory compatibility enforcement (centralized pre-run) based on a stable plain-text deployment version marker file (`.exasolLauncher.version`) and semver comparison.
- Refactored cmd layer to avoid hardcoded compatibility version strings by introducing named compatibility milestones (`cmd/exasol/compatibility_versions.go`).
- Improved UX for non-initialized / legacy deployment directories (heuristic: `.workflowState.json`) with actionable errors.
- Compatibility comparisons now ignore prerelease/build suffixes (e.g. `1.2.0-rc1` behaves like `1.2.0`).
- Moved compatibility enforcement + logging and version update hint logging into internal packages to keep `cmd/exasol/root.go` focused on orchestration.
- Updated docs to reflect the stable marker contract and release-process maintenance requirement.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

- `cmd/exasol` focused tests (including compatibility tests)
- `internal/compatibility` tests (including prerelease/RC normalization)
- `internal/deploy/init_test.go` (verifies `.exasolLauncher.version` is written)
- `internal/config` state tests

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally (focused suites; full `task all` not run)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

- Release candidates are treated as their base version for compatibility comparisons (suffixes ignored), but compatibility milestone constants must remain plain release versions only.