### PR TITLE
feat: Warn about tracked resources left on deploy failure

### DIFF
--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -31,6 +31,20 @@ const (
 	TofuLockfileUpdate   = tofu.LockfileUpdate
 )
 
+const (
+	deployFailureResourceHint = "Deployment may have created cloud resources " +
+		"that can incur costs. " +
+		"Fix the problem and run `deploy` again, or run `destroy` to clean up."
+)
+
+func appendDeployFailureResourceHint(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	return fmt.Errorf("%w\n\n%s", err, deployFailureResourceHint)
+}
+
 //nolint:revive
 func Deploy(
 	ctx context.Context,
@@ -153,22 +167,34 @@ func deployFromManifests(
 			); err != nil {
 				unregister()
 
-				err = exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateDeploymentFailed{
-					Error: err.Error(),
-				}, deploymentDir)
+				deployErr := appendDeployFailureResourceHint(err)
+				if stateErr := exasolState.SetWorkflowStateAndWrite(
+					&config.WorkflowStateDeploymentFailed{
+						Error: deployErr.Error(),
+					},
+					deploymentDir,
+				); stateErr != nil {
+					slog.Warn("failed to persist deployment failure state", "error", stateErr)
+				}
 
-				return err
+				return deployErr
 			}
 
 			// Installation phase (remoteExec tasks)
 			if err := runInstallSteps(ctx, deploymentDir, installManifest,
 				externalCommandOutput, externalCommandOutput); err != nil {
 				unregister()
-				err = exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateDeploymentFailed{
-					Error: err.Error(),
-				}, deploymentDir)
+				deployErr := appendDeployFailureResourceHint(err)
+				if stateErr := exasolState.SetWorkflowStateAndWrite(
+					&config.WorkflowStateDeploymentFailed{
+						Error: deployErr.Error(),
+					},
+					deploymentDir,
+				); stateErr != nil {
+					slog.Warn("failed to persist deployment failure state", "error", stateErr)
+				}
 
-				return err
+				return deployErr
 			}
 
 			// Stop handling interrupts before committing success state

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -1,0 +1,42 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestAppendDeployFailureResourceHint(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	baseErr := errors.New("tofu apply failed")
+
+	// When
+	err := appendDeployFailureResourceHint(baseErr)
+
+	// Then
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	if !errors.Is(err, baseErr) {
+		t.Fatalf("expected wrapped error to match base error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), deployFailureResourceHint) {
+		t.Fatalf("expected error to include resource hint, got: %q", err.Error())
+	}
+}
+
+func TestAppendDeployFailureResourceHintNilInput(t *testing.T) {
+	t.Parallel()
+
+	// Given/When
+	err := appendDeployFailureResourceHint(nil)
+	// Then
+	if err != nil {
+		t.Fatalf("expected nil, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Description

Improve deploy failure UX by warning users that cloud resources may already exist and listing resources currently tracked by OpenTofu state for manual cleanup.

## Related Issue


Fixes #

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Added deploy failure hint explaining potential cloud costs and next steps (deploy retry or destroy).
 

## Testing

- Added/updated unit tests in internal/deploy:
      - Failure hint wrapping.
- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details
1. Build binary.
2. Run deploy on a real deployment directory.
3. Confirm error output includes:
      - Cloud-cost warning.

## Checklist

<!-- Mark completed items with an "x" -->

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

<!-- Any additional information, screenshots, or context -->
