### PR TITLE
feat: connect command json support

### DIFF
--- a/cmd/exasol/connect.go
+++ b/cmd/exasol/connect.go
@@ -16,45 +16,62 @@ const connectCmdLongDesc = connectCmdShortDesc + `
 Establish an SQL connection to the database instance in an active deployment.
 `
 
+const connectCmdExample = `  exasol connect
+  exasol connect --json
+	printf 'SELECT 1;\n' | exasol connect --json=compact`
+
 var connectOpts = connect.Opts{
 	ExecuteOnSemicolon: true,
+	JSONFormat:         connect.JSONFormatPretty,
 }
 
 var connectCmd = &cobra.Command{
 	Use:          "connect",
 	Short:        connectCmdShortDesc,
 	Long:         connectCmdLongDesc,
+	Example:      connectCmdExample,
 	Args:         cobra.NoArgs,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
+		connectOpts.OutputJSON = cmd.Flags().Changed("json")
+
 		return deploy.Connect(cmd.Context(), &connectOpts, commonFlags.Deployment())
 	},
 }
 
 func registerConnectFlags() {
-	connectCmd.PersistentFlags().StringVarP(
+	connectCmd.Flags().StringVarP(
 		&connectOpts.Username,
 		"username", "u", "sys",
 		"Database username",
 	)
 
-	connectCmd.PersistentFlags().StringVarP(
+	connectCmd.Flags().StringVarP(
 		&connectOpts.Password,
 		"password", "p", "",
 		"Database password",
 	)
 
 	// This name is inspired by curl's --insecure flag.
-	connectCmd.PersistentFlags().BoolVarP(
+	connectCmd.Flags().BoolVarP(
 		&connectOpts.InsecureSkipCertValidation,
 		"insecure", "k", false,
 		"Skip server certificate verification",
 	)
 
-	connectCmd.PersistentFlags().BoolVar(
+	connectCmd.Flags().BoolVar(
 		&connectOpts.ExecuteOnSemicolon,
 		"execute-on-semicolon", true,
 		"Execute SQL only after semicolon terminators are entered",
+	)
+
+	JSONFormatVarP(
+		connectCmd.Flags(),
+		&connectOpts.JSONFormat,
+		"json",
+		"j",
+		connect.JSONFormatPretty,
+		"Output in JSON format: pretty, compact",
 	)
 }
 

--- a/cmd/exasol/connect_json_format_flag.go
+++ b/cmd/exasol/connect_json_format_flag.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"errors"
+
+	"github.com/exasol/exasol-personal/internal/connect"
+	"github.com/spf13/pflag"
+)
+
+type JSONFormatValue struct {
+	target *connect.JSONFormat
+}
+
+func NewJSONFormatValue(
+	target *connect.JSONFormat,
+	defaultValue connect.JSONFormat,
+) *JSONFormatValue {
+	if target != nil {
+		*target = defaultValue
+	}
+
+	return &JSONFormatValue{target: target}
+}
+
+func (v *JSONFormatValue) String() string {
+	if v == nil || v.target == nil {
+		return ""
+	}
+
+	return v.target.String()
+}
+
+func (*JSONFormatValue) Type() string {
+	return "string"
+}
+
+func (v *JSONFormatValue) Set(input string) error {
+	if v == nil || v.target == nil {
+		return errors.New("json format target is nil")
+	}
+
+	format, err := connect.ParseJSONFormat(input)
+	if err != nil {
+		return err
+	}
+
+	*v.target = format
+
+	return nil
+}
+
+func JSONFormatVarP(
+	flagSet *pflag.FlagSet,
+	target *connect.JSONFormat,
+	name string,
+	shorthand string,
+	defaultValue connect.JSONFormat,
+	usage string,
+) {
+	flagSet.VarP(NewJSONFormatValue(target, defaultValue), name, shorthand, usage)
+
+	flag := flagSet.Lookup(name)
+	if flag == nil {
+		return
+	}
+
+	flag.NoOptDefVal = defaultValue.String()
+}

--- a/cmd/exasol/connect_test.go
+++ b/cmd/exasol/connect_test.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/connect"
+	"github.com/spf13/pflag"
+)
+
+func TestJSONFormatValueSet(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name     string
+		input    string
+		expected connect.JSONFormat
+	}{
+		{name: "empty defaults to pretty", input: "", expected: connect.JSONFormatPretty},
+		{
+			name:     "trims and lowercases compact",
+			input:    "  COMPACT  ",
+			expected: connect.JSONFormatCompact,
+		},
+		{name: "keeps pretty", input: "pretty", expected: connect.JSONFormatPretty},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var target connect.JSONFormat
+			value := NewJSONFormatValue(&target, connect.JSONFormatPretty)
+
+			if err := value.Set(test.input); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if target != test.expected {
+				t.Fatalf("unexpected parsed format: got %q expected %q", target, test.expected)
+			}
+		})
+	}
+}
+
+func TestJSONFormatValueSetRejectsInvalidValue(t *testing.T) {
+	t.Parallel()
+
+	var target connect.JSONFormat
+	value := NewJSONFormatValue(&target, connect.JSONFormatPretty)
+
+	err := value.Set("yaml")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "expected one of") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestJSONFormatVarP_SetsPrettyWhenFlagHasNoValue(t *testing.T) {
+	t.Parallel()
+
+	flagSet := pflag.NewFlagSet("connect", pflag.ContinueOnError)
+	var target connect.JSONFormat
+	JSONFormatVarP(
+		flagSet,
+		&target,
+		"json",
+		"j",
+		connect.JSONFormatPretty,
+		"Output in JSON format: pretty, compact",
+	)
+
+	if err := flagSet.Parse([]string{"--json"}); err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if target != connect.JSONFormatPretty {
+		t.Fatalf("unexpected format: got %q expected %q", target, connect.JSONFormatPretty)
+	}
+	if !flagSet.Changed("json") {
+		t.Fatal("expected json flag to be marked changed")
+	}
+}
+
+func TestJSONFormatVarP_AcceptsExplicitCompactValue(t *testing.T) {
+	t.Parallel()
+
+	flagSet := pflag.NewFlagSet("connect", pflag.ContinueOnError)
+	var target connect.JSONFormat
+	JSONFormatVarP(
+		flagSet,
+		&target,
+		"json",
+		"j",
+		connect.JSONFormatPretty,
+		"Output in JSON format: pretty, compact",
+	)
+
+	if err := flagSet.Parse([]string{"--json=compact"}); err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+	if target != connect.JSONFormatCompact {
+		t.Fatalf("unexpected format: got %q expected %q", target, connect.JSONFormatCompact)
+	}
+}
+
+func TestConnectCmdExamplesMentionJSONOptions(t *testing.T) {
+	t.Parallel()
+
+	for _, expected := range []string{
+		"--json",
+		"printf 'SELECT 1;\\n' | exasol connect --json=compact",
+	} {
+		if !strings.Contains(connectCmdExample, expected) {
+			t.Fatalf("expected examples to contain %q", expected)
+		}
+	}
+}
+
+// nolint: paralleltest // Mutates the shared command usage template for inspection.
+func TestConnectUsageShowsJSONFormatUnderFlags(t *testing.T) {
+	originalTemplate := connectCmd.UsageTemplate()
+	connectCmd.SetUsageTemplate(customUsageTemplate)
+	t.Cleanup(func() {
+		connectCmd.SetUsageTemplate(originalTemplate)
+	})
+
+	// Match the runtime setup where help is added explicitly.
+	if connectCmd.Flags().Lookup("help") == nil {
+		connectCmd.Flags().BoolP("help", "h", false, "Help for connect")
+	}
+
+	usage := connectCmd.UsageString()
+	if !strings.Contains(usage, "--json string") {
+		t.Fatalf("expected usage to list --json under flags, got:\n%s", usage)
+	}
+	if !strings.Contains(usage, "Output in JSON format: pretty, compact") {
+		t.Fatalf("expected usage to describe --json, got:\n%s", usage)
+	}
+	if !strings.Contains(usage, "Examples:") {
+		t.Fatalf("expected usage to include examples, got:\n%s", usage)
+	}
+	if !strings.Contains(usage, connectCmdExample) {
+		t.Fatalf("expected usage to include connect examples, got:\n%s", usage)
+	}
+
+	// Sanity check: the flag is local to the connect command, not persistent/inherited.
+	jsonFlag := connectCmd.LocalNonPersistentFlags().Lookup("json")
+	if jsonFlag == nil {
+		t.Fatal("expected --json to be a local non-persistent flag")
+	}
+	if jsonFlag.NoOptDefVal != connect.JSONFormatPretty.String() {
+		t.Fatalf(
+			"expected --json NoOptDefVal=%q, got %q",
+			connect.JSONFormatPretty,
+			jsonFlag.NoOptDefVal,
+		)
+	}
+	if connectCmd.LocalNonPersistentFlags().Lookup("json-format") != nil {
+		t.Fatal("did not expect --json-format to remain registered")
+	}
+}

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -5,10 +5,12 @@ package connect
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/exasol/exasol-personal/internal/config"
 	"github.com/exasol/exasol-personal/internal/connect/exasol"
