### PR TITLE
feat: accept multiline queries by executing on semicolon

### DIFF
--- a/cmd/exasol/connect.go
+++ b/cmd/exasol/connect.go
@@ -16,7 +16,9 @@ const connectCmdLongDesc = connectCmdShortDesc + `
 Establish an SQL connection to the database instance in an active deployment.
 `
 
-var connectOpts connect.Opts
+var connectOpts = connect.Opts{
+	ExecuteOnSemicolon: true,
+}
 
 var connectCmd = &cobra.Command{
 	Use:          "connect",
@@ -47,6 +49,12 @@ func registerConnectFlags() {
 		&connectOpts.InsecureSkipCertValidation,
 		"insecure", "k", false,
 		"Skip server certificate verification",
+	)
+
+	connectCmd.PersistentFlags().BoolVar(
+		&connectOpts.ExecuteOnSemicolon,
+		"execute-on-semicolon", true,
+		"Execute SQL only after semicolon terminators are entered",
 	)
 }
 

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -21,6 +21,7 @@ type Opts struct {
 	Username                   string
 	Password                   string
 	InsecureSkipCertValidation bool
+	ExecuteOnSemicolon         bool
 }
 
 //nolint:revive
@@ -94,7 +95,7 @@ func Connect(ctx context.Context, opts *Opts, deploymentDir string) error {
 		}
 	}
 
