### PR TITLE
Refactor the e2e test framework and introduce support for azure

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -177,9 +177,31 @@ tasks:
     desc: Run deployment tests
     deps: [tests-setup]
     dir: '{{.TESTS_DIR}}'
+    vars:
+      INFRA: '{{default "aws" .INFRA}}'
     cmds:
       - |
-        poetry run pytest -vv --exasol-path={{.BUILD_DIR}}{{.SEP}}{{.BINARY_NAME}} {{.TESTS_DIR}}{{.SEP}}tests{{.SEP}}deployment
+        poetry run pytest -vv --exasol-path={{.BUILD_DIR}}{{.SEP}}{{.BINARY_NAME}} --infra={{.INFRA}} {{.TESTS_DIR}}{{.SEP}}tests{{.SEP}}deployment
+
+  tests-deployment-infrastructure:
+    desc: Run infrastructure-focused deployment tests
+    deps: [tests-setup]
+    dir: '{{.TESTS_DIR}}'
+    vars:
+      INFRA: '{{default "aws" .INFRA}}'
+    cmds:
+      - |
+        poetry run pytest -vv --exasol-path={{.BUILD_DIR}}{{.SEP}}{{.BINARY_NAME}} --infra={{.INFRA}} -m "infrastructure_e2e" {{.TESTS_DIR}}{{.SEP}}tests{{.SEP}}deployment
+
+  tests-deployment-installation:
+    desc: Run installation-focused end-to-end tests
+    deps: [tests-setup]
+    dir: '{{.TESTS_DIR}}'
+    vars:
+      INFRA: '{{default "aws" .INFRA}}'
+    cmds:
+      - |
+        poetry run pytest -vv --exasol-path={{.BUILD_DIR}}{{.SEP}}{{.BINARY_NAME}} --infra={{.INFRA}} -m "installation_e2e" {{.TESTS_DIR}}{{.SEP}}tests{{.SEP}}deployment
 
   lint-ruff:
     desc: Run ruff check

--- a/doc/ci.md
+++ b/doc/ci.md
@@ -41,7 +41,7 @@ This ensures multi-platform compatibility is validated on the main branch.
 
 ### Deployment Tests (`tests-deployment.yml`)
 
