### PR TITLE
feat: Support to enable backup archive in azure - SPOT-28929

### DIFF
--- a/assets/infrastructure/azure/README.md
+++ b/assets/infrastructure/azure/README.md
@@ -21,7 +21,10 @@ This document describes the Infrastructure as Code (IaC) implementation for Exas
 - The data disk is attached at LUN `0`.
 - The node metadata exposes a provider-neutral final disk alias `/dev/exasol_data_01`.
 - The udev match clause for the data disk is fully resolved at Terraform plan time using the deterministic LUN-based symlink path (`/dev/disk/azure/data/by-lun/<lun>`). During node preparation, a udev rule is written from this pre-built clause and udev creates the `/dev/exasol_data_01` alias automatically when the disk appears — no runtime discovery or polling is needed.
-- Remote archive integration is not currently implemented in this Azure preset.
+- A remote archive volume on Azure Blob Storage is created and registered automatically when `blob_archive_enabled` is true (default).
+- The preset creates a per-deployment Storage Account and a private Blob container named `archive`.
+- The Storage Account keeps the standard blob endpoint enabled, but access is restricted with storage firewall rules to the deployment subnet.
+- Exasol currently uses the storage account name and an access key to authenticate the Azure remote archive volume.
 
 ### Networking
 - A single resource group contains the deployment resources.
@@ -63,6 +66,7 @@ The following inbound ports are opened from `var.allowed_cidr`:
 1. OpenTofu plan/apply:
    - generates a deployment ID
    - creates the resource group, network, NSG, public IPs, NICs, VMs, and managed data disks
+   - creates Azure Blob Storage resources for the remote archive volume when `blob_archive_enabled` is true
    - renders cloud-init for each node
 2. Cloud-init on each node:
    - writes deployment metadata and node metadata under `/etc/exasol_launcher/`
@@ -71,6 +75,7 @@ The following inbound ports are opened from `var.allowed_cidr`:
 3. Node initialization:
    - systemd runs the shared preparation and installation workflow
    - Exasol is installed using the common disk alias `/dev/exasol_data_01`
+   - the access node registers the Azure Blob container as the remote archive volume `default_archive`
 4. Local artifacts:
    - `deployment.json` - deployment summary
    - `secrets.json` - generated credentials
@@ -84,6 +89,7 @@ The following inbound ports are opened from `var.allowed_cidr`:
 ## Credentials
 - Database and Admin UI passwords are generated unless explicitly provided.
 - The generated SSH private key is written locally with mode `0600`.
+- Remote archive registration uses the Azure Storage Account name and access key generated for the deployment.
 
 ## Permissions
 - The operator identity running OpenTofu needs Azure permissions to manage:
@@ -93,6 +99,8 @@ The following inbound ports are opened from `var.allowed_cidr`:
   - NICs and NSGs
   - virtual machines
   - managed disks
+- Storage Accounts and Blob containers
+- The deployment identity must also be able to read storage account keys because Exasol's Azure remote archive integration uses shared-key authentication.
 - For broad access, Azure built-in `Contributor` scoped to the target resource group is usually sufficient.
 - For least privilege, use a custom Azure RBAC role that covers the resource types above.
 - The checked-in RBAC role examples in this directory can be used as custom Azure role definitions for this preset.
@@ -103,11 +111,10 @@ The following inbound ports are opened from `var.allowed_cidr`:
 
 ## Configuration Notes
 - `power_state` controls the VM lifecycle: `running` starts VMs, `stopped` deallocates them (releases compute but preserves disks).
-- Remote archive integration is not currently implemented for Azure.
+- `blob_archive_enabled` controls whether Azure Blob Storage resources are created and the remote archive volume is registered.
 - `availabilityZone` is currently empty in the generated deployment metadata.
 - `disk_sku` controls the Azure managed disk SKU used for both OS and data disks.
 
 ## Notes and Limitations
 - The preset currently relies on public IP connectivity for node access.
