### PR TITLE
feat: Do not print hints on non-interactive connect command input

### DIFF
--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -6,6 +6,7 @@ package connect
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/exasol/exasol-personal/internal/connect/exasol"
 	"github.com/exasol/exasol-personal/internal/connect/tablewriter"
 	generaltypes "github.com/exasol/exasol-personal/internal/connect/types"
+	"github.com/exasol/exasol-personal/internal/util"
 )
 
 type Opts struct {
@@ -86,9 +88,10 @@ func Connect(ctx context.Context, opts *Opts, deploymentDir string) error {
 
 	defer database.Close()
 
-	_, err = fmt.Fprintln(os.Stderr, "Type \"exit\" to exit the shell")
-	if err != nil {
-		return err
+	if util.IsInteractiveStdin() {
+		if err := printExitHint(os.Stderr); err != nil {
+			return err
+		}
 	}
 
 	return RunShell(func(input string) error {
@@ -104,6 +107,12 @@ func Connect(ctx context.Context, opts *Opts, deploymentDir string) error {
 
 		return printResult(queryResult)
 	})
+}
+
+func printExitHint(output io.Writer) error {
+	_, err := fmt.Fprintln(output, "Type \"exit\" to exit the shell")
+
+	return err
 }
 
 func printResult(queryResult generaltypes.QueryResulter) error {

--- a/internal/connect/exasol/database.go
+++ b/internal/connect/exasol/database.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"regexp"
@@ -16,6 +17,7 @@ import (
 	exasoltypes "github.com/exasol/exasol-driver-go/pkg/types"
 	"github.com/exasol/exasol-personal/internal/connect/exasol/types"
 	generaltypes "github.com/exasol/exasol-personal/internal/connect/types"
+	"github.com/exasol/exasol-personal/internal/util"
 )
 
 var ErrNoVersion = errors.New("the database didn't return version when queried")
@@ -115,9 +117,11 @@ func (db *Database) Connect(ctx context.Context) error {
 		return nil
 	}
 
-	_, err = fmt.Fprintln(os.Stderr, "Exasol", version)
+	if util.IsInteractiveStdin() {
+		return printVersion(os.Stderr, version)
+	}
 
-	return err
+	return nil
 }
 
 func (db *Database) Close() error {
@@ -199,4 +203,10 @@ func parseQueryResult(result json.RawMessage) (*exasoltypes.SqlQueryResponseResu
 	}
 
 	return &resultSet, nil
+}
+
+func printVersion(output io.Writer, version string) error {
+	_, err := fmt.Fprintln(output, "Exasol", version)
+
+	return err
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -137,6 +137,16 @@ func GetTerminalWidth() (int, bool) {
 	return width, true
 }
 
+// IsInteractiveStdin returns true when stdin is attached to a terminal.
+func IsInteractiveStdin() bool {
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+
+	return (stat.Mode() & os.ModeCharDevice) != 0
+}
+
 var (
 	ErrSourceNotDir = errors.New("source is not a directory")
 	ErrDestNotDir   = errors.New("destination is not a directory")

--- a/tests/tests/deployment/test_custom.py
+++ b/tests/tests/deployment/test_custom.py
@@ -11,7 +11,6 @@ from collections.abc import Iterator
 from typing import Final
 
 import pytest
-import semver
 
 from framework.deployment import Deployment
 from framework.launcher import DeploymentConfig, Launcher
@@ -139,16 +138,7 @@ def test_custom_deployment_success(
         stderr = proc.stderr.strip()
         stdout = proc.stdout.strip()
 
-        lines = stderr.splitlines()
-        version_line, exit_hint_lint = lines[0], lines[1]
-
-        assert exit_hint_lint.strip() == 'Type "exit" to exit the shell'
-
-        # Check the Exasol version that is printed as the first line
-        exasol_name, exasol_version = version_line.split(" ")
-
-        assert exasol_name == "Exasol"
-        assert semver.VersionInfo.is_valid(exasol_version)
+        assert stderr == ""
 
         # Check the query output.
         expected = textwrap.dedent("""

--- a/tests/tests/deployment/test_standard_deployment.py
+++ b/tests/tests/deployment/test_standard_deployment.py
@@ -123,16 +123,7 @@ def test_single_query(reusable_deployment: Deployment) -> None:
     stderr = proc.stderr.strip()
     stdout = proc.stdout.strip()
 
-    lines = stderr.splitlines()
-    version_line, exit_hint_lint = lines[0], lines[1]
-
-    assert exit_hint_lint.strip() == 'Type "exit" to exit the shell'
-
-    # Check the Exasol version that is printed as the first line
-    exasol_name, exasol_version = version_line.split(" ")
-
-    assert exasol_name == "Exasol"
-    assert semver.VersionInfo.is_valid(exasol_version)
+    assert stderr == ""
 
     # Check the query output.
     expected = textwrap.dedent("""
@@ -291,11 +282,14 @@ def test_connect_table_width(reusable_deployment: Deployment) -> None:
 
     os.close(master_fd)
 
-    # Skip first line because it contains the DB version
-    # which is dynamic.
-    actual_lines = str(output_raw, "utf-8").split("\n")[1:]
-    actual_lines = [line.rstrip("\r") for line in actual_lines]
-    actual = "\n".join(actual_lines).strip("\n")
+    output_lines = [line.rstrip("\r") for line in str(output_raw, "utf-8").split("\n")]
+    version_line = output_lines[0].strip()
+    output_without_version = "\n".join(output_lines[1:]).strip("\n")
+
+    # Interactive shell should print the version and exit hint.
+    exasol_name, exasol_version = version_line.split(" ")
+    assert exasol_name == "Exasol"
+    assert semver.VersionInfo.is_valid(exasol_version)
 
     expected = textwrap.dedent("""
     Type "exit" to exit the shell
@@ -307,7 +301,7 @@ def test_connect_table_width(reusable_deployment: Deployment) -> None:
     └────┴─────────────────────────────────────────────────────┘
     """)
 
-    assert actual == expected.strip("\n")
+    assert output_without_version == expected.strip("\n")
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Description

`exasol connect` now suppresses startup banner/help output in non-interactive mode (for piped/redirected SQL input), while preserving version and exit hint output in interactive sessions.

## Related Issue

<!-- Link to the related issue(s). Use "Fixes #123" or "Closes #123" to auto-close issues when PR is merged -->

Fixes #

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

<!-- List the key changes in this PR -->

-
-
-

## Testing


- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

tests were updated to cover both behaviors.

## Checklist

<!-- Mark completed items with an "x" -->

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

<!-- Any additional information, screenshots, or context -->
