### PR TITLE
feat: simplification of infrastructure artifacts file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ If you have already deleted the deployment directory and the exasol binary, you 
 
 ## 🔜 Next steps
 
-Once the deployment process is complete, use `exasol info` for information about how to connect to your Exasol database. The credentials for connecting to the database from a client are stored in the file `secrets-exasol-<deployment id>.json` in the deployment directory.
+Once the deployment process is complete, use `exasol info` for information about how to connect to your Exasol database. The credentials for connecting to the database from a client are stored in the file `secrets.json` in the deployment directory.
 
 You can also use the built-in SQL client in Exasol Launcher to connect directly to the database from the command line:
 ```bash
@@ -207,7 +207,7 @@ See also...
 Exasol Admin is an easy-to-use web interface that you can use to administer your new Exasol database. Instructions for how to access Exasol Admin is shown in the terminal output at the end of the install process.
 
 - To find the Exasol Admin URL after the installation has completed, use `exasol info`.
-- The credentials for connecting to Exasol Admin are stored in the file `secrets-exasol-<deployment id>.json` in the deployment directory.
+- The credentials for connecting to Exasol Admin are stored in the file `secrets.json` in the deployment directory.
 
 Your browser may show a security warning when connecting to Exasol Admin because of the self-signed certificate. Accept this warning and continue.
 

--- a/assets/infrastructure/aws/README.md
+++ b/assets/infrastructure/aws/README.md
@@ -81,10 +81,10 @@ The following ports must be reachable from the operator’s network, controlled 
    - Public and private IPs, instance IDs, and DNS names per node.
    - SSH access info per node and the sensitive SSH private key.
    - Database access info per node (main port `8563`, Admin UI at `https://<dns>:8443`).
-    - Local files written to `var.infrastructure_artifact_dir` (the deployment directory root when used via the launcher):
-     - `deployment-<deployment_id>.json` — summary of nodes and access info
-       - `secrets-<deployment_id>.json` — generated credentials (sensitive)
-     - `<deployment_id>.pem` — SSH private key (mode `0600`)
+      - Local files written to `var.infrastructure_artifact_dir` (the deployment directory root when used via the launcher):
+      - `deployment.json` — summary of nodes and access info
+      - `secrets.json` — generated credentials (sensitive)
+       - `node_access.pem` — SSH private key (mode `0600`)
 
 ## Credentials
 - Exasol Database and Admin UI passwords are generated and injected; outputs are sensitive.