-Full end-to-end tests that provision real AWS infrastructure. These are expensive and slow, so they run only when needed:
+Full end-to-end tests that provision real cloud infrastructure. These are expensive and slow, so they run only when needed:
 
 **Trigger manually via:**
 - GitHub Actions UI: [tests-deployment.yml](https://github.com/exasol/exasol-personal/actions/workflows/tests-deployment.yml) → "Run workflow"
@@ -51,7 +51,11 @@ Security guards:
 - Uses OIDC and short-lived AWS credentials
 - Should be protected by an environment approval gate and ref restrictions in repository settings
 
-**Warning:** These tests create real AWS resources and incur costs.
+Workflow input:
+- `infra`: Infrastructure preset for deployment tests (`aws` or `azure`, default `aws`)
+- The current workflow includes credential bootstrap for AWS. Azure runs require Azure credentials to be available in the runner environment.
+
+**Warning:** These tests create real cloud resources and incur costs.
 
 ## AWS Identity Provider and IAM Role for Deployment Tests
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -97,8 +97,17 @@ task tests-unit
 # Run Python integration tests
 task tests-integration
 
-# Run Python deployment tests (requires AWS credentials)
+# Run Python deployment tests (default: AWS)
 task tests-deployment
+
+# Run Python deployment tests with Azure preset
+task tests-deployment INFRA=azure
+
+# Run infrastructure-focused deployment tests
+task tests-deployment-infrastructure INFRA=aws
+
+# Run installation-focused end-to-end tests
+task tests-deployment-installation INFRA=aws
 ```
 
 #### From tests/ Directory
@@ -120,9 +129,18 @@ poetry run pytest --exasol-path=../bin/exasol tests/integration/test_cli.py::tes
 # Run with verbose output
 poetry run pytest --exasol-path=../bin/exasol tests/integration -v
 
-# Run deployment tests (requires AWS credentials)
+# Run deployment tests (default: AWS preset)
 export AWS_PROFILE=your-profile
 poetry run pytest --exasol-path=../bin/exasol tests/deployment
+
+# Run deployment tests with Azure preset
+poetry run pytest --exasol-path=../bin/exasol --infra=azure tests/deployment
+
+# Run only infrastructure-focused deployment tests
+poetry run pytest --exasol-path=../bin/exasol --infra=aws -m "infrastructure_e2e" tests/deployment
+
+# Run only installation-focused end-to-end tests
+poetry run pytest --exasol-path=../bin/exasol --infra=aws -m "installation_e2e" tests/deployment
 ```
 
 ## Continuous Integration

--- a/tests/framework/deployment.py
+++ b/tests/framework/deployment.py
@@ -3,10 +3,11 @@
 
 import json
 import logging
+import secrets
 import tempfile
 import time
 from pathlib import Path
-from subprocess import CompletedProcess, Popen
+from subprocess import CalledProcessError, CompletedProcess, Popen
 from typing import Final, Unpack
 
 import websocket
@@ -26,6 +27,11 @@ StatusStopped = "stopped"
 
 class Deployment:
     DEPLOYMENT_DIR_PREFIX: Final = "exasol-launcher-"
+    AZURE_NIC_RESERVATION_ERROR: Final = "NicReservedForAnotherVm"
+    DESTROY_RETRY_MAX_ATTEMPTS: Final = 5
+    DESTROY_RETRY_INITIAL_DELAY_SECONDS: Final = 15.0
+    DESTROY_RETRY_MAX_DELAY_SECONDS: Final = 200.0
+    DESTROY_RETRY_JITTER_FACTOR: Final = 0.20
 
     def __init__(
         self,
@@ -79,20 +85,80 @@ class Deployment:
             self.deployment_dir.name,
         )
 
-        self.launcher.destroy(self.deployment_dir.name, "--auto-approve")
+        cleanup_error = self._destroy_with_retries()
 
-        if not self.launcher.has_status(self.deployment_dir.name, StatusInitialized):
-            msg = f"Expected status `{StatusInitialized}` after `destroy`"
-            raise RuntimeError(msg)
-
-        logging.info("Verifying deployment info after destroy")
-
-        if not self.has_no_deployment():
-            msg = """no file should exist and 'initialized but not yet completed'
-                    msg after `init`"""
-            raise RuntimeError(msg)
+        if cleanup_error is not None:
+            logging.error(
+                "Cleanup did not complete for deployment_dir=%s: %s\n"
+                "deployment.log tail:\n%s\n"
+                "Deployment directory is preserved for manual investigation/cleanup.",
+                self.deployment_dir.name,
+                cleanup_error,
+                self.deployment_log_tail(),
+            )
+            return
 
         self.deployment_dir.cleanup()
+
+    def _destroy_with_retries(self) -> str | None:
+        """Destroy the deployment with exponential backoff for retryable errors."""
+        delay_seconds = self.DESTROY_RETRY_INITIAL_DELAY_SECONDS
+
+        for attempt in range(1, self.DESTROY_RETRY_MAX_ATTEMPTS + 1):
+            attempt_error: str | None = None
+            try:
+                self.launcher.destroy(self.deployment_dir.name, "--auto-approve")
+
+                if not self.launcher.has_status(
+                    self.deployment_dir.name,
+                    StatusInitialized,
+                ):
+                    attempt_error = (
+                        f"Expected status `{StatusInitialized}` after `destroy`"
+                    )
+
+                logging.info("Verifying deployment info after destroy")
+
+                if attempt_error is None and not self.has_no_deployment():
+                    attempt_error = (
+                        "no file should exist and 'initialized but not yet completed' "
+                        "msg after `init`"
+                    )
+            except (CalledProcessError, RuntimeError) as exc:
+                attempt_error = str(exc)
+
+            if attempt_error is None:
+                return None
+
+            log_tail = self.deployment_log_tail()
+            retryable = self._is_retryable_destroy_error(log_tail)
+            if (not retryable) or (attempt == self.DESTROY_RETRY_MAX_ATTEMPTS):
+                return attempt_error
+
+            jitter = delay_seconds * self.DESTROY_RETRY_JITTER_FACTOR
+            jitter_fraction = secrets.randbelow(1001) / 1000.0
+            wait_seconds = delay_seconds + (jitter * jitter_fraction)
+            logging.warning(
+                "Retryable destroy failure for deployment_dir=%s "
+                "(attempt %s/%s). Waiting %.1fs before retry.\n"
+                "deployment.log tail:\n%s",
+                self.deployment_dir.name,
+                attempt,
+                self.DESTROY_RETRY_MAX_ATTEMPTS,
+                wait_seconds,
+                log_tail,
+            )
+            time.sleep(wait_seconds)
+            delay_seconds = min(
+                delay_seconds * 2.0,
+                self.DESTROY_RETRY_MAX_DELAY_SECONDS,
+            )
+
+        return "Destroy retries exhausted"
+
+    def _is_retryable_destroy_error(self, log_tail: str) -> bool:
+        """Return true when the destroy failure is considered transient."""
+        return self.AZURE_NIC_RESERVATION_ERROR in log_tail
 
     def deploy(self, *args: str) -> CompletedProcess[str]:
         return self.launcher.deploy(self.deployment_dir.name, *args)
@@ -254,3 +320,14 @@ class Deployment:
         status: str = json.loads(response)["status"]
 
         return status == "ok"
+
+    def deployment_log_tail(self, max_lines: int = 200) -> str:
+        """Return the tail of deployment.log for diagnostics."""
+        log_file = Path(self.deployment_dir.name) / "deployment.log"
+        if not log_file.exists():
+            return "<deployment.log not found>"
+
+        with log_file.open(encoding="utf-8", errors="replace") as f:
+            lines = f.readlines()
+
+        return "".join(lines[-max_lines:]).strip()

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -29,6 +29,13 @@ types-requests = "^2.31.0"
 log_cli = true
 log_cli_level = "INFO"
 log_cli_format = "%(asctime)s %(levelname)s %(funcName)s: %(message)s"
+markers = [
+    "launcher_tests: Tests that validate launcher CLI and behavioral contracts without real cloud deployment.",
+    "installation_e2e: End-to-end tests focused on installation-level behavior.",
+    "infrastructure_e2e: End-to-end tests focused on cloud infrastructure behavior.",
+    "provider_aws: Tests that assert AWS-specific behavior.",
+    "provider_azure: Tests that assert Azure-specific behavior.",
+]
 
 [tool.mypy]
 python_version = "3.13"

--- a/tests/tests/conftest.py
+++ b/tests/tests/conftest.py
@@ -13,8 +13,22 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         default="exasol",
         help="Path to the exasol binary",
     )
