### PR TITLE
fix(docs): Remove AWS specifics from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,17 @@ Your browser may show a security warning when connecting to Exasol Admin because
 
 ## 🔒 Connect using SSH
 
-To connect with SSH to the compute instance that your Exasol database is running on, use `exasol diag shell`.
+To connect with SSH to your deployment use one of the following commands:
+
+```bash
+# Connect to the compute instance your database is running on:
+exasol shell host`
+```
+
+```bash
+# Connect to the COS container your node is running on:
+exasol shell container
+```
 
 ## 📦 Presets
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ To connect with SSH to your deployment use one of the following commands:
 
 ```bash
 # Connect to the compute instance your database is running on:
-exasol shell host`
+exasol shell host
 ```
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ FILE 'product_reviews.parquet';
 Both tables are distributed by `PRODUCT_ID`, enabling efficient joins between them.
 
 
-## ⚙️ Choosing cluster size and instance types
+## ⚙️ Choosing cluster size and compute instance types
 
 By default the launcher deploys a single-node cluster on a memory-optimized instance (e.g. `r6i.xlarge` on AWS, `Standard_E4s_v3` on Azure, `standard.extra-large` on Exoscale). To change the number of nodes or the instance type, use the `--cluster-size` and `--instance-type` options:
 ```bash
@@ -163,9 +163,9 @@ To save costs, you can temporarily stop Exasol Personal by using the following c
 ```bash
 exasol stop
 ```
-This stops the EC2 instance(s) that Exasol Personal is running on.
+This stops the compute instance(s) that Exasol Personal is running on.
 
-Networking and data volumes that the database data is stored on will continue to incur costs when instances are stopped.
+Networking and data volumes that the database data is stored on will continue to incur costs when compute instances are stopped.
 
 To start Exasol Personal again, use the following command:
 ```bash
@@ -175,13 +175,13 @@ The IP addresses of the nodes will change when you restart Exasol Personal. Chec
 
 ## 🗑️ Remove Exasol Personal
 
-To completely remove an Exasol Personal deployment, use `exasol destroy`. This command will terminate the EC2 instance and delete it and all associated resources in AWS.
+To completely remove an Exasol Personal deployment, use `exasol destroy`. This command will terminate and delete the compute instances and all associated resources on your cloud platform.
 
 To learn more about this command, use `exasol destroy --help`.
 
-Deleting the deployment directory and the Exasol Launcher will not remove the resources that were created in your AWS account. To completely remove a deployment, you must use the `exasol destroy` command.
+Deleting the deployment directory and the Exasol Launcher will not remove the resources that were created in your cloud environment. To completely remove a deployment, you must use the `exasol destroy` command.
 
-If you have already deleted the deployment directory and the exasol binary, you must log in to the AWS console and manually terminate the EC2 instances and associated resources.
+If you have already deleted the deployment directory and the Exasol Launcher, you must remove the resources manually in your cloud provider’s console.
 
 ## 🔜 Next steps
 
@@ -206,7 +206,7 @@ Your browser may show a security warning when connecting to Exasol Admin because
 
 ## 🔒 Connect using SSH
 
-To connect with SSH to the EC2 instance that your Exasol database is running on, use `exasol diag shell`.
+To connect with SSH to the compute instance that your Exasol database is running on, use `exasol diag shell`.
 
 ## 📦 Presets
 
@@ -235,7 +235,7 @@ You can store your own preset directories anywhere on your filesystem and pass t
 
 ### Building your own preset
 
-See [doc/presets.md](doc/presets.md) for the full preset contract: manifest schema, required output artifacts, variable channels, and the reference implementation in `assets/infrastructure/aws/`.
+See [doc/presets.md](doc/presets.md) for the full preset contract: manifest schema, required output artifacts, variable channels, and the reference implementations in `assets/infrastructure`.
 
 ## ⚖️ Licensing
 


### PR DESCRIPTION
## Description

fix(docs): Remove AWS specifics from README

## Related Issue

<!-- Link to the related issue(s). Use "Fixes #123" or "Closes #123" to auto-close issues when PR is merged -->


## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat`: New feature
- [ x] `fix`: Bug fix
- [ x] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

Removed specific mentions of AWS, EC2 etc from the document 

## Testing

<!-- Describe how you tested your changes -->

- [ ] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

Proof-read

## Checklist

<!-- Mark completed items with an "x" -->

- [ ] Code follows the project's [coding guidelines](doc/best_practices.md)
- [ ] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [ ] Added/updated tests
- [ ] All tests pass locally
- [ x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes


