### PR TITLE
Make paths relative to deployment directory

### DIFF
--- a/assets/infrastructure/aws/cloudinit.tf
+++ b/assets/infrastructure/aws/cloudinit.tf
@@ -10,15 +10,15 @@
 
 locals {
   # --- Path "constants" ---
-  # Changing these paths will break the deployment processes as we use them to find the installation preset contents  
-  installation_cloudconf_dir = "${var.installation_preset_dir}/cloudconf"
-  installation_files_dir     = "${var.installation_preset_dir}/files"
+  # Changing these paths will break the deployment processes as we use them to find the installation preset contents
+  installation_cloudconf_dir = "${local.installation_preset_dir}/cloudconf"
+  installation_files_dir     = "${local.installation_preset_dir}/files"
 
   # Optional infrastructure-preset-provided host file overlay.
   # This is used for infrastructure-specific scripts or configs that should not live in provider-agnostic installation presets.
   infrastructure_files_dir = "${path.module}/files"
 
-  # Changing these paths will break the installation processes on the hosts as they look for these files  
+  # Changing these paths will break the installation processes on the hosts as they look for these files
   launcher_config_dir             = "/etc/exasol_launcher"
   infrastructure_json_target_path = "${local.launcher_config_dir}/infrastructure.json"
   node_json_target_path           = "${local.launcher_config_dir}/node.json"
@@ -80,7 +80,7 @@ locals {
     tlsCa              = tls_self_signed_cert.tls_ca_cert.cert_pem
     tlsCert            = tls_locally_signed_cert.tls_cert.cert_pem
 
-    # Optional infrastructure-specific hook scripts.      
+    # Optional infrastructure-specific hook scripts.
     preInstall = {
       # preInstall hooks run on *all* nodes
       root = {
@@ -109,9 +109,9 @@ locals {
   # Per-node metadata written to disk (separate from infrastructure.json for clarity).
   node_payload_by_name = {
     for n in local.nodes : n.name => {
-      name         = n.name
-      privateIp    = n.ip
-      myId         = n.name
+      name      = n.name
+      privateIp = n.ip
+      myId      = n.name
 
       # Exasol always uses the same final disk alias across providers.
       # The udev match clause identifies the data disk so prepareExasol.sh can

--- a/assets/infrastructure/aws/outputs.tf
+++ b/assets/infrastructure/aws/outputs.tf
@@ -6,6 +6,7 @@ data "aws_instance" "nodes" {
 
 locals {
   infrastructure_artifact_dir = abspath(var.infrastructure_artifact_dir)
+  installation_preset_dir     = "${local.infrastructure_artifact_dir}/${var.installation_preset_dir}"
   key_file_name               = "node_access.pem"
   key_file_path               = "${local.infrastructure_artifact_dir}/${local.key_file_name}"
 

--- a/assets/infrastructure/azure/cloudinit.tf
+++ b/assets/infrastructure/azure/cloudinit.tf
@@ -10,15 +10,15 @@
 
 locals {
   # --- Path "constants" ---
-  # Changing these paths will break the deployment processes as we use them to find the installation preset contents  
-  installation_cloudconf_dir      = "${var.installation_preset_dir}/cloudconf"
-  installation_files_dir          = "${var.installation_preset_dir}/files"
+  # Changing these paths will break the deployment processes as we use them to find the installation preset contents
+  installation_cloudconf_dir = "${local.installation_preset_dir}/cloudconf"
+  installation_files_dir     = "${local.installation_preset_dir}/files"
 
   # Optional infrastructure-preset-provided host file overlay.
   # This is used for infrastructure-specific scripts or configs that should not live in provider-agnostic installation presets.
-  infrastructure_files_dir        = "${path.module}/files"
+  infrastructure_files_dir = "${path.module}/files"
 
-  # Changing these paths will break the installation processes on the hosts as they look for these files  
+  # Changing these paths will break the installation processes on the hosts as they look for these files
   launcher_config_dir             = "/etc/exasol_launcher"
   infrastructure_json_target_path = "${local.launcher_config_dir}/infrastructure.json"
   node_json_target_path           = "${local.launcher_config_dir}/node.json"
@@ -28,14 +28,14 @@ locals {
   # as its own cloud-init "part" (stable lexicographic order) to avoid Terraform-side YAML
   # merging logic and keep the behavior easy to understand.
   installation_cloudconf_files = sort(
-    fileset(local.installation_cloudconf_dir, "*")    
+    fileset(local.installation_cloudconf_dir, "*")
   )
 
   # Materialize metadata of files to be installed.
   installation_node_files = [
     for rel in fileset(local.installation_files_dir, "**") : {
-      src_path  = "${local.installation_files_dir}/${rel}"
-      dest_path = "/${rel}"
+      src_path    = "${local.installation_files_dir}/${rel}"
+      dest_path   = "/${rel}"
       permissions = endswith(rel, ".sh") ? "0755" : "0644"
     }
   ]
@@ -44,8 +44,8 @@ locals {
   # These are applied after installation preset files, so infra presets can override paths when necessary.
   infrastructure_node_files = [
     for rel in fileset(local.infrastructure_files_dir, "**") : {
-      src_path  = "${local.infrastructure_files_dir}/${rel}"
-      dest_path = "/${rel}"
+      src_path    = "${local.infrastructure_files_dir}/${rel}"
+      dest_path   = "/${rel}"
       permissions = endswith(rel, ".sh") ? "0755" : "0644"
     }
   ]
@@ -65,10 +65,10 @@ locals {
   infrastructure_payload = {
 
     # Mandatory section. These values shall always be provided
-    deploymentId    = local.deployment_id
-    numNodes        = length(local.nodes)
-    n11Ip           = local.n11_ip
-        
+    deploymentId = local.deployment_id
+    numNodes     = length(local.nodes)
+    n11Ip        = local.n11_ip
+
     adminPrivateKey    = tls_private_key.ssh_key.private_key_pem
     hostAddrs          = local.node_ips_space_sep
     hostExternalAddrs  = local.node_ips_space_sep
@@ -78,7 +78,7 @@ locals {
     tlsCa              = tls_self_signed_cert.tls_ca_cert.cert_pem
     tlsCert            = tls_locally_signed_cert.tls_cert.cert_pem
 
-    # Optional infrastructure-specific hook scripts.      
+    # Optional infrastructure-specific hook scripts.
     preInstall = {
       # preInstall hooks run on *all* nodes
       root = {
@@ -92,7 +92,7 @@ locals {
       # postInstall hooks run on the *access node (n11) only*
       scripts = var.blob_archive_enabled ? ["/opt/exasol_launcher/scripts/azure_registerBlobArchiveVolume.sh"] : []
     }
-        
+
     azure = {
       location     = var.location
       instanceType = var.instance_type
@@ -130,9 +130,9 @@ locals {
   # Per-node metadata written to disk (separate from infrastructure.json for clarity).
   node_payload_by_name = {
     for n in local.nodes : n.name => {
-      name         = n.name
-      privateIp    = n.ip
-      myId         = n.name
+      name      = n.name
+      privateIp = n.ip
+      myId      = n.name
 
       # Azure disk device names (/dev/sdX) are not stable across reboots, but the
       # LUN-based symlink path is deterministic and known at plan time. The udev match
@@ -157,8 +157,8 @@ data "cloudinit_config" "cloud_config" {
     content {
       content_type = "text/cloud-config"
       # Numeric prefix makes ordering/precedence explicit when debugging multipart user-data.
-      filename     = "10-cloudconf-${part.value}"
-      content      = file("${local.installation_cloudconf_dir}/${part.value}")
+      filename = "10-cloudconf-${part.value}"
+      content  = file("${local.installation_cloudconf_dir}/${part.value}")
     }
   }
 
@@ -167,12 +167,12 @@ data "cloudinit_config" "cloud_config" {
   part {
     content_type = "text/cloud-config"
     filename     = "20-azure-waagent-config.yaml"
-    content      = yamlencode({
+    content = yamlencode({
       write_files = [
         {
           path        = "/etc/waagent.conf.d/10-exasol.conf"
           permissions = "0644"
-          content     = join("\n", [
+          content = join("\n", [
             "Provisioning.Enabled=n",
             "Provisioning.UseCloudInit=y",
             "Provisioning.RegenerateSshHostKeyPair=n",
@@ -186,8 +186,8 @@ data "cloudinit_config" "cloud_config" {
   part {
     content_type = "text/cloud-config"
     # Keep this last so it can intentionally override earlier preset cloud-config values.
-    filename     = "99-write-files.yaml"
-    content      = yamlencode({
+    filename = "99-write-files.yaml"
+    content = yamlencode({
       write_files = concat(
         [
           {

--- a/assets/infrastructure/azure/outputs.tf
+++ b/assets/infrastructure/azure/outputs.tf
@@ -1,5 +1,6 @@
 locals {
   infrastructure_artifact_dir = abspath(var.infrastructure_artifact_dir)
+  installation_preset_dir     = "${local.infrastructure_artifact_dir}/${var.installation_preset_dir}"
   key_file_name               = "node_access.pem"
   key_file_path               = "${local.infrastructure_artifact_dir}/${local.key_file_name}"
 

--- a/assets/infrastructure/exoscale/cloudinit.tf
+++ b/assets/infrastructure/exoscale/cloudinit.tf
@@ -11,8 +11,8 @@
 locals {
   # --- Path "constants" ---
   # Changing these paths will break the deployment processes as we use them to find the installation preset contents
-  installation_cloudconf_dir = "${var.installation_preset_dir}/cloudconf"
-  installation_files_dir     = "${var.installation_preset_dir}/files"
+  installation_cloudconf_dir = "${local.installation_preset_dir}/cloudconf"
+  installation_files_dir     = "${local.installation_preset_dir}/files"
 
   # Optional infrastructure-preset-provided host file overlay.
   # This is used for infrastructure-specific scripts or configs that should not live in provider-agnostic installation presets.
@@ -99,12 +99,12 @@ locals {
     exoscale = {
       zone = var.zone
       archive = {
-        enabled    = var.s3_archive_enabled
-        bucketId   = local.archive_bucket_id
-        volumeName = "default_archive"
+        enabled     = var.s3_archive_enabled
+        bucketId    = local.archive_bucket_id
+        volumeName  = "default_archive"
         sosEndpoint = local.sos_endpoint
-        accessKey  = var.s3_archive_enabled ? exoscale_iam_api_key.archive_sos_key[0].key : ""
-        secretKey  = var.s3_archive_enabled ? exoscale_iam_api_key.archive_sos_key[0].secret : ""
+        accessKey   = var.s3_archive_enabled ? exoscale_iam_api_key.archive_sos_key[0].key : ""
+        secretKey   = var.s3_archive_enabled ? exoscale_iam_api_key.archive_sos_key[0].secret : ""
       }
     }
   }
@@ -112,9 +112,9 @@ locals {
   # Per-node metadata written to disk (separate from infrastructure.json for clarity).
   node_payload_by_name = {
     for n in local.nodes : n.name => {
-      name         = n.name
-      privateIp    = n.ip
-      myId         = n.name
+      name      = n.name
+      privateIp = n.ip
+      myId      = n.name
 
       # Exasol always uses the same final disk alias across providers.
       # The udev match clause identifies the data disk so prepareExasol.sh can

--- a/assets/infrastructure/exoscale/outputs.tf
+++ b/assets/infrastructure/exoscale/outputs.tf
@@ -1,5 +1,6 @@
 locals {
   infrastructure_artifact_dir = abspath(var.infrastructure_artifact_dir)
+  installation_preset_dir     = "${local.infrastructure_artifact_dir}/${var.installation_preset_dir}"
   key_file_name               = "node_access.pem"
   key_file_path               = "${local.infrastructure_artifact_dir}/${local.key_file_name}"
 

--- a/internal/config/node_details.go
+++ b/internal/config/node_details.go
@@ -13,6 +13,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/exasol/exasol-personal/internal/util"
 )
 
 const (
@@ -51,18 +53,18 @@ type nodeDetailsNodesDatabase struct {
 }
 
 type nodeDetailsNodesSsh struct {
-	Command  string `json:"command"`
-	KeyFile  string `json:"keyFile"`
-	KeyName  string `json:"keyName"`
-	Port     string `json:"port"`
-	Username string `json:"username"`
+	Command  string              `json:"command"`
+	KeyFile  util.DeploymentPath `json:"keyFile"`
+	KeyName  string              `json:"keyName"`
+	Port     string              `json:"port"`
+	Username string              `json:"username"`
 }
 
 type SSHDetails struct {
 	Host    string
 	Port    string
 	User    string
-	KeyFile string
+	KeyFile util.DeploymentPath
 }
 
 func ReadNodeDetails(deploymentDir string) (*NodeDetails, error) {

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -307,11 +307,7 @@ func (builder *nodeListBuilder) getRemote(node string) (*remote.SSHConnectionOpt
 		return nil, err
 	}
 
-	keyFilePath := sshDetails.KeyFile
-	if !filepath.IsAbs(keyFilePath) {
-		keyFilePath = filepath.Join(builder.deploymentDir, keyFilePath)
-	}
-
+	keyFilePath := sshDetails.KeyFile.Abs(builder.deploymentDir)
 	keyData, err := os.ReadFile(keyFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("%w: could not read SSH key file %s", err, keyFilePath)

--- a/internal/deploy/deploymentControl.go
+++ b/internal/deploy/deploymentControl.go
@@ -321,6 +321,7 @@ func applyAction(
 	if err := tofu.ApplyAction(
 		ctx,
 		*tofuCfg,
+		deploymentDir,
 		startStopArg,
 		out,
 		outErr,

--- a/internal/deploy/init.go
+++ b/internal/deploy/init.go
@@ -140,9 +140,8 @@ func InitDeployment(
 			}
 
 			// These values should always be part of the infra vars per contract
-			// It tell the infrastructure preset where to write deployment artifacts fot the launcher
-			infraVars["infrastructure_artifact_dir"] = deploymentDir
-			infraVars["installation_preset_dir"] = installDir
+			// It tell the infrastructure preset where to write deployment artifacts for the launcher
+			infraVars["installation_preset_dir"] = config.InstallationFilesDirectory
 			// Launcher-governed identity values.
 			infraVars["deployment_id"] = deploymentId
 			infraVars["cluster_identity"] = clusterIdentity

--- a/internal/deploy/init_test.go
+++ b/internal/deploy/init_test.go
@@ -86,10 +86,6 @@ func TestInitDeployment_CreatesTfVarsWhenTofuConfigured(t *testing.T) {
 		t.Fatalf("expected tfvars to contain cluster_size, got: %s", content)
 	}
 
-	if !strings.Contains(content, "infrastructure_artifact_dir") {
-		t.Fatalf("expected tfvars to contain infrastructure_artifact_dir, got: %s", content)
-	}
-
 	if !strings.Contains(content, "installation_preset_dir") {
 		t.Fatalf("expected tfvars to contain installation_preset_dir, got: %s", content)
 	}

--- a/internal/deploy/shell.go
+++ b/internal/deploy/shell.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/exasol/exasol-personal/internal/config"
 	"github.com/exasol/exasol-personal/internal/remote"
@@ -63,11 +62,7 @@ func sshRemoteForNodeUnsafe(deploymentDir string, selectedNode string) (*remote.
 		return nil, err
 	}
 
-	keyFilePath := sshDetails.KeyFile
-	if !filepath.IsAbs(keyFilePath) {
-		keyFilePath = filepath.Join(deploymentDir, keyFilePath)
-	}
-
+	keyFilePath := sshDetails.KeyFile.Abs(deploymentDir)
 	keyData, err := os.ReadFile(keyFilePath)
 	if err != nil {
 		return nil, fmt.Errorf("%w: could not read SSH key file %s", err, keyFilePath)

--- a/internal/tofu/operations.go
+++ b/internal/tofu/operations.go
@@ -114,6 +114,7 @@ func ApplyPlan(
 func ApplyAction(
 	ctx context.Context,
 	cfg Config,
+	deploymentDir string,
 	action string,
 	out, outErr io.Writer,
 ) error {
@@ -123,7 +124,7 @@ func ApplyAction(
 
 	applyOpts := ApplyOptions{
 		// Cannot use plan file
-		VarArgs: []string{action},
+		VarArgs: []string{action, "infrastructure_artifact_dir=" + deploymentDir},
 		// Must use Vars file
 		VarsFilePath:  cfg.VarsOutputFile(),
 		StateFilePath: cfg.StateFile(),

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -72,6 +72,40 @@ func AbsPathNoFail(path string) string {
 	return absPath
 }
 
+type DeploymentPath struct {
+	path string
+}
+
+func NewDeploymentPath(path string, deploymentDir string) DeploymentPath {
+	if filepath.IsAbs(path) {
+		relPath, err := filepath.Rel(deploymentDir, path)
+		if err != nil {
+			panic("Path not in deployment directory")
+		}
+
+		return DeploymentPath{relPath}
+	}
+
+	return DeploymentPath{path}
+}
+
+func (o *DeploymentPath) Abs(deploymentDir string) string {
+	return filepath.Join(deploymentDir, o.path)
+}
+
+func (o *DeploymentPath) String() string {
+	return o.path
+}
+
+func (o *DeploymentPath) MarshalText() ([]byte, error) {
+	return []byte(o.path), nil
+}
+
+func (o *DeploymentPath) UnmarshalText(text []byte) error {
+	o.path = string(text)
+	return nil
+}
+
 type Optional[T any] struct {
 	value   T
 	present bool


### PR DESCRIPTION
## Description

Some paths in the configuration files that should be relative to the deployment directory were being stored as absolute, making it so the deployment directory couldn't be moved once it was created.

This issue affected the infrastructure and installation directories and the paths to the SSH key files.

## Related Issue

[SPOT-29898](https://exasol.atlassian.net/browse/SPOT-29898)

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Removed `infrastructure_artifact_dir` from the tfvars file. It is now passed directly as an argument to tofu.
- Added `DeploymentPath` type to enforce paths being relative to the deployment directory on the type level.

## Testing

- [x] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

To manually test this change a deployment was initialized and deployed and then, the command `grep -r "$PWD"` was executed in the deployment directory. The only file that should show up is `deployment.log`.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

[SPOT-29898]: https://exasol.atlassian.net/browse/SPOT-29898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