### PR TITLE
refactoring: improved command compatibility handling and test

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -88,7 +88,7 @@ tasks:
       - |
         version=$(git describe --tags --abbrev=0) # First character is "v".
         go build -o {{.BUILD_DIR_NAME}}/{{.BINARY_NAME}} \
-          -ldflags "-X main.version=${version:1}" {{.MAIN_PATH_REL}}
+          -ldflags "-X main.CurrentLauncherVersion=${version:1}" {{.MAIN_PATH_REL}}
 
   build-windows:
     desc: Cross-compile the Windows binary (defaults to GOARCH=amd64)
@@ -105,7 +105,7 @@ tasks:
       - |
         version=$(git describe --tags --abbrev=0) # First character is "v".
         go build -o {{.BUILD_DIR_NAME}}/{{.OUTPUT_NAME}} \
-          -ldflags "-X main.version=${version:1}" {{.MAIN_PATH_REL}}
+          -ldflags "-X main.CurrentLauncherVersion=${version:1}" {{.MAIN_PATH_REL}}
 
 
   deps-update-golang:

--- a/cmd/exasol/compatibility.go
+++ b/cmd/exasol/compatibility.go
@@ -6,6 +6,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/blang/semver/v4"
 	deploymentcompatibility "github.com/exasol/exasol-personal/internal/compatibility"
 	"github.com/spf13/cobra"
 )
@@ -21,8 +22,41 @@ const (
 		"compatibility but is missing annotation %q"
 )
 