-- Archive storage integration is not yet implemented with Azure-native services.
 - The SSH private key is written as `node_access.pem`.

--- a/assets/infrastructure/azure/cloudinit.tf
+++ b/assets/infrastructure/azure/cloudinit.tf
@@ -90,12 +90,22 @@ locals {
     }
     postInstall = {
       # postInstall hooks run on the *access node (n11) only*
-      scripts = []
+      scripts = var.blob_archive_enabled ? ["/opt/exasol_launcher/scripts/azure_registerBlobArchiveVolume.sh"] : []
     }
         
     azure = {
       location     = var.location
       instanceType = var.instance_type
+
+      archive = {
+        enabled            = var.blob_archive_enabled
+        storageAccountName = local.archive_storage_account_name
+        containerName      = local.archive_container_name
+        url                = local.archive_container_url
+        username           = local.archive_storage_account_name
+        password           = try(azurerm_storage_account.remote_archive[0].primary_access_key, "")
+        volumeName         = local.archive_volume_name
+      }
 
       image = {
         publisher = var.image_publisher

--- a/assets/infrastructure/azure/files/opt/exasol_launcher/scripts/azure_registerBlobArchiveVolume.sh
+++ b/assets/infrastructure/azure/files/opt/exasol_launcher/scripts/azure_registerBlobArchiveVolume.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+# This script registers an Azure Blob container as a remote archive volume using confd_client.
+# Note that this is only run on one node (n11) via the post-install systemd unit.
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# shellcheck source=./logging.sh
+source "${SCRIPT_DIR}/logging.sh"
+
+# shellcheck source=./config.sh
+source "${SCRIPT_DIR}/config.sh"
+
+source "${SCRIPT_DIR}/shared_post_install.sh"
+
+log_substep_info "Looking up cluster PLAY_ID"
+PLAY_ID="$("$C4_PATH" config -e .play.id)"
+
+ARCHIVE_ENABLED="$(infra_jq -er '.azure.archive.enabled')"
+if [[ "${ARCHIVE_ENABLED}" != "true" ]]; then
+  log_substep_info "Archive setup disabled; skipping registration"
+  exit 0
+fi
+
+archive_url="$(infra_jq -er '.azure.archive.url')"
+archive_username="$(infra_jq -er '.azure.archive.username')"
+archive_password="$(infra_jq -er '.azure.archive.password')"
+archive_volume_name="$(infra_jq -er '.azure.archive.volumeName')"
+
+log_substep_info "Registering Azure Blob container ${archive_url} as archive volume"
+
+{
+  printf 'ARCHIVE_URL=%q\n' "${archive_url}"
+  printf 'ARCHIVE_USERNAME=%q\n' "${archive_username}"
+  printf 'ARCHIVE_PASSWORD=%q\n' "${archive_password}"
+  printf 'ARCHIVE_VOLUME_NAME=%q\n' "${archive_volume_name}"
+  cat <<'CONNECTEOF'
+set -Eeuo pipefail
+
+DB_NAME=$(confd_client db_list --json | jq '.[0]')
+if [[ -z "${DB_NAME}" ]]; then
+  exit 1
+fi
+
+OWNER_TUPLE=$(confd_client db_info db_name: "${DB_NAME}" --json | jq -c '.config.owner')
+if [[ -z "${OWNER_TUPLE}" ]]; then
+  exit 1
+fi
+
+if ! confd_client remote_volume_add \
+  vol_type: azure \
+  url: "${ARCHIVE_URL}" \
+  username: "${ARCHIVE_USERNAME}" \
+  password: "${ARCHIVE_PASSWORD}" \
+  owner: "${OWNER_TUPLE}" \
+  remote_volume_name: "${ARCHIVE_VOLUME_NAME}"; then
+  exit 1
+fi
+
+CONNECTEOF
+} | "$C4_PATH" connect -s cos -i "$PLAY_ID"

--- a/assets/infrastructure/azure/main.tf
+++ b/assets/infrastructure/azure/main.tf
@@ -94,9 +94,19 @@ resource "azurerm_storage_account" "remote_archive" {
   account_kind             = "StorageV2"
 
   https_traffic_only_enabled      = true
+
+  # Enforce a modern transport baseline for archive access.
   min_tls_version                 = "TLS1_2"
+
+  # Prevent anonymous public access to blobs in this storage account.
   allow_nested_items_to_be_public = false
+
+  # Exasol currently authenticates Azure remote archive volumes with the
+  # storage account name and an access key, so shared key auth must stay enabled.
   shared_access_key_enabled       = true
+
+  # Keep the standard blob endpoint reachable and rely on network_rules below
+  # to restrict access to the deployment subnet.
   public_network_access_enabled   = true
 
   network_rules {

--- a/assets/infrastructure/azure/main.tf
+++ b/assets/infrastructure/azure/main.tf
@@ -25,6 +25,15 @@ locals {
   adminui_password_final = var.adminui_password != "" ? var.adminui_password : random_password.adminui.result
 }
 
+resource "random_string" "archive_storage_suffix" {
+  count   = var.blob_archive_enabled ? 1 : 0
+  length  = 6
+  upper   = false
+  lower   = true
+  numeric = true
+  special = false
+}
+
 # Fetch specs of specified VM size from Azure
 data "azapi_resource_list" "vm_sizes" {
   type                   = "Microsoft.Compute/locations/vmSizes@2024-11-01"
@@ -39,6 +48,11 @@ locals {
   selected_vm    = one([for s in local.vm_sizes : s if s.name == var.instance_type])
   instance_vcpus = local.selected_vm != null ? local.selected_vm.numberOfCores : 0
   instance_ram_gb = local.selected_vm != null ? local.selected_vm.memoryInMB / 1024 : 0
+
+  archive_storage_account_name = var.blob_archive_enabled ? "exa${var.deployment_id}${random_string.archive_storage_suffix[0].result}" : ""
+  archive_container_name       = "archive"
+  archive_container_url        = var.blob_archive_enabled ? "https://${local.archive_storage_account_name}.blob.core.windows.net/${local.archive_container_name}" : ""
+  archive_volume_name          = "default_archive"
 }
 
 resource "azurerm_resource_group" "rg" {
@@ -67,6 +81,38 @@ resource "azurerm_subnet" "subnet" {
   resource_group_name  = azurerm_resource_group.rg.name
   virtual_network_name = azurerm_virtual_network.vnet.name
   address_prefixes     = [var.subnet_cidr]
+  service_endpoints    = var.blob_archive_enabled ? ["Microsoft.Storage"] : []
+}
+
+resource "azurerm_storage_account" "remote_archive" {
+  count                    = var.blob_archive_enabled ? 1 : 0
+  name                     = local.archive_storage_account_name
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = azurerm_resource_group.rg.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  account_kind             = "StorageV2"
+
+  https_traffic_only_enabled      = true
+  min_tls_version                 = "TLS1_2"
+  allow_nested_items_to_be_public = false
+  shared_access_key_enabled       = true
+  public_network_access_enabled   = true
+
+  network_rules {
+    default_action             = "Deny"
+    bypass                     = ["AzureServices"]
+    virtual_network_subnet_ids = [azurerm_subnet.subnet.id]
+  }
+
+  tags = local.common_tags
+}
+
+resource "azurerm_storage_container" "remote_archive" {
+  count                 = var.blob_archive_enabled ? 1 : 0
+  name                  = local.archive_container_name
+  storage_account_id    = azurerm_storage_account.remote_archive[0].id
+  container_access_type = "private"
 }
 
 resource "azurerm_public_ip" "nodes" {

--- a/assets/infrastructure/azure/rbac-role.broad.json
+++ b/assets/infrastructure/azure/rbac-role.broad.json
@@ -6,6 +6,7 @@
     "Microsoft.Resources/subscriptions/resourceGroups/*",
     "Microsoft.Network/*",
     "Microsoft.Compute/*",
+    "Microsoft.Storage/*",
     "Microsoft.Authorization/*/read",
     "Microsoft.Insights/*/read"
   ],

--- a/assets/infrastructure/azure/rbac-role.minimal.json
+++ b/assets/infrastructure/azure/rbac-role.minimal.json
@@ -40,6 +40,14 @@
     "Microsoft.Compute/disks/write",
     "Microsoft.Compute/disks/delete",
 
+    "Microsoft.Storage/storageAccounts/read",
+    "Microsoft.Storage/storageAccounts/write",
+    "Microsoft.Storage/storageAccounts/delete",
+    "Microsoft.Storage/storageAccounts/listkeys/action",
+    "Microsoft.Storage/storageAccounts/blobServices/containers/read",
+    "Microsoft.Storage/storageAccounts/blobServices/containers/write",
+    "Microsoft.Storage/storageAccounts/blobServices/containers/delete",
+
     "Microsoft.Compute/locations/vmSizes/read",
     "Microsoft.Compute/locations/operations/read",
     "Microsoft.Network/locations/operations/read",

--- a/assets/infrastructure/azure/variables_public.tf
+++ b/assets/infrastructure/azure/variables_public.tf
@@ -50,3 +50,9 @@ variable "adminui_password" {
   default     = ""
   sensitive   = true
 }
+
+variable "blob_archive_enabled" {
+  description = "Enable remote archive/backup integration: creates Azure Blob Storage resources and registers a remote archive volume."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
## Description

Enable remote backup archive support for the Azure infrastructure preset

## Related Issue

[SPOT-28929](https://exasol.atlassian.net/browse/SPOT-28929)

Fixes #

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [x] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

<!-- List the key changes in this PR -->

- Added a new Azure preset flag blob_archive_enabled in variables_public.tf
- Extended the Azure infrastructure in main.tf
- wires a post-install hook when archive support is enabled
- Added a new Azure-specific post-install script in azure_registerBlobArchiveVolume.sh
- Updated the roles in Azure RBAC role files

## Testing

<!-- Describe how you tested your changes -->

- [x] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

Manually validated by triggering a backup via the relevant confd_client job, and confirmed that the resulting backup artifacts were archived and uploaded to the Azure Blob container.

```
loaj@HW4746:~/workspace/new-exasol-personal/exasol-personal/bin/az_deploy_1$ az storage blob list \
  --account-name "$ACCOUNT" \
  --account-key "$ACCOUNT_KEY" \
  --container-name archive \
  --query '[].name' -o table
Result
------------------------------------------------
Exasol/id_1/level_0/node_0/backup_202603181801
Exasol/id_1/level_0/node_0/expire_202603251801
Exasol/id_1/level_0/node_0/metadata_202603181801
Exasol/id_1/level_0/node_0/status_202603181801
loaj@HW4746:~/workspace/new-exasol-personal/exasol-personal/bin/az_deploy_1$ az storage blob list \
  --account-name "$ACCOUNT" \
  --account-key "$ACCOUNT_KEY" \
  --container-name archive \
  --prefix 'Exasol/id_1/level_0/node_0/backup_202603181801' \
  --query '[].name' -o table
Result
----------------------------------------------
Exasol/id_1/level_0/node_0/backup_202603181801
loaj@HW4746:~/workspace/new-exasol-personal/exasol-personal/bin/az_deploy_1$

```

## Checklist

<!-- Mark completed items with an "x" -->

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [ ] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

<!-- Any additional information, screenshots, or context -->


[SPOT-28929]: https://exasol.atlassian.net/browse/SPOT-28929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