-	return RunShell(func(input string) error {
+	return RunShellWithOpts(func(input string) error {
 		// The input string is expected to be trimmed of whitespace
 		if input == "" {
 			return nil
@@ -106,7 +107,7 @@ func Connect(ctx context.Context, opts *Opts, deploymentDir string) error {
 		}
 
 		return printResult(queryResult)
-	})
+	}, ShellOpts{ExecuteOnSemicolon: opts.ExecuteOnSemicolon})
 }
 
 func printExitHint(output io.Writer) error {

--- a/internal/connect/shell.go
+++ b/internal/connect/shell.go
@@ -21,13 +21,23 @@ const exitCommand = "exit"
 // ProcessInputFunc defines a way to process a shell input.
 type ProcessInputFunc func(input string) error
 
-type shell struct {
-	lineReader   types.LineReader
-	processInput ProcessInputFunc
+type ShellOpts struct {
+	ExecuteOnSemicolon bool
 }
 
-func newShell(lineReader types.LineReader, processInput ProcessInputFunc) *shell {
-	return &shell{lineReader, processInput}
+type shell struct {
+	lineReader          types.LineReader
+	processInput        ProcessInputFunc
+	executeOnSemicolon  bool
+	pendingStatementBuf string
+}
+
+func newShell(lineReader types.LineReader, processInput ProcessInputFunc, opts ShellOpts) *shell {
+	return &shell{
+		lineReader:         lineReader,
+		processInput:       processInput,
+		executeOnSemicolon: opts.ExecuteOnSemicolon,
+	}
 }
 
 func (sh *shell) close() error {
@@ -49,17 +59,119 @@ func (sh *shell) run() error {
 			return err
 		}
 
-		line = strings.TrimSpace(line)
-
-		if line == exitCommand {
+		trimmedLine := strings.TrimSpace(line)
+		if trimmedLine == exitCommand && strings.TrimSpace(sh.pendingStatementBuf) == "" {
 			slog.Debug("got the exit command, exitting")
 			return nil
 		}
 
-		if err := sh.processInput(line); err != nil {
+		if !sh.executeOnSemicolon {
+			if err := sh.processInput(trimmedLine); err != nil {
+				slog.Error(err.Error())
+			}
+
+			continue
+		}
+
+		sh.processInputSemicolonMode(line)
+	}
+}
+
+func (sh *shell) processInputSemicolonMode(line string) {
+	if sh.pendingStatementBuf != "" {
+		sh.pendingStatementBuf += "\n"
+	}
+	sh.pendingStatementBuf += line
+
+	statements, remainder := splitSemicolonTerminatedStatements(sh.pendingStatementBuf)
+	sh.pendingStatementBuf = remainder
+
+	for _, statement := range statements {
+		if err := sh.processInput(strings.TrimSpace(statement)); err != nil {
 			slog.Error(err.Error())
 		}
 	}
+}
+
+func splitSemicolonTerminatedStatements(sql string) ([]string, string) {
+	var (
+		statements     []string
+		start          int
+		inSingleQuotes bool
+		inDoubleQuotes bool
+		inLineComment  bool
+		inBlockComment bool
+	)
+
+	for charIndex := 0; charIndex < len(sql); charIndex++ {
+		if inLineComment {
+			if sql[charIndex] == '\n' {
+				inLineComment = false
+			}
+
+			continue
+		}
+
+		if inBlockComment {
+			if sql[charIndex] == '*' && charIndex+1 < len(sql) && sql[charIndex+1] == '/' {
+				inBlockComment = false
+				charIndex++
+			}
+
+			continue
+		}
+
+		if inSingleQuotes {
+			if sql[charIndex] == '\'' && charIndex+1 < len(sql) && sql[charIndex+1] == '\'' {
+				charIndex++
+				continue
+			}
+			if sql[charIndex] == '\'' {
+				inSingleQuotes = false
+			}
+
+			continue
+		}
+
+		if inDoubleQuotes {
+			if sql[charIndex] == '"' && charIndex+1 < len(sql) && sql[charIndex+1] == '"' {
+				charIndex++
+				continue
+			}
+			if sql[charIndex] == '"' {
+				inDoubleQuotes = false
+			}
+
+			continue
+		}
+
+		switch sql[charIndex] {
+		case '\'':
+			inSingleQuotes = true
+		case '"':
+			inDoubleQuotes = true
+		case '-':
+			if charIndex+1 < len(sql) && sql[charIndex+1] == '-' {
+				inLineComment = true
+				charIndex++
+			}
+		case '/':
+			if charIndex+1 < len(sql) && sql[charIndex+1] == '*' {
+				inBlockComment = true
+				charIndex++
+			}
+		case ';':
+			statement := strings.TrimSpace(sql[start:charIndex])
+			if statement != "" {
+				statements = append(statements, statement)
+			}
+			start = charIndex + 1
+		default:
+			continue
+		}
+	}
+
+	return statements, sql[start:]
 }
 
 func getHistoryFilePath() (string, error) {
@@ -77,8 +189,12 @@ func getHistoryFilePath() (string, error) {
 	return historyFilePath, nil
 }
 
-func runShellImpl(lineReader types.LineReader, processInput ProcessInputFunc) error {
-	shell := newShell(lineReader, processInput)
+func runShellImpl(
+	lineReader types.LineReader,
+	processInput ProcessInputFunc,
+	opts ShellOpts,
+) error {
+	shell := newShell(lineReader, processInput, opts)
 
 	defer shell.close()
 
@@ -88,6 +204,10 @@ func runShellImpl(lineReader types.LineReader, processInput ProcessInputFunc) er
 // RunShell runs the shell, processing incoming input
 // with the passed callback. Blocks until the shell exits.
 func RunShell(processInput ProcessInputFunc) error {
+	return RunShellWithOpts(processInput, ShellOpts{ExecuteOnSemicolon: true})
+}
+
+func RunShellWithOpts(processInput ProcessInputFunc, opts ShellOpts) error {
 	historyFilePath, err := getHistoryFilePath()
 	if err != nil {
 		return fmt.Errorf("couldn't get the history file path: %w", err)
@@ -98,5 +218,5 @@ func RunShell(processInput ProcessInputFunc) error {
 		return err
 	}
 
-	return runShellImpl(lineReader, processInput)
+	return runShellImpl(lineReader, processInput, opts)
 }

--- a/internal/connect/shell_test.go
+++ b/internal/connect/shell_test.go
@@ -21,10 +21,14 @@ type mockInputsProcessor struct {
 	callCount int
 	inputs    []string
 	retErr    bool
+	failOn    map[string]error
 }
 
 func (mp *mockInputsProcessor) processInput(input string) error {
 	mp.callCount++
+	if err := mp.failOn[input]; err != nil {
+		return err
+	}
 	if mp.retErr {
 		return errInputsProcessor
 	}
@@ -35,6 +39,13 @@ func (mp *mockInputsProcessor) processInput(input string) error {
 }
 
 func (mp *mockInputsProcessor) returnError() { mp.retErr = true }
+
+func (mp *mockInputsProcessor) failOnInput(input string, err error) {
+	if mp.failOn == nil {
+		mp.failOn = map[string]error{}
+	}
+	mp.failOn[input] = err
+}
 
 // nolint: revive
 func TestRunShell(t *testing.T) {
@@ -47,11 +58,13 @@ func TestRunShell(t *testing.T) {
 
 	for _, test := range []struct {
 		name  string
+		opts  ShellOpts
 		given func(*mocks)
 		then  func(*testing.T, *mocks, error)
 	}{
 		{
-			name: "single query",
+			name: "single query without semicolon is buffered",
+			opts: ShellOpts{ExecuteOnSemicolon: true},
 			given: func(mocks *mocks) {
 				mocks.shell.ReadlineReturnsOnCall(0, "SELECT * FROM Dual", nil)
 				mocks.shell.ReadlineReturnsOnCall(1, "", errTest)
@@ -61,12 +74,12 @@ func TestRunShell(t *testing.T) {
 
 				require.ErrorIs(t, err, errTest)
 				require.Equal(t, 2, mocks.shell.ReadlineCallCount())
-				require.Equal(t, 1, mocks.inputsProcessor.callCount)
-				require.Equal(t, []string{"SELECT * FROM Dual"}, mocks.inputsProcessor.inputs)
+				require.Equal(t, 0, mocks.inputsProcessor.callCount)
 			},
 		},
 		{
 			name: "interrupt",
+			opts: ShellOpts{ExecuteOnSemicolon: true},
 			given: func(mocks *mocks) {
 				mocks.shell.ReadlineReturnsOnCall(0, "", types.ErrInterrupt)
 				mocks.shell.ReadlineReturnsOnCall(1, "", errTest)
@@ -80,7 +93,77 @@ func TestRunShell(t *testing.T) {
 			},
 		},
 		{
-			name: "multiple queries",
+			name: "multiline query executes on semicolon",
+			opts: ShellOpts{ExecuteOnSemicolon: true},
+			given: func(mocks *mocks) {
+				mocks.shell.ReadlineReturnsOnCall(0, "OPEN SCHEMA dummy  ", nil)
+				mocks.shell.ReadlineReturnsOnCall(1, "SELECT * FROM Dual;", nil)
+				mocks.shell.ReadlineReturnsOnCall(2, "", errTest)
+			},
+			then: func(t *testing.T, mocks *mocks, err error) {
+				t.Helper()
+
+				require.ErrorIs(t, err, errTest)
+				require.Equal(t, []string{"OPEN SCHEMA dummy  \nSELECT * FROM Dual"}, mocks.inputsProcessor.inputs)
+			},
+		},
+		{
+			name: "multiple queries same line execute separately",
+			opts: ShellOpts{ExecuteOnSemicolon: true},
+			given: func(mocks *mocks) {
+				mocks.shell.ReadlineReturnsOnCall(0, "OPEN SCHEMA dummy;SELECT * FROM Dual;", nil)
+				mocks.shell.ReadlineReturnsOnCall(1, "", errTest)
+			},
+			then: func(t *testing.T, mocks *mocks, err error) {
+				t.Helper()
+
+				require.ErrorIs(t, err, errTest)
+				require.Equal(t, []string{
+					"OPEN SCHEMA dummy",
+					"SELECT * FROM Dual",
+				}, mocks.inputsProcessor.inputs)
+			},
+		},
+		{
+			name: "input processor error",
+			opts: ShellOpts{ExecuteOnSemicolon: true},
+			given: func(mocks *mocks) {
+				mocks.shell.ReadlineReturnsOnCall(0, "SELECT * FROM Dual;", nil)
+				mocks.shell.ReadlineReturnsOnCall(1, "", errTest)
+				mocks.inputsProcessor.returnError()
+			},
+			then: func(t *testing.T, mocks *mocks, err error) {
+				t.Helper()
+
+				// Inputs processor error shouldn't stop it.
+				require.ErrorIs(t, err, errTest)
+				require.Equal(t, 2, mocks.shell.ReadlineCallCount())
+				require.Equal(t, 1, mocks.inputsProcessor.callCount)
+			},
+		},
+		{
+			name: "semicolon mode continues after a failed statement on same line",
+			opts: ShellOpts{ExecuteOnSemicolon: true},
+			given: func(mocks *mocks) {
+				mocks.inputsProcessor.failOnInput("INVALID SQL", errInputsProcessor)
+				mocks.shell.ReadlineReturnsOnCall(
+					0,
+					"SELECT 1;INVALID SQL;SELECT 2;",
+					nil,
+				)
+				mocks.shell.ReadlineReturnsOnCall(1, "", errTest)
+			},
+			then: func(t *testing.T, mocks *mocks, err error) {
+				t.Helper()
+
+				require.ErrorIs(t, err, errTest)
+				require.Equal(t, 3, mocks.inputsProcessor.callCount)
+				require.Equal(t, []string{"SELECT 1", "SELECT 2"}, mocks.inputsProcessor.inputs)
+			},
+		},
+		{
+			name: "line mode executes per line",
+			opts: ShellOpts{ExecuteOnSemicolon: false},
 			given: func(mocks *mocks) {
 				mocks.shell.ReadlineReturnsOnCall(0, "OPEN SCHEMA dummy  ", nil)
 				mocks.shell.ReadlineReturnsOnCall(1, "  SELECT * FROM exa", nil)
@@ -98,22 +181,6 @@ func TestRunShell(t *testing.T) {
 				}, mocks.inputsProcessor.inputs)
 			},
 		},
-		{
-			name: "input processor error",
-			given: func(mocks *mocks) {
-				mocks.shell.ReadlineReturnsOnCall(0, "SELECT * FROM Dual", nil)
-				mocks.shell.ReadlineReturnsOnCall(1, "", errTest)
-				mocks.inputsProcessor.returnError()
-			},
-			then: func(t *testing.T, mocks *mocks, err error) {
-				t.Helper()
-
-				// Inputs processor error shouldn't stop it.
-				require.ErrorIs(t, err, errTest)
-				require.Equal(t, 2, mocks.shell.ReadlineCallCount())
-				require.Equal(t, 1, mocks.inputsProcessor.callCount)
-			},
-		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -121,9 +188,63 @@ func TestRunShell(t *testing.T) {
 			mocks := &mocks{&typesfakes.FakeLineReader{}, &mockInputsProcessor{}}
 			test.given(mocks)
 
-			err := runShellImpl(mocks.shell, mocks.inputsProcessor.processInput)
+			err := runShellImpl(mocks.shell, mocks.inputsProcessor.processInput, test.opts)
 
 			test.then(t, mocks, err)
 		})
 	}
+}
+
+func TestSplitSemicolonTerminatedStatements(t *testing.T) {
+	t.Parallel()
+
+	t.Run("keeps semicolons inside single quotes", func(t *testing.T) {
+		t.Parallel()
+
+		statements, remainder := splitSemicolonTerminatedStatements("SELECT 'a;b';")
+		require.Equal(t, []string{"SELECT 'a;b'"}, statements)
+		require.Empty(t, remainder)
+	})
+
+	t.Run("returns remaining unterminated statement", func(t *testing.T) {
+		t.Parallel()
+
+		sql := "OPEN SCHEMA foo;" +
+			"SELECT * FROM dual"
+		statements, remainder := splitSemicolonTerminatedStatements(sql)
+		require.Equal(t, []string{"OPEN SCHEMA foo"}, statements)
+		require.Equal(t, "SELECT * FROM dual", remainder)
+	})
+
+	t.Run("keeps semicolons inside double quotes", func(t *testing.T) {
+		t.Parallel()
+
+		statements, remainder := splitSemicolonTerminatedStatements(`SELECT "a;b";`)
+		require.Equal(t, []string{`SELECT "a;b"`}, statements)
+		require.Empty(t, remainder)
+	})
+
+	t.Run("ignores semicolons in sql line comments", func(t *testing.T) {
+		t.Parallel()
+
+		sql := "SELECT 1 -- ; in comment\n" +
+			";SELECT 2;"
+		statements, remainder := splitSemicolonTerminatedStatements(sql)
+		require.Equal(t, []string{"SELECT 1 -- ; in comment", "SELECT 2"}, statements)
+		require.Empty(t, remainder)
+	})
+
+	t.Run("ignores semicolons in sql block comments", func(t *testing.T) {
+		t.Parallel()
+
+		sql := "SELECT 1 /* ; in comment */;" +
+			"SELECT 2;"
+		statements, remainder := splitSemicolonTerminatedStatements(sql)
+		require.Equal(
+			t,
+			[]string{"SELECT 1 /* ; in comment */", "SELECT 2"},
+			statements,
+		)
+		require.Empty(t, remainder)
+	})
 }


### PR DESCRIPTION
## Description

Default `connect` shell behavior now executes SQL only after a terminating semicolon (;), which supports multiline/pasted SQL statements. A compatibility flag allows reverting to line-by-line execution.

## Related Issue

<!-- Link to the related issue(s). Use "Fixes #123" or "Closes #123" to auto-close issues when PR is merged -->

Fixes #

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

<!-- List the key changes in this PR -->

- Added shell execution options with semicolon mode support
- Implemented statement buffering in semicolon mode
- Wired connect to pass semicolon execution mode
- Added CLI flag `--execute-on-semicolon` with a `true` default

## Testing

<!-- Describe how you tested your changes -->

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

<!-- Describe your testing approach -->

## Checklist

<!-- Mark completed items with an "x" -->

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

<!-- Any additional information, screenshots, or context -->
