### PR TITLE
ci: Enable CI test matrix for AWS/Azure/Exoscale

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
       with:
         go-version-file: go.mod
 

--- a/.github/actions/status-set/action.yml
+++ b/.github/actions/status-set/action.yml
@@ -16,7 +16,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/github-script@v7
+    - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:
         script: |
           let state = '${{ inputs.status }}';

--- a/.github/actions/tests-deployment/action.yml
+++ b/.github/actions/tests-deployment/action.yml
@@ -1,5 +1,14 @@
 name: tests-deployment
 description: Run Deployment Tests
+inputs:
+  infra:
+    description: Infrastructure preset for deployment tests.
+    required: false
+    default: aws
+  task:
+    description: Taskfile target to execute for deployment tests.
+    required: false
+    default: tests-deployment
 runs:
   using: "composite"
   steps:
@@ -7,4 +16,4 @@ runs:
       uses: ./.github/actions/setup-python
     - name: Run Deployment Tests
       shell: bash
-      run: task tests-deployment
+      run: task ${{ inputs.task }} INFRA=${{ inputs.infra }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
       

--- a/.github/workflows/tests-deployment.yml
+++ b/.github/workflows/tests-deployment.yml
@@ -2,21 +2,69 @@ name: Deployment Tests
 
 on:
   workflow_dispatch:
+    inputs:
+      os:
+        description: Operating system selector
+        required: false
+        default: all
+        type: choice
+        options:
+          - all
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
 
 permissions: {}
 
 env:
   STATUS_DESC: "Deployment tests testing Exasol launcher end to end"
-  JOB_NAME: tests-deployment
 
 jobs:
+  plan-tests-deployment:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      - id: plan
+        shell: bash
+        run: |
+          selected_os="${{ inputs.os }}"
+          if [ -z "${selected_os}" ]; then
+            selected_os="all"
+          fi
+
+          # Declarative test plan. Toggle rows via "enabled" and route by "task".
+          full_plan_json='[
+            {"enabled": true,   "infra": "aws",      "os": "ubuntu-latest",  "task": "tests-deployment"},
+            {"enabled": false,  "infra": "aws",      "os": "windows-latest", "task": "tests-deployment"},
+            {"enabled": false,  "infra": "aws",      "os": "macos-latest",   "task": "tests-deployment"},
+            {"enabled": false,  "infra": "azure",    "os": "ubuntu-latest",  "task": "tests-deployment-infrastructure"},
+            {"enabled": true,   "infra": "azure",    "os": "windows-latest", "task": "tests-deployment-infrastructure"},
+            {"enabled": false,  "infra": "azure",    "os": "macos-latest",   "task": "tests-deployment-infrastructure"},
+            {"enabled": false,  "infra": "exoscale", "os": "ubuntu-latest",  "task": "tests-deployment-infrastructure"},
+            {"enabled": false,  "infra": "exoscale", "os": "windows-latest", "task": "tests-deployment-infrastructure"},
+            {"enabled": true,   "infra": "exoscale", "os": "macos-latest",   "task": "tests-deployment-infrastructure"}
+          ]'
+
+          filtered_plan_json="$(jq -c --arg os "${selected_os}" '
+            map(select(.enabled == true))
+            | if $os == "all" then . else map(select(.os == $os)) end
+            | map(del(.enabled))
+          ' <<< "${full_plan_json}")"
+
+          echo "matrix=${filtered_plan_json}" >> "${GITHUB_OUTPUT}"
+
   tests-deployment:
+    needs: plan-tests-deployment
+    environment:
+      name: deployment-tests
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        include: ${{ fromJSON(needs.plan-tests-deployment.outputs.matrix) }}
     runs-on: ${{ matrix.os }}
     permissions:
-      id-token: write # Required for AWS credentials setup
+      id-token: write # Required for cloud OIDC auth
       contents: read # Required for actions/checkout
       statuses: write # Required for status updates
     steps:
@@ -26,15 +74,53 @@ jobs:
           fetch-depth: 0
       - uses: ./.github/actions/status-set
         with:
-          context: ${{ env.JOB_NAME }}
+          context: tests-deployment-${{ matrix.infra }}-${{ matrix.os }}
           status: pending
           description: ${{ env.STATUS_DESC }}
           target-url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - uses: ./.github/actions/setup-aws
+        if: ${{ matrix.infra == 'aws' }}
         with:
           aws-ci-role: ${{ vars.AWS_CI_ROLE_PLATFORM }}
           aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Setup Azure credentials
