### PR TITLE
feat: Add logging to file in parallel to stdout

### DIFF
--- a/cmd/exasol/deploy.go
+++ b/cmd/exasol/deploy.go
@@ -48,6 +48,7 @@ var deployCmd = &cobra.Command{
 func init() {
 	requireMinorVersionCompatibility(deployCmd, CurrentLauncherVersion)
 	requireInitializedDeploymentDir(deployCmd)
+	requireDeploymentFileLogging(deployCmd)
 	registerDeploymentDirFlag(deployCmd, commonFlags)
 	registerVerboseFlag(deployCmd, commonFlags)
 	registerDeployFlags(deployCmd, commonFlags)

--- a/cmd/exasol/deploymentControl.go
+++ b/cmd/exasol/deploymentControl.go
@@ -85,6 +85,7 @@ func registerStartFlags() {
 func init() {
 	requireMinorVersionCompatibility(startCmd, CurrentLauncherVersion)
 	requireInitializedDeploymentDir(startCmd)
+	requireDeploymentFileLogging(startCmd)
 	registerStartFlags()
 	registerVerboseFlag(startCmd, commonFlags)
 	registerDeploymentDirFlag(startCmd, commonFlags)
@@ -92,6 +93,7 @@ func init() {
 
 	requireMinorVersionCompatibility(stopCmd, CurrentLauncherVersion)
 	requireInitializedDeploymentDir(stopCmd)
+	requireDeploymentFileLogging(stopCmd)
 	registerVerboseFlag(stopCmd, commonFlags)
 	registerDeploymentDirFlag(stopCmd, commonFlags)
 	rootCmd.AddCommand(stopCmd)

--- a/cmd/exasol/deployment_logging.go
+++ b/cmd/exasol/deployment_logging.go
@@ -1,0 +1,160 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	deploymentLogsDirPermissions            = 0o750
+	deploymentLogFilePermissions            = 0o600
+	deploymentLogFileName                   = "deployment.log"
+	annotationRequiresDeploymentFileLogging = "exasol.requiresDeploymentFileLogging"
+	commandInit                             = "init"
+	commandInstall                          = "install"
+)
+
+var deploymentLogCleanup = func() {}
+
+func requireDeploymentFileLogging(cmd *cobra.Command) {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations[annotationRequiresDeploymentFileLogging] = annotationEnabledValue
+}
+
+func deploymentFileLoggingIsRequired(cmd *cobra.Command) bool {
+	v, ok := cmd.Annotations[annotationRequiresDeploymentFileLogging]
+	return ok && v == annotationEnabledValue
+}
+
+var startDeploymentLogSession = func(
+	_ context.Context,
+	commandName string,
+	deploymentDir string,
+) (func(), error) {
+	logFilePath := deploymentLogFilePath(deploymentDir)
+	logDir := filepath.Dir(logFilePath)
+	if err := os.MkdirAll(logDir, deploymentLogsDirPermissions); err != nil {
+		slog.Warn(
+			"failed to enable deployment file logging; continuing without deployment file logging",
+			"deployment_dir", deploymentDir,
+			"error", err.Error(),
+		)
+
+		return func() {}, nil
+	}
+
+	file, err := os.OpenFile(
+		logFilePath,
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY,
+		deploymentLogFilePermissions,
+	)
+	if err != nil {
+		slog.Warn(
+			"failed to open deployment log file; continuing without deployment file logging",
+			"path", logFilePath,
+			"error", err.Error(),
+		)
+
+		return func() {}, nil
+	}
+
+	globalDeploymentFileSink.Set(file, slog.LevelDebug)
+	writeDeploymentLogBootstrap(file, commandName, deploymentDir)
+
+	slog.Info("deployment log file", "status", "started", "path", logFilePath)
+
+	return func() {
+		slog.Info("deployment log file", "status", "finished", "path", logFilePath)
+		globalDeploymentFileSink.Clear()
+
+		if err := file.Close(); err != nil {
+			slog.Warn("failed to close deployment log file", "path",
+				logFilePath, "error", err.Error())
+		}
+	}, nil
+}
+
+func setDeploymentLogCleanup(cleanup func()) {
+	if cleanup == nil {
+		deploymentLogCleanup = func() {}
+		return
+	}
+
+	deploymentLogCleanup = cleanup
+}
+
+func runDeploymentLogCleanup() {
+	deploymentLogCleanup()
+	deploymentLogCleanup = func() {}
+}
+
+func setupDeploymentLogSession(cmd *cobra.Command, deploymentDir string) error {
+	// Default cleanup is always a no-op, so Execute() can always defer cleanup once.
+	setDeploymentLogCleanup(func() {})
+
+	if !deploymentFileLoggingIsRequired(cmd) {
+		return nil
+	}
+
+	cleanup, err := startDeploymentLogSession(cmd.Context(), cmd.Name(), deploymentDir)
+	setDeploymentLogCleanup(cleanup)
+
+	if err != nil {
+		// Never fail the command because persistent logging setup failed.
+		slog.Warn("failed to set up persistent logging; continuing without deployment file logging",
+			"error", err.Error())
+	}
+
+	return nil
+}
+
+func deploymentLogSessionStartsAfterInit(cmd *cobra.Command) bool {
+	switch cmd.Name() {
+	case commandInit, commandInstall:
+		return true
+	default:
+		return false
+	}
+}
+
+func deploymentLogFilePath(deploymentDir string) string {
+	return filepath.Join(deploymentDir, deploymentLogFileName)
+}
+
+func writeDeploymentLogBootstrap(
+	file *os.File,
+	commandName string,
+	deploymentDir string,
+) {
+	writeBootstrapRecord(file, "deployment log session started",
+		slog.String("command", commandName),
+		slog.String("deployment_dir", deploymentDir),
+	)
+	writeBootstrapRecord(file, "system information",
+		slog.String("os", runtime.GOOS),
+		slog.String("arch", runtime.GOARCH),
+		slog.Int("cpus", runtime.NumCPU()),
+		slog.String("go_version", runtime.Version()),
+		slog.Int("pid", os.Getpid()),
+	)
+}
+
+func writeBootstrapRecord(file *os.File, message string, attrs ...slog.Attr) {
+	record := slog.NewRecord(time.Now().UTC(), slog.LevelInfo, message, 0)
+	record.AddAttrs(attrs...)
+
+	if _, err := file.WriteString(formatFileLogRecord(record)); err != nil {
+		slog.Warn("failed to write bootstrap log entry", "error", err.Error())
+	}
+}

--- a/cmd/exasol/deployment_logging_test.go
+++ b/cmd/exasol/deployment_logging_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func TestRequireDeploymentFileLogging(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{Use: "deploy"}
+	if deploymentFileLoggingIsRequired(cmd) {
+		t.Fatal("expected deployment file logging to be disabled by default")
+	}
+
+	requireDeploymentFileLogging(cmd)
+	if !deploymentFileLoggingIsRequired(cmd) {
+		t.Fatal("expected deployment file logging to be required after annotation")
+	}
+}
+
+func TestDeploymentLogSessionStartsAfterInit(t *testing.T) {
+	t.Parallel()
+
+	if !deploymentLogSessionStartsAfterInit(&cobra.Command{Use: commandInit}) {
+		t.Fatal("expected init to defer deployment log setup")
+	}
+	if !deploymentLogSessionStartsAfterInit(&cobra.Command{Use: commandInstall}) {
+		t.Fatal("expected install to defer deployment log setup")
+	}
+	if deploymentLogSessionStartsAfterInit(&cobra.Command{Use: "deploy"}) {
+		t.Fatal("expected deploy to start deployment log setup in root pre-run")
+	}
+}
+
+func TestStartDeploymentLogSession_CreatesDeploymentLogWithoutState(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	deploymentDir := t.TempDir()
+
+	// When
+	cleanup, err := startDeploymentLogSession(context.Background(), "deploy", deploymentDir)
+	if err != nil {
+		t.Fatalf("unexpected setup error: %v", err)
+	}
+	t.Cleanup(cleanup)
+
+	logFilePath := deploymentLogFilePath(deploymentDir)
+
+	// Then
+	if _, err := os.Stat(logFilePath); err != nil {
+		t.Fatalf("expected log file to exist at %q: %v", logFilePath, err)
+	}
+	if _, err := os.Stat(
+		filepath.Join(deploymentDir,
+			config.ExasolPersonalStateFileName)); !os.IsNotExist(
+		err,
+	) {
+		t.Fatalf("expected state file to remain untouched, got err=%v", err)
+	}
+
+	content, err := os.ReadFile(logFilePath)
+	if err != nil {
+		t.Fatalf("failed to read log file: %v", err)
+	}
+	if !strings.Contains(string(content), "deployment log session started") {
+		t.Fatalf("expected bootstrap entry in log file, got: %q", string(content))
+	}
+}
+
+func TestStartDeploymentLogSession_CreatesLogFileWhenDeploymentDirectoryDoesNotExistYet(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	// Given
+	parentDir := t.TempDir()
+	deploymentDir := filepath.Join(parentDir, "deployment")
+
+	// When
+	cleanup, err := startDeploymentLogSession(context.Background(), "init", deploymentDir)
+	if err != nil {
+		t.Fatalf("unexpected setup error: %v", err)
+	}
+	t.Cleanup(cleanup)
+
+	// Then
+	if _, err := os.Stat(deploymentLogFilePath(deploymentDir)); err != nil {
+		t.Fatalf("expected log file to be created, got err=%v", err)
+	}
+}

--- a/cmd/exasol/destroy.go
+++ b/cmd/exasol/destroy.go
@@ -62,6 +62,7 @@ var destroyCmd = &cobra.Command{
 func init() {
 	requireMinorVersionCompatibility(destroyCmd, CurrentLauncherVersion)
 	requireInitializedDeploymentDir(destroyCmd)
+	requireDeploymentFileLogging(destroyCmd)
 	registerDeploymentDirFlag(destroyCmd, commonFlags)
 	registerDestroyFlags(destroyCmd)
 	rootCmd.AddCommand(destroyCmd)

--- a/cmd/exasol/init.go
+++ b/cmd/exasol/init.go
@@ -51,6 +51,7 @@ func init() {
 	// exists, the compatibility check protects against operating on an incompatible
 	// deployment.
 	requireMinorVersionCompatibility(initCmd, minSupportedDeploymentVersionBaseline)
+	requireDeploymentFileLogging(initCmd)
 
 	// Augment long help with embedded preset names so users know what they can pass.
 	initCmd.Long = strings.TrimRight(initCmdLongDesc, "\n") +
@@ -67,7 +68,7 @@ func init() {
 
 		safePrint(deploy.EulaNoticeText)
 
-		return deploy.InitDeployment(
+		err := deploy.InitDeployment(
 			cmd.Context(),
 			infraPreset,
 			installPreset,
@@ -77,6 +78,11 @@ func init() {
 			!commonFlags.NoLauncherVersionCheck,
 			CurrentLauncherVersion,
 		)
+		if err != nil {
+			return err
+		}
+
+		return setupDeploymentLogSession(cmd, commonFlags.DeploymentDir)
 	}
 
 	registerInitFlags(initCmd, commonFlags)

--- a/cmd/exasol/install.go
+++ b/cmd/exasol/install.go
@@ -42,6 +42,8 @@ var installCmd = &cobra.Command{
 // nolint: gochecknoinits
 func init() {
 	// Install creates (init) and then operates on (deploy) the deployment directory.
+	requireDeploymentFileLogging(installCmd)
+
 	installCmd.Long = strings.TrimRight(installCmd.Long, "\n") +
 		"\n\t" + presetNamesForHelp(presets.PresetTypeInfrastructure,
 		presets.ListEmbeddedInfrastructuresPresets()) +
@@ -71,7 +73,7 @@ func init() {
 			return fmt.Errorf("initialization failed: %w", err)
 		}
 
-		return nil
+		return setupDeploymentLogSession(cmd, commonFlags.DeploymentDir)
 	}
 
 	// Perform deployment after initialization completes.

--- a/cmd/exasol/log_routing.go
+++ b/cmd/exasol/log_routing.go
@@ -1,0 +1,158 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+)
+
+type deploymentFileSink struct {
+	mu       sync.RWMutex
+	writer   io.Writer
+	minLevel slog.Level
+}
+
+func (s *deploymentFileSink) Set(writer io.Writer, minLevel slog.Level) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.writer = writer
+	s.minLevel = minLevel
+}
+
+func (s *deploymentFileSink) Clear() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.writer = nil
+}
+
+func (s *deploymentFileSink) Handle(record slog.Record) error {
+	s.mu.RLock()
+	writer := s.writer
+	minLevel := s.minLevel
+	s.mu.RUnlock()
+
+	if writer == nil {
+		return nil
+	}
+	if record.Level < minLevel {
+		return nil
+	}
+
+	_, err := writer.Write([]byte(formatFileLogRecord(record)))
+
+	return err
+}
+
+var globalDeploymentFileSink = &deploymentFileSink{}
+
+type routingHandler struct {
+	terminalHandler slog.Handler
+	fileSink        *deploymentFileSink
+}
+
+func newRoutingHandler(terminalHandler slog.Handler, fileSink *deploymentFileSink) slog.Handler {
+	return &routingHandler{
+		terminalHandler: terminalHandler,
+		fileSink:        fileSink,
+	}
+}
+
+func (h *routingHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	// Terminal visibility follows terminal handler. File capture can still require
+	// lower levels (e.g. debug) even when terminal is configured at info.
+	if h.terminalHandler.Enabled(ctx, level) {
+		return true
+	}
+
+	h.fileSink.mu.RLock()
+	defer h.fileSink.mu.RUnlock()
+
+	if h.fileSink.writer == nil {
+		return false
+	}
+
+	return level >= h.fileSink.minLevel
+}
+
+func (h *routingHandler) Handle(ctx context.Context, record slog.Record) error {
+	var terminalErr error
+	var fileErr error
+
+	if h.terminalHandler.Enabled(ctx, record.Level) {
+		terminalErr = h.terminalHandler.Handle(ctx, record)
+	}
+
+	fileErr = h.fileSink.Handle(record)
+
+	if terminalErr != nil {
+		return terminalErr
+	}
+	if fileErr != nil {
+		return fileErr
+	}
+
+	return nil
+}
+
+func (h *routingHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &routingHandler{
+		terminalHandler: h.terminalHandler.WithAttrs(attrs),
+		fileSink:        h.fileSink,
+	}
+}
+
+func (h *routingHandler) WithGroup(name string) slog.Handler {
+	return &routingHandler{
+		terminalHandler: h.terminalHandler.WithGroup(name),
+		fileSink:        h.fileSink,
+	}
+}
+
+func formatFileLogRecord(record slog.Record) string {
+	timestamp := record.Time
+	if timestamp.IsZero() {
+		timestamp = time.Now().UTC()
+	}
+
+	attrs := make([]string, 0)
+	record.Attrs(func(attr slog.Attr) bool {
+		attrs = append(attrs, fmt.Sprintf("%s=%v", attr.Key, attr.Value.Any()))
+
+		return true
+	})
+
+	attrsSuffix := ""
+	if len(attrs) > 0 {
+		attrsSuffix = " " + strings.Join(attrs, " ")
+	}
+
+	return fmt.Sprintf(
+		"[%s] [%s] %s%s\n",
+		timestamp.UTC().Format(time.RFC3339),
+		levelLabel(record.Level),
+		record.Message,
+		attrsSuffix,
+	)
+}
+
+func levelLabel(level slog.Level) string {
+	switch {
+	case level >= slog.LevelError:
+		return "ERROR"
+	case level >= slog.LevelWarn:
+		return "WARN"
+	case level >= slog.LevelInfo:
+		return "INFO"
+	default:
+		return "DEBUG"
+	}
+}

--- a/cmd/exasol/log_routing_test.go
+++ b/cmd/exasol/log_routing_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+type testTerminalHandler struct {
+	minLevel slog.Level
+	messages []string
+}
+
+func (h *testTerminalHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.minLevel
+}
+
+func (h *testTerminalHandler) Handle(_ context.Context, record slog.Record) error {
+	h.messages = append(h.messages, record.Message)
+	return nil
+}
+
+func (h *testTerminalHandler) WithAttrs(_ []slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *testTerminalHandler) WithGroup(_ string) slog.Handler {
+	return h
+}
+
+func TestRoutingHandler_DoesNotLeakDebugToTerminal(t *testing.T) {
+	t.Parallel()
+
+	terminal := &testTerminalHandler{minLevel: slog.LevelInfo}
+	fileBuffer := &bytes.Buffer{}
+	sink := &deploymentFileSink{}
+	sink.Set(fileBuffer, slog.LevelDebug)
+
+	handler := newRoutingHandler(terminal, sink)
+
+	debugRecord := slog.NewRecord(
+		time.Now().UTC(),
+		slog.LevelDebug,
+		"debug message",
+		0,
+	)
+	if err := handler.Handle(context.Background(), debugRecord); err != nil {
+		t.Fatalf("unexpected handle error: %v", err)
+	}
+
+	if len(terminal.messages) != 0 {
+		t.Fatalf("expected terminal to skip debug records, got: %#v", terminal.messages)
+	}
+	if !bytes.Contains(fileBuffer.Bytes(), []byte("[DEBUG] debug message")) {
+		t.Fatalf("expected file sink to include debug message, got: %q", fileBuffer.String())
+	}
+}
+
+func TestRoutingHandler_DebugRecordWritesToFileSink(t *testing.T) {
+	t.Parallel()
+
+	terminal := &testTerminalHandler{minLevel: slog.LevelDebug}
+	fileBuffer := &bytes.Buffer{}
+	sink := &deploymentFileSink{}
+	sink.Set(fileBuffer, slog.LevelDebug)
+
+	handler := newRoutingHandler(terminal, sink)
+
+	record := slog.NewRecord(
+		time.Now().UTC(),
+		slog.LevelDebug,
+		"normal debug message",
+		0,
+	)
+
+	if err := handler.Handle(context.Background(), record); err != nil {
+		t.Fatalf("unexpected handle error: %v", err)
+	}
+
+	if !bytes.Contains(fileBuffer.Bytes(), []byte("[DEBUG] normal debug message")) {
+		t.Fatalf("expected file sink to include debug message, got: %q", fileBuffer.String())
+	}
+}

--- a/cmd/exasol/root.go
+++ b/cmd/exasol/root.go
@@ -71,6 +71,12 @@ var rootCmd = &cobra.Command{
 			return err
 		}
 
+		if !deploymentLogSessionStartsAfterInit(cmd) {
+			if err := setupDeploymentLogSession(cmd, commonFlags.DeploymentDir); err != nil {
+				return err
+			}
+		}
+
 		// Best-effort version update hint (non-blocking; logs only when an update is available).
 		// Design decision: never block commands on this.
 		if cmd.Name() != "version" {
@@ -85,25 +91,27 @@ var rootCmd = &cobra.Command{
 }
 
 func setupLogging() error {
-	var logger *slog.Logger
+	var terminalHandler slog.Handler
 
 	selectedLevel, ok := logLevelMap[commonFlags.LogLevel]
 	if !ok {
 		return fmt.Errorf("%w: \"%s\"", ErrInvalidLogLevel, commonFlags.LogLevel)
 	}
+
 	if term.IsTerminal(int(os.Stdout.Fd())) {
 		levelVar := slog.LevelVar{}
 		levelVar.Set(selectedLevel)
 		// Design decision: when attached to a terminal, prefer human-friendly logs.
-		logger = slog.New(tint.NewHandler(os.Stderr, &tint.Options{
+		terminalHandler = tint.NewHandler(os.Stderr, &tint.Options{
 			Level: &levelVar, TimeFormat: time.DateTime,
-		}))
+		})
 	} else {
-		logger = slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+		terminalHandler = slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
 			Level: selectedLevel,
-		}))
+		})
 	}
-	slog.SetDefault(logger)
+
+	slog.SetDefault(slog.New(newRoutingHandler(terminalHandler, globalDeploymentFileSink)))
 
 	slog.Debug(
 		"using log level",
@@ -124,6 +132,8 @@ func addHelpFlag(cmd *cobra.Command) {
 }
 
 func Execute() error {
+	defer runDeploymentLogCleanup()
+
 	registerLogLevelFlag(rootCmd, commonFlags)
 
 	// Register infrastructure variable flags only for commands that need them.


### PR DESCRIPTION
## Description

Add logging to file in parallel to terminal output.
The log file is tied to a `deployment_id`, and registers debug log level by default, even if `stdout` skips it.


Fixes #

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Log file creation
- Logging handlers for `slog` stdout/file fanout
- Function annotators to specify which calls should be logged to file

## Testing

<!-- Describe how you tested your changes -->

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

Several tests written, manual deployment tests with logfile creation

## Checklist

<!-- Mark completed items with an "x" -->

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes
