### PR TITLE
fix: repaired host version check config query

### DIFF
--- a/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/isDbVersionCheckEnabled.sh
+++ b/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/isDbVersionCheckEnabled.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
-# isDbVersionCheckEnabled.sh - Returns success (exit 0) iff DB version checks are enabled.
-#
-# Intended usage:
-#   - systemd ExecCondition= for optional host-side fallback behavior
+# isDbVersionCheckEnabled.sh - Returns success (exit 0) if DB version checks are enabled.
 #
 # Contract:
 #   - exit 0 => DB version checks enabled
@@ -20,7 +17,7 @@ if [[ ! -f "${INSTALL_JSON}" ]]; then
   exit 2
 fi
 
-no_db_version_check="$(install_jq -er '.no_db_version_check // false')"
+no_db_version_check="$(install_jq -er '.no_db_version_check // false' || echo false)"
 if [[ "${no_db_version_check}" == "true" ]]; then
   exit 1
 fi

--- a/cmd/exasol/version.go
+++ b/cmd/exasol/version.go
@@ -82,7 +82,7 @@ func printLatestVersionText(
 
 	fmt.Fprintf(
 		os.Stdout,
-		"A new version of Exasol Personal is available: %s "+
+		"The latest official version of Exasol Personal available is: %s "+
 			"(you are using %s)\n",
 		response.LatestVersion.Version,
 		currentVersion,


### PR DESCRIPTION
## Description

Fixed how "isDbVersionCheckEnabled.sh" handles the exit codes of the jq query for the `no_db_version_check` config value.

## Related Issue



Fixes #

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Testing

<!-- Describe how you tested your changes -->

- [x] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

## Checklist

<!-- Mark completed items with an "x" -->

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [ ] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

