### PR TITLE
docs: Add S3 permissions to instructions how to set up AWS account

### DIFF
--- a/HOWTO_SETUP_AWS_ACCOUNT.md
+++ b/HOWTO_SETUP_AWS_ACCOUNT.md
@@ -24,6 +24,7 @@ The AWS account must have the permissions and quota to launch large type instanc
    - `IAMReadOnlyAccess`
    - `IAMUserChangePassword`
    - `AmazonSSMFullAccess`
+   - `AmazonS3FullAccess`
 3. Generate AWS access keys for the user.
 
 If you want to use multi factor authentication (MFA) or other methods for authentication in your AWS account, additional steps may be required. For more information, refer to the AWS documentation: https://docs.aws.amazon.com/.


### PR DESCRIPTION
Added instructions on S3 permissions to HOTWO setuo AWS account


## Related Issue

N/A

Fixes #

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [x ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

## Testing


- [ ] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [x ] Manually tested the changes

### Test Details


## Checklist

<!-- Mark completed items with an "x" -->

- [ x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [ ] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [ ] Added/updated tests
- [ ] All tests pass locally
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

<!-- Any additional information, screenshots, or context -->
