### PR TITLE
docs: Reference policy file in AWS account setup howto

### DIFF
--- a/HOWTO_SETUP_AWS_ACCOUNT.md
+++ b/HOWTO_SETUP_AWS_ACCOUNT.md
@@ -19,12 +19,7 @@ The AWS account must have the permissions and quota to launch large type instanc
 ### 🔐 In the AWS IAM console, do the following:
 
 1. Create a new user for the Exasol instance.
-2. Attach the following IAM policies to the Exasol user:
-   - `AmazonEC2FullAccess`
-   - `IAMReadOnlyAccess`
-   - `IAMUserChangePassword`
-   - `AmazonSSMFullAccess`
-   - `AmazonS3FullAccess`
+2. Attach [this](./assets/infrastructure/aws/iam-policy.broad.json) security policy to the Exasol user.
 3. Generate AWS access keys for the user.
 
 If you want to use multi factor authentication (MFA) or other methods for authentication in your AWS account, additional steps may be required. For more information, refer to the AWS documentation: https://docs.aws.amazon.com/.


### PR DESCRIPTION
## Summary

- Replace the list of individual AWS managed policies (`AmazonEC2FullAccess`, `IAMReadOnlyAccess`, etc.) in `HOWTO_SETUP_AWS_ACCOUNT.md` with a direct link to the checked-in `iam-policy.broad.json` policy file.

## Why

The old instructions pointed users at five separate AWS-managed policies, some of which grant excessive permissions (e.g. full IAM access). The repo already ships purpose-built policy files (`iam-policy.broad.json` and `iam-policy.minimal.json`) that are scoped to Exasol resource naming patterns. Linking to the broad policy keeps the setup guide simple while directing users to a maintained, auditable policy definition.

## Test plan

- [ ] Verify the link `./assets/infrastructure/aws/iam-policy.broad.json` resolves correctly from the doc root.
- [ ] Manually attach `iam-policy.broad.json` to a test IAM user and confirm a fresh Exasol deployment succeeds.