### PR TITLE
feat: Implement exasol shell container to open an interactive shell into cos…

### DIFF
--- a/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/connectCos.sh
+++ b/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/connectCos.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# shellcheck source=./shared_post_install.sh
+source "${SCRIPT_DIR}/shared_post_install.sh"
+
+PLAY_ID="$("$C4_PATH" config -e .play.id)"
+
+exec "$C4_PATH" connect -s cos -i "$PLAY_ID"

--- a/cmd/exasol/diag.go
+++ b/cmd/exasol/diag.go
@@ -11,7 +11,7 @@ const diagCmdShortDesc = "Diagnostic tools for an active deployment"
 
 const diagCmdLongDesc = diagCmdShortDesc + `
 
-Includes subcommands for shell connections and deployment configuration inspection.
+Includes subcommands for deployment configuration inspection and recovery tooling.
 `
 
 var diagCmd = &cobra.Command{

--- a/cmd/exasol/diagShell.go
+++ b/cmd/exasol/diagShell.go
@@ -8,43 +8,49 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const shellCmdShortDesc = "Establish a secure shell connection to a node"
+const diagShellCmdShortDesc = "Establish a secure shell connection to a node"
 
-const shellCmdLongDesc = shellCmdShortDesc + `
+const diagShellCmdLongDesc = diagShellCmdShortDesc + `
 
 Creates a secure shell connection to a node in the active deployment.
 If no specific node is specified, connects to the first node available.
 `
 
-var shellCmdOpts = struct {
+var diagShellCmdOpts = struct {
 	Node string
 }{
 	Node: "",
 }
 
-var shellCmd = &cobra.Command{
-	Use:   "shell",
-	Short: shellCmdShortDesc,
-	Long:  shellCmdLongDesc,
-	Args:  cobra.NoArgs,
+var diagShellCmd = &cobra.Command{
+	Use:        "shell",
+	Short:      diagShellCmdShortDesc,
+	Long:       diagShellCmdLongDesc,
+	Args:       cobra.NoArgs,
+	Hidden:     true,
+	Deprecated: "use 'exasol shell host' instead",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cmd.SilenceUsage = true
-		return deploy.Shell(cmd.Context(), commonFlags.DeploymentDir, shellCmdOpts.Node)
+		return deploy.OpenHostShell(
+			cmd.Context(),
+			commonFlags.DeploymentDir,
+			diagShellCmdOpts.Node,
+		)
 	},
 }
 
-func registerShellFlags() {
-	shellCmd.Flags().StringVarP(
-		&shellCmdOpts.Node, "node", "n", "",
+func registerDiagShellFlags() {
+	diagShellCmd.Flags().StringVarP(
+		&diagShellCmdOpts.Node, "node", "n", "",
 		"Name of the node to connect to. Connects to the first available node if not specified",
 	)
 }
 
 // nolint: gochecknoinits
 func init() {
-	requireMinorVersionCompatibility(shellCmd, CurrentLauncherVersion)
-	requireInitializedDeploymentDir(shellCmd)
-	registerShellFlags()
-	registerDeploymentDirFlag(shellCmd, commonFlags)
-	diagCmd.AddCommand(shellCmd)
+	requireMinorVersionCompatibility(diagShellCmd, CurrentLauncherVersion)
+	requireInitializedDeploymentDir(diagShellCmd)
+	registerDiagShellFlags()
+	registerDeploymentDirFlag(diagShellCmd, commonFlags)
+	diagCmd.AddCommand(diagShellCmd)
 }

--- a/cmd/exasol/shell.go
+++ b/cmd/exasol/shell.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import "github.com/spf13/cobra"
+
+const shellRootCmdShortDesc = "Shell access to deployment host and container"
+
+const shellRootCmdLongDesc = shellRootCmdShortDesc + `
+
+Includes subcommands for host OS shell and COS container shell access.
+`
+
+var shellRootCmd = &cobra.Command{
+	Use:   "shell",
+	Short: shellRootCmdShortDesc,
+	Long:  shellRootCmdLongDesc,
+	Args:  cobra.NoArgs,
+}
+
+// nolint: gochecknoinits
+func init() {
+	rootCmd.AddCommand(shellRootCmd)
+}

--- a/cmd/exasol/shellContainer.go
+++ b/cmd/exasol/shellContainer.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"github.com/exasol/exasol-personal/internal/deploy"
+	"github.com/spf13/cobra"
+)
+
+const shellContainerCmdShortDesc = "Establish an interactive COS container shell connection"
+
+const shellContainerCmdLongDesc = shellContainerCmdShortDesc + `
+
+Creates an interactive COS container shell connection in the active deployment.
+COS is cluster-scoped and uses the access node.
+`
+
+var shellContainerCmd = &cobra.Command{
+	Use:   "container",
+	Short: shellContainerCmdShortDesc,
+	Long:  shellContainerCmdLongDesc,
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		cmd.SilenceUsage = true
+		return deploy.OpenCOSShell(cmd.Context(), commonFlags.DeploymentDir)
+	},
+}
+
+// nolint: gochecknoinits
+func init() {
+	requireMinorVersionCompatibility(shellContainerCmd, CurrentLauncherVersion)
+	requireInitializedDeploymentDir(shellContainerCmd)
+	registerDeploymentDirFlag(shellContainerCmd, commonFlags)
+	shellRootCmd.AddCommand(shellContainerCmd)
+}

--- a/cmd/exasol/shellHost.go
+++ b/cmd/exasol/shellHost.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"github.com/exasol/exasol-personal/internal/deploy"
+	"github.com/spf13/cobra"
+)
+
+const shellHostCmdShortDesc = "Establish a secure shell connection to a host node"
+
+const shellHostCmdLongDesc = shellHostCmdShortDesc + `
+
+Creates a secure host OS shell connection to a node in the active deployment.
+If no specific node is specified, connects to the first node available.
+`
+
+var shellHostCmdOpts = struct {
+	Node string
+}{
+	Node: "",
+}
+
+var shellHostCmd = &cobra.Command{
+	Use:   "host",
+	Short: shellHostCmdShortDesc,
+	Long:  shellHostCmdLongDesc,
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		cmd.SilenceUsage = true
+		return deploy.OpenHostShell(cmd.Context(), commonFlags.DeploymentDir, shellHostCmdOpts.Node)
+	},
+}
+
+func registerShellHostFlags() {
+	shellHostCmd.Flags().StringVarP(
+		&shellHostCmdOpts.Node, "node", "n", "",
+		"Name of the node to connect to. Connects to the first available node if not specified",
+	)
+}
+
+// nolint: gochecknoinits
+func init() {
+	requireMinorVersionCompatibility(shellHostCmd, CurrentLauncherVersion)
+	requireInitializedDeploymentDir(shellHostCmd)
+	registerShellHostFlags()
+	registerDeploymentDirFlag(shellHostCmd, commonFlags)
+	shellRootCmd.AddCommand(shellHostCmd)
+}

--- a/internal/deploy/connection_instructions.go
+++ b/internal/deploy/connection_instructions.go
@@ -114,7 +114,8 @@ To connect using the CLI:
 
 === SSH Connection Instructions ===
   Public IP: ` + connectionDetails.PublicIp + `
-  Preferred: exasol diag shell
+  Primary admin shell (COS): exasol shell container
+  Host shell (OS): exasol shell host
   Alternative: ` + connectionDetails.SSHCommand + `
 
 `

--- a/internal/deploy/shell.go
+++ b/internal/deploy/shell.go
@@ -16,24 +16,43 @@ import (
 
 var ErrNoNodesFound = errors.New("no nodes found in the active deployment")
 
-// Start an interactive shell using stdin stdout & stderr.
-func Shell(ctx context.Context, deploymentDir string, selectedNode string) error {
+// OpenHostShell starts an interactive shell using stdin stdout & stderr.
+func OpenHostShell(ctx context.Context, deploymentDir string, selectedNode string) error {
 	return withDeploymentSharedLock(ctx, deploymentDir, func(dir string) error {
-		return shellUnsafe(ctx, dir, selectedNode)
+		sshRemote, err := sshRemoteForNodeUnsafe(dir, selectedNode)
+		if err != nil {
+			return err
+		}
+
+		return sshRemote.Shell(ctx, os.Stdout, os.Stderr)
 	})
 }
 
-func shellUnsafe(ctx context.Context, deploymentDir string, selectedNode string) error {
+// OpenCOSShell opens an interactive COS session via the access node (n11).
+func OpenCOSShell(ctx context.Context, deploymentDir string) error {
+	return withDeploymentSharedLock(ctx, deploymentDir, func(dir string) error {
+		sshRemote, err := sshRemoteForNodeUnsafe(dir, "n11")
+		if err != nil {
+			return err
+		}
+
+		cosCommand := "/usr/bin/env bash /opt/exasol_launcher/scripts/connectCos.sh"
+
+		return sshRemote.RunInteractiveCommand(ctx, cosCommand, os.Stdout, os.Stderr)
+	})
+}
+
+func sshRemoteForNodeUnsafe(deploymentDir string, selectedNode string) (*remote.SSHRemote, error) {
 	nodeDetails, err := config.ReadNodeDetails(deploymentDir)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if selectedNode == "" {
 		nodes := nodeDetails.ListNodes()
 
 		if len(nodes) == 0 {
-			return ErrNoNodesFound
+			return nil, ErrNoNodesFound
 		}
 
 		selectedNode = nodes[0]
@@ -41,7 +60,7 @@ func shellUnsafe(ctx context.Context, deploymentDir string, selectedNode string)
 
 	sshDetails, err := nodeDetails.GetSSHDetails(selectedNode)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	keyFilePath := sshDetails.KeyFile
@@ -51,7 +70,7 @@ func shellUnsafe(ctx context.Context, deploymentDir string, selectedNode string)
 
 	keyData, err := os.ReadFile(keyFilePath)
 	if err != nil {
-		return fmt.Errorf("%w: could not read SSH key file %s", err, keyFilePath)
+		return nil, fmt.Errorf("%w: could not read SSH key file %s", err, keyFilePath)
 	}
 
 	sshRemote := remote.NewSshRemote(&remote.SSHConnectionOptions{
@@ -61,5 +80,5 @@ func shellUnsafe(ctx context.Context, deploymentDir string, selectedNode string)
 		Key:  keyData,
 	})
 
-	return sshRemote.Shell(ctx, os.Stdout, os.Stderr)
+	return sshRemote, nil
 }

--- a/internal/remote/remote.go
+++ b/internal/remote/remote.go
@@ -14,6 +14,15 @@ type Remote interface {
 	// Returns ErrFailedToConnect on failure to connect.
 	Shell(ctx context.Context, out io.Writer, errOut io.Writer) error
 
+	// RunInteractiveCommand starts a remote command in a PTY using stdio as input.
+	// Returns ErrFailedToConnect on failure to connect.
+	RunInteractiveCommand(
+		ctx context.Context,
+		command string,
+		out io.Writer,
+		errOut io.Writer,
+	) error
+
 	// RunScript runs the script on the remote server.
 	// Returns ErrFailedToConnect on failure to connect.
 	RunScript(ctx context.Context, script io.Reader, out io.Writer, errOut io.Writer) error

--- a/internal/remote/ssh.go
+++ b/internal/remote/ssh.go
@@ -74,6 +74,45 @@ func (s *SSHRemote) Shell(ctx context.Context, out io.Writer, errOut io.Writer) 
 	return nil
 }
 
+func (s *SSHRemote) RunInteractiveCommand(
+	ctx context.Context,
+	command string,
+	out io.Writer,
+	errOut io.Writer,
+) error {
+	session, err := startSSHSession(s.options)
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	restore, err := configureSSHSessionPty(session, out, errOut)
+	if err != nil {
+		return err
+	}
+	defer restore()
+
+	shellSessionCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	go func() {
+		<-shellSessionCtx.Done()
+		session.Close() // nolint: gosec
+	}()
+
+	// Run command in an interactive PTY session so tools like c4 connect can
+	// provide a terminal-like UX.
+	if err := session.Run(command); err != nil {
+		if errors.Is(err, &ssh.ExitError{}) {
+			return nil
+		}
+
+		return err
+	}
+
+	return nil
+}
+
 func (s *SSHRemote) RunScript(ctx context.Context, script io.Reader, out, errOut io.Writer) error {
 	// Normalize Windows CRLF to Unix LF to prevent Bash errors (remove carriage returns)
 	// Ensures scripts run correctly across all platforms

--- a/tests/tests/deployment/test_standard_deployment.py
+++ b/tests/tests/deployment/test_standard_deployment.py
@@ -314,6 +314,55 @@ def test_connect_table_width(reusable_deployment: Deployment) -> None:
     sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
 )
 @pytest.mark.installation_e2e
+def test_diag_cos_runs_confd_client(reusable_deployment: Deployment) -> None:
+    # Given: A running deployment and a PTY for an interactive container shell session.
+    launcher_path = reusable_deployment.launcher.launcher_path
+    deployment_dir = reusable_deployment.deployment_dir.name
+    master_fd, slave_fd = os.openpty()
+
+    proc = subprocess.Popen(
+        [launcher_path, "shell", "container", "--deployment-dir", deployment_dir],
+        stdin=slave_fd,
+        stdout=slave_fd,
+        stderr=slave_fd,
+    )
+
+    try:
+        # When: We run a COS-only command and then exit the session.
+        os.write(master_fd, b"confd_client db_list --json\n")
+        os.write(master_fd, b"echo COS_DB_LIST_RC:$?\n")
+        os.write(master_fd, b"exit\n")
+        os.write(master_fd, b"exit\n")
+
+        return_code = proc.wait(timeout=120)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+
+        os.close(slave_fd)
+
+    # Read all output from the PTY.
+    output_raw = b""
+    try:
+        while chunk := os.read(master_fd, 1024):
+            output_raw += chunk
+    except OSError:
+        pass
+    finally:
+        os.close(master_fd)
+
+    output = output_raw.decode("utf-8", errors="replace")
+
+    # Then: The command succeeded from COS and the session exited cleanly.
+    assert return_code == 0
+    assert "COS_DB_LIST_RC:0" in output
+    assert "command not found" not in output.lower()
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
+)
+@pytest.mark.installation_e2e
 def test_license_session_limit(reusable_deployment: Deployment) -> None:
     # license_session_limit is the limit defined in Exasol Personal
     # license. This value should match it.


### PR DESCRIPTION
## Description

Added a `exasol shell container` command to open an interactive shell into the cos container, for easy access into database administration.
Moved `exasol diag shell` to  `exasol shell host` and left the original route intact with a deprecation warning

## Related Issue


## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [x] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Added and documented the `exasol diag cos` command
- Moved `exasol diag shell` to  `exasol shell host`
- Added utility methods for executing an interactive shell through an SSH connection
- Added e2e tests for the `exasol shell container` command

## Testing

<!-- Describe how you tested your changes -->

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details


## Checklist

<!-- Mark completed items with an "x" -->

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

<!-- Any additional information, screenshots, or context -->