--- a/assets/infrastructure/aws/outputs.tf
+++ b/assets/infrastructure/aws/outputs.tf
@@ -6,7 +6,7 @@ data "aws_instance" "nodes" {
 
 locals {
   infrastructure_artifact_dir = abspath(var.infrastructure_artifact_dir)
-  key_file_name               = "${local.deployment_id}.pem"
+  key_file_name               = "node_access.pem"
   key_file_path               = "${local.infrastructure_artifact_dir}/${local.key_file_name}"
 
   deployment_info = {
@@ -85,13 +85,13 @@ output "available_zones_for_instance_type" {
 
 # Save deployment_info to a local JSON file (for consumption by the Exasol Launcher or other tool)
 resource "local_file" "deployment_info" {
-  filename = "${local.infrastructure_artifact_dir}/deployment-${local.deployment_id}.json"
+  filename = "${local.infrastructure_artifact_dir}/deployment.json"
   content  = jsonencode(local.deployment_info)
 }
 
 # Save deployment_secrets to a local JSON file (for secure storage)
 resource "local_file" "deployment_secrets" {
-  filename = "${local.infrastructure_artifact_dir}/secrets-${local.deployment_id}.json"
+  filename = "${local.infrastructure_artifact_dir}/secrets.json"
   content  = jsonencode(local.deployment_secrets)
 }
 

--- a/assets/infrastructure/aws/variables_internal.tf
+++ b/assets/infrastructure/aws/variables_internal.tf
@@ -1,9 +1,9 @@
 # Variables required for terraform/tofu integration of an infrastructure preset with the Exasol Personal launcher.
 # Ensure all deployment artifacts which required for Exasol Personal launcher integration are written to this directory
 # These are:
-#  deployment-<id>.json  -- meta information about the deployed infrastructure
-#  scecrets-<id>.json -- secrets to access the database services
-#  <id>.pem  -- a ssh key to access all deployed hosts
+#  deployment.json  -- meta information about the deployed infrastructure
+#  secrets.json -- secrets to access the database services
+#  node_access.pem  -- a ssh key to access all deployed hosts
 #
 # A change here might break the interaction with the Exasol Personal launcher CLI
 # The Exasol Personal launcher expected some files to be present at the root of the deployment directory

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -224,9 +224,9 @@ The deployment directory is the central artifact containing everything needed to
 - `installation/` - Installation preset assets used during installation on the nodes
 
 **Outputs:**
-- `deployment-exasol-<deploymentId>.json` - Deployment information (IPs, connection details)
-- `secrets-exasol-<deploymentId>.json` - Credentials required by the launcher (sensitive)
-- `<deploymentId>.pem` - SSH private key
+- `deployment.json` - Deployment information (IPs, connection details)
+- `secrets.json` - Credentials required by the launcher (sensitive)
+- `node_access.pem` - SSH private key
 
 **Key characteristics:**
 - Self-contained (portable to another machine if needed)

--- a/doc/presets.md
+++ b/doc/presets.md
@@ -30,26 +30,28 @@ During `init`, the selected presets are extracted into the **deployment director
 
 The deployment directory layout matters because infrastructure code often references installation assets by *relative path*.
 
+In addition, during `init`/`install` the launcher resolves **installation preset variables** (from `installation.yaml`) and writes them to the path configured by `installation.yaml:variables:outputFile` (commonly `files/etc/exasol_launcher/installation.json`). Infrastructure presets that support unattended installation must ensure this file is copied onto the nodes (typically via the installation preset’s `files/**` overlay).
+
 ## Mandatory root-level deployment artifacts for Tofu deployments (written by infrastructure presets)
 
-In addition to the extracted preset directories, the launcher expects the **infrastructure preset** to write a small set of artifacts into the directory spefied by the Terraform variable `infrastructure_artifact_dir` - which is typically the root of deployment directory. These artifacts are consumed by commands like `exasol info`, `exasol connect`, and `exasol diag shell`.
+In addition to the extracted preset directories, the launcher expects the **infrastructure preset** to write a small set of artifacts into the directory specified by the Terraform variable `infrastructure_artifact_dir` - which is typically the root of the deployment directory. These artifacts are consumed by commands like `exasol info`, `exasol connect`, and `exasol diag shell`.
 
-The current launcher implementation discovers these files by glob pattern, so both the **location (deployment root typically)** and the **filename pattern** are part of the contract.
+The launcher discovers these files by **static filename**, so both the **location (deployment root typically)** and the **filenames** are part of the contract.
 
 Required artifacts:
 
-- `deployment-exasol-<deploymentId>.json`
+- `deployment.json`
   - Purpose: non-sensitive *node details* used by the launcher (IPs/DNS, SSH connection info, DB/Admin UI endpoints, TLS cert).
   - Minimal required content (high-level): a `deploymentId` plus a `nodes` map keyed by node name (e.g. `n11`) containing at least a reachable host (`dnsName` and/or `publicIp`), SSH details (user, port, key file), DB connection details (db port, UI port, URL), and the TLS certificate PEM used for fingerprinting.
 
-- `secrets-exasol-<deploymentId>.json`
+- `secrets.json`
   - Purpose: sensitive credentials used by the launcher.
   - Minimal required content: `dbPassword` and `adminUiPassword`.
   - Presets may include additional fields (for example usernames), but the launcher must be able to parse the required ones.
 
-- `<deploymentId>.pem`
+- `node_access.pem`
   - Purpose: SSH private key used for remote exec and diagnostic shell.
-  - Requirement: must be readable by the current user and typically needs mode `0600`. The `deployment-…json` should reference this key via `nodes[*].ssh.keyFile` (absolute or relative paths are supported; relative paths are resolved against the deployment directory).
+  - Requirement: must be readable by the current user and typically needs mode `0600`. `deployment.json` should reference this key via `nodes[*].ssh.keyFile` (absolute or relative paths are supported; relative paths are resolved against the deployment directory).
 
 Reference implementation:
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,17 +16,21 @@ import (
 
 var ErrNoFileMatchedGlobPattern = errors.New("no file matched the pattern")
 
-func findGlob(dir string, pattern string) (string, error) {
-	globPath := filepath.Join(dir, pattern)
-	matches, err := filepath.Glob(globPath)
-	if err != nil {
-		return "", err
+// findExistingFile checks if a given filename exists in dir.
+//
+// It returns (fullPath, true, nil) if the file exists, (fullPath, false, nil)
+// if it does not exist, and ("", false, err) for unexpected errors.
+func findExistingFile(dir string, filename string) (string, bool, error) {
+	fullPath := filepath.Join(dir, filename)
+	_, err := os.Stat(fullPath)
+	if err == nil {
+		return fullPath, true, nil
 	}
-	if len(matches) > 0 {
-		return matches[0], nil
+	if errors.Is(err, os.ErrNotExist) {
+		return fullPath, false, nil
 	}
 
-	return "", fmt.Errorf("%w: %s", ErrNoFileMatchedGlobPattern, globPath)
+	return "", false, err
 }
 
 var ErrMissingConfigFile = errors.New("failed to load config file")

--- a/internal/config/node_details.go
+++ b/internal/config/node_details.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	nodeDetailsGlob       = "deployment-exasol-*.json"
+	nodeDetailsFileName   = "deployment.json"
 	ConnectionInstruction = "connection-instructions.txt"
 )
 
@@ -66,9 +66,16 @@ type SSHDetails struct {
 }
 
 func ReadNodeDetails(deploymentDir string) (*NodeDetails, error) {
-	filepath, err := findGlob(deploymentDir, nodeDetailsGlob)
+	filepath, exists, err := findExistingFile(deploymentDir, nodeDetailsFileName)
 	if err != nil {
 		return nil, err
+	}
+	if !exists {
+		return nil, fmt.Errorf(
+			"node details file not found in deployment directory: expected %q in %s",
+			nodeDetailsFileName,
+			deploymentDir,
+		)
 	}
 
 	slog.Debug("reading node details file", "file", filepath)

--- a/internal/config/secrets.go
+++ b/internal/config/secrets.go
@@ -9,7 +9,7 @@ import (
 )
 
 //nolint:gosec // gosec thinks this is a password
-const secretsGlob = "secrets-exasol-*.json"
+const secretsFileName = "secrets.json"
 
 type Secrets struct {
 	DbPassword      string `json:"dbPassword"`
@@ -17,9 +17,16 @@ type Secrets struct {
 }
 
 func GetSecretsFilePath(deploymentDir string) (string, error) {
-	filepath, err := findGlob(deploymentDir, secretsGlob)
+	filepath, exists, err := findExistingFile(deploymentDir, secretsFileName)
 	if err != nil {
 		return "", fmt.Errorf("failed to get the secrets file path: %w", err)
+	}
+	if !exists {
+		return "", fmt.Errorf(
+			"secrets file not found in deployment directory: expected %q in %s",
+			secretsFileName,
+			deploymentDir,
+		)
 	}
 
 	return filepath, nil

--- a/tests/framework/deployment.py
+++ b/tests/framework/deployment.py
@@ -197,19 +197,16 @@ class Deployment:
         """
         logging.info("Getting admin UI credentials from secrets file")
 
-        secrets_glob = "secrets-exasol-*.json"
         deployment_dir_path = Path(self.deployment_dir.name)
 
-        # Find the secrets file
-        secrets_files = list(deployment_dir_path.glob(secrets_glob))
-        if not secrets_files:
+        secrets_file = deployment_dir_path / "secrets.json"
+        if not secrets_file.exists():
             msg = (
-                f"No secrets file matching {secrets_glob} found in "
+                "No secrets file found: expected 'secrets.json' in "
                 f"{self.deployment_dir.name}"
             )
             raise FileNotFoundError(msg)
 
-        secrets_file = secrets_files[0]
         logging.info("Reading secrets from: %s", secrets_file)
 
         with secrets_file.open() as f:

--- a/tests/framework/outputs.py
+++ b/tests/framework/outputs.py
@@ -8,7 +8,7 @@ from typing import Final
 
 from pydantic import BaseModel
 
-OUTPUTS_FILE_GLOB: Final = "deployment-exasol-*.json"
+OUTPUTS_FILE: Final = "deployment.json"
 
 
 class Database(BaseModel):
@@ -39,20 +39,15 @@ class Outputs(BaseModel):
 
 def _read_outputs(deployment_dir: str) -> str:
     deployment_dir_path = Path(deployment_dir)
-    outputs_raw = ""
 
-    for file in deployment_dir_path.glob(OUTPUTS_FILE_GLOB):
-        logging.info("Reading outputs file at: %s", file.name)
-
-        with file.open() as outputs_file:
-            outputs_raw = outputs_file.read()
-        break
-
-    if outputs_raw == "":
-        msg = f"couldn't read the outputs file {OUTPUTS_FILE_GLOB}"
+    outputs_filepath = deployment_dir_path / OUTPUTS_FILE
+    if not outputs_filepath.exists():
+        msg = f"couldn't read the outputs file {OUTPUTS_FILE}"
         raise RuntimeError(msg)
 
-    return outputs_raw
+    logging.info("Reading outputs file at: %s", outputs_filepath.name)
+    with outputs_filepath.open() as outputs_file:
+        return outputs_file.read()
 
 
 def get_outputs(deployment_dir: str) -> Outputs:


### PR DESCRIPTION
## Description

Simplification of infrastructure artifacts file names
They didn't need to contain the deployment id in their name.

## Related Issue

noticed during SPOT-29371

Fixes #

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [x] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [x] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

The infrastructure preset should now create `deployment.json` and `secrets.json` and `node_access.pem` as outputs.
Those files existed before but had the deployment id in their name. This isn't required and expected anymore.

## Testing

<!-- Describe how you tested your changes -->

- [x] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

<!-- Describe your testing approach -->

## Checklist

<!-- Mark completed items with an "x" -->

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

The deployment id as part of the file name was an artifact from earlier prototypes. No longer needed
