### PR TITLE
fix: flush pending statement on EOF in semicolon mode

### DIFF
--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -107,7 +107,10 @@ func Connect(ctx context.Context, opts *Opts, deployment config.DeploymentDir) e
 		}
 
 		return printResult(queryResult)
-	}, ShellOpts{ExecuteOnSemicolon: opts.ExecuteOnSemicolon})
+	}, ShellOpts{
+		ExecuteOnSemicolon: opts.ExecuteOnSemicolon,
+		FlushPendingOnEOF:  !util.IsInteractiveStdin(),
+	})
 }
 
 func printExitHint(output io.Writer) error {

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -107,10 +107,7 @@ func Connect(ctx context.Context, opts *Opts, deployment config.DeploymentDir) e
 		}
 
 		return printResult(queryResult)
-	}, ShellOpts{
-		ExecuteOnSemicolon: opts.ExecuteOnSemicolon,
-		FlushPendingOnEOF:  !util.IsInteractiveStdin(),
-	})
+	}, ShellOpts{ExecuteOnSemicolon: opts.ExecuteOnSemicolon})
 }
 
 func printExitHint(output io.Writer) error {

--- a/internal/connect/shell.go
+++ b/internal/connect/shell.go
@@ -23,19 +23,12 @@ type ProcessInputFunc func(input string) error
 
 type ShellOpts struct {
 	ExecuteOnSemicolon bool
-	// FlushPendingOnEOF makes the shell execute any buffered (un-`;`-terminated)
-	// statement when the input stream closes. Intended for non-interactive stdin
-	// (pipes, redirected files) so the final statement is not silently dropped.
-	// Must stay false for interactive sessions, where Ctrl-D after typing an
-	// incomplete statement should discard the buffer rather than execute it.
-	FlushPendingOnEOF bool
 }
 
 type shell struct {
 	lineReader          types.LineReader
 	processInput        ProcessInputFunc
 	executeOnSemicolon  bool
-	flushPendingOnEOF   bool
 	pendingStatementBuf string
 }
 
@@ -44,7 +37,6 @@ func newShell(lineReader types.LineReader, processInput ProcessInputFunc, opts S
 		lineReader:         lineReader,
 		processInput:       processInput,
 		executeOnSemicolon: opts.ExecuteOnSemicolon,
-		flushPendingOnEOF:  opts.FlushPendingOnEOF,
 	}
 }
 
@@ -59,10 +51,6 @@ func (sh *shell) execStatement(stmt string) {
 }
 
 func (sh *shell) handleEOF() {
-	if !sh.flushPendingOnEOF {
-		return
-	}
-
 	remaining := strings.TrimSpace(sh.pendingStatementBuf)
 	if remaining == "" {
 		return
@@ -228,7 +216,9 @@ func runShellImpl(
 // RunShell runs the shell, processing incoming input
 // with the passed callback. Blocks until the shell exits.
 func RunShell(processInput ProcessInputFunc) error {
-	return RunShellWithOpts(processInput, ShellOpts{ExecuteOnSemicolon: true})
+	return RunShellWithOpts(processInput, ShellOpts{
+		ExecuteOnSemicolon: true,
+	})
 }
 
 func RunShellWithOpts(processInput ProcessInputFunc, opts ShellOpts) error {

--- a/internal/connect/shell.go
+++ b/internal/connect/shell.go
@@ -23,12 +23,19 @@ type ProcessInputFunc func(input string) error
 
 type ShellOpts struct {
 	ExecuteOnSemicolon bool
+	// FlushPendingOnEOF makes the shell execute any buffered (un-`;`-terminated)
+	// statement when the input stream closes. Intended for non-interactive stdin
+	// (pipes, redirected files) so the final statement is not silently dropped.
+	// Must stay false for interactive sessions, where Ctrl-D after typing an
+	// incomplete statement should discard the buffer rather than execute it.
+	FlushPendingOnEOF bool
 }
 
 type shell struct {
 	lineReader          types.LineReader
 	processInput        ProcessInputFunc
 	executeOnSemicolon  bool
+	flushPendingOnEOF   bool
 	pendingStatementBuf string
 }
 
@@ -37,11 +44,31 @@ func newShell(lineReader types.LineReader, processInput ProcessInputFunc, opts S
 		lineReader:         lineReader,
 		processInput:       processInput,
 		executeOnSemicolon: opts.ExecuteOnSemicolon,
+		flushPendingOnEOF:  opts.FlushPendingOnEOF,
 	}
 }
 
 func (sh *shell) close() error {
 	return sh.lineReader.Close()
+}
+
+func (sh *shell) execStatement(stmt string) {
+	if err := sh.processInput(stmt); err != nil {
+		slog.Error(err.Error())
+	}
+}
+
+func (sh *shell) handleEOF() {
+	if !sh.flushPendingOnEOF {
+		return
+	}
+
+	remaining := strings.TrimSpace(sh.pendingStatementBuf)
+	if remaining == "" {
+		return
+	}
+
+	sh.execStatement(remaining)
 }
 
 func (sh *shell) run() error {
@@ -53,6 +80,8 @@ func (sh *shell) run() error {
 			if errors.Is(err, types.ErrInterrupt) {
 				continue
 			} else if errors.Is(err, io.EOF) {
+				sh.handleEOF()
+
 				return nil
 			}
 
@@ -66,10 +95,7 @@ func (sh *shell) run() error {
 		}
 
 		if !sh.executeOnSemicolon {
-			if err := sh.processInput(trimmedLine); err != nil {
-				slog.Error(err.Error())
-			}
-
+			sh.execStatement(trimmedLine)
 			continue
 		}
 
@@ -87,9 +113,7 @@ func (sh *shell) processInputSemicolonMode(line string) {
 	sh.pendingStatementBuf = remainder
 
 	for _, statement := range statements {
-		if err := sh.processInput(strings.TrimSpace(statement)); err != nil {
-			slog.Error(err.Error())
-		}
+		sh.execStatement(strings.TrimSpace(statement))
 	}
 }
 

--- a/internal/connect/shell_test.go
+++ b/internal/connect/shell_test.go
@@ -5,6 +5,7 @@ package connect
 
 import (
 	"errors"
+	"io"
 	"testing"
 
 	"github.com/exasol/exasol-personal/internal/connect/types"
@@ -73,6 +74,36 @@ func TestRunShell(t *testing.T) {
 				t.Helper()
 
 				require.ErrorIs(t, err, errTest)
+				require.Equal(t, 2, mocks.shell.ReadlineCallCount())
+				require.Equal(t, 0, mocks.inputsProcessor.callCount)
+			},
+		},
+		{
+			name: "non-interactive EOF flushes buffered statement without semicolon",
+			opts: ShellOpts{ExecuteOnSemicolon: true, FlushPendingOnEOF: true},
+			given: func(mocks *mocks) {
+				mocks.shell.ReadlineReturnsOnCall(0, "SELECT * FROM Dual", nil)
+				mocks.shell.ReadlineReturnsOnCall(1, "", io.EOF)
+			},
+			then: func(t *testing.T, mocks *mocks, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
+				require.Equal(t, 2, mocks.shell.ReadlineCallCount())
+				require.Equal(t, []string{"SELECT * FROM Dual"}, mocks.inputsProcessor.inputs)
+			},
+		},
+		{
+			name: "interactive EOF discards buffered statement without semicolon",
+			opts: ShellOpts{ExecuteOnSemicolon: true, FlushPendingOnEOF: false},
+			given: func(mocks *mocks) {
+				mocks.shell.ReadlineReturnsOnCall(0, "DROP TABLE Foo", nil)
+				mocks.shell.ReadlineReturnsOnCall(1, "", io.EOF)
+			},
+			then: func(t *testing.T, mocks *mocks, err error) {
+				t.Helper()
+
+				require.NoError(t, err)
 				require.Equal(t, 2, mocks.shell.ReadlineCallCount())
 				require.Equal(t, 0, mocks.inputsProcessor.callCount)
 			},

--- a/internal/connect/shell_test.go
+++ b/internal/connect/shell_test.go
@@ -79,8 +79,8 @@ func TestRunShell(t *testing.T) {
 			},
 		},
 		{
-			name: "non-interactive EOF flushes buffered statement without semicolon",
-			opts: ShellOpts{ExecuteOnSemicolon: true, FlushPendingOnEOF: true},
+			name: "EOF flushes buffered statement without semicolon",
+			opts: ShellOpts{ExecuteOnSemicolon: true},
 			given: func(mocks *mocks) {
 				mocks.shell.ReadlineReturnsOnCall(0, "SELECT * FROM Dual", nil)
 				mocks.shell.ReadlineReturnsOnCall(1, "", io.EOF)
@@ -91,21 +91,6 @@ func TestRunShell(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, 2, mocks.shell.ReadlineCallCount())
 				require.Equal(t, []string{"SELECT * FROM Dual"}, mocks.inputsProcessor.inputs)
-			},
-		},
-		{
-			name: "interactive EOF discards buffered statement without semicolon",
-			opts: ShellOpts{ExecuteOnSemicolon: true, FlushPendingOnEOF: false},
-			given: func(mocks *mocks) {
-				mocks.shell.ReadlineReturnsOnCall(0, "DROP TABLE Foo", nil)
-				mocks.shell.ReadlineReturnsOnCall(1, "", io.EOF)
-			},
-			then: func(t *testing.T, mocks *mocks, err error) {
-				t.Helper()
-
-				require.NoError(t, err)
-				require.Equal(t, 2, mocks.shell.ReadlineCallCount())
-				require.Equal(t, 0, mocks.inputsProcessor.callCount)
 			},
 		},
 		{

--- a/tests/tests/deployment/test_standard_deployment.py
+++ b/tests/tests/deployment/test_standard_deployment.py
@@ -208,8 +208,8 @@ def test_file_import(reusable_deployment: Deployment) -> None:
         "OPEN SCHEMA test_file_import;",
         'CREATE TABLE Users ("id" INT PRIMARY KEY, "user_id" VARCHAR(32), '
         '"firstname" VARCHAR(100), "lastname" VARCHAR(100), '
-        '"sex" VARCHAR(10), "email" VARCHAR(255))',
-        f"IMPORT INTO Users FROM LOCAL CSV FILE '{people_csv_path.absolute()}'",
+        '"sex" VARCHAR(10), "email" VARCHAR(255));',
+        f"IMPORT INTO Users FROM LOCAL CSV FILE '{people_csv_path.absolute()}';",
         "SELECT * FROM Users",
     ]
 


### PR DESCRIPTION
## Description

When SQL is piped into `exasol connect` (non-interactive stdin), the shell silently dropped the final statement if it lacked a trailing `;`. No error, exit code 0.

Examples that were broken:
- `echo "SELECT 1" | exasol connect`
- `exasol connect < migration.sql` where the file's last statement has no `;`
- The CI tests `test_single_query` and `test_file_import`, which pipe queries without `;`

## Related Issue

<!-- Link to the related issue(s). Use "Fixes #123" or "Closes #123" to auto-close issues when PR is merged -->

Fixes #

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- On non-interactive io.EOF, flush any buffered statement before returning, so piped or redirected input without a trailing ; no longer drops the final statement. Interactive EOF still discards it.
- ErrInterrupt (Ctrl-C) keeps its current behavior and does not execute the buffered statement.
- Extracted the repeated processInput + slog.Error handling into a small execStatement helper.
- Added unit tests covering both EOF behaviors.

## Testing

<!-- Describe how you tested your changes -->

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

### Test Details

Unit Testing has been written to cover the code changes.

## Checklist

<!-- Mark completed items with an "x" -->

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

<!-- Any additional information, screenshots, or context -->