@@ -17,12 +19,50 @@ import (
 	"github.com/exasol/exasol-personal/internal/util"
 )
 
+type JSONFormat string
+
+const (
+	JSONFormatPretty  JSONFormat = "pretty"
+	JSONFormatCompact JSONFormat = "compact"
+)
+
+func (format JSONFormat) String() string {
+	return string(format)
+}
+
+func ParseJSONFormat(format string) (JSONFormat, error) {
+	normalized := JSONFormat(strings.ToLower(strings.TrimSpace(format)))
+
+	switch normalized {
+	case "", JSONFormatPretty:
+		return JSONFormatPretty, nil
+	case JSONFormatCompact:
+		return JSONFormatCompact, nil
+	default:
+		return "", fmt.Errorf(
+			"invalid json format %q (expected one of: %s, %s)",
+			format,
+			JSONFormatPretty,
+			JSONFormatCompact,
+		)
+	}
+}
+
 type Opts struct {
 	Username                   string
 	Password                   string
 	InsecureSkipCertValidation bool
 	ExecuteOnSemicolon         bool
+	OutputJSON                 bool
+	JSONFormat                 JSONFormat
 }
+
+type jsonQueryResult struct {
+	Columns []string   `json:"columns"`
+	Rows    [][]string `json:"rows"`
+}
+
+type resultPrinter func(io.Writer, generaltypes.QueryResulter) error
 
 //nolint:revive
 func NewExasolConnection(
@@ -89,6 +129,12 @@ func Connect(ctx context.Context, opts *Opts, deployment config.DeploymentDir) e
 
 	defer database.Close()
 
+	output := os.Stdout
+	printer := printResultTable
+	if opts.OutputJSON {
+		printer = newJSONResultPrinter(opts.JSONFormat)
+	}
+
 	if util.IsInteractiveStdin() {
 		if err := printExitHint(os.Stderr); err != nil {
 			return err
@@ -106,7 +152,7 @@ func Connect(ctx context.Context, opts *Opts, deployment config.DeploymentDir) e
 			return err
 		}
 
-		return printResult(queryResult)
+		return printer(output, queryResult)
 	}, ShellOpts{ExecuteOnSemicolon: opts.ExecuteOnSemicolon})
 }
 
@@ -116,12 +162,47 @@ func printExitHint(output io.Writer) error {
 	return err
 }
 
-func printResult(queryResult generaltypes.QueryResulter) error {
+func normalizeJSONFormat(format JSONFormat) JSONFormat {
+	switch JSONFormat(strings.ToLower(strings.TrimSpace(format.String()))) {
+	case JSONFormatPretty:
+		return JSONFormatPretty
+	case JSONFormatCompact:
+		return JSONFormatCompact
+	default:
+		return JSONFormatPretty
+	}
+}
+
+func newJSONResultPrinter(jsonFormat JSONFormat) resultPrinter {
+	format := normalizeJSONFormat(jsonFormat)
+
+	return func(output io.Writer, queryResult generaltypes.QueryResulter) error {
+		return printResultJSON(output, queryResult, format)
+	}
+}
+
+func printResultJSON(
+	output io.Writer,
+	queryResult generaltypes.QueryResulter,
+	jsonFormat JSONFormat,
+) error {
+	encoder := json.NewEncoder(output)
+	if normalizeJSONFormat(jsonFormat) == JSONFormatPretty {
+		encoder.SetIndent("", "  ")
+	}
+
+	return encoder.Encode(jsonQueryResult{
+		Columns: queryResult.ColumnNames(),
+		Rows:    queryResult.Rows(),
+	})
+}
+
+func printResultTable(output io.Writer, queryResult generaltypes.QueryResulter) error {
 	rows := queryResult.Rows()
 
 	slog.Debug("printing query result", "num_rows", len(rows))
 
-	table := tablewriter.New(os.Stdout)
+	table := tablewriter.New(output)
 	table.SetHeader(queryResult.ColumnNames())
 
 	if err := table.SetRows(rows); err != nil {

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -1,0 +1,164 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package connect
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	prettyJSONResult = "{\n" +
+		"  \"columns\": [\n" +
+		"    \"ID\",\n" +
+		"    \"NAME\"\n" +
+		"  ],\n" +
+		"  \"rows\": [\n" +
+		"    [\n" +
+		"      \"1\",\n" +
+		"      \"Alice\"\n" +
+		"    ],\n" +
+		"    [\n" +
+		"      \"2\",\n" +
+		"      \"Bob\"\n" +
+		"    ]\n" +
+		"  ]\n" +
+		"}\n"
+	compactJSONResult = "{\"columns\":[\"ID\",\"NAME\"]," +
+		"\"rows\":[[\"1\",\"Alice\"],[\"2\",\"Bob\"]]}\n"
+	emptyPrettyJSON = "{\n" +
+		"  \"columns\": [],\n" +
+		"  \"rows\": []\n" +
+		"}\n"
+	unknownPrettyJSON = "{\n" +
+		"  \"columns\": [\n" +
+		"    \"ID\"\n" +
+		"  ],\n" +
+		"  \"rows\": [\n" +
+		"    [\n" +
+		"      \"1\"\n" +
+		"    ]\n" +
+		"  ]\n" +
+		"}\n"
+)
+
+type stubQueryResult struct {
+	columnNames []string
+	rows        [][]string
+}
+
+func (s stubQueryResult) ColumnNames() []string {
+	return s.columnNames
+}
+
+func (s stubQueryResult) Rows() [][]string {
+	return s.rows
+}
+
+func TestPrintResultJSON(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name       string
+		format     JSONFormat
+		result     stubQueryResult
+		expected   string
+		normalized JSONFormat
+	}{
+		{
+			name:   "renders columns and rows as pretty json",
+			format: JSONFormatPretty,
+			result: stubQueryResult{
+				columnNames: []string{"ID", "NAME"},
+				rows:        [][]string{{"1", "Alice"}, {"2", "Bob"}},
+			},
+			expected:   prettyJSONResult,
+			normalized: JSONFormatPretty,
+		},
+		{
+			name:   "renders columns and rows as compact json",
+			format: JSONFormatCompact,
+			result: stubQueryResult{
+				columnNames: []string{"ID", "NAME"},
+				rows:        [][]string{{"1", "Alice"}, {"2", "Bob"}},
+			},
+			expected:   compactJSONResult,
+			normalized: JSONFormatCompact,
+		},
+		{
+			name:   "renders empty results as empty arrays",
+			format: JSONFormatPretty,
+			result: stubQueryResult{
+				columnNames: []string{},
+				rows:        [][]string{},
+			},
+			expected:   emptyPrettyJSON,
+			normalized: JSONFormatPretty,
+		},
+		{
+			name:   "unknown format falls back to pretty json",
+			format: JSONFormat("surprise"),
+			result: stubQueryResult{
+				columnNames: []string{"ID"},
+				rows:        [][]string{{"1"}},
+			},
+			expected:   unknownPrettyJSON,
+			normalized: JSONFormatPretty,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+
+			// Given a query result that should be emitted as JSON.
+			// When the result is rendered in the requested JSON mode.
+			printer := newJSONResultPrinter(test.format)
+			err := printer(&buf, test.result)
+
+			// Then the output is valid JSON in the expected shape.
+			require.NoError(t, err)
+			require.Equal(t, test.expected, buf.String())
+			require.Equal(t, test.normalized, normalizeJSONFormat(test.format))
+
+			var decoded jsonQueryResult
+			require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
+			require.Equal(t, test.result.columnNames, decoded.Columns)
+			require.Equal(t, test.result.rows, decoded.Rows)
+		})
+	}
+}
+
+func TestParseJSONFormat(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name      string
+		input     string
+		expected  JSONFormat
+		wantError bool
+	}{
+		{name: "empty defaults to pretty", input: "", expected: JSONFormatPretty},
+		{name: "pretty accepted", input: "pretty", expected: JSONFormatPretty},
+		{name: "compact accepted", input: "compact", expected: JSONFormatCompact},
+		{name: "case and whitespace normalized", input: "  PRETTY  ", expected: JSONFormatPretty},
+		{name: "invalid value rejected", input: "yaml", wantError: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			format, err := ParseJSONFormat(test.input)
+			if test.wantError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.expected, format)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Add JSON output support to `exasol connect`, including configurable pretty/compact formatting for SQL query results. This keeps the default table output unchanged while making the command easier to use in scripts and automation.

## Related Issue

SPOT-30635

## Type of Change

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Added `--json[=pretty|compact]` with strong typing and validation
- Added/updated tests for JSON rendering, flag parsing, and help output

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

 / 

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

Example
```
> ../exasol connect --json
Exasol 2025.2.0
Type "exit" to exit the shell
> select * from EXA_ALL_USERS;
{
  "columns": [
    "USER_NAME",
    "CREATED",
    "USER_CONSUMER_GROUP",
    "USER_COMMENT"
  ],
  "rows": [
    [
      "SYS",
      "2026-05-11 11:03:52.000000",
      "SYS_CONSUMER_GROUP",
      "SYS is the system user and possesses universal privileges. Please remember to change the initial password of this privileged user."
    ],
    [
      "EXA_PROUST_MONITOR",
      "2026-05-11 11:03:59.000000",
      "\u003cnil\u003e",
      "\u003cnil\u003e"
    ]
  ]
}
```

This preserves tabular output structure while supporting both human-readable and script-friendly JSON modes.

