### PR TITLE
feat: host-side launcher version check + configurable version checking

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,6 +14,10 @@ before:
 builds:
   - env:
       - CGO_ENABLED=0
+    flags:
+      - -tags=official_release
+    ldflags:
+      - -X main.CurrentLauncherVersion={{ .Version }}
     targets:
       - darwin_arm64
       - darwin_amd64

--- a/assets/infrastructure/aws/cloudinit.tf
+++ b/assets/infrastructure/aws/cloudinit.tf
@@ -11,12 +11,12 @@
 locals {
   # --- Path "constants" ---
   # Changing these paths will break the deployment processes as we use them to find the installation preset contents  
-  installation_cloudconf_dir      = "${var.installation_preset_dir}/cloudconf"
-  installation_files_dir          = "${var.installation_preset_dir}/files"
+  installation_cloudconf_dir = "${var.installation_preset_dir}/cloudconf"
+  installation_files_dir     = "${var.installation_preset_dir}/files"
 
   # Optional infrastructure-preset-provided host file overlay.
   # This is used for infrastructure-specific scripts or configs that should not live in provider-agnostic installation presets.
-  infrastructure_files_dir        = "${path.module}/files"
+  infrastructure_files_dir = "${path.module}/files"
 
   # Changing these paths will break the installation processes on the hosts as they look for these files  
   launcher_config_dir             = "/etc/exasol_launcher"
@@ -28,14 +28,14 @@ locals {
   # as its own cloud-init "part" (stable lexicographic order) to avoid Terraform-side YAML
   # merging logic and keep the behavior easy to understand.
   installation_cloudconf_files = sort(
-    fileset(local.installation_cloudconf_dir, "*")    
+    fileset(local.installation_cloudconf_dir, "*")
   )
 
   # Materialize metadata of files to be installed.
   installation_node_files = [
     for rel in fileset(local.installation_files_dir, "**") : {
-      src_path  = "${local.installation_files_dir}/${rel}"
-      dest_path = "/${rel}"
+      src_path    = "${local.installation_files_dir}/${rel}"
+      dest_path   = "/${rel}"
       permissions = endswith(rel, ".sh") ? "0755" : "0644"
     }
   ]
@@ -44,8 +44,8 @@ locals {
   # These are applied after installation preset files, so infra presets can override paths when necessary.
   infrastructure_node_files = [
     for rel in fileset(local.infrastructure_files_dir, "**") : {
-      src_path  = "${local.infrastructure_files_dir}/${rel}"
-      dest_path = "/${rel}"
+      src_path    = "${local.infrastructure_files_dir}/${rel}"
+      dest_path   = "/${rel}"
       permissions = endswith(rel, ".sh") ? "0755" : "0644"
     }
   ]
@@ -54,14 +54,6 @@ locals {
   node_ips           = [for n in local.nodes : n.ip]
   node_ips_space_sep = join(" ", local.node_ips)
   n11_ip             = one([for n in local.nodes : n.ip if n.name == "n11"])
-
-  # JSON-friendly node list (camelCase keys).
-  nodes_payload = [
-    for n in local.nodes : {
-      name      = n.name
-      privateIp = n.ip
-    }
-  ]
 
   # Deployment metadata written to disk.
   # Keep this focused: only include information that is plausibly useful on the node
@@ -72,14 +64,13 @@ locals {
   # NOTE: This includes sensitive material (SSH private key, DB/AdminUI passwords, TLS key).
   infrastructure_payload = {
 
-    # Mandatory section. These values shall always be provided
-    deploymentId    = local.deployment_id
-    clusterSize     = var.cluster_size
-    ubuntuVersion   = var.ubuntu_version
-    nodes           = local.nodes_payload
-    numNodes        = length(local.nodes)
-    n11Ip           = local.n11_ip
-        
+    # Keep only fields currently consumed by host-side scripts.
+    # This payload is delivered through cloud-init user-data and contributes
+    # directly to the 16KB AWS limit.
+    deploymentId = local.deployment_id
+    numNodes     = length(local.nodes)
+    n11Ip        = local.n11_ip
+
     adminPrivateKey    = tls_private_key.ssh_key.private_key_pem
     hostAddrs          = local.node_ips_space_sep
     hostExternalAddrs  = local.node_ips_space_sep
@@ -88,7 +79,6 @@ locals {
     tlsKey             = tls_private_key.tls_key.private_key_pem
     tlsCa              = tls_self_signed_cert.tls_ca_cert.cert_pem
     tlsCert            = tls_locally_signed_cert.tls_cert.cert_pem
-    barrierPort       = "120"    
 
     # Optional infrastructure-specific hook scripts.      
     preInstall = {
@@ -104,32 +94,13 @@ locals {
       # postInstall hooks run on the *access node (n11) only*
       scripts = var.s3_archive_enabled ? ["/opt/exasol_launcher/scripts/aws_registerS3ArchiveVolume.sh"] : []
     }
-        
-    # Cloud-provider specific details live under a dedicated subsection.
+
+    # Cloud-provider specific values needed by optional infra hooks.
     aws = {
-      region           = data.aws_region.current.id
-      availabilityZone = local.selected_az
-      instanceType     = var.instance_type
-
-      image = {
-        amiId         = var.ami_id
-        selectedAmiId = local.selected_ami_id
-      }
-
-      storage = {
-        volumeType       = var.volume_type
-        osVolumeSizeGb   = var.os_volume_size
-        dataVolumeSizeGb = var.data_volume_size
-      }
-
-      network = {
-        vpcCidr    = var.vpc_cidr
-        subnetCidr = var.subnet_cidr
-      }
-
+      region = data.aws_region.current.id
       archive = {
-        enabled  = var.s3_archive_enabled
-        bucketId = local.archive_bucket_id
+        enabled    = var.s3_archive_enabled
+        bucketId   = local.archive_bucket_id
         volumeName = "default_archive"
       }
     }
@@ -148,6 +119,11 @@ locals {
 
 data "cloudinit_config" "cloud_config" {
   for_each = { for node in local.nodes : node.name => node }
+  # Keep payload size below AWS user-data limits as presets/scripts evolve.
+  # We pass rendered output into aws_instance.user_data_base64, so explicit
+  # base64+gzip here ensures a compressed transport representation.
+  gzip          = true
+  base64_encode = true
 
   dynamic "part" {
     for_each = local.installation_cloudconf_files
@@ -155,16 +131,16 @@ data "cloudinit_config" "cloud_config" {
     content {
       content_type = "text/cloud-config"
       # Numeric prefix makes ordering/precedence explicit when debugging multipart user-data.
-      filename     = "10-cloudconf-${part.value}"
-      content      = file("${local.installation_cloudconf_dir}/${part.value}")
+      filename = "10-cloudconf-${part.value}"
+      content  = file("${local.installation_cloudconf_dir}/${part.value}")
     }
   }
 
   part {
     content_type = "text/cloud-config"
     # Keep this last so it can intentionally override earlier preset cloud-config values.
-    filename     = "99-write-files.yaml"
-    content      = yamlencode({
+    filename = "99-write-files.yaml"
+    content = yamlencode({
       write_files = concat(
         [
           {

--- a/assets/infrastructure/aws/files/opt/exasol_launcher/scripts/aws_registerS3ArchiveVolume.sh
+++ b/assets/infrastructure/aws/files/opt/exasol_launcher/scripts/aws_registerS3ArchiveVolume.sh
@@ -11,10 +11,10 @@ source "${SCRIPT_DIR}/logging.sh"
 # shellcheck source=./config.sh
 source "${SCRIPT_DIR}/config.sh"
 
-# shared_post_install.sh provides C4_PATH and PLAY_ID
 source "${SCRIPT_DIR}/shared_post_install.sh"
 
 log_substep_info "Looking up cluster PLAY_ID"
+PLAY_ID="$("$C4_PATH" config -e .play.id)"
 
 # Skip archive registration when disabled in deployment variables
 ARCHIVE_ENABLED="$(infra_jq -er '.aws.archive.enabled')"

--- a/assets/installation/ubuntu/files/etc/systemd/system/exasol_launcher.target
+++ b/assets/installation/ubuntu/files/etc/systemd/system/exasol_launcher.target
@@ -1,15 +1,5 @@
-# Installation Completion Target
-#
-# Purpose: Represents successful completion of the entire installation workflow
-# Type: systemd target (aggregates service dependencies)
-#
-# Dependencies: Requires database readiness and post-installation to complete
-# Status: When this target becomes active, installation is complete
-#
-# Monitoring: The launcher polls this target's ActiveState to detect:
-# - active → Installation succeeded
-# - failed → Installation failed
-# - activating → Installation in progress
+# Exasol installation completion target.
+# Launcher monitors this target state as the workflow outcome.
 
 [Unit]
 Description=Exasol Launcher Complete

--- a/assets/installation/ubuntu/files/etc/systemd/system/exasol_launcher.target
+++ b/assets/installation/ubuntu/files/etc/systemd/system/exasol_launcher.target
@@ -14,6 +14,7 @@
 [Unit]
 Description=Exasol Launcher Complete
 Requires=exasol_launcher_ready.service exasol_launcher_post_install.service
+Wants=exasol_launcher_host_version_check.timer
 After=exasol_launcher_ready.service exasol_launcher_post_install.service
 
 [Install]

--- a/assets/installation/ubuntu/files/etc/systemd/system/exasol_launcher_host_version_check.service
+++ b/assets/installation/ubuntu/files/etc/systemd/system/exasol_launcher_host_version_check.service
@@ -1,13 +1,5 @@
-# Host-side launcher version check
-#
-# Purpose: Best-effort fallback scheduled check for launcher updates
-# Runs as: ubuntu user
-# Runs on: Access node only, and only when DB version checks are enabled
-# Dependencies: Requires database readiness marker and network
-#
-# Failure semantics:
-# - Must never impact deployment availability.
-# - Script exits 0 even when request fails/timeouts.
+# Best-effort host-side fallback version check.
+# Runs only on the access node and only when DB checks are enabled.
 
 [Unit]
 Description=Exasol Launcher Host Version Check

--- a/assets/installation/ubuntu/files/etc/systemd/system/exasol_launcher_host_version_check.service
+++ b/assets/installation/ubuntu/files/etc/systemd/system/exasol_launcher_host_version_check.service
@@ -1,0 +1,25 @@
+# Host-side launcher version check
+#
+# Purpose: Best-effort fallback scheduled check for launcher updates
+# Runs as: ubuntu user
+# Runs on: Access node only, and only when DB version checks are enabled
+# Dependencies: Requires database readiness marker and network
+#
+# Failure semantics:
+# - Must never impact deployment availability.
+# - Script exits 0 even when request fails/timeouts.
+
+[Unit]
+Description=Exasol Launcher Host Version Check
+Wants=network-online.target
+After=network-online.target exasol_launcher_ready.service
+ConditionPathExists=/var/lib/exasol_launcher/state/ready.complete
+ConditionPathExists=/etc/exasol_launcher/installation.json
+
+[Service]
+Type=oneshot
+ExecCondition=/opt/exasol_launcher/scripts/isAccessNode.sh
+ExecCondition=/opt/exasol_launcher/scripts/isDbVersionCheckEnabled.sh
+ExecStart=/opt/exasol_launcher/scripts/hostLauncherVersionCheck.sh
+User=ubuntu
+WorkingDirectory=~

--- a/assets/installation/ubuntu/files/etc/systemd/system/exasol_launcher_host_version_check.timer
+++ b/assets/installation/ubuntu/files/etc/systemd/system/exasol_launcher_host_version_check.timer
@@ -1,0 +1,20 @@
+# Host-side launcher version check scheduler
+#
+# Purpose: Trigger the fallback launcher version check periodically.
+# Cadence: roughly once per day with jitter to avoid synchronized bursts.
+# Persistence: catch up one missed run after reboot.
+
+[Unit]
+Description=Schedule Exasol Launcher Host Version Check
+Requires=exasol_launcher_ready.service
+After=exasol_launcher_ready.service
+
+[Timer]
+Unit=exasol_launcher_host_version_check.service
+OnActiveSec=15min
+OnUnitActiveSec=24h
+RandomizedDelaySec=30min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/assets/installation/ubuntu/files/etc/systemd/system/exasol_launcher_host_version_check.timer
+++ b/assets/installation/ubuntu/files/etc/systemd/system/exasol_launcher_host_version_check.timer
@@ -1,8 +1,5 @@
-# Host-side launcher version check scheduler
-#
-# Purpose: Trigger the fallback launcher version check periodically.
-# Cadence: roughly once per day with jitter to avoid synchronized bursts.
-# Persistence: catch up one missed run after reboot.
+# Scheduler for host-side fallback version checks.
+# Daily cadence with jitter and persistent catch-up.
 
 [Unit]
 Description=Schedule Exasol Launcher Host Version Check

--- a/assets/installation/ubuntu/files/etc/systemd/system/exasol_launcher_install.service
+++ b/assets/installation/ubuntu/files/etc/systemd/system/exasol_launcher_install.service
@@ -1,17 +1,5 @@
-# Installation Phase
-#
-# Purpose: Installs and initializes the Exasol cluster
-# Runs as: ubuntu user
-# Runs on: Primary node (n11) only - coordinates installation across all nodes
-# Dependencies: Requires preparation and node synchronization to complete first
-#
-# Tasks:
-# - Executes c4 host play to install across all cluster nodes
-# - Creates the database with configured passwords
-# - Starts AdminUI service
-#
-# Idempotency: Only runs if install.complete marker doesn't exist
-# Node-specific: ExecCondition checks node.json to ensure primary-only execution
+# Cluster install phase (access node only).
+# Idempotent via install.complete marker.
 
 [Unit]
 Description=Exasol Launcher Installation

--- a/assets/installation/ubuntu/files/etc/systemd/system/exasol_launcher_node_barrier_client.service
+++ b/assets/installation/ubuntu/files/etc/systemd/system/exasol_launcher_node_barrier_client.service
@@ -1,16 +1,5 @@
-# Node Synchronization Barrier - Client Side
-#
-# Purpose: Signals readiness to the primary node for cluster synchronization
-# Runs as: ubuntu user (needs SSH access)
-# Runs on: All nodes (including n11)
-# Dependencies: Requires both preparation phases to complete first
-#
-# Tasks:
-# - Registers this node's readiness with the primary node (n11)
-# - Retries until successful registration
-#
-# Pattern: Client side of server-client coordination for cluster-wide barrier
-# Note: Even n11 runs this service to register with itself
+# Node barrier client: each node registers readiness with n11.
+# Runs as ubuntu to use SSH.
 
 [Unit]
 Description=Exasol Launcher Installation Node Barrier Client
@@ -22,6 +11,5 @@ After=exasol_launcher_prepare.service exasol_launcher_prepare_user.service
 Type=oneshot
 ExecStart=/opt/exasol_launcher/scripts/waitNodesReady.sh client
 ExecStartPost=/usr/bin/touch /var/lib/exasol_launcher/state/node_barrier_client.complete
-# Run as ubuntu because we use ssh
 User=ubuntu
 WorkingDirectory=~

--- a/assets/installation/ubuntu/files/etc/systemd/system/exasol_launcher_node_barrier_server.service
+++ b/assets/installation/ubuntu/files/etc/systemd/system/exasol_launcher_node_barrier_server.service
@@ -1,17 +1,5 @@
-# Node Synchronization Barrier - Server Side
-#
-# Purpose: Coordinates cluster-wide synchronization before installation begins
-# Runs as: root (default user, needs to listen on port)
-# Runs on: Primary node (n11) only
-# Dependencies: Requires both preparation phases to complete first
-#
-# Tasks:
-# - Acts as synchronization point for all cluster nodes
-# - Waits for all nodes to register their readiness
-# - Completes when expected number of nodes have checked in
-#
-# Pattern: Server-client coordination where n11 is the synchronization authority
-# Idempotency: Only runs if node_barrier_server.complete marker doesn't exist
+# Node barrier server on n11; waits for all nodes before install.
+# Idempotent via node_barrier_server.complete marker.
 
 [Unit]
 Description=Exasol Launcher Installation Node Barrier Server

--- a/assets/installation/ubuntu/files/etc/systemd/system/exasol_launcher_post_install.service
+++ b/assets/installation/ubuntu/files/etc/systemd/system/exasol_launcher_post_install.service
@@ -1,15 +1,5 @@
-# Post-Installation Configuration Phase
-#
-# Purpose: Performs final configuration after database is ready
-# Runs as: ubuntu user
-# Runs on: Primary node (n11) only
-# Dependencies: Requires both installation and readiness
-#
-# Tasks:
-# - Uploads TLS certificates to all nodes via confd API
-# - Executes optional infrastructure-specific post-install actions (declared in infrastructure.json)
-#
-# Idempotency: Only runs if post_install.complete marker doesn't exist
+# Post-install phase on n11 after DB readiness.
+# Idempotent via post_install.complete marker.
 
 [Unit]
 Description=Exasol Launcher Post-Install

--- a/assets/installation/ubuntu/files/etc/systemd/system/exasol_launcher_prepare.service
+++ b/assets/installation/ubuntu/files/etc/systemd/system/exasol_launcher_prepare.service
@@ -1,16 +1,5 @@
-# System Preparation Phase
-#
-# Purpose: Prepares the system for Exasol installation
-# Runs as: root (requires system configuration permissions)
-# Dependencies: None (first phase in installation workflow)
-#
-# Tasks:
-# - Downloads the c4 installer binary
-# - Configures udev rules for EBS volume access
-# - Runs c4 preplay to prepare system for rootless container execution
-#
-# Idempotency: Only runs if exasol_launcher_prepare.complete marker doesn't exist
-# Progress logging: Logs phase start/completion to journal for launcher monitoring
+# Root preparation phase (first in workflow).
+# Idempotent via exasol_launcher_prepare.complete marker.
 
 [Unit]
 Description=Exasol Launcher System Preparation

--- a/assets/installation/ubuntu/files/etc/systemd/system/exasol_launcher_prepare_user.service
+++ b/assets/installation/ubuntu/files/etc/systemd/system/exasol_launcher_prepare_user.service
@@ -1,14 +1,5 @@
-# User Preparation Phase
-#
-# Purpose: Sets up SSH authentication between cluster nodes
-# Runs as: ubuntu user
-# Dependencies: Requires system preparation to complete first
-#
-# Tasks:
-# - Distributes admin SSH private key to all cluster nodes
-# - Enables password-less SSH between nodes for c4 orchestration
-#
-# Idempotency: Only runs if prepare_user.complete marker doesn't exist
+# User preparation phase for inter-node SSH.
+# Idempotent via prepare_user.complete marker.
 
 [Unit]
 Description=Exasol Launcher User Preparation

--- a/assets/installation/ubuntu/files/etc/systemd/system/exasol_launcher_ready.service
+++ b/assets/installation/ubuntu/files/etc/systemd/system/exasol_launcher_ready.service
@@ -1,15 +1,5 @@
-# Database Ready Wait Phase
-#
-# Purpose: Waits for Exasol to become fully operational
-# Runs as: ubuntu user
-# Dependencies: Requires installation to complete first
-#
-# Tasks:
-# - Waits for c4 process to be running
-# - Waits for Exasol to accept connections
-# - Waits for AdminUI (confd) to be accessible
-#
-# Idempotency: Only runs if ready.complete marker doesn't exist
+# DB readiness phase after install.
+# Idempotent via ready.complete marker.
 
 [Unit]
 Description=Exasol Launcher Ready

--- a/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/hostLauncherVersionCheck.sh
+++ b/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/hostLauncherVersionCheck.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=./config.sh
+source "${SCRIPT_DIR}/config.sh"
+
+# Local scheduler-level guard in case timer cadence is changed later.
+readonly CHECK_INTERVAL_SECONDS=$((24 * 60 * 60))
+readonly LAST_ATTEMPT_FILE="/var/lib/exasol_launcher/state/launcher_version_check.last_attempt_epoch"
+readonly DEFAULT_VERSION_CHECK_URL="https://metrics.exasol.com/v1/version-check"
+readonly VERSION_CHECK_CATEGORY="Exasol 8"
+readonly VERSION_CHECK_OS="Linux"
+readonly VERSION_CHECK_ARCH="x86_64"
+
+read_install_var() {
+  local key="$1"
+  install_jq -er ".${key} // \"\"" 2>/dev/null || echo ""
+}
+
+db_check_enabled="false"
+if "${SCRIPT_DIR}/isDbVersionCheckEnabled.sh"; then
+  db_check_enabled="true"
+fi
+if [[ "${db_check_enabled}" != "true" ]]; then
+  echo "DB version checks disabled; skipping host launcher version check"
+  exit 0
+fi
+
+cluster_identity="$(read_install_var "cluster_identity")"
+exasol_version="$(read_install_var "exasol_version")"
+version_check_url="$(read_install_var "version_check_url")"
+if [[ -z "${version_check_url}" ]]; then
+  version_check_url="${DEFAULT_VERSION_CHECK_URL}"
+fi
+if [[ -z "${exasol_version}" ]]; then
+  exasol_version="2025.2.0"
+fi
+
+# Missing launcher-governed values means init/deploy artifacts are incomplete.
+# Treat as a soft skip so this auxiliary feature cannot affect deployment health.
+if [[ -z "${cluster_identity}" ]]; then
+  echo "missing cluster_identity; skipping host launcher version check"
+  exit 0
+fi
+
+now_epoch="$(date +%s)"
+last_attempt_epoch=0
+if [[ -f "${LAST_ATTEMPT_FILE}" ]]; then
+  last_attempt_epoch="$(cat "${LAST_ATTEMPT_FILE}" 2>/dev/null || echo 0)"
+fi
+
+if [[ $((now_epoch - last_attempt_epoch)) -lt ${CHECK_INTERVAL_SECONDS} ]]; then
+  echo "host launcher version check skipped due to local rate limit"
+  exit 0
+fi
+
+mkdir -p "$(dirname "${LAST_ATTEMPT_FILE}")"
+# Record attempts before the network call so repeated failures/timeouts do not loop rapidly.
+echo "${now_epoch}" > "${LAST_ATTEMPT_FILE}"
+
+if curl \
+  --silent \
+  --show-error \
+  --fail \
+  --get \
+  --connect-timeout 3 \
+  --max-time 3 \
+  "${version_check_url}" \
+  --data-urlencode "category=${VERSION_CHECK_CATEGORY}" \
+  --data-urlencode "operatingSystem=${VERSION_CHECK_OS}" \
+  --data-urlencode "architecture=${VERSION_CHECK_ARCH}" \
+  --data-urlencode "version=${exasol_version}" \
+  --data-urlencode "clusterIdentity=${cluster_identity}" \
+  >/dev/null; then
+  echo "host launcher version check completed"
+else
+  # Best-effort semantics: failures remain visible in logs but never fail the unit.
+  echo "host launcher version check failed"
+fi
+
+exit 0

--- a/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/hostLauncherVersionCheck.sh
+++ b/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/hostLauncherVersionCheck.sh
@@ -8,7 +8,7 @@ source "${SCRIPT_DIR}/config.sh"
 # Local scheduler-level guard in case timer cadence is changed later.
 readonly CHECK_INTERVAL_SECONDS=$((24 * 60 * 60))
 readonly LAST_ATTEMPT_FILE="/var/lib/exasol_launcher/state/launcher_version_check.last_attempt_epoch"
-readonly DEFAULT_VERSION_CHECK_URL="https://metrics.exasol.com/v1/version-check"
+readonly DEFAULT_VERSION_CHECK_URL="https://metrics-test.exasol.com/v1/version-check"
 readonly VERSION_CHECK_CATEGORY="Exasol 8"
 readonly VERSION_CHECK_OS="Linux"
 readonly VERSION_CHECK_ARCH="x86_64"

--- a/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/hostLauncherVersionCheck.sh
+++ b/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/hostLauncherVersionCheck.sh
@@ -71,7 +71,7 @@ if curl \
   --data-urlencode "operatingSystem=${VERSION_CHECK_OS}" \
   --data-urlencode "architecture=${VERSION_CHECK_ARCH}" \
   --data-urlencode "version=${exasol_version}" \
-  --data-urlencode "clusterIdentity=${cluster_identity}" \
+  --data-urlencode "identity=${cluster_identity}" \
   >/dev/null; then
   echo "host launcher version check completed"
 else

--- a/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/installExasol.sh
+++ b/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/installExasol.sh
@@ -12,8 +12,6 @@ log_step_info "Installing Exasol"
 
 log_substep_info "Setting up c4 config"
 
-exasol_version='@exasol-2025.2.0'
-
 if [[ ! -x ./c4 ]]; then
   log_error "c4 binary not found. Please run /opt/exasol_launcher/scripts/prepare.sh first."
   exit 1
@@ -35,16 +33,26 @@ adminui_password_b64="$(infra_jq -er '.adminUiPasswordB64')"
 # Optional installation-preset variables (launcher-generated).
 db_version_check_enabled="true"
 cluster_identity=""
+version_check_url=""
 if [[ -f "${INSTALL_JSON}" ]]; then
+  # exasol_version is required: package selection and host-side fallback checks
+  # must stay aligned to the same configured DB version.
+  exasol_version="$(install_jq -er '.exasol_version')"
   no_db_version_check="$(install_jq -er '.no_db_version_check // false' 2>/dev/null || echo false)"
   if [[ "${no_db_version_check}" == "true" ]]; then
     db_version_check_enabled="false"
   fi
   cluster_identity="$(install_jq -er '.cluster_identity // ""' 2>/dev/null || echo "")"
+  version_check_url="$(install_jq -er '.version_check_url // ""' 2>/dev/null || echo "")"
+  log_substep_info "exasol version: ${exasol_version}"
   log_substep_info "cluster identity: ${cluster_identity}"
 else
-  log_substep_info "installation variables file not found at ${INSTALL_JSON}; using defaults"
+  log_error "installation variables file not found at ${INSTALL_JSON}"
+  exit 1
 fi
+
+# c4 expects a package/workcopy id, not a bare semantic version.
+exasol_working_copy="@exasol-${exasol_version}"
 
 cat << CONFEOF | tee ./config > /dev/null
 CCC_HOST_ADDRS="${host_addrs}"
@@ -52,7 +60,7 @@ CCC_HOST_EXTERNAL_ADDRS="${host_external_addrs}"
 CCC_HOST_KEY_PAIR_FILE="id_rsa"
 CCC_HOST_IMAGE_USER=ubuntu
 CCC_HOST_DATADISK="/dev/exasol_data_01"
-CCC_PLAY_WORKING_COPY=${exasol_version}
+CCC_PLAY_WORKING_COPY=${exasol_working_copy}
 CCC_PLAY_ROOTLESS=true
 CCC_PLAY_DB_PASSWORD=$(quote_b64 "${db_password_b64}")
 CCC_ADMINUI_START_SERVER=true
@@ -65,6 +73,10 @@ CONFEOF
 # Append optional values only when set.
 if [[ -n "${cluster_identity}" ]]; then
   echo "CCC_PLAY_CLUSTER_IDENTITY=\"${cluster_identity}\"" | tee -a ./config > /dev/null
+fi
+if [[ -n "${version_check_url}" ]]; then
+  # Keep DB-native update checks on the same endpoint base URL chosen by launcher config.
+  echo "CCC_PLAY_VERSION_UPDATE_CHECK_ENDPOINT=\"${version_check_url}\"" | tee -a ./config > /dev/null
 fi
 
 log_substep_info "Starting Exasol installation using c4"

--- a/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/installExasol.sh
+++ b/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/installExasol.sh
@@ -13,7 +13,7 @@ log_step_info "Installing Exasol"
 log_substep_info "Setting up c4 config"
 
 if [[ ! -x ./c4 ]]; then
-  log_error "c4 binary not found. Please run /opt/exasol_launcher/scripts/prepare.sh first."
+  log_error "c4 binary not found."
   exit 1
 fi
 
@@ -30,7 +30,7 @@ host_external_addrs="$(infra_jq -er '.hostExternalAddrs')"
 db_password_b64="$(infra_jq -er '.dbPasswordB64')"
 adminui_password_b64="$(infra_jq -er '.adminUiPasswordB64')"
 
-# Optional installation-preset variables (launcher-generated).
+# Optional installation-preset variables.
 db_version_check_enabled="true"
 cluster_identity=""
 version_check_url=""
@@ -51,7 +51,6 @@ else
   exit 1
 fi
 
-# c4 expects a package/workcopy id, not a bare semantic version.
 exasol_working_copy="@exasol-${exasol_version}"
 
 cat << CONFEOF | tee ./config > /dev/null

--- a/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/isAccessNode.sh
+++ b/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/isAccessNode.sh
@@ -3,8 +3,6 @@
 #
 # Intended usage:
 #   - systemd ExecCondition= for services that must only run on the access node
-#
-# Contract:
 #   - exit 0 => this node is n11
 #   - exit 1 => this node is NOT n11
 #   - exit >1 => unexpected error (missing config, jq failure)

--- a/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/isDbVersionCheckEnabled.sh
+++ b/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/isDbVersionCheckEnabled.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# isDbVersionCheckEnabled.sh - Returns success (exit 0) iff DB version checks are enabled.
+#
+# Intended usage:
+#   - systemd ExecCondition= for optional host-side fallback behavior
+#
+# Contract:
+#   - exit 0 => DB version checks enabled
+#   - exit 1 => DB version checks disabled
+#   - exit >1 => unexpected error (missing config, jq failure)
+
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=./config.sh
+source "${SCRIPT_DIR}/config.sh"
+
+if [[ ! -f "${INSTALL_JSON}" ]]; then
+  echo "installation config not found: ${INSTALL_JSON}" >&2
+  exit 2
+fi
+
+no_db_version_check="$(install_jq -er '.no_db_version_check // false')"
+if [[ "${no_db_version_check}" == "true" ]]; then
+  exit 1
+fi
+
+exit 0

--- a/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/monitorInstallation.sh
+++ b/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/monitorInstallation.sh
@@ -14,18 +14,13 @@
 
 set -euo pipefail
 
-# ============================================================================
 # Setup and Dependencies
-# ============================================================================
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 # shellcheck source=./logging.sh
 source "${SCRIPT_DIR}/logging.sh"
 
-# ============================================================================
 # Cloud-Init Monitoring
-# ============================================================================
-
 readonly CLOUD_INIT_LOG="/var/log/cloud-init-output.log"
 readonly CLOUD_INIT_DONE_MARKER="/var/lib/exasol_launcher/state/cloud-init.complete"
 CLOUD_INIT_TAIL_PID=""
@@ -84,10 +79,7 @@ wait_for_cloud_init() {
   log_step_info "Cloud-init - bootstrap completed"    
 }
 
-# ============================================================================
 # Journal Monitoring
-# ============================================================================
-
 CURSOR_FILE="/var/lib/exasol_launcher/state/journal.cursor"
 JOURNAL_PID=""
 
@@ -145,12 +137,8 @@ start_journalctl_tail() {
   JOURNAL_PID=$!
 }
 
-# ============================================================================
 # Installation Status Monitoring
-# ============================================================================
-
 readonly SUCCESS_MARKER="/var/lib/exasol_launcher/state/post_install.complete"
-
 check_service_failure() {
   local service=$1
   local active_state
@@ -215,10 +203,7 @@ monitor_installation_status() {
   done
 }
 
-# ============================================================================
 # Cleanup and Signal Handling
-# ============================================================================
-
 cleanup() {
   stop_cloud_init_tail
   stop_journalctl_tail
@@ -226,10 +211,7 @@ cleanup() {
 
 trap cleanup EXIT
 
-# ============================================================================
 # Main Execution
-# ============================================================================
-
 main() {
   wait_for_cloud_init
   

--- a/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/shared_post_install.sh
+++ b/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/shared_post_install.sh
@@ -4,13 +4,5 @@
 # Path to c4 executable for the DB
 # Needed to hardcode this because we need to use exactly this c4 from this path
 # It looks for its config in ../etc/c4.yaml or rather $HOME/.ccc/ccc/etc/c4.yaml
-# We use the synlink in $HOME/.local/bin here though instead to abstract from these internals.
-# Unfortunately, it appears the installation process doesn't update PATH in .bashrc
-# until some point later during the init (we should probably fix that)
-# Otherwise we could have simply sourced $HOME/.bashrc
+# We use the symlink in $HOME/.local/bin here though instead to abstract from these internals.
 C4_PATH="$HOME/.local/bin/c4"
-
-# Play ID (or deployment ID)
-# Needed for subsequent c4 operations as most ops need to target a specific deployment
-# We have only one deployment here, but it is better to make this explicit
-PLAY_ID="$("$C4_PATH" config -e .play.id)"

--- a/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/uploadTLSCert.sh
+++ b/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/uploadTLSCert.sh
@@ -12,9 +12,10 @@ source "${SCRIPT_DIR}/config.sh"
 
 log_step_info "Configuring TLS certificates..."
 
-# shared_post_install.sh provides C4_PATH and PLAY_ID
-log_substep_info "Looking up cluster PLAY_ID"
 source "${SCRIPT_DIR}/shared_post_install.sh"
+
+log_substep_info "Looking up cluster PLAY_ID"
+PLAY_ID="$("$C4_PATH" config -e .play.id)"
 
 log_substep_info "Uploading TLS certificate"
 # Doing this via stdin avoids a lot of quoting issues compared to passing commands to `c4 connect`

--- a/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/waitC4Present.sh
+++ b/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/waitC4Present.sh
@@ -7,11 +7,7 @@ source "${SCRIPT_DIR}/logging.sh"
 
 log_substep_info "Waiting for local c4 to be installed"
 
-# Path to c4 executable
-# Needed to hardcode this because we need to use exactly this c4 from this path
-# It looks for its config in ../etc/c4.yaml or rather $HOME/.ccc/ccc/etc/c4.yaml
-# We use the synlink in $HOME/.local/bin here though instead to abstract from these internals.
-C4_PATH=$HOME/.local/bin/c4
+source "${SCRIPT_DIR}/shared_post_install.sh"
 
 FOUND=0
 # Wait up to ~10 minutes, downloading packages and getting them to all nodes

--- a/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/waitConfdStartup.sh
+++ b/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/waitConfdStartup.sh
@@ -19,14 +19,7 @@ log_substep_info "Waiting for confd to be ready ..."
 # 5 minutes should be enough typically
 TIMEOUT_SECONDS=300
 
-# Path to c4 executable for the DB
-# Needed to hardcode this because we need to use exactly this c4 from this path
-# It looks for its config in ../etc/c4.yaml or rather $HOME/.ccc/ccc/etc/c4.yaml
-# We use the synlink in $HOME/.local/bin here though instead to abstract from these internals.
-# Unfortunetedly, it appears the installation process doesn't update PATH in .bashrc
-# until some point later during the init (we should probly fix that)
-# Otherwise we could have simply sourced $HOME/.bashrc
-C4_PATH=$HOME/.local/bin/c4
+source "${SCRIPT_DIR}/shared_post_install.sh"
 
 CONFD_PORT=$($C4_PATH config -F -e .play.confd_port)
 

--- a/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/waitDatabaseBootup.sh
+++ b/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/waitDatabaseBootup.sh
@@ -15,23 +15,13 @@ source "${SCRIPT_DIR}/logging.sh"
 
 log_substep_info "Waiting for Exasol to boot up"
 
-# Timeout for the waiting operation
-# 5 minutes should be enough typically
-TIMEOUT_SECONDS=300
+# 10 minutes should be enough typically
+TIMEOUT_SECONDS=600
 
-# Path to c4 executable for the DB
-# Needed to hardcode this because we need to use exactly this c4 from this path
-# It looks for its config in ../etc/c4.yaml or rather $HOME/.ccc/ccc/etc/c4.yaml
-# We use the synlink in $HOME/.local/bin here though instead to abstract from these internals.
-# Unfortunetedly, it appears the installation process doesn't update PATH in .bashrc
-# until some point later during the init (we should probly fix that)
-# Otherwise we could have simply sourced $HOME/.bashrc
-C4_PATH=$HOME/.local/bin/c4
+source "${SCRIPT_DIR}/shared_post_install.sh"
 
-# Play ID (or deployment ID)
-# Needed for subsequent c4 operations as most ops need to target a specific deployment
-# We have only one deployment here, but it is better to make this explicit
-PLAY_ID=$($C4_PATH config -e .play.id)
+log_substep_info "Looking up cluster PLAY_ID"
+PLAY_ID="$("$C4_PATH" config -e .play.id)"
 log_substep_info "Cluster PLAY_ID=$PLAY_ID"
 
 if CCC_CLOUD_ACTION_WAIT_TIMEOUT=3600 timeout "$TIMEOUT_SECONDS" $C4_PATH wait $PLAY_ID --stage d; then

--- a/assets/installation/ubuntu/installation.yaml
+++ b/assets/installation/ubuntu/installation.yaml
@@ -4,6 +4,10 @@ description:  Installs Exasol on Ubuntu distributions.
 variables:
   outputFile: files/etc/exasol_launcher/installation.json
   vars:
+    exasol_version:
+      description: Exasol database version to install. Only change this if you are sure the release is compatible.
+      type: string
+      default: "2025.2.0"
     no_db_version_check:
       description: Disable the daily database version check (C4).
       type: bool

--- a/doc/presets.md
+++ b/doc/presets.md
@@ -163,7 +163,7 @@ Therefore, installation presets declare **installation variables** in `installat
 
 The launcher writes the resolved values into the installation preset directory in the deployment directory (at the manifest-defined path). Infrastructure presets that support unattended installation must ensure that this path is deployed to the node filesystem (for example via a host file overlay mechanism).
 
-Installation scripts may read installation-owned configuration from that file when they are executed. In addition to explicitly declared installation variables, the launcher can include implicit core values (such as `deployment_id` and `cluster_identity`) so scripts do not need to reconstruct them.
+Installation scripts may read installation-owned configuration from that file when they are executed. In addition to explicitly declared installation variables, the launcher can include implicit core values (such as `deployment_id`, `cluster_identity`, and `version_check_url`) so scripts do not need to reconstruct them.
 
 Optional extensions used by some presets:
 

--- a/doc/version_checking.md
+++ b/doc/version_checking.md
@@ -2,10 +2,11 @@
 
 This document describes the **update-checking** features in Exasol Personal.
 
-There are two related (but independent) mechanisms:
+There are three related mechanisms:
 
 - **Launcher version check:** the Exasol Personal launcher checks whether a newer launcher release is available.
 - **Database version check:** during installation, the launcher can enable the Exasol database’s own daily version check.
+- **Host-side launcher version check:** a temporary fallback on the deployed host system can periodically check for newer launcher releases without requiring CLI usage.
 
 ## Launcher version check (launcher updates)
 
@@ -102,3 +103,36 @@ The identity format is:
 `exasol-personal;<deployment-id>;<infra-preset-name>;<install-preset-name>`
 
 This identity is separate from the launcher’s own `clusterIdentity` parameter for launcher update checks.
+
+## Host-side version check fallback (temporary)
+
+In addition to launcher-initiated checks, the deployed host system performs periodic version checks against the same version-check API endpoint.
+
+This mechanism exists as a backup for the database version check. It is intended for cases where the database-side daily check is unavailable or not used, so long-running deployments can still report update activity and receive launcher update information even when operators do not invoke the CLI regularly.
+
+Because it is only a fallback, it is expected to be temporary and may be removed once the database version check is the sole mechanism needed for scheduled update awareness.
+
+### Scope and activation
+
+- The scheduled check runs on the **access node** only, so each deployment performs the check from exactly one host.
+- It becomes active only after the database is reported as ready.
+- It is enabled only when the database version check is enabled for the deployment.
+- It is installed as part of the installation preset and runs on a host-local schedule managed by the operating system, with a `systemd` service and timer being the intended implementation vehicle.
+
+### Behavior and failure semantics
+
+The host-side check is intentionally **best-effort**:
+
+- It must not affect database availability or block normal deployment operations.
+- It uses the same endpoint base URL as launcher version checks (including launcher-side endpoint overrides).
+- It uses a database-compatible request profile (`category=Exasol 8`, `operatingSystem=Linux`, `architecture=x86_64`) and sends the configured Exasol version from installation variables.
+- It is rate limited so failures, including timeouts and temporary connectivity problems, do not create tight retry loops.
+- Failed attempts are still recorded for local bookkeeping so the next retry is deferred by the normal schedule rather than happening immediately.
+
+### Deployment identity
+
+The scheduled host-side check uses a stable deployment identity so the service can attribute requests to a deployment over time without relying on CLI activity.
+
+For Exasol Personal deployments, that identity is privacy-conscious: it is stable enough for per-deployment behavior and metrics, but it does not expose sensitive operator or environment data.
+
+The configured identity is the same `CCC_PLAY_CLUSTER_IDENTITY` value used for the database version check.

--- a/doc/version_checking.md
+++ b/doc/version_checking.md
@@ -50,7 +50,7 @@ The launcher sends the following query parameters:
 - `operatingSystem`
 - `architecture`
 - `version`
-- `clusterIdentity`
+- `identity`
 
 The response contains a `latestVersion` object with metadata for the newest available release on that platform (version, download URL, checksums, and platform).
 
@@ -101,8 +101,6 @@ For Exasol Personal deployments, installation sets a predictable `CCC_PLAY_CLUST
 The identity format is:
 
 `exasol-personal;<deployment-id>;<infra-preset-name>;<install-preset-name>`
-
-This identity is separate from the launcher’s own `clusterIdentity` parameter for launcher update checks.
 
 ## Host-side version check fallback (temporary)
 

--- a/internal/deploy/init.go
+++ b/internal/deploy/init.go
@@ -162,6 +162,7 @@ func InitDeployment(
 				installManifest.Variables,
 				clusterIdentity,
 				deploymentId,
+				GetVersionCheckURL(),
 				installVars,
 			); err != nil {
 				return err

--- a/internal/deploy/init_test.go
+++ b/internal/deploy/init_test.go
@@ -114,6 +114,9 @@ func TestInitDeployment_CreatesTfVarsWhenTofuConfigured(t *testing.T) {
 	if !strings.Contains(installContent, "\"cluster_identity\"") {
 		t.Fatalf("expected installation vars to contain cluster_identity, got: %s", installContent)
 	}
+	if !strings.Contains(installContent, "\"version_check_url\"") {
+		t.Fatalf("expected installation vars to contain version_check_url, got: %s", installContent)
+	}
 }
 
 func TestInitDeployment_ErrWhenDirNotEmpty(t *testing.T) {

--- a/internal/deploy/installation_variables.go
+++ b/internal/deploy/installation_variables.go
@@ -24,6 +24,7 @@ func writeInstallationVariablesFile(
 	spec *presets.Variables,
 	clusterIdentity string,
 	deploymentId string,
+	versionCheckURL string,
 	overrides map[string]string,
 ) error {
 	if spec == nil {
@@ -49,6 +50,8 @@ func writeInstallationVariablesFile(
 	// Always include launcher-governed identity values.
 	resolved["deployment_id"] = deploymentId
 	resolved["cluster_identity"] = clusterIdentity
+	// Host-side scheduled checks reuse the same endpoint selection as launcher checks.
+	resolved["version_check_url"] = versionCheckURL
 
 	// Apply defaults from manifest.
 	for name, def := range spec.Vars {
@@ -110,7 +113,7 @@ func writeInstallationVariablesFile(
 
 func isReservedInstallationVariableName(name string) bool {
 	switch strings.TrimSpace(name) {
-	case "deployment_id", "cluster_identity":
+	case "deployment_id", "cluster_identity", "version_check_url":
 		return true
 	default:
 		return false

--- a/internal/deploy/version_check.go
+++ b/internal/deploy/version_check.go
@@ -28,6 +28,17 @@ const (
 	VersionCheckLockTimeout = 250 * time.Millisecond
 )
 
+// GetVersionCheckURL resolves the version-check endpoint URL.
+// The endpoint can be overridden for tests and controlled environments.
+func GetVersionCheckURL() string {
+	versionCheckURL := os.Getenv(VersionCheckURLEnvVar)
+	if versionCheckURL == "" {
+		versionCheckURL = DefaultVersionCheckURL
+	}
+
+	return versionCheckURL
+}
+
 // VersionCheckDetails contains platform-specific information for version checking.
 type VersionCheckDetails struct {
 	OperatingSystem string
@@ -61,13 +72,6 @@ func GetVersionCheckDetails(deploymentDir string) *VersionCheckDetails {
 		arch = "x86_64"
 	}
 
-	// Check for environment variable override
-
-	versionCheckURL := os.Getenv(VersionCheckURLEnvVar)
-	if versionCheckURL == "" {
-		versionCheckURL = DefaultVersionCheckURL
-	}
-
 	// Determine cluster identity.
 	clusterIdentity := ""
 	if deploymentDir != "" {
@@ -89,7 +93,7 @@ func GetVersionCheckDetails(deploymentDir string) *VersionCheckDetails {
 		Architecture:    arch,
 		Category:        VersionCheckCategory,
 		ClusterIdentity: clusterIdentity,
-		URL:             versionCheckURL,
+		URL:             GetVersionCheckURL(),
 	}
 }
 

--- a/internal/deploy/version_check.go
+++ b/internal/deploy/version_check.go
@@ -144,7 +144,7 @@ func CheckLatestVersion(
 	params.Add("architecture", details.Architecture)
 	params.Add("version", currentVersion)
 	if strings.TrimSpace(details.ClusterIdentity) != "" {
-		params.Add("clusterIdentity", details.ClusterIdentity)
+		params.Add("identity", details.ClusterIdentity)
 	}
 
 	requestURL := fmt.Sprintf("%s?%s", details.URL, params.Encode())

--- a/internal/deploy/version_check.go
+++ b/internal/deploy/version_check.go
@@ -21,9 +21,8 @@ import (
 )
 
 const (
-	DefaultVersionCheckURL = "https://metrics.exasol.com/v1/version-check"
-	VersionCheckURLEnvVar  = "EXASOL_VERSION_CHECK_URL"
-	VersionCheckCategory   = "Exasol Personal"
+	VersionCheckURLEnvVar = "EXASOL_VERSION_CHECK_URL"
+	VersionCheckCategory  = "Exasol Personal"
 
 	VersionCheckLockTimeout = 250 * time.Millisecond
 )

--- a/internal/deploy/version_check_details_test.go
+++ b/internal/deploy/version_check_details_test.go
@@ -10,6 +10,25 @@ import (
 	"github.com/exasol/exasol-personal/internal/config"
 )
 
+func TestGetVersionCheckURL_DefaultWhenEnvMissing(t *testing.T) {
+	t.Setenv(VersionCheckURLEnvVar, "")
+
+	url := GetVersionCheckURL()
+	if url != DefaultVersionCheckURL {
+		t.Fatalf("expected default URL %q, got %q", DefaultVersionCheckURL, url)
+	}
+}
+
+func TestGetVersionCheckURL_UsesEnvOverride(t *testing.T) {
+	const expected = "https://example.com/custom-check"
+	t.Setenv(VersionCheckURLEnvVar, expected)
+
+	url := GetVersionCheckURL()
+	if url != expected {
+		t.Fatalf("expected env override URL %q, got %q", expected, url)
+	}
+}
+
 func TestGetVersionCheckDetails_EmptyClusterIdentityWhenNoDeploymentDir(t *testing.T) {
 	t.Parallel()
 

--- a/internal/deploy/version_check_url_default.go
+++ b/internal/deploy/version_check_url_default.go
@@ -1,0 +1,12 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+//go:build !official_release
+
+package deploy
+
+// DefaultVersionCheckURL is the default endpoint used for version checking.
+//
+// For official release builds, this value is overridden via a build tag in
+// version_check_url_official_release.go.
+const DefaultVersionCheckURL = "https://metrics-test.exasol.com/v1/version-check"

--- a/internal/deploy/version_check_url_official_release.go
+++ b/internal/deploy/version_check_url_official_release.go
@@ -1,0 +1,10 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+//go:build official_release
+
+package deploy
+
+// DefaultVersionCheckURL is the default endpoint used for version checking in
+// official release builds.
+const DefaultVersionCheckURL = "https://metrics.exasol.com/v1/version-check"

--- a/tests/mock_version_server.py
+++ b/tests/mock_version_server.py
@@ -76,16 +76,16 @@ class VersionServerHandler(BaseHTTPRequestHandler):
         operating_system = params.get("operatingSystem", [""])[0]
         architecture = params.get("architecture", [""])[0]
         version = params.get("version", [""])[0]
-        cluster_identity = params.get("clusterIdentity", [""])[0]
+        identity = params.get("identity", [""])[0]
 
         logger.info(
             "received version check request: category=%s operatingSystem=%s "
-            "architecture=%s version=%s clusterIdentity=%s",
+            "architecture=%s version=%s identity=%s",
             category,
             operating_system,
             architecture,
             version,
-            cluster_identity,
+            identity,
         )
 
         with data_lock:


### PR DESCRIPTION
## Description

Add host-side launcher version checking and make version-check endpoints configurable. Also reduces AWS cloud-init payload size (to avoid the 16KB limit) and adjusts installer/systemd assets accordingly.

## Related Issue

Fixes #29662

## Type of Change

- [x] `feat`: New feature
- [x] `fix`: Bug fix
- [x] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Add host-side launcher version check (systemd service + timer + script) and support configurable `exasol-version`
- Make version check URL selection safer (official releases use prod API; allow env override) and fix cluster identity name in version-update API calls
- Reduce AWS cloud-init payload size and update related installer/systemd assets; add/extend tests + docs

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

- Includes packaging/asset updates so the new host-side version-check units/scripts are deployed with the installer.