-// nolint: unparam
-func requireDeploymentCompatibility(cmd *cobra.Command, minSupportedDeploymentVersion string) {
+func requireMinorVersionCompatibility(
+	cmd *cobra.Command,
+	minSupportedDeploymentMinorVersion string,
+) {
+	minSupported, err := normalizeVersionToMinor(minSupportedDeploymentMinorVersion)
+	if err != nil {
+		// Do not panic here: this helper is used when defining commands.
+		// If the version is invalid, keep it as-is so the compatibility enforcement
+		// returns a structured InvalidVersionError at runtime.
+		requireVersionCompatibility(cmd, minSupportedDeploymentMinorVersion)
+		return
+	}
+
+	requireVersionCompatibility(cmd, minSupported)
+}
+
+func normalizeVersionToMinor(raw string) (string, error) {
+	ver, err := semver.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+
+	// Compatibility requirements are expressed at minor granularity:
+	// keep major/minor and normalize patch to 0.
+	ver.Patch = 0
+
+	// Keep normalization consistent with internal compatibility logic:
+	// comparisons ignore prerelease/build metadata.
+	ver.Pre = nil
+	ver.Build = nil
+
+	return ver.String(), nil
+}
+
+func requireVersionCompatibility(cmd *cobra.Command, minSupportedDeploymentVersion string) {
 	if cmd.Annotations == nil {
 		cmd.Annotations = map[string]string{}
 	}
@@ -86,7 +120,7 @@ func enforceDeploymentDirectoryCompatibility(cmd *cobra.Command, deploymentDir s
 
 	return deploymentcompatibility.EnforceDeploymentDirectoryCompatibility(
 		deploymentDir,
-		version,
+		CurrentLauncherVersion,
 		req,
 		initReq,
 	)

--- a/cmd/exasol/compatibility_test.go
+++ b/cmd/exasol/compatibility_test.go
@@ -4,28 +4,33 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	deploymentcompatibility "github.com/exasol/exasol-personal/internal/compatibility"
 	"github.com/spf13/cobra"
 )
 
 func TestEnforceDeploymentDirectoryCompatibility_FailsEarlyWhenNotInitialized(t *testing.T) {
 	t.Parallel()
 
+	// Given: an empty, uninitialized deployment directory and a command that
+	// requires an initialized deployment directory.
 	tmp := t.TempDir()
-
 	cmd := &cobra.Command{Use: "deploy"}
-	requireDeploymentCompatibility(cmd, minSupportedDeploymentVersionBaseline)
+	requireVersionCompatibility(cmd, minSupportedDeploymentVersionBaseline)
 	requireInitializedDeploymentDir(cmd)
 
+	// When: compatibility enforcement runs.
 	err := enforceDeploymentDirectoryCompatibility(cmd, tmp)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
 
+	// Then: it fails early with a helpful error message.
 	msg := err.Error()
 	if !strings.Contains(msg, "deployment directory is not initialized") {
 		t.Fatalf("unexpected error message: %q", msg)
@@ -41,23 +46,26 @@ func TestEnforceDeploymentDirectoryCompatibility_FailsEarlyWhenNotInitialized(t 
 func TestEnforceDeploymentDirectoryCompatibility_HintsLegacyWorkflowStateLayout(t *testing.T) {
 	t.Parallel()
 
+	// Given: a deployment directory that matches the legacy layout used before
+	// the launcher state file existed.
 	tmp := t.TempDir()
-
-	// Simulate legacy deployment directories created before state file
-	// .exasolLauncherState.json existed.
 	err := os.WriteFile(filepath.Join(tmp, ".workflowState.json"), []byte("{}"), 0o600)
 	if err != nil {
 		t.Fatalf("failed to create legacy workflow state file: %v", err)
 	}
-
+	// Given: an init-like command that may operate on uninitialized directories
+	// (so it must not require an initialized deployment dir).
 	cmd := &cobra.Command{Use: "some_init_like_command"}
-	requireDeploymentCompatibility(cmd, minSupportedDeploymentVersionBaseline)
-	// Note: init/install must NOT require an initialized deployment dir.
+	requireVersionCompatibility(cmd, minSupportedDeploymentVersionBaseline)
+
+	// When: compatibility enforcement runs.
 	err = enforceDeploymentDirectoryCompatibility(cmd, tmp)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
 
+	// Then: it fails with an explicit hint that the directory is from an older
+	// launcher layout.
 	msg := err.Error()
 	if !strings.Contains(msg, "deployment directory appears to be from an older version") {
 		t.Fatalf("expected legacy version hint, got: %q", msg)
@@ -67,5 +75,225 @@ func TestEnforceDeploymentDirectoryCompatibility_HintsLegacyWorkflowStateLayout(
 	}
 	if !strings.Contains(msg, "1.0.0") {
 		t.Fatalf("expected message to suggest older launcher version, got: %q", msg)
+	}
+}
+
+func TestRequireMinorVersionDeploymentCompatibility_NormalizesPatchToZero(t *testing.T) {
+	t.Parallel()
+
+	// Given: a command and a semver string that includes patch, prerelease and build metadata.
+	cmd := &cobra.Command{Use: "deploy"}
+
+	// When: the command declares a minor-level minimum.
+	requireMinorVersionCompatibility(cmd, "1.2.3-rc1+build.7")
+
+	// Then: the stored minimum is normalized to major.minor.0 and compatibility is required.
+	if !deploymentCompatibilityIsRequired(cmd) {
+		t.Fatal("expected deployment compatibility to be required")
+	}
+	got := minSupportedDeploymentVersionFromAnnotations(cmd)
+	if got != "1.2.0" {
+		t.Fatalf("expected min supported deployment version to be normalized to 1.2.0, got %q", got)
+	}
+}
+
+func TestDeploymentCompatibilityRules_MinorMinimumAndNeverNewerThanLauncher(t *testing.T) {
+	t.Parallel()
+
+	// Given: a command declares a minor-level minimum (patch is ignored) and we build
+	// the compatibility requirement from the command annotations.
+	cmd := &cobra.Command{Use: "deploy"}
+	requireMinorVersionCompatibility(cmd, "1.2.5")
+
+	req := deploymentcompatibility.Requirement{
+		CommandName:                   cmd.Name(),
+		MinSupportedDeploymentVersion: minSupportedDeploymentVersionFromAnnotations(cmd),
+	}
+	// Given: the declared minimum is normalized to the minor baseline.
+	if req.MinSupportedDeploymentVersion != "1.2.0" {
+		t.Fatalf("expected normalized minimum 1.2.0, got %q", req.MinSupportedDeploymentVersion)
+	}
+
+	// Given: test cases spanning the contract space: allowed versions, too-new deployments,
+	// and deployments that are too old for the declared minimum.
+	testCases := []struct {
+		name              string
+		deploymentVersion string
+		launcherVersion   string
+		allowed           bool
+		reason            deploymentcompatibility.Reason
+	}{
+		{
+			name:              "allows same minor at patch 0",
+			deploymentVersion: "1.2.0",
+			launcherVersion:   "1.2.5",
+			allowed:           true,
+		},
+		{
+			name:              "rejects deployment newer patch than launcher",
+			deploymentVersion: "1.2.7",
+			launcherVersion:   "1.2.5",
+			allowed:           false,
+			reason:            deploymentcompatibility.ReasonDeploymentNewerThanLauncher,
+		},
+		{
+			name:              "rejects deployment newer minor than launcher",
+			deploymentVersion: "1.3.0",
+			launcherVersion:   "1.2.5",
+			allowed:           false,
+			reason:            deploymentcompatibility.ReasonDeploymentNewerThanLauncher,
+		},
+		{
+			name:              "rejects deployment older than minimum minor",
+			deploymentVersion: "1.1.9",
+			launcherVersion:   "1.2.5",
+			allowed:           false,
+			reason:            deploymentcompatibility.ReasonDeploymentTooOld,
+		},
+	}
+
+	for _, testcase := range testCases {
+		t.Run(testcase.name, func(t *testing.T) {
+			t.Parallel()
+
+			// When: the compatibility check compares deployment, launcher and requirement.
+			res := deploymentcompatibility.Check(
+				testcase.deploymentVersion,
+				testcase.launcherVersion,
+				req,
+			)
+
+			// Then: the result matches the rule expectations.
+			if res.Allowed != testcase.allowed {
+				t.Fatalf(
+					"expected allowed=%v, got allowed=%v (err=%v)",
+					testcase.allowed,
+					res.Allowed,
+					res.Err,
+				)
+			}
+			if testcase.allowed {
+				if res.Err != nil {
+					t.Fatalf("expected nil error when allowed, got: %v", res.Err)
+				}
+
+				return
+			}
+
+			var inc *deploymentcompatibility.IncompatibleError
+			if !errors.As(res.Err, &inc) {
+				t.Fatalf("expected IncompatibleError, got %T: %v", res.Err, res.Err)
+			}
+			if inc.Reason != testcase.reason {
+				t.Fatalf("expected reason %q, got %q", testcase.reason, inc.Reason)
+			}
+		})
+	}
+}
+
+func TestDeploymentCompatibilityRules_StrictRevisionRequirement(t *testing.T) {
+	t.Parallel()
+
+	// Given: a command declares a strict (patch-accurate) minimum.
+	cmd := &cobra.Command{Use: "deploy"}
+	requireVersionCompatibility(cmd, "1.2.5")
+
+	req := deploymentcompatibility.Requirement{
+		CommandName:                   cmd.Name(),
+		MinSupportedDeploymentVersion: minSupportedDeploymentVersionFromAnnotations(cmd),
+	}
+
+	// When: the deployment is below the strict patch minimum.
+	res := deploymentcompatibility.Check("1.2.4", "1.2.5", req)
+	// Then: it is rejected as too old.
+	if res.Allowed {
+		t.Fatal("expected disallowed")
+	}
+	var inc *deploymentcompatibility.IncompatibleError
+	if !errors.As(res.Err, &inc) {
+		t.Fatalf("expected IncompatibleError, got %T: %v", res.Err, res.Err)
+	}
+	if inc.Reason != deploymentcompatibility.ReasonDeploymentTooOld {
+		t.Fatalf(
+			"expected reason %q, got %q",
+			deploymentcompatibility.ReasonDeploymentTooOld,
+			inc.Reason,
+		)
+	}
+
+	// When: the deployment exactly meets the strict patch requirement.
+	res = deploymentcompatibility.Check("1.2.5", "1.2.5", req)
+	// Then: it is allowed.
+	if !res.Allowed {
+		t.Fatalf("expected allowed, got: %v", res.Err)
+	}
+}
+
+func TestDeploymentCompatibilityRules_OlderMinorMinimumAllowsNewerDeploymentsUpToLauncher(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	// Given: a command declares that it still supports deployments as old as 1.1.*,
+	// while the launcher is already in 1.3.*.
+	cmd := &cobra.Command{Use: "status"}
+	requireMinorVersionCompatibility(cmd, "1.1.9")
+
+	req := deploymentcompatibility.Requirement{
+		CommandName:                   cmd.Name(),
+		MinSupportedDeploymentVersion: minSupportedDeploymentVersionFromAnnotations(cmd),
+	}
+	// Given: the declared minimum is normalized to the minor baseline.
+	if req.MinSupportedDeploymentVersion != "1.1.0" {
+		t.Fatalf("expected normalized minimum 1.1.0, got %q", req.MinSupportedDeploymentVersion)
+	}
+
+	// When: the deployment is from a newer minor but still not newer than the launcher.
+	res := deploymentcompatibility.Check("1.2.7", "1.3.1", req)
+	// Then: it is allowed.
+	if !res.Allowed {
+		t.Fatalf("expected allowed, got: %v", res.Err)
+	}
+
+	// When: the deployment is older than the declared minimum.
+	res = deploymentcompatibility.Check("1.0.9", "1.3.1", req)
+	// Then: it is rejected as too old.
+	if res.Allowed {
+		t.Fatal("expected disallowed")
+	}
+	var inc *deploymentcompatibility.IncompatibleError
+	if !errors.As(res.Err, &inc) {
+		t.Fatalf("expected IncompatibleError, got %T: %v", res.Err, res.Err)
+	}
+	if inc.Reason != deploymentcompatibility.ReasonDeploymentTooOld {
+		t.Fatalf(
+			"expected reason %q, got %q",
+			deploymentcompatibility.ReasonDeploymentTooOld,
+			inc.Reason,
+		)
+	}
+}
+
+func TestRequireMinorVersionDeploymentCompatibility_DoesNotPanicOnInvalidVersion(t *testing.T) {
+	t.Parallel()
+
+	// Given: an invalid version string is used while defining command compatibility.
+	cmd := &cobra.Command{Use: "deploy"}
+	requireMinorVersionCompatibility(cmd, "not-a-version")
+
+	// When: the runtime compatibility checker runs using the requirement stored in the command.
+	req := deploymentcompatibility.Requirement{
+		CommandName:                   cmd.Name(),
+		MinSupportedDeploymentVersion: minSupportedDeploymentVersionFromAnnotations(cmd),
+	}
+	res := deploymentcompatibility.Check("1.0.0", "1.0.0", req)
+
+	// Then: we do not panic; the invalid version is reported as a structured error.
+	if res.Allowed {
+		t.Fatal("expected disallowed")
+	}
+	var inv *deploymentcompatibility.InvalidVersionError
+	if !errors.As(res.Err, &inv) {
+		t.Fatalf("expected InvalidVersionError, got %T: %v", res.Err, res.Err)
 	}
 }

--- a/cmd/exasol/compatibility_versions.go
+++ b/cmd/exasol/compatibility_versions.go
@@ -34,4 +34,10 @@ const (
 	//	// minSupportedDeploymentVersion_<featureName> is the first deployment version
 	//	// that includes <featureName> changes (explain the incompatibility here).
 	//	minSupportedDeploymentVersion_<featureName> = "X.Y.Z"
+
+	// NOTE: use this once it is clear in which version this change was released:
+	// The deployment id now generated and owner by the launcher instead of the infra preset
+	// The deployment id is also removed from the file artifacts like `secrets.json`
+	// which are written as part of the contract between launcher and infra preset.
+	// minSupported_deploymentIdByLauncher = "1.3.0" ??
 )

--- a/cmd/exasol/connect.go
+++ b/cmd/exasol/connect.go
@@ -52,7 +52,7 @@ func registerConnectFlags() {
 
 // nolint: gochecknoinits
 func init() {
-	requireDeploymentCompatibility(connectCmd, minSupportedDeploymentVersionBaseline)
+	requireMinorVersionCompatibility(connectCmd, CurrentLauncherVersion)
 	requireInitializedDeploymentDir(connectCmd)
 	registerConnectFlags()
 	registerDeploymentDirFlag(connectCmd, commonFlags)

--- a/cmd/exasol/deploy.go
+++ b/cmd/exasol/deploy.go
@@ -46,7 +46,7 @@ var deployCmd = &cobra.Command{
 
 // nolint: gochecknoinits
 func init() {
-	requireDeploymentCompatibility(deployCmd, minSupportedDeploymentVersionBaseline)
+	requireMinorVersionCompatibility(deployCmd, CurrentLauncherVersion)
 	requireInitializedDeploymentDir(deployCmd)
 	registerDeploymentDirFlag(deployCmd, commonFlags)
 	registerVerboseFlag(deployCmd, commonFlags)

--- a/cmd/exasol/deploymentControl.go
+++ b/cmd/exasol/deploymentControl.go
@@ -83,14 +83,14 @@ func registerStartFlags() {
 
 // nolint: gochecknoinits
 func init() {
-	requireDeploymentCompatibility(startCmd, minSupportedDeploymentVersionBaseline)
+	requireMinorVersionCompatibility(startCmd, CurrentLauncherVersion)
 	requireInitializedDeploymentDir(startCmd)
 	registerStartFlags()
 	registerVerboseFlag(startCmd, commonFlags)
 	registerDeploymentDirFlag(startCmd, commonFlags)
 	rootCmd.AddCommand(startCmd)
 
-	requireDeploymentCompatibility(stopCmd, minSupportedDeploymentVersionBaseline)
+	requireMinorVersionCompatibility(stopCmd, CurrentLauncherVersion)
 	requireInitializedDeploymentDir(stopCmd)
 	registerVerboseFlag(stopCmd, commonFlags)
 	registerDeploymentDirFlag(stopCmd, commonFlags)

--- a/cmd/exasol/destroy.go
+++ b/cmd/exasol/destroy.go
@@ -60,7 +60,7 @@ var destroyCmd = &cobra.Command{
 
 // nolint: gochecknoinits
 func init() {
-	requireDeploymentCompatibility(destroyCmd, minSupportedDeploymentVersionBaseline)
+	requireMinorVersionCompatibility(destroyCmd, CurrentLauncherVersion)
 	requireInitializedDeploymentDir(destroyCmd)
 	registerDeploymentDirFlag(destroyCmd, commonFlags)
 	registerDestroyFlags(destroyCmd)

--- a/cmd/exasol/diagInfo.go
+++ b/cmd/exasol/diagInfo.go
@@ -30,7 +30,7 @@ var infoCmd = &cobra.Command{
 
 // nolint: gochecknoinits
 func init() {
-	requireDeploymentCompatibility(infoCmd, minSupportedDeploymentVersionBaseline)
+	requireMinorVersionCompatibility(infoCmd, CurrentLauncherVersion)
 	requireInitializedDeploymentDir(infoCmd)
 	registerDeploymentDirFlag(infoCmd, commonFlags)
 	diagCmd.AddCommand(infoCmd)

--- a/cmd/exasol/diagShell.go
+++ b/cmd/exasol/diagShell.go
@@ -42,7 +42,7 @@ func registerShellFlags() {
 
 // nolint: gochecknoinits
 func init() {
-	requireDeploymentCompatibility(shellCmd, minSupportedDeploymentVersionBaseline)
+	requireMinorVersionCompatibility(shellCmd, CurrentLauncherVersion)
 	requireInitializedDeploymentDir(shellCmd)
 	registerShellFlags()
 	registerDeploymentDirFlag(shellCmd, commonFlags)

--- a/cmd/exasol/hidden.go
+++ b/cmd/exasol/hidden.go
@@ -37,7 +37,7 @@ var printConnectionInstructions = &cobra.Command{
 
 // nolint: gochecknoinits
 func init() {
-	requireDeploymentCompatibility(
+	requireMinorVersionCompatibility(
 		printConnectionInstructions,
 		minSupportedDeploymentVersionBaseline,
 	)

--- a/cmd/exasol/info.go
+++ b/cmd/exasol/info.go
@@ -83,7 +83,7 @@ var deploymentInfoCmd = &cobra.Command{
 
 // nolint: gochecknoinits
 func init() {
-	requireDeploymentCompatibility(deploymentInfoCmd, minSupportedDeploymentVersionBaseline)
+	requireMinorVersionCompatibility(deploymentInfoCmd, CurrentLauncherVersion)
 	requireInitializedDeploymentDir(deploymentInfoCmd)
 	registerDeploymentDirFlag(deploymentInfoCmd, commonFlags)
 	registerOutputFlags(deploymentInfoCmd, commonFlags)

--- a/cmd/exasol/init.go
+++ b/cmd/exasol/init.go
@@ -50,7 +50,7 @@ func init() {
 	// Init creates the deployment directory state; if a deployment directory already
 	// exists, the compatibility check protects against operating on an incompatible
 	// deployment.
-	requireDeploymentCompatibility(initCmd, minSupportedDeploymentVersionBaseline)
+	requireMinorVersionCompatibility(initCmd, minSupportedDeploymentVersionBaseline)
 
 	// Augment long help with embedded preset names so users know what they can pass.
 	initCmd.Long = strings.TrimRight(initCmdLongDesc, "\n") +
@@ -75,7 +75,7 @@ func init() {
 			installVars,
 			commonFlags.DeploymentDir,
 			!commonFlags.NoLauncherVersionCheck,
-			version,
+			CurrentLauncherVersion,
 		)
 	}
 

--- a/cmd/exasol/install.go
+++ b/cmd/exasol/install.go
@@ -42,8 +42,6 @@ var installCmd = &cobra.Command{
 // nolint: gochecknoinits
 func init() {
 	// Install creates (init) and then operates on (deploy) the deployment directory.
-	requireDeploymentCompatibility(installCmd, minSupportedDeploymentVersionBaseline)
-
 	installCmd.Long = strings.TrimRight(installCmd.Long, "\n") +
 		"\n\t" + presetNamesForHelp(presets.PresetTypeInfrastructure,
 		presets.ListEmbeddedInfrastructuresPresets()) +
@@ -68,7 +66,7 @@ func init() {
 			installVars,
 			commonFlags.DeploymentDir,
 			!commonFlags.NoLauncherVersionCheck,
-			version,
+			CurrentLauncherVersion,
 		); err != nil {
 			return fmt.Errorf("initialization failed: %w", err)
 		}
@@ -103,6 +101,7 @@ func init() {
 	// init runs in PreRunE, deploy runs in PersistentPostRunE
 	installCmd.RunE = func(_ *cobra.Command, _ []string) error { return nil }
 
+	requireMinorVersionCompatibility(installCmd, CurrentLauncherVersion)
 	registerDeploymentDirFlag(installCmd, commonFlags)
 	registerVerboseFlag(installCmd, commonFlags)
 	registerDeployFlags(installCmd, commonFlags)

--- a/cmd/exasol/root.go
+++ b/cmd/exasol/root.go
@@ -74,7 +74,10 @@ var rootCmd = &cobra.Command{
 		// Best-effort version update hint (non-blocking; logs only when an update is available).
 		// Design decision: never block commands on this.
 		if cmd.Name() != "version" {
-			deploy.MaybeLogVersionUpdateHint(cmd.Context(), commonFlags.DeploymentDir, version)
+			deploy.MaybeLogVersionUpdateHint(
+				cmd.Context(), commonFlags.DeploymentDir,
+				CurrentLauncherVersion,
+			)
 		}
 
 		return nil

--- a/cmd/exasol/status.go
+++ b/cmd/exasol/status.go
@@ -72,7 +72,7 @@ func registerStatusFlags() {
 
 // nolint: gochecknoinits
 func init() {
-	requireDeploymentCompatibility(statusCmd, minSupportedDeploymentVersionBaseline)
+	requireMinorVersionCompatibility(statusCmd, CurrentLauncherVersion)
 	requireInitializedDeploymentDir(statusCmd)
 	registerStatusFlags()
 	registerDeploymentDirFlag(statusCmd, commonFlags)

--- a/cmd/exasol/unlock.go
+++ b/cmd/exasol/unlock.go
@@ -36,7 +36,7 @@ var unlockCmd = &cobra.Command{
 
 // nolint: gochecknoinits
 func init() {
-	requireDeploymentCompatibility(unlockCmd, minSupportedDeploymentVersionBaseline)
+	requireMinorVersionCompatibility(unlockCmd, minSupportedDeploymentVersionBaseline)
 	requireInitializedDeploymentDir(unlockCmd)
 	registerDeploymentDirFlag(unlockCmd, commonFlags)
 	diagCmd.AddCommand(unlockCmd)

--- a/cmd/exasol/version.go
+++ b/cmd/exasol/version.go
@@ -24,9 +24,9 @@ Example usage:
     exasol version --latest --json
 `
 
-// This variable must be named like this an remain in the main package,
-// because we inject it's value during the build process with -ldflags.
-var version = "0.0.0"
+// This variable must be named like this and remain in the main package,
+// because we inject it's true value during the build process with -ldflags.
+var CurrentLauncherVersion = "0.0.0"
 
 var versionCheckOpts = struct {
 	Latest bool
@@ -42,13 +42,13 @@ var versionCmd = &cobra.Command{
 		ctx := cmd.Context()
 
 		if !versionCheckOpts.Latest {
-			_, err := fmt.Fprintln(os.Stdout, semver.MustParse(version))
+			_, err := fmt.Fprintln(os.Stdout, semver.MustParse(CurrentLauncherVersion))
 			return err
 		}
 
 		response, err := deploy.FetchLatestVersion(
 			ctx,
-			version,
+			CurrentLauncherVersion,
 			commonFlags.DeploymentDir,
 		)
 		if err != nil {
@@ -61,7 +61,7 @@ var versionCmd = &cobra.Command{
 			return encoder.Encode(response)
 		}
 
-		return printLatestVersionText(version, response)
+		return printLatestVersionText(CurrentLauncherVersion, response)
 	},
 }
 


### PR DESCRIPTION
## Description

This PR improves deployment-directory compatibility enforcement by introducing a minor-version compatibility helper that normalizes minimum supported versions to `major.minor.0` (patch-agnostic), while keeping strict patch-level requirements available when needed. It also adds a rule-focused unit test suite that explicitly documents and verifies the intended compatibility rules.

## Related Issue

SPOT-29563

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Implemented `requireMinorVersionCompatibility(...)` to normalize min supported versions to minor granularity (`x.y.0`) while stripping prerelease/build metadata.
- Fixed the cmd-layer compatibility helper wiring so the correct command annotations are set (and avoids panics on invalid inputs).
- Changed the build-time injected "version" variable which holds the version launcher version from the Git tag into "CurrentLauncherVersion" for clarity.
- Added/updated unit tests to explicitly cover the compatibility contract:
  - minor minimum behavior (patch ignored for the minimum)
  - “deployment must not be newer than launcher” rule (always enforced)
  - strict patch-level minimum behavior when using `requireVersionCompatibility(...)`

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

- Added/updated Go unit tests in `cmd/exasol/compatibility_test.go` to cover the compatibility rules and normalization behavior.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

- The minor-version helper is intended for the common case (commands compatible with all patches within a minor line). Commands that truly require patch-level accuracy should continue using `requireVersionCompatibility(...)`.