### PR TITLE
fix: Make tests not look for hints on non-interactive stdin

### DIFF
--- a/tests/tests/deployment/test_standard_deployment.py
+++ b/tests/tests/deployment/test_standard_deployment.py
@@ -6,6 +6,7 @@
 import logging
 import os
 import platform
+import re
 import signal
 import struct
 import subprocess
@@ -22,7 +23,6 @@ from typing import Final
 
 import pytest
 import requests
-import semver
 
 from framework.deployment import (
     Deployment,
@@ -283,16 +283,9 @@ def test_connect_table_width(reusable_deployment: Deployment) -> None:
     os.close(master_fd)
 
     output_lines = [line.rstrip("\r") for line in str(output_raw, "utf-8").split("\n")]
-    version_line = output_lines[0].strip()
-    output_without_version = "\n".join(output_lines[1:]).strip("\n")
-
-    # Interactive shell should print the version and exit hint.
-    exasol_name, exasol_version = version_line.split(" ")
-    assert exasol_name == "Exasol"
-    assert semver.VersionInfo.is_valid(exasol_version)
+    output = "\n".join(output_lines).strip("\n")
 
     expected = textwrap.dedent("""
-    Type "exit" to exit the shell
     ┌────┬─────────────────────────────────────────────────────┐
     │ id │                        name                         │
     ├────┼─────────────────────────────────────────────────────┤
@@ -301,7 +294,49 @@ def test_connect_table_width(reusable_deployment: Deployment) -> None:
     └────┴─────────────────────────────────────────────────────┘
     """)
 
-    assert output_without_version == expected.strip("\n")
+    assert output == expected.strip("\n")
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
+)
+@pytest.mark.installation_e2e
+def test_connect_interactive_shows_version_and_exit_hint(
+    reusable_deployment: Deployment,
+) -> None:
+    launcher_path = reusable_deployment.launcher.launcher_path
+    deployment_dir = reusable_deployment.deployment_dir.name
+    master_fd, slave_fd = os.openpty()
+
+    proc = subprocess.Popen(
+        [launcher_path, "connect", "--deployment-dir", deployment_dir],
+        stdin=slave_fd,
+        stdout=slave_fd,
+        stderr=slave_fd,
+    )
+
+    try:
+        os.write(master_fd, b"exit\n")
+        return_code = proc.wait(timeout=120)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+        os.close(slave_fd)
+
+    output_raw = b""
+    try:
+        while chunk := os.read(master_fd, 1024):
+            output_raw += chunk
+    except OSError:
+        pass
+    finally:
+        os.close(master_fd)
+
+    output = output_raw.decode("utf-8", errors="replace")
+
+    assert return_code == 0
+    assert 'Type "exit" to exit the shell' in output
+    assert re.search(r"\bExasol \d+\.\d+\.\d+\b", output) is not None
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Description
Make tests not look for hints on non-interactive stdin

## Related Issue


Fixes #

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

<!-- List the key changes in this PR -->

-
-
-

## Testing

<!-- Describe how you tested your changes -->

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

<!-- Describe your testing approach -->

## Checklist

<!-- Mark completed items with an "x" -->

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

<!-- Any additional information, screenshots, or context -->