+    parser.addoption(
+        "--infra",
+        type=str,
+        required=False,
+        action="store",
+        default="aws",
+        choices=["aws", "azure"],
+        help="Infrastructure preset to use for deployment tests",
+    )
 
 
 @pytest.fixture(scope="session")
 def exasol_path(request: pytest.FixtureRequest) -> str:
     return str(request.config.getoption("--exasol-path"))
+
+
+@pytest.fixture(scope="session")
+def infra(request: pytest.FixtureRequest) -> str:
+    return str(request.config.getoption("--infra"))

--- a/tests/tests/deployment/test_custom.py
+++ b/tests/tests/deployment/test_custom.py
@@ -16,6 +16,8 @@ import semver
 from framework.deployment import Deployment
 from framework.launcher import DeploymentConfig, Launcher
 
+pytestmark = [pytest.mark.infrastructure_e2e]
+
 
 @pytest.fixture
 def instance_type(request: pytest.FixtureRequest) -> str | None:
@@ -26,17 +28,18 @@ def instance_type(request: pytest.FixtureRequest) -> str | None:
 @pytest.fixture
 def custom_deployment(
     exasol_path: str,
+    infra: str,
     instance_type: str | None,
 ) -> Iterator[tuple[Deployment, DeploymentConfig]]:
     """Deployment with custom parameters to test all customization options."""
     test_pw: Final = """$x\n${y}\nunbalanced quote: ' another one: " $(echo test)"""
     test_admin_pw: Final = "MyAdminUI!Pass123"
 
-    if not instance_type:
+    if instance_type is None and infra == "aws":
         instance_type = "t3.xlarge"
 
     config = DeploymentConfig(
-        infra="aws",
+        infra=infra,
         cluster_size=1,
         instance_type=instance_type,
         data_volume_size=120,
@@ -57,29 +60,57 @@ def custom_deployment(
         deployment.cleanup()
 
 
+@pytest.mark.parametrize(
+    ("target_infra", "instance_type"),
+    [
+        pytest.param(
+            "aws",
+            "t3.micro",
+            marks=pytest.mark.provider_aws,
+            id="aws-t3.micro",
+        ),
+        pytest.param(
+            "aws",
+            "t2.small",
+            marks=pytest.mark.provider_aws,
+            id="aws-t2.small",
+        ),
+        pytest.param(
+            "azure",
+            "Standard_B2s",
+            marks=pytest.mark.provider_azure,
+            id="azure-Standard_B2s",
+        ),
+    ],
+    indirect=["instance_type"],
+)
 @pytest.mark.usefixtures("instance_type")
-@pytest.mark.parametrize("instance_type", ["t3.micro", "t2.small"], indirect=True)
 def test_custom_deployment_rejects_small_instance_types(
     request: pytest.FixtureRequest,
+    infra: str,
+    target_infra: str,
 ) -> None:
     """Deployment should fail for undersized instance types."""
+    if infra != target_infra:
+        pytest.skip(f"{target_infra}-specific instance type validation")
+
+    expected_instance_type = request.getfixturevalue("instance_type")
+
     try:
         _deployment, config = request.getfixturevalue("custom_deployment")
-        assert config.instance_type in ("t3.micro", "t2.small")
+        assert config.instance_type == expected_instance_type
         pytest.fail(f"Deployment should fail for instance_type={config.instance_type}")
     except (subprocess.CalledProcessError, RuntimeError):
         # Expected failure from Terraform or deployment layer - pass
-        inst_type = request.getfixturevalue("instance_type")
         logging.info(
             "Expected deployment failure for instance_type=%s",
-            inst_type,
+            expected_instance_type,
         )
         return
     except Exception as unexpected:
-        inst_type = request.getfixturevalue("instance_type")
         logging.exception(
             "Unexpected exception occurred for instance_type=%s",
-            inst_type,
+            expected_instance_type,
         )
         pytest.fail(f"Unexpected exception type: {type(unexpected).__name__}")
 

--- a/tests/tests/deployment/test_standard_deployment.py
+++ b/tests/tests/deployment/test_standard_deployment.py
@@ -53,8 +53,9 @@ def _connect_worker(launcher_path: str, deployment_dir: str) -> None:
 
 
 @pytest.fixture(scope="session")
-def reusable_deployment(exasol_path: str) -> Deployment:  # type: ignore[misc]
-    config = DeploymentConfig(infra="aws", cluster_size=2)
+def reusable_deployment(exasol_path: str, infra: str) -> Deployment:  # type: ignore[misc]
+    cluster_size = 2 if infra == "aws" else 1
+    config = DeploymentConfig(infra=infra, cluster_size=cluster_size)
     deployment = Deployment(Launcher(exasol_path), config=config)
     try:
         deployment_proc = deployment.deploy_no_block()
@@ -83,7 +84,10 @@ def reusable_deployment(exasol_path: str) -> Deployment:  # type: ignore[misc]
 
         deploy_return_code = deployment_proc.wait(timeout=20 * 60)
         if deploy_return_code != 0:
-            msg = f"Deploy command failed with code {deploy_return_code}"
+            msg = (
+                f"Deploy command failed with code {deploy_return_code}\n"
+                f"deployment.log tail:\n{deployment.deployment_log_tail()}"
+            )
             raise RuntimeError(msg)
 
         logging.info("Checking status database available")
@@ -98,6 +102,7 @@ def reusable_deployment(exasol_path: str) -> Deployment:  # type: ignore[misc]
         deployment.cleanup()
 
 
+@pytest.mark.installation_e2e
 def test_connectable(reusable_deployment: Deployment) -> None:
     assert reusable_deployment.db_connectable()
 
@@ -110,6 +115,7 @@ def test_connectable(reusable_deployment: Deployment) -> None:
 @pytest.mark.skipif(
     sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
 )
+@pytest.mark.installation_e2e
 def test_single_query(reusable_deployment: Deployment) -> None:
     query: Final = "SELECT * FROM Dual"
 
@@ -143,6 +149,7 @@ def test_single_query(reusable_deployment: Deployment) -> None:
 @pytest.mark.skipif(
     sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
 )
+@pytest.mark.installation_e2e
 def test_exit_command(reusable_deployment: Deployment) -> None:
     queries: Final = [
         "exit",
@@ -160,6 +167,7 @@ def test_exit_command(reusable_deployment: Deployment) -> None:
 @pytest.mark.skipif(
     sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
 )
+@pytest.mark.installation_e2e
 def test_multiple_queries(reusable_deployment: Deployment) -> None:
     queries: Final = [
         "CREATE SCHEMA test_multiple_queries;",
@@ -198,6 +206,7 @@ def test_multiple_queries(reusable_deployment: Deployment) -> None:
 @pytest.mark.skipif(
     sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
 )
+@pytest.mark.installation_e2e
 def test_file_import(reusable_deployment: Deployment) -> None:
     people_csv_path: Final = Path(__file__).parent / Path("assets/people.csv")
 
@@ -241,6 +250,7 @@ def test_file_import(reusable_deployment: Deployment) -> None:
 @pytest.mark.skipif(
     sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
 )
+@pytest.mark.installation_e2e
 def test_connect_table_width(reusable_deployment: Deployment) -> None:
     queries: Final = [
         "CREATE SCHEMA test_connect_table_width;",
@@ -303,6 +313,7 @@ def test_connect_table_width(reusable_deployment: Deployment) -> None:
 @pytest.mark.skipif(
     sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
 )
+@pytest.mark.installation_e2e
 def test_license_session_limit(reusable_deployment: Deployment) -> None:
     # license_session_limit is the limit defined in Exasol Personal
     # license. This value should match it.
@@ -346,6 +357,7 @@ def test_license_session_limit(reusable_deployment: Deployment) -> None:
 @pytest.mark.skipif(
     sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
 )
+@pytest.mark.infrastructure_e2e
 def test_stop_and_start(reusable_deployment: Deployment) -> None:
     # Using resuable_deployment fixture
     assert reusable_deployment.db_connectable()
@@ -395,6 +407,7 @@ def test_stop_and_start(reusable_deployment: Deployment) -> None:
 @pytest.mark.skipif(
     sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
 )
+@pytest.mark.infrastructure_e2e
 def test_start_interrupt_sets_interrupted_state(
     reusable_deployment: Deployment,
 ) -> None:
@@ -453,8 +466,11 @@ def test_start_interrupt_sets_interrupted_state(
 @pytest.mark.skipif(
     sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
 )
+@pytest.mark.infrastructure_e2e
+@pytest.mark.provider_aws
 def test_remote_archive_registered(
     reusable_deployment: Deployment,
+    infra: str,
 ) -> None:
     """Scenario: Verify that a remote archive volume is registered via Admin UI.
 
@@ -465,6 +481,9 @@ def test_remote_archive_registered(
     Then we should receive a successful response
     And the response should contain the 'default_archive' backup option
     """
+    if infra != "aws":
+        pytest.skip("Remote archive verification is only supported for AWS today")
+
     # ========== GIVEN ==========
     # Ensure deployment is running (previous tests may have stopped it)
     if not reusable_deployment.has_status(StatusDatabaseReady):


### PR DESCRIPTION
## Description

Refactors deployment e2e testing to support multi-provider execution (AWS/Azure), separates installation vs infrastructure test taxonomy, improves Azure teardown stability, and prepares test structure for future
CI matrix expansion.

## Related Issue


## Type of Change

- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [x] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [x] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

<!-- List the key changes in this PR -->

- Added provider-aware deployment test execution (--infra plumbing in test fixtures/tasks/workflow/action), so deployment tests can run against AWS or Azure.
- Refactored deployment test taxonomy:
    - installation_e2e and infrastructure_e2e are now disjoint.
    - Infra-only tests are explicitly marked; installation tests are no longer implicitly infra via module-level mark.
- Added/updated provider-specific coverage in custom deployment tests:
  - undersized AWS instance rejection (t3.micro, t2.small)
  - undersized Azure instance rejection (Standard_B2s)
  - Improved cleanup robustness for Azure destroy race conditions.

## Testing

<!-- Describe how you tested your changes -->

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

<!-- Describe your testing approach -->

## Checklist

<!-- Mark completed items with an "x" -->

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

<!-- Any additional information, screenshots, or context -->