+        if: ${{ matrix.infra == 'azure' }}
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Validate Azure location input
+        if: ${{ matrix.infra == 'azure' }}
+        shell: bash
+        run: |
+          location="${{ vars.AZURE_LOCATION }}"
+          source="vars.AZURE_LOCATION"
+          if [ -z "${location}" ]; then
+            location="${{ secrets.AZURE_LOCATION }}"
+            source="secrets.AZURE_LOCATION"
+          fi
+
+          if [ -z "${location}" ]; then
+            echo "AZURE_LOCATION is required for Azure deployment tests (set vars.AZURE_LOCATION or secrets.AZURE_LOCATION, e.g. westeurope)."
+            exit 1
+          fi
+
+          echo "Using Azure location from ${source}"
+          echo "TF_VAR_location=${location}" >> "$GITHUB_ENV"
+
+      - name: Setup Exoscale credentials
+        if: ${{ matrix.infra == 'exoscale' }}
+        shell: bash
+        run: |
+          echo "EXOSCALE_API_KEY=${{ secrets.EXOSCALE_API_KEY }}" >> "$GITHUB_ENV"
+          echo "EXOSCALE_API_SECRET=${{ secrets.EXOSCALE_API_SECRET }}" >> "$GITHUB_ENV"
+          # The Exoscale preset uses an aliased AWS provider for SOS endpoint resources.
+          echo "AWS_ACCESS_KEY_ID=${{ secrets.EXOSCALE_API_KEY }}" >> "$GITHUB_ENV"
+          echo "AWS_SECRET_ACCESS_KEY=${{ secrets.EXOSCALE_API_SECRET }}" >> "$GITHUB_ENV"
 
       # Doing a second build here again. In theory, we could
       # upload the build artifact from the ci.yml workflow
@@ -42,11 +128,19 @@ jobs:
       # is short and we can afford building it a second time.
       - uses: ./.github/actions/build
       - uses: ./.github/actions/tests-deployment
+        env:
+          ARM_USE_OIDC: ${{ matrix.infra == 'azure' && 'true' || '' }}
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        with:
+          infra: ${{ matrix.infra }}
+          task: ${{ matrix.task }}
 
       - uses: ./.github/actions/status-set
         if: always()
         with:
-          context: ${{ env.JOB_NAME }}
+          context: tests-deployment-${{ matrix.infra }}-${{ matrix.os }}
           status: ${{ job.status }}
           description: ${{ env.STATUS_DESC }}
           target-url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/assets/infrastructure/azure/main.tf
+++ b/assets/infrastructure/azure/main.tf
@@ -4,7 +4,7 @@ locals {
     Project    = "exasol-personal"
     Deployment = local.deployment_id
     CreatedAt  = var.deployment_created_at
-    Owner      = data.azuread_user.current.user_principal_name
+    Owner      = data.azurerm_client_config.current.object_id
   }
 
   deployment_id = "exasol-${var.deployment_id}"

