### PR TITLE
chore: Make dependabot stabilization window depend on metadata instea…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,8 @@ updates:
       interval: "weekly"
     groups:
       python-weekly-patch-updates:
+        patterns:
+          - "*"
         update-types:
           - "patch"
     open-pull-requests-limit: 10
@@ -28,6 +30,8 @@ updates:
       interval: "weekly"
     groups:
       go-weekly-patch-updates:
+        patterns:
+          - "*"
         update-types:
           - "patch"
     open-pull-requests-limit: 10

--- a/.github/workflows/dependabot-stabilization.yml
+++ b/.github/workflows/dependabot-stabilization.yml
@@ -13,12 +13,17 @@ jobs:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
       - name: Check if PR is minor update
         id: check_minor
         run: |
-          LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
-
-          if echo "$LABELS" | grep -q '"minor"'; then
+          UPDATE_TYPE='${{ steps.metadata.outputs.update-type }}'
+          if [ "$UPDATE_TYPE" = "version-update:semver-minor" ]; then
             echo "is_minor=true" >> $GITHUB_OUTPUT
           else
             echo "is_minor=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
…d of labels

## Description

Make dependabot grouping depend on dependabot metadata instead of PR labels


Fixes #

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [x] `chore`: Maintenance tasks

## Changes Made

- Update patterns to group patches correctly
- Fix stabilization window `if` block to depend on metadata and not labels

## Testing

<!-- Describe how you tested your changes -->

- [ ] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [ ] Manually tested the changes

### Test Details


## Checklist

<!-- Mark completed items with an "x" -->

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [ ] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [ ] Added/updated tests
- [ ] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

<!-- Any additional information, screenshots, or context -->