--- a/assets/infrastructure/azure/ssh.tf
+++ b/assets/infrastructure/azure/ssh.tf
@@ -5,10 +5,6 @@ resource "tls_private_key" "ssh_key" {
 
 data "azurerm_client_config" "current" {}
 
-data "azuread_user" "current" {
-  object_id = data.azurerm_client_config.current.object_id
-}
-
 locals {
   ssh_key_name = "${local.deployment_id}-key"
 }

--- a/doc/ci.md
+++ b/doc/ci.md
@@ -52,8 +52,17 @@ Security guards:
 - Should be protected by an environment approval gate and ref restrictions in repository settings
 
 Workflow input:
-- `infra`: Infrastructure preset for deployment tests (`aws` or `azure`, default `aws`)
-- The current workflow includes credential bootstrap for AWS. Azure runs require Azure credentials to be available in the runner environment.
+- `os`: OS selector for the deployment matrix (`all`, `ubuntu-latest`, `windows-latest`, `macos-latest`; default `all`)
+- The workflow uses a declarative test plan (provider/OS/task rows) and filters rows before matrix expansion, so non-selected OS jobs are not created.
+- Current enabled rows:
+  - AWS runs `tests-deployment` (installation + infrastructure lanes)
+  - Azure runs `tests-deployment-infrastructure`
+  - Exoscale rows are currently disabled in the test plan and can be re-enabled by toggling the plan entries.
+- Credential bootstrap:
+  - AWS via OIDC role assumption
+  - Azure via OIDC (`azure/login`)
+  - Exoscale via `EXOSCALE_API_KEY` / `EXOSCALE_API_SECRET` secrets
+  - Azure identifiers are sourced from GitHub secrets: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`
 
 **Warning:** These tests create real cloud resources and incur costs.
 

--- a/tests/framework/launcher.py
+++ b/tests/framework/launcher.py
@@ -3,6 +3,7 @@
 
 import json
 import logging
+import os
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -22,6 +23,7 @@ class DeploymentConfig:
     data_volume_size: int | None = None
     db_password: str | None = None
     adminui_password: str | None = None
+    location: str | None = None
 
 
 class Launcher:
@@ -98,6 +100,12 @@ class Launcher:
             init_args.extend(["--db-password", config.db_password])
         if config.adminui_password is not None:
             init_args.extend(["--adminui-password", config.adminui_password])
+        if config.infra == "azure":
+            location = config.location
+            if location is None:
+                location = os.getenv("TF_VAR_LOCATION") or os.getenv("AZURE_LOCATION")
+            if location is not None and location.strip() != "":
+                init_args.extend(["--location", location])
 
         return self.run_command(
             "init",

--- a/tests/tests/conftest.py
+++ b/tests/tests/conftest.py
@@ -19,7 +19,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         required=False,
         action="store",
         default="aws",
-        choices=["aws", "azure"],
+        choices=["aws", "azure", "exoscale"],
         help="Infrastructure preset to use for deployment tests",
     )
 

--- a/tests/tests/deployment/test_custom.py
+++ b/tests/tests/deployment/test_custom.py
@@ -35,8 +35,13 @@ def custom_deployment(
     test_pw: Final = """$x\n${y}\nunbalanced quote: ' another one: " $(echo test)"""
     test_admin_pw: Final = "MyAdminUI!Pass123"
 
-    if instance_type is None and infra == "aws":
-        instance_type = "t3.xlarge"
+    if instance_type is None:
+        if infra == "aws":
+            instance_type = "t3.xlarge"
+        elif infra == "exoscale":
+            # Use a non-default Exoscale instance type in custom deployment tests
+            # to validate instance-type customization works.
+            instance_type = "standard.large"
 
     config = DeploymentConfig(
         infra=infra,
@@ -120,9 +125,13 @@ def test_custom_deployment_rejects_small_instance_types(
 )
 def test_custom_deployment_success(
     custom_deployment: tuple[Deployment, DeploymentConfig],
+    infra: str,
 ) -> None:
     deployment, config = custom_deployment
     query: Final = "SELECT * FROM Dual"
+
+    if infra == "exoscale":
+        assert config.instance_type == "standard.large"
 
     assert config.db_password is not None
     for p in [(), ("--password", config.db_password)]:

--- a/tests/tests/deployment/test_standard_deployment.py
+++ b/tests/tests/deployment/test_standard_deployment.py
@@ -517,6 +517,7 @@ def test_start_interrupt_sets_interrupted_state(
 )
 @pytest.mark.infrastructure_e2e
 @pytest.mark.provider_aws
+@pytest.mark.provider_azure
 def test_remote_archive_registered(
     reusable_deployment: Deployment,
     infra: str,
@@ -530,8 +531,8 @@ def test_remote_archive_registered(
     Then we should receive a successful response
     And the response should contain the 'default_archive' backup option
     """
-    if infra != "aws":
-        pytest.skip("Remote archive verification is only supported for AWS today")
+    if infra not in {"aws", "azure"}:
+        pytest.skip("Remote archive verification is only supported for AWS/Azure today")
 
     # ========== GIVEN ==========
     # Ensure deployment is running (previous tests may have stopped it)


### PR DESCRIPTION
## Description

Enable a CI job matrix to test AWS/Azure/Exoscale and establish testing paths on different cloud providers

## Related Issue

Fixes #

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

<!-- List the key changes in this PR -->

- Azure login in CI
- Test matrix of  [`test_taxonomy`,`os`,`infra_provider`]


## Testing

<!-- Describe how you tested your changes -->

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

<!-- Describe your testing approach -->

## Checklist

<!-- Mark completed items with an "x" -->

- [ ] Code follows the project's [coding guidelines](doc/best_practices.md)
- [ ] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [ ] Added/updated tests
- [ ] All tests pass locally
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

<!-- Any additional information, screenshots, or context -->
