### PR TITLE
Infrastructure backends

### DIFF
--- a/assets/infrastructure/aws/infrastructure.yaml
+++ b/assets/infrastructure/aws/infrastructure.yaml
@@ -1,5 +1,10 @@
 name: Exasol in AWS on Ubuntu
 description: Provisioning in AWS. Ubuntu, S3 archive volume, dynamic IP.
+backend: tofu
+
+compatibility:
+  provides:
+    - remote-exec
 
 tofu:
   variablesFile: variables_public.tf

--- a/assets/infrastructure/aws/outputs.tf
+++ b/assets/infrastructure/aws/outputs.tf
@@ -12,6 +12,7 @@ locals {
   key_file_path               = "${local.infrastructure_artifact_dir}/${local.key_file_name}"
 
   deployment_info = {
+    backend          = "tofu"
     deploymentId     = local.deployment_id
     region           = data.aws_region.current.id
     availabilityZone = local.selected_az
@@ -20,6 +21,17 @@ locals {
     instanceType     = var.instance_type
     vpcId            = aws_vpc.vpc.id
     subnetId         = aws_subnet.subnet.id
+    connection = length(values(data.aws_instance.nodes)) > 0 ? {
+      host          = values(data.aws_instance.nodes)[0].public_dns
+      displayHost   = values(data.aws_instance.nodes)[0].public_dns
+      publicIp      = values(data.aws_instance.nodes)[0].public_ip
+      dbPort        = 8563
+      uiPort        = 8443
+      username      = "sys"
+      sshCommand    = "ssh -i ${local.key_file_relative_path} ubuntu@${values(data.aws_instance.nodes)[0].public_dns} -p 22"
+      sshPort       = "22"
+      shellSupported = true
+    } : null
     nodes = {
       for k, node in data.aws_instance.nodes :
       k => {

--- a/assets/infrastructure/azure/infrastructure.yaml
+++ b/assets/infrastructure/azure/infrastructure.yaml
@@ -1,5 +1,10 @@
 name: Exasol in Azure on Ubuntu
 description: Provisioning in Azure. Ubuntu, managed disks, static public IP.
+backend: tofu
+
+compatibility:
+  provides:
+    - remote-exec
 
 tofu:
   variablesFile: variables_public.tf

--- a/assets/infrastructure/azure/outputs.tf
+++ b/assets/infrastructure/azure/outputs.tf
@@ -6,6 +6,7 @@ locals {
   key_file_path               = "${local.infrastructure_artifact_dir}/${local.key_file_name}"
 
   deployment_info = {
+    backend          = "tofu"
     deploymentId     = local.deployment_id
     region           = azurerm_resource_group.rg.location
     availabilityZone = ""
@@ -14,6 +15,17 @@ locals {
     instanceType     = var.instance_type
     vpcId            = azurerm_virtual_network.vnet.id
     subnetId         = azurerm_subnet.subnet.id
+    connection = length(values(azurerm_linux_virtual_machine.nodes)) > 0 ? {
+      host           = values(azurerm_public_ip.nodes)[0].fqdn
+      displayHost    = values(azurerm_public_ip.nodes)[0].fqdn
+      publicIp       = values(azurerm_public_ip.nodes)[0].ip_address
+      dbPort         = 8563
+      uiPort         = 8443
+      username       = "sys"
+      sshCommand     = "ssh -i ${local.key_file_relative_path} ubuntu@${values(azurerm_public_ip.nodes)[0].ip_address} -p 22"
+      sshPort        = "22"
+      shellSupported = true
+    } : null
     nodes = {
       for k, vm in azurerm_linux_virtual_machine.nodes :
       k => {

--- a/assets/infrastructure/exoscale/infrastructure.yaml
+++ b/assets/infrastructure/exoscale/infrastructure.yaml
@@ -1,5 +1,10 @@
 name: Exasol on Exoscale with Ubuntu
 description: Provisioning on Exoscale. Ubuntu, SOS archive volume, public IPs.
+backend: tofu
+
+compatibility:
+  provides:
+    - remote-exec
 
 tofu:
   variablesFile: variables_public.tf

--- a/assets/infrastructure/exoscale/outputs.tf
+++ b/assets/infrastructure/exoscale/outputs.tf
@@ -6,6 +6,7 @@ locals {
   key_file_path               = "${local.infrastructure_artifact_dir}/${local.key_file_name}"
 
   deployment_info = {
+    backend          = "tofu"
     deploymentId     = local.deployment_id
     region           = var.zone
     availabilityZone = var.zone
@@ -14,6 +15,17 @@ locals {
     instanceType     = var.instance_type
     vpcId            = exoscale_private_network.cluster.id
     subnetId         = exoscale_private_network.cluster.id
+    connection = length(exoscale_compute_instance.nodes) > 0 ? {
+      host           = values(exoscale_compute_instance.nodes)[0].public_ip_address
+      displayHost    = values(exoscale_compute_instance.nodes)[0].public_ip_address
+      publicIp       = values(exoscale_compute_instance.nodes)[0].public_ip_address
+      dbPort         = 8563
+      uiPort         = 8443
+      username       = "sys"
+      sshCommand     = "ssh -i ${local.key_file_relative_path} ubuntu@${values(exoscale_compute_instance.nodes)[0].public_ip_address} -p 22"
+      sshPort        = "22"
+      shellSupported = true
+    } : null
     nodes = {
       for k, node_config in local.nodes :
       node_config.name => {

--- a/assets/installation/ubuntu/installation.yaml
+++ b/assets/installation/ubuntu/installation.yaml
@@ -1,6 +1,10 @@
 name: Exasol on Ubuntu
 description:  Installs Exasol on Ubuntu distributions.
 
+compatibility:
+  requires:
+    - remote-exec
+
 variables:
   outputFile: files/etc/exasol_launcher/installation.json
   vars:

--- a/cmd/exasol/info.go
+++ b/cmd/exasol/info.go
@@ -21,7 +21,7 @@ const deploymentInfoCmdLongDesc = deploymentInfoCmdShortDesc + `
 Shows key deployment attributes in plain text, including:
 
 - Deployment name, Deployment State, Cluster size and Cluster State
-- Node details (public IP, Admin UI, DB port, DNS, SSH info)
+- Connection details appropriate for the active deployment backend
 
 You can use the '--json' option to print the output in JSON format.
 

--- a/cmd/exasol/init.go
+++ b/cmd/exasol/init.go
@@ -36,8 +36,7 @@ var initCmd = &cobra.Command{
 	Use:   "init <infra preset name-or-path> [install preset name-or-path]",
 	Short: initCmdShortDesc,
 	Long:  initCmdLongDesc,
-	Example: "  exasol init " +
-		presets.DefaultInfrastructure + "\n" +
+	Example: "  exasol init " + presets.DefaultInfrastructure + "\n" +
 		"  exasol init " + presets.DefaultInfrastructure + " " +
 		presets.DefaultInstallation + "\n" +
 		"  exasol init ./my-infra-preset ./my-install-preset",
@@ -60,16 +59,23 @@ func init() {
 		"\n\t" + presetNamesForHelp(presets.PresetTypeInstallation,
 		presets.ListEmbeddedInstallationsPresets())
 
+	if matrix := embeddedPresetCompatibilityMatrix(); matrix != "" {
+		initCmd.Long += "\n\n\t" + strings.ReplaceAll(matrix, "\n", "\n\t")
+	}
+
 	initCmd.RunE = func(cmd *cobra.Command, args []string) error {
 		deployment := commonFlags.Deployment()
 		infraVars := collectInfrastructureVariableOverrides(cmd)
 		installVars := collectInstallationVariableOverrides(cmd)
 		infraPreset := presetRefFromArg(args[0])
-		installPreset := defaultedPresetRefFromOptionalArg(args, 1, defaultInstallationPresetRef())
+		installPreset, err := resolveInstallationPresetRef(args, 1, infraPreset)
+		if err != nil {
+			return err
+		}
 
 		safePrint(deploy.EulaNoticeText)
 
-		err := deploy.InitDeployment(
+		err = deploy.InitDeployment(
 			cmd.Context(),
 			infraPreset,
 			installPreset,

--- a/cmd/exasol/install.go
+++ b/cmd/exasol/install.go
@@ -50,13 +50,20 @@ func init() {
 		"\n\t" + presetNamesForHelp(presets.PresetTypeInstallation,
 		presets.ListEmbeddedInstallationsPresets())
 
+	if matrix := embeddedPresetCompatibilityMatrix(); matrix != "" {
+		installCmd.Long += "\n\n\t" + strings.ReplaceAll(matrix, "\n", "\n\t")
+	}
+
 	// Run initialization
 	installCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		deployment := commonFlags.Deployment()
 		infraVars := collectInfrastructureVariableOverrides(cmd)
 		installVars := collectInstallationVariableOverrides(cmd)
 		infraPreset := presetRefFromArg(args[0])
-		installPreset := defaultedPresetRefFromOptionalArg(args, 1, defaultInstallationPresetRef())
+		installPreset, err := resolveInstallationPresetRef(args, 1, infraPreset)
+		if err != nil {
+			return err
+		}
 
 		safePrint(deploy.EulaNoticeText)
 

--- a/cmd/exasol/install_variables.go
+++ b/cmd/exasol/install_variables.go
@@ -176,15 +176,19 @@ func scanInstallationPresetSelection(args []string) (*deploy.PresetRef, error) {
 		return nil, errors.New("infra preset not provided")
 	}
 
-	// Optional installation preset argument; default when omitted.
-	installArg := presets.DefaultInstallation
 	if cmdIndex+2 < len(positionals) {
-		installArg = positionals[cmdIndex+2]
+		ref := presetRefFromArg(positionals[cmdIndex+2])
+		if strings.TrimSpace(ref.Name) == "" && strings.TrimSpace(ref.Path) == "" {
+			return nil, errors.New("no valid preset value")
+		}
+
+		return &ref, nil
 	}
 
-	ref := presetRefFromArg(installArg)
-	if strings.TrimSpace(ref.Name) == "" && strings.TrimSpace(ref.Path) == "" {
-		return nil, errors.New("no valid preset value")
+	infraRef := presetRefFromArg(positionals[cmdIndex+1])
+	ref, err := deploy.ResolveDefaultInstallationPreset(infraRef)
+	if err != nil {
+		return nil, err
 	}
 
 	return &ref, nil

--- a/cmd/exasol/preset_help.go
+++ b/cmd/exasol/preset_help.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/exasol/exasol-personal/internal/presets"
+)
+
+func embeddedPresetCompatibilityMatrix() string {
+	infraIDs := presets.ListEmbeddedInfrastructuresPresets()
+	installIDs := presets.ListEmbeddedInstallationsPresets()
+	if len(infraIDs) == 0 || len(installIDs) == 0 {
+		return ""
+	}
+
+	infraManifests := map[string]*presets.InfrastructureManifest{}
+	for _, infraID := range infraIDs {
+		manifest, err := presets.ReadInfrastructureManifest(infraID)
+		if err != nil {
+			continue
+		}
+		infraManifests[infraID] = manifest
+	}
+
+	installManifests := map[string]*presets.InstallManifest{}
+	for _, installID := range installIDs {
+		manifest, err := presets.ReadInstallManifest(installID)
+		if err != nil {
+			continue
+		}
+		installManifests[installID] = manifest
+	}
+
+	if len(infraManifests) == 0 || len(installManifests) == 0 {
+		return ""
+	}
+
+	firstColumnWidth := len("infrastructure")
+	for infraID := range infraManifests {
+		if len(infraID) > firstColumnWidth {
+			firstColumnWidth = len(infraID)
+		}
+	}
+
+	columnWidths := map[string]int{}
+	for installID := range installManifests {
+		width := len(installID)
+		if width < len("yes") {
+			width = len("yes")
+		}
+		columnWidths[installID] = width
+	}
+
+	var builder strings.Builder
+	_, _ = builder.WriteString("Compatibility matrix (embedded presets):\n")
+	_, _ = builder.WriteString(fmt.Sprintf("  %-*s", firstColumnWidth, "infrastructure"))
+	for _, installID := range installIDs {
+		if _, ok := installManifests[installID]; !ok {
+			continue
+		}
+		_, _ = builder.WriteString(fmt.Sprintf("  %-*s", columnWidths[installID], installID))
+	}
+	_ = builder.WriteByte('\n')
+
+	for _, infraID := range infraIDs {
+		infraManifest, ok := infraManifests[infraID]
+		if !ok {
+			continue
+		}
+		_, _ = builder.WriteString(fmt.Sprintf("  %-*s", firstColumnWidth, infraID))
+		for _, installID := range installIDs {
+			installManifest, ok := installManifests[installID]
+			if !ok {
+				continue
+			}
+			cell := "no"
+			if embeddedPresetPairCompatible(infraManifest, installManifest) {
+				cell = "yes"
+			}
+			_, _ = builder.WriteString(fmt.Sprintf("  %-*s", columnWidths[installID], cell))
+		}
+		_ = builder.WriteByte('\n')
+	}
+
+	return strings.TrimRight(builder.String(), "\n")
+}
+
+func embeddedPresetPairCompatible(
+	infrastructureManifest *presets.InfrastructureManifest,
+	installationManifest *presets.InstallManifest,
+) bool {
+	if infrastructureManifest == nil || installationManifest == nil {
+		return false
+	}
+
+	required := installationManifest.RequiredCapabilities()
+	if len(required) == 0 {
+		return true
+	}
+
+	providedSet := map[string]struct{}{}
+	for _, capability := range infrastructureManifest.ProvidedCapabilities() {
+		providedSet[capability] = struct{}{}
+	}
+
+	for _, capability := range required {
+		if _, ok := providedSet[capability]; !ok {
+			return false
+		}
+	}
+
+	return true
+}

--- a/cmd/exasol/presets_list.go
+++ b/cmd/exasol/presets_list.go
@@ -16,6 +16,8 @@ var presetsListFlags = struct {
 	TypeFilter string
 }{}
 
+const embeddedPresetAppendixPartCount = 1
+
 func filterPresetCatalog(typeFilter string) (PresetCatalog, error) {
 	filter := normalizePresetTypeFilter(typeFilter)
 	cat := GetPresetCatalog()
@@ -121,7 +123,33 @@ func renderPresetListText(writer io.Writer, typeFilter string, catalog PresetCat
 		}
 	}
 
-	return nil
+	if filter != "" {
+		return nil
+	}
+
+	appendix := embeddedPresetAppendixText()
+	if appendix == "" {
+		return nil
+	}
+	if wroteAny {
+		if _, err := fmt.Fprintln(writer); err != nil {
+			return err
+		}
+	}
+
+	_, err := fmt.Fprintln(writer, appendix)
+
+	return err
+}
+
+func embeddedPresetAppendixText() string {
+	parts := make([]string, 0, embeddedPresetAppendixPartCount)
+
+	if matrix := embeddedPresetCompatibilityMatrix(); matrix != "" {
+		parts = append(parts, matrix)
+	}
+
+	return strings.Join(parts, "\n\n")
 }
 
 var presetsListCmd = &cobra.Command{

--- a/cmd/exasol/root.go
+++ b/cmd/exasol/root.go
@@ -26,11 +26,13 @@ Getting Started:
   into that directory, e.g., with "cd deployment".
 
   To create and run an Exasol deployment, run "exasol install <infra preset name-or-path>".
-  This single command initializes your deployment directory, provisions cloud infrastructure,
-  and installs the database. It uses either a built-in infrastructure preset or a custom preset 
-  at a path you provide. Built-in presets are: aws, azure, and exoscale.
+	This single command initializes your deployment directory, prepares the selected infrastructure,
+	and installs the database. It uses either a built-in infrastructure preset or a custom preset 
+	at a path you provide. Built-in presets are: aws, azure, and exoscale.
 
-  Note: Ensure your cloud provider credentials are configured in your environment before running.`
+	Note: Cloud presets require provider credentials in your environment.
+  Use "exasol init --help", "exasol install --help", or "exasol presets list" to see the preset
+  compatibility matrix.`
 
 	rootCmdExample = `  exasol install aws`
 
@@ -78,7 +80,7 @@ var rootCmd = &cobra.Command{
 
 		// Best-effort version update hint (non-blocking; logs only when an update is available).
 		// Design decision: never block commands on this.
-		if cmd.Name() != "version" {
+		if cmd.Name() != "version" && !cmd.Hidden {
 			deploy.MaybeLogVersionUpdateHint(
 				cmd.Context(), deployment,
 				CurrentLauncherVersion,

--- a/cmd/exasol/util.go
+++ b/cmd/exasol/util.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	"github.com/exasol/exasol-personal/internal/deploy"
-	"github.com/exasol/exasol-personal/internal/presets"
 	"github.com/zclconf/go-cty/cty"
 	ctyjson "github.com/zclconf/go-cty/cty/json"
 )
@@ -93,23 +92,16 @@ func presetRefFromArg(arg string) deploy.PresetRef {
 	return deploy.PresetRef{Name: arg}
 }
 
-func defaultInstallationPresetRef() deploy.PresetRef {
-	return deploy.PresetRef{Name: presets.DefaultInstallation}
-}
-
-func defaultedPresetRefFromOptionalArg(
+func resolveInstallationPresetRef(
 	args []string,
 	index int,
-	def deploy.PresetRef,
-) deploy.PresetRef {
-	if index < 0 || index >= len(args) {
-		return def
-	}
-	if strings.TrimSpace(args[index]) == "" {
-		return def
+	infrastructurePreset deploy.PresetRef,
+) (deploy.PresetRef, error) {
+	if index >= 0 && index < len(args) && strings.TrimSpace(args[index]) != "" {
+		return presetRefFromArg(args[index]), nil
 	}
 
-	return presetRefFromArg(args[index])
+	return deploy.ResolveDefaultInstallationPreset(infrastructurePreset)
 }
 
 func presetNamesForHelp(listname string, names []string) string {

--- a/internal/config/connection_info.go
+++ b/internal/config/connection_info.go
@@ -1,0 +1,140 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type ConnectionInfo struct {
+	DeploymentName             string
+	DeploymentState            string
+	ClusterSize                int
+	ClusterState               string
+	Host                       string
+	DisplayHost                string
+	DBPort                     int
+	UIPort                     int
+	Username                   string
+	CertFingerprint            string
+	InsecureSkipCertValidation bool
+	SecretsFilePath            string
+	PublicIP                   string
+	SSHCommand                 string
+	SSHPort                    string
+	ShellSupported             bool
+}
+
+func ResolveConnectionInfo(deployment DeploymentDir) (*ConnectionInfo, error) {
+	info, err := ReadDeploymentInfo(deployment)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get deployment info: %w", err)
+	}
+
+	return info.ConnectionInfo(deployment)
+}
+
+func (info *DeploymentInfo) ConnectionInfo(deployment DeploymentDir) (*ConnectionInfo, error) {
+	if info == nil {
+		return nil, errors.New("deployment info is required")
+	}
+	if info.Connection == nil {
+		return nil, errors.New("deployment connection details are missing")
+	}
+
+	secretsFilePath, err := SecretsFilePath(deployment)
+	if err != nil {
+		return nil, err
+	}
+
+	host := strings.TrimSpace(info.Connection.Host)
+	if host == "" {
+		return nil, errors.New("deployment connection host is missing")
+	}
+	if info.Connection.DBPort <= 0 {
+		return nil, errors.New("deployment database port is missing")
+	}
+	if info.Connection.UIPort <= 0 {
+		return nil, errors.New("deployment UI port is missing")
+	}
+
+	displayHost := strings.TrimSpace(info.Connection.DisplayHost)
+	if displayHost == "" {
+		displayHost = host
+	}
+
+	username := strings.TrimSpace(info.Connection.Username)
+	if username == "" {
+		username = "sys"
+	}
+
+	certFingerPrint := resolveConnectionCertFingerprint(info)
+
+	return &ConnectionInfo{
+		DeploymentName:             info.DeploymentId,
+		DeploymentState:            info.DeploymentState,
+		ClusterSize:                info.ClusterSize,
+		ClusterState:               info.ClusterState,
+		Host:                       host,
+		DisplayHost:                displayHost,
+		DBPort:                     info.Connection.DBPort,
+		UIPort:                     info.Connection.UIPort,
+		Username:                   username,
+		CertFingerprint:            certFingerPrint,
+		InsecureSkipCertValidation: info.Connection.InsecureSkipCertValidation,
+		SecretsFilePath:            secretsFilePath,
+		PublicIP:                   strings.TrimSpace(info.Connection.PublicIp),
+		SSHCommand:                 strings.TrimSpace(info.Connection.SSHCommand),
+		SSHPort:                    strings.TrimSpace(info.Connection.SSHPort),
+		ShellSupported:             info.Connection.ShellSupported,
+	}, nil
+}
+
+func resolveConnectionCertFingerprint(info *DeploymentInfo) string {
+	if info == nil || info.Connection == nil {
+		return ""
+	}
+	if fingerPrint := strings.TrimSpace(info.Connection.CertFingerprint); fingerPrint != "" {
+		return fingerPrint
+	}
+
+	return legacyNodeTLSCertFingerprintFallback(info)
+}
+
+// legacyNodeTLSCertFingerprintFallback preserves TLS fingerprint resolution for deployment.json
+// files that still only contain nodes[*].tlsCert. Keep this fallback isolated so it can be
+// removed when legacy node-derived connection metadata is no longer supported.
+func legacyNodeTLSCertFingerprintFallback(info *DeploymentInfo) string {
+	certFingerprint, err := info.GetCertFingerprint()
+	if err != nil {
+		return ""
+	}
+
+	return certFingerprint
+}
+
+func parseConnectionPort(value string) int {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+
+	port, _ := strconv.Atoi(value)
+
+	return port
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value
+		}
+	}
+
+	return ""
+}

--- a/internal/config/connection_info_test.go
+++ b/internal/config/connection_info_test.go
@@ -1,0 +1,159 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package config
+
+import "testing"
+
+const (
+	testNodeTLSCertPEM = `-----BEGIN CERTIFICATE-----
+MIIDFzCCAf+gAwIBAgIUX7bPqKmldD5pRIXsmMVaqy07D3MwDQYJKoZIhvcNAQEL
+BQAwGzEZMBcGA1UEAwwQZXhhY2x1c3Rlci5sb2NhbDAeFw0yNjA1MTgxNjUxNTFa
+Fw0yNjA1MTkxNjUxNTFaMBsxGTAXBgNVBAMMEGV4YWNsdXN0ZXIubG9jYWwwggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCobbqt5Z1WFsnQuhN3UGGGc2xL
+iR4S7e16/H9edtiFs03vpBevGFaZ1E/80t4fNyK3Zh3+a0QBrMOq4lL8Az3hpT/t
+d7ejE6SXic+gFelelrEKExhoUBW+QvaPMKgOs/I3CqpUANy3i9eBufEEO7wD5zNY
+3NpSGkjO24FA132M2ZHbA4vT/LDrQgqmCFmLfVK/AVHwJHP1FPa7cdpkXSfoNMS8
+mP/ic62xKa/3eN8eKErSd46IBD6Se5H5NaTdTd5Px5QlHTjiGUYFf5sSPGytjHdO
+10EZQtAINJDr8G+7xtv7/4VIOr5InTsTZ7YEoPOsLjR5JbbX6dANqetjU7g3AgMB
+AAGjUzBRMB0GA1UdDgQWBBRbFgxPkDn3OVTIxkhGipwGmLWYrzAfBgNVHSMEGDAW
+gBRbFgxPkDn3OVTIxkhGipwGmLWYrzAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3
+DQEBCwUAA4IBAQAkminqClEKemWcz2qnFm7S+0JGvm/afImPLeI86cMm+K3FlCAk
+gt0+Z+ievDe6Qlzx2hd/5ZNb06doWROAQW0Wa48YpxxYzDJYsMg2cYXcNHyfpLRY
+Maod08st83Omazh8q4gdMXoPHewrvqWw8rQ8aFCYcKv2tb6ydLybfFRgQJcPGY5A
+weHW+6xccsl/oQKBumqaAPic0Vogx7l73MvfI8HpwgMJz2PpeTf0aCG3Z3MJO2rw
+R+38EnmWEQ6v9DLI3rNssbU6Dz6UMW+W68SitvJfsyjh9bCXt++yox1hfZOHIMGp
+lKXb6y8Al2UTdJ3ED+yONdAc7OHg4e3vwJ8R
+-----END CERTIFICATE-----`
+
+	testCertSHA256Fingerprint = "CDEC9FB892603FDC23D7CFCC86A533434B5E16E69E7744E057506F2006BD732E"
+)
+
+func TestResolveConnectionInfo_UsesNormalizedDeploymentConnection(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	deployment := NewDeploymentDir(t.TempDir())
+	if err := WriteSecrets(deployment.Root(), &Secrets{DbPassword: "secret"}); err != nil {
+		t.Fatalf("failed to write secrets: %v", err)
+	}
+	if err := WriteDeploymentInfo(deployment.Root(), &DeploymentInfo{
+		DeploymentId:    "dep-1",
+		DeploymentState: "running",
+		ClusterSize:     1,
+		ClusterState:    "running",
+		Connection: &DeploymentConnection{
+			Host:           "example.local",
+			DBPort:         8563,
+			UIPort:         8443,
+			PublicIp:       "203.0.113.10",
+			SSHCommand:     "ssh ubuntu@example.local -p 22",
+			SSHPort:        "22",
+			ShellSupported: true,
+		},
+	}); err != nil {
+		t.Fatalf("failed to write deployment info: %v", err)
+	}
+
+	// When
+	info, err := ResolveConnectionInfo(deployment)
+	// Then
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if info.Host != "example.local" {
+		t.Fatalf("expected host %q, got %q", "example.local", info.Host)
+	}
+	if info.DisplayHost != "example.local" {
+		t.Fatalf("expected display host %q, got %q", "example.local", info.DisplayHost)
+	}
+	if info.Username != "sys" {
+		t.Fatalf("expected username %q, got %q", "sys", info.Username)
+	}
+	if !info.ShellSupported {
+		t.Fatal("expected shell support to be preserved")
+	}
+	if info.SecretsFilePath != deployment.Resolve(secretsFileName) {
+		t.Fatalf(
+			"expected secrets path %q, got %q",
+			deployment.Resolve(secretsFileName),
+			info.SecretsFilePath,
+		)
+	}
+}
+
+func TestResolveConnectionInfo_UsesExplicitConnectionCertFingerprint(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	deployment := NewDeploymentDir(t.TempDir())
+	writeConnectionInfoTestFiles(t, deployment, &DeploymentInfo{
+		DeploymentId: "dep-1",
+		Connection: &DeploymentConnection{
+			Host:            "example.local",
+			DBPort:          8563,
+			UIPort:          8443,
+			CertFingerprint: " explicit-fingerprint ",
+		},
+		Nodes: map[string]DeploymentNode{
+			primaryNodeName: {TlsCert: testNodeTLSCertPEM},
+		},
+	})
+
+	// When
+	info, err := ResolveConnectionInfo(deployment)
+	// Then
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if info.CertFingerprint != "explicit-fingerprint" {
+		t.Fatalf("expected explicit fingerprint, got %q", info.CertFingerprint)
+	}
+}
+
+func TestResolveConnectionInfo_UsesLegacyNodeTLSCertFingerprintFallback(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	deployment := NewDeploymentDir(t.TempDir())
+	writeConnectionInfoTestFiles(t, deployment, &DeploymentInfo{
+		DeploymentId: "dep-1",
+		Connection: &DeploymentConnection{
+			Host:   "example.local",
+			DBPort: 8563,
+			UIPort: 8443,
+		},
+		Nodes: map[string]DeploymentNode{
+			primaryNodeName: {TlsCert: testNodeTLSCertPEM},
+		},
+	})
+
+	// When
+	info, err := ResolveConnectionInfo(deployment)
+	// Then
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if info.CertFingerprint != testCertSHA256Fingerprint {
+		t.Fatalf(
+			"expected legacy node fingerprint %q, got %q",
+			testCertSHA256Fingerprint,
+			info.CertFingerprint,
+		)
+	}
+}
+
+func writeConnectionInfoTestFiles(
+	t *testing.T,
+	deployment DeploymentDir,
+	deploymentInfo *DeploymentInfo,
+) {
+	t.Helper()
+
+	if err := WriteSecrets(deployment.Root(), &Secrets{DbPassword: "secret"}); err != nil {
+		t.Fatalf("failed to write secrets: %v", err)
+	}
+	if err := WriteDeploymentInfo(deployment.Root(), deploymentInfo); err != nil {
+		t.Fatalf("failed to write deployment info: %v", err)
+	}
+}

--- a/internal/config/node_details.go
+++ b/internal/config/node_details.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -18,45 +19,69 @@ import (
 const (
 	nodeDetailsFileName   = "deployment.json"
 	ConnectionInstruction = "connection-instructions.txt"
+	primaryNodeName       = "n11"
+	defaultUsername       = "sys"
 )
 
-type NodeDetails struct {
-	DeploymentId     string                     `json:"deploymentId"`
-	DeploymentState  string                     `json:"deploymentState,omitempty"`
-	Region           string                     `json:"region"`
-	AvailabilityZone string                     `json:"availabilityZone"`
-	ClusterSize      int                        `json:"clusterSize"`
-	ClusterState     string                     `json:"clusterState"`
-	InstanceType     string                     `json:"instanceType"`
-	VpcId            string                     `json:"vpcId"`
-	SubnetId         string                     `json:"subnetId"`
-	Nodes            map[string]nodeDetailsNode `json:"nodes"`
+type DeploymentInfo struct {
+	Backend          string                    `json:"backend,omitempty"`
+	DeploymentId     string                    `json:"deploymentId"`
+	DeploymentState  string                    `json:"deploymentState,omitempty"`
+	Region           string                    `json:"region,omitempty"`
+	AvailabilityZone string                    `json:"availabilityZone,omitempty"`
+	ClusterSize      int                       `json:"clusterSize,omitempty"`
+	ClusterState     string                    `json:"clusterState,omitempty"`
+	InstanceType     string                    `json:"instanceType,omitempty"`
+	VpcId            string                    `json:"vpcId,omitempty"`
+	SubnetId         string                    `json:"subnetId,omitempty"`
+	Nodes            map[string]DeploymentNode `json:"nodes,omitempty"`
+	Connection       *DeploymentConnection     `json:"connection,omitempty"`
 }
 
-type nodeDetailsNode struct {
-	AvailabilityZone string                   `json:"availabilityZone"`
-	Database         nodeDetailsNodesDatabase `json:"database"`
-	DnsName          string                   `json:"dnsName"`
-	InstanceId       string                   `json:"instanceId"`
-	PrivateIp        string                   `json:"privateIp"`
-	PublicIp         string                   `json:"publicIp"`
-	Ssh              nodeDetailsNodesSsh      `json:"ssh"`
-	TlsCert          string                   `json:"tlsCert"`
+type DeploymentNode struct {
+	AvailabilityZone string             `json:"availabilityZone,omitempty"`
+	Database         DeploymentDatabase `json:"database,omitempty"`
+	DnsName          string             `json:"dnsName,omitempty"`
+	InstanceId       string             `json:"instanceId,omitempty"`
+	PrivateIp        string             `json:"privateIp,omitempty"`
+	PublicIp         string             `json:"publicIp,omitempty"`
+	Ssh              DeploymentSSH      `json:"ssh,omitempty"`
+	TlsCert          string             `json:"tlsCert,omitempty"`
 }
 
-type nodeDetailsNodesDatabase struct {
-	DbPort string `json:"dbPort"`
-	UiPort string `json:"uiPort"`
-	Url    string `json:"url"`
+type DeploymentDatabase struct {
+	DbPort string `json:"dbPort,omitempty"`
+	UiPort string `json:"uiPort,omitempty"`
+	Url    string `json:"url,omitempty"`
 }
 
-type nodeDetailsNodesSsh struct {
-	Command  string `json:"command"`
-	KeyFile  string `json:"keyFile"`
-	KeyName  string `json:"keyName"`
-	Port     string `json:"port"`
-	Username string `json:"username"`
+type DeploymentSSH struct {
+	Command  string `json:"command,omitempty"`
+	KeyFile  string `json:"keyFile,omitempty"`
+	KeyName  string `json:"keyName,omitempty"`
+	Port     string `json:"port,omitempty"`
+	Username string `json:"username,omitempty"`
 }
+
+type DeploymentConnection struct {
+	Host                       string `json:"host,omitempty"`
+	DisplayHost                string `json:"displayHost,omitempty"`
+	PublicIp                   string `json:"publicIp,omitempty"`
+	DBPort                     int    `json:"dbPort,omitempty"`
+	UIPort                     int    `json:"uiPort,omitempty"`
+	Username                   string `json:"username,omitempty"`
+	CertFingerprint            string `json:"certFingerprint,omitempty"`
+	InsecureSkipCertValidation bool   `json:"insecureSkipCertValidation,omitempty"`
+	SSHCommand                 string `json:"sshCommand,omitempty"`
+	SSHPort                    string `json:"sshPort,omitempty"`
+	ShellSupported             bool   `json:"shellSupported,omitempty"`
+}
+
+type (
+	NodeDetails              = DeploymentInfo
+	nodeDetailsNode          = DeploymentNode
+	nodeDetailsNodesDatabase = DeploymentDatabase
+)
 
 type SSHDetails struct {
 	Host    string
@@ -65,28 +90,61 @@ type SSHDetails struct {
 	KeyFile string
 }
 
-func ReadNodeDetails(deployment DeploymentDir) (*NodeDetails, error) {
-	filepath, exists, err := findExistingFile(deployment.Root(), nodeDetailsFileName)
+func ReadDeploymentInfo(deployment DeploymentDir) (*DeploymentInfo, error) {
+	deploymentInfoPath, exists, err := findExistingFile(deployment.Root(), nodeDetailsFileName)
 	if err != nil {
 		return nil, err
 	}
 	if !exists {
 		return nil, fmt.Errorf(
-			"node details file not found in deployment directory: expected %q in %s",
+			"deployment info file not found in deployment directory: expected %q in %s",
 			nodeDetailsFileName,
 			deployment.Root(),
 		)
 	}
 
-	slog.Debug("reading node details file", "file", filepath)
+	slog.Debug("reading deployment info file", "file", deploymentInfoPath)
 
-	return readConfig[NodeDetails](filepath, "node details")
+	info, err := readConfig[DeploymentInfo](deploymentInfoPath, "deployment info")
+	if err != nil {
+		return nil, err
+	}
+
+	normalizeDeploymentInfo(info)
+	if !hasRecognizedDeploymentInfo(info) {
+		return nil, errors.New("deployment info file has no recognizable schema")
+	}
+
+	return info, nil
+}
+
+func ReadNodeDetails(deployment DeploymentDir) (*NodeDetails, error) {
+	return ReadDeploymentInfo(deployment)
+}
+
+func WriteDeploymentInfo(deploymentDir string, info *DeploymentInfo) error {
+	if info == nil {
+		return errors.New("deployment info is required")
+	}
+
+	normalized := *info
+	normalizeDeploymentInfo(&normalized)
+
+	return writeConfig(
+		&normalized,
+		filepath.Join(deploymentDir, nodeDetailsFileName),
+		"deployment info",
+	)
+}
+
+func GetDeploymentInfoFilePath(deploymentDir string) (string, bool, error) {
+	return findExistingFile(deploymentDir, nodeDetailsFileName)
 }
 
 var ErrNoNodeDetailsFile = errors.New("node details file not found in deployment directory")
 
 // Returns the list of node names, sorted increasingly.
-func (s *NodeDetails) ListNodes() []string {
+func (s *DeploymentInfo) ListNodes() []string {
 	result := make([]string, 0, len(s.Nodes))
 	for nodeName := range s.Nodes {
 		result = append(result, nodeName)
@@ -99,7 +157,7 @@ func (s *NodeDetails) ListNodes() []string {
 
 var ErrUnknownNodeName = errors.New("unknown node name")
 
-func (s *NodeDetails) GetSSHDetails(
+func (s *DeploymentInfo) GetSSHDetails(
 	nodeName string,
 	deployment DeploymentDir,
 ) (*SSHDetails, error) {
@@ -116,17 +174,19 @@ func (s *NodeDetails) GetSSHDetails(
 	}, nil
 }
 
-// GetDeploymentHostPort returns the host-port string
-// of the form "{ip}:{port}".
-//
-// Always returns the host-port for the first node only.
-func (s *NodeDetails) GetDeploymentHostPort() (string, int, error) {
+// GetDeploymentHostPort returns the host-port string of the primary database endpoint.
+func (s *DeploymentInfo) GetDeploymentHostPort() (string, int, error) {
+	if s.Connection != nil && strings.TrimSpace(s.Connection.Host) != "" &&
+		s.Connection.DBPort > 0 {
+		return s.Connection.Host, s.Connection.DBPort, nil
+	}
+
 	if len(s.Nodes) == 0 {
 		return "", 0, errors.New("no nodes found in the active deployment's infrastructure")
 	}
 
 	// Prefer node "n11"; if missing, fall back to the first sorted node
-	nodeName := "n11"
+	nodeName := primaryNodeName
 	node, exists := s.Nodes[nodeName]
 	if !exists {
 		names := s.ListNodes()
@@ -137,7 +197,6 @@ func (s *NodeDetails) GetDeploymentHostPort() (string, int, error) {
 		node = s.Nodes[nodeName]
 	}
 
-	// Determine host: prefer DNS name; fall back to public IP
 	host := strings.TrimSpace(node.DnsName)
 	if host == "" {
 		host = strings.TrimSpace(node.PublicIp)
@@ -149,7 +208,6 @@ func (s *NodeDetails) GetDeploymentHostPort() (string, int, error) {
 		)
 	}
 
-	// Parse and validate DB port
 	portRaw := strings.TrimSpace(node.Database.DbPort)
 	if portRaw == "" {
 		return "", 0, errors.New("database port is empty in node details")
@@ -167,13 +225,16 @@ func (s *NodeDetails) GetDeploymentHostPort() (string, int, error) {
 }
 
 // GetCertFingerprint returns the fingerprint (sha256 checksum) of the host certificate.
-func (s *NodeDetails) GetCertFingerprint() (string, error) {
+func (s *DeploymentInfo) GetCertFingerprint() (string, error) {
+	if s.Connection != nil && strings.TrimSpace(s.Connection.CertFingerprint) != "" {
+		return strings.TrimSpace(s.Connection.CertFingerprint), nil
+	}
+
 	if len(s.Nodes) == 0 {
 		return "", errors.New("no nodes found in the active deployment's infrastructure")
 	}
 
-	// Prefer node "n11"; if missing, fall back to the first sorted node
-	nodeName := "n11"
+	nodeName := primaryNodeName
 	node, exists := s.Nodes[nodeName]
 	if !exists {
 		names := s.ListNodes()
@@ -184,7 +245,6 @@ func (s *NodeDetails) GetCertFingerprint() (string, error) {
 		node = s.Nodes[nodeName]
 	}
 
-	// Validate that the TLS certificate is present
 	pemStr := strings.TrimSpace(node.TlsCert)
 	if pemStr == "" {
 		return "", fmt.Errorf("node %s has empty tls certificate", nodeName)
@@ -201,4 +261,91 @@ func (s *NodeDetails) GetCertFingerprint() (string, error) {
 	hash := sha256.Sum256(certDER.Bytes)
 
 	return strings.ToUpper(hex.EncodeToString(hash[:])), nil
+}
+
+func normalizeDeploymentInfo(info *DeploymentInfo) {
+	if info == nil {
+		return
+	}
+
+	info.Backend = strings.TrimSpace(info.Backend)
+
+	if info.Connection == nil && len(info.Nodes) > 0 {
+		info.Connection = deriveConnectionFromNodes(info)
+	}
+
+	if info.Connection != nil {
+		if strings.TrimSpace(info.Connection.DisplayHost) == "" {
+			info.Connection.DisplayHost = firstNonEmpty(
+				info.Connection.DisplayHost,
+				info.Connection.Host,
+				info.Connection.PublicIp,
+			)
+		}
+		if strings.TrimSpace(info.Connection.Host) == "" {
+			info.Connection.Host = firstNonEmpty(
+				info.Connection.Host,
+				info.Connection.PublicIp,
+			)
+		}
+		if strings.TrimSpace(info.Connection.Username) == "" {
+			info.Connection.Username = defaultUsername
+		}
+	}
+
+	if info.Backend == "" {
+		if len(info.Nodes) > 0 || info.Region != "" || info.VpcId != "" || info.SubnetId != "" {
+			info.Backend = "tofu"
+		}
+	}
+}
+
+func hasRecognizedDeploymentInfo(info *DeploymentInfo) bool {
+	if info == nil {
+		return false
+	}
+
+	return strings.TrimSpace(info.DeploymentId) != "" ||
+		strings.TrimSpace(info.Backend) != "" ||
+		info.Connection != nil ||
+		len(info.Nodes) > 0 ||
+		strings.TrimSpace(info.Region) != "" ||
+		strings.TrimSpace(info.VpcId) != "" ||
+		strings.TrimSpace(info.SubnetId) != ""
+}
+
+func deriveConnectionFromNodes(info *DeploymentInfo) *DeploymentConnection {
+	if info == nil || len(info.Nodes) == 0 {
+		return nil
+	}
+
+	nodes := info.ListNodes()
+	if len(nodes) == 0 {
+		return nil
+	}
+
+	primaryNodeName := primaryNodeName
+	if _, ok := info.Nodes[primaryNodeName]; !ok {
+		primaryNodeName = nodes[0]
+	}
+	mainNode := info.Nodes[primaryNodeName]
+	host := firstNonEmpty(mainNode.DnsName, mainNode.PublicIp)
+
+	connection := &DeploymentConnection{
+		Host:           host,
+		DisplayHost:    host,
+		PublicIp:       mainNode.PublicIp,
+		DBPort:         parseConnectionPort(mainNode.Database.DbPort),
+		UIPort:         parseConnectionPort(mainNode.Database.UiPort),
+		Username:       defaultUsername,
+		SSHCommand:     mainNode.Ssh.Command,
+		SSHPort:        mainNode.Ssh.Port,
+		ShellSupported: true,
+	}
+
+	if certFingerprint, err := info.GetCertFingerprint(); err == nil {
+		connection.CertFingerprint = certFingerprint
+	}
+
+	return connection
 }

--- a/internal/config/secrets.go
+++ b/internal/config/secrets.go
@@ -6,6 +6,7 @@ package config
 import (
 	"fmt"
 	"log/slog"
+	"path/filepath"
 )
 
 //nolint:gosec // gosec thinks this is a password
@@ -17,7 +18,7 @@ type Secrets struct {
 }
 
 func SecretsFilePath(deployment DeploymentDir) (string, error) {
-	filepath, exists, err := findExistingFile(deployment.Root(), secretsFileName)
+	secretsPath, exists, err := findExistingFile(deployment.Root(), secretsFileName)
 	if err != nil {
 		return "", fmt.Errorf("failed to get the secrets file path: %w", err)
 	}
@@ -29,16 +30,24 @@ func SecretsFilePath(deployment DeploymentDir) (string, error) {
 		)
 	}
 
-	return filepath, nil
+	return secretsPath, nil
 }
 
 func ReadSecrets(deployment DeploymentDir) (*Secrets, error) {
-	filepath, err := SecretsFilePath(deployment)
+	secretsPath, err := SecretsFilePath(deployment)
 	if err != nil {
 		return nil, err
 	}
 
-	slog.Debug("reading secrets file", "file", filepath)
+	slog.Debug("reading secrets file", "file", secretsPath)
 
-	return readConfig[Secrets](filepath, "secrets")
+	return readConfig[Secrets](secretsPath, "secrets")
+}
+
+func WriteSecrets(deploymentDir string, secrets *Secrets) error {
+	if secrets == nil {
+		secrets = &Secrets{}
+	}
+
+	return writeConfig(secrets, filepath.Join(deploymentDir, secretsFileName), "secrets")
 }

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -6,6 +6,7 @@ package connect
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -67,6 +68,7 @@ type resultPrinter func(io.Writer, generaltypes.QueryResulter) error
 //nolint:revive
 func NewExasolConnection(
 	deployment config.DeploymentDir,
+	connectionInfo *config.ConnectionInfo,
 	username string,
 	password string,
 	insecureSkipCertValidation bool,
@@ -78,27 +80,23 @@ func NewExasolConnection(
 		}
 		password = secrets.DbPassword
 	}
-
-	nodeDetails, err := config.ReadNodeDetails(deployment)
-	if err != nil {
-		return nil, fmt.Errorf("reading node details: %w", err)
-	}
-
-	host, port, err := nodeDetails.GetDeploymentHostPort()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get deployment host-port: %w", err)
-	}
-	certFingerprint, err := nodeDetails.GetCertFingerprint()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get deployment tls certificate: %w", err)
+	if connectionInfo == nil {
+		return nil, errors.New("reading deployment connection info: missing connection info")
 	}
 
 	optsFns := []exasol.OptFn{}
-	if insecureSkipCertValidation {
+	if insecureSkipCertValidation || connectionInfo.InsecureSkipCertValidation {
 		optsFns = append(optsFns, exasol.WithoutValidateServerCertificate)
 	}
 
-	database, err := exasol.New(username, password, host, certFingerprint, port, optsFns...)
+	database, err := exasol.New(
+		username,
+		password,
+		connectionInfo.Host,
+		connectionInfo.CertFingerprint,
+		connectionInfo.DBPort,
+		optsFns...,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -106,19 +104,29 @@ func NewExasolConnection(
 	slog.Debug(
 		"connecting to database",
 		"username", username,
-		"host", host,
-		"port", port,
+		"host", connectionInfo.Host,
+		"port", connectionInfo.DBPort,
 		"insecure_skip_cert_validation", insecureSkipCertValidation,
 	)
 
 	return database, nil
 }
 
-func Connect(ctx context.Context, opts *Opts, deployment config.DeploymentDir) error {
+func Connect(
+	ctx context.Context,
+	opts *Opts,
+	deployment config.DeploymentDir,
+	connectionInfo *config.ConnectionInfo,
+) error {
 	slog.Debug("running connect")
 
 	database, err := NewExasolConnection(
-		deployment, opts.Username, opts.Password, opts.InsecureSkipCertValidation)
+		deployment,
+		connectionInfo,
+		opts.Username,
+		opts.Password,
+		opts.InsecureSkipCertValidation,
+	)
 	if err != nil {
 		return err
 	}

--- a/internal/deploy/backend.go
+++ b/internal/deploy/backend.go
@@ -1,0 +1,100 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/presets"
+)
+
+const backendTypeTofu = "tofu"
+
+type deploymentBackend interface {
+	ValidateEnvironment() error
+	OpenHostShell(ctx context.Context, deployment config.DeploymentDir, selectedNode string) error
+	OpenCOSShell(ctx context.Context, deployment config.DeploymentDir) error
+	Deploy(
+		ctx context.Context,
+		deployment config.DeploymentDir,
+		manifest *presets.InfrastructureManifest,
+		out, outErr io.Writer,
+		tofuLockfileMode TofuLockfileMode,
+	) error
+	Start(
+		ctx context.Context,
+		deployment config.DeploymentDir,
+		manifest *presets.InfrastructureManifest,
+		out, outErr io.Writer,
+		waitTimeoutSeconds int,
+	) error
+	Stop(
+		ctx context.Context,
+		deployment config.DeploymentDir,
+		manifest *presets.InfrastructureManifest,
+		out, outErr io.Writer,
+	) error
+	Destroy(
+		ctx context.Context,
+		deployment config.DeploymentDir,
+		manifest *presets.InfrastructureManifest,
+		out, outErr io.Writer,
+	) error
+}
+
+func resolveBackendKind(manifest *presets.InfrastructureManifest) (string, error) {
+	if manifest == nil {
+		return "", fmt.Errorf("%w: missing infrastructure manifest", ErrUnknownDeploymentType)
+	}
+
+	backend := strings.TrimSpace(manifest.Backend)
+	if backend == "" && manifest.Tofu != nil {
+		backend = backendTypeTofu
+	}
+
+	if backend == "" {
+		return "", fmt.Errorf(
+			"%w: infrastructure manifest does not declare a supported backend",
+			ErrUnknownDeploymentType,
+		)
+	}
+
+	return backend, nil
+}
+
+func resolveBackendForDeployment(
+	deployment config.DeploymentDir,
+) (deploymentBackend, error) {
+	manifest, err := config.ReadInfrastructureManifest(deployment)
+	if err != nil {
+		return nil, err
+	}
+
+	backend, err := resolveBackendForManifest(manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	return backend, nil
+}
+
+func resolveBackendForManifest(
+	manifest *presets.InfrastructureManifest,
+) (deploymentBackend, error) {
+	backend, err := resolveBackendKind(manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	switch backend {
+	case backendTypeTofu:
+		return tofuBackend{}, nil
+	default:
+		return nil, fmt.Errorf("%w: %q", ErrUnknownDeploymentType, backend)
+	}
+}

--- a/internal/deploy/backend_test.go
+++ b/internal/deploy/backend_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/presets"
+)
+
+func TestResolveBackendForManifest_UsesExplicitBackend(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	manifest := &presets.InfrastructureManifest{Backend: backendTypeTofu}
+
+	// When
+	backend, err := resolveBackendForManifest(manifest)
+	// Then
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if _, ok := backend.(tofuBackend); !ok {
+		t.Fatalf("expected tofuBackend, got %T", backend)
+	}
+}
+
+func TestResolveBackendForManifest_FallsBackToTofuForLegacyManifest(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	manifest := &presets.InfrastructureManifest{
+		Tofu: &presets.InfrastructureTofu{},
+	}
+
+	// When
+	backend, err := resolveBackendForManifest(manifest)
+	// Then
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if _, ok := backend.(tofuBackend); !ok {
+		t.Fatalf("expected tofuBackend, got %T", backend)
+	}
+}
+
+func TestResolveBackendForManifest_RejectsUnknownBackend(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	manifest := &presets.InfrastructureManifest{Backend: "unknown"}
+
+	// When
+	_, err := resolveBackendForManifest(manifest)
+
+	// Then
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrUnknownDeploymentType) {
+		t.Fatalf("expected ErrUnknownDeploymentType, got %v", err)
+	}
+}

--- a/internal/deploy/connect.go
+++ b/internal/deploy/connect.go
@@ -53,7 +53,12 @@ func Connect(ctx context.Context, opts *connect.Opts, deployment config.Deployme
 				return util.LoggedError(err, "run `status` for more information")
 			}
 
-			return connect.Connect(ctx, opts, deployment)
+			connectionInfo, err := config.ResolveConnectionInfo(deployment)
+			if err != nil {
+				return err
+			}
+
+			return connect.Connect(ctx, opts, deployment, connectionInfo)
 		})
 
 	return err

--- a/internal/deploy/connection_instructions.go
+++ b/internal/deploy/connection_instructions.go
@@ -6,7 +6,6 @@ package deploy
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -25,10 +24,12 @@ const (
 
 type ConnectionDetails struct {
 	Hostname        string
+	DisplayHost     string
 	DBPort          string
 	UIPort          string
 	Username        string
 	CertFingerprint string
+	InsecureSkipTLS bool
 	SecretsFilePath string
 	DeploymentName  string
 	PublicIp        string
@@ -36,6 +37,8 @@ type ConnectionDetails struct {
 	SSHPort         string
 	ClusterState    string
 	ClusterSize     int
+	ShellSupported  bool
+	AdminUISecured  bool
 }
 
 type DocumentationLink struct {
@@ -52,57 +55,62 @@ type Details struct {
 }
 
 func getConnectionDetails(deployment config.DeploymentDir) (*ConnectionDetails, error) {
-	nodeDetails, err := config.ReadNodeDetails(deployment)
+	deploymentInfo, err := config.ReadDeploymentInfo(deployment)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get node details: %w", err)
+		return nil, fmt.Errorf("failed to read deployment info: %w", err)
 	}
-
-	certFingerprint, err := nodeDetails.GetCertFingerprint()
+	connectionInfo, err := deploymentInfo.ConnectionInfo(deployment)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get deployment tls certificate: %w", err)
+		return nil, fmt.Errorf("failed to resolve deployment connection info: %w", err)
 	}
-
-	nodes := nodeDetails.ListNodes()
-	if len(nodes) == 0 {
-		return nil, errors.New("no nodes found in deployment")
-	}
-	mainNode := nodeDetails.Nodes[nodes[0]]
-
-	secretsFilePath, err := config.SecretsFilePath(deployment)
+	secrets, err := config.ReadSecrets(deployment)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read deployment secrets: %w", err)
 	}
 
 	return &ConnectionDetails{
-		DeploymentName:  nodeDetails.DeploymentId,
-		ClusterSize:     nodeDetails.ClusterSize,
-		ClusterState:    nodeDetails.ClusterState,
-		Hostname:        mainNode.DnsName,
-		PublicIp:        mainNode.PublicIp,
-		DBPort:          mainNode.Database.DbPort,
-		UIPort:          mainNode.Database.UiPort,
-		SSHCommand:      mainNode.Ssh.Command,
-		SSHPort:         mainNode.Ssh.Port,
-		Username:        "sys",
-		CertFingerprint: certFingerprint,
-		SecretsFilePath: secretsFilePath,
+		DeploymentName:  connectionInfo.DeploymentName,
+		ClusterSize:     connectionInfo.ClusterSize,
+		ClusterState:    connectionInfo.ClusterState,
+		Hostname:        connectionInfo.Host,
+		DisplayHost:     connectionInfo.DisplayHost,
+		PublicIp:        connectionInfo.PublicIP,
+		DBPort:          strconv.Itoa(connectionInfo.DBPort),
+		UIPort:          strconv.Itoa(connectionInfo.UIPort),
+		SSHCommand:      connectionInfo.SSHCommand,
+		SSHPort:         connectionInfo.SSHPort,
+		Username:        connectionInfo.Username,
+		CertFingerprint: connectionInfo.CertFingerprint,
+		InsecureSkipTLS: connectionInfo.InsecureSkipCertValidation,
+		SecretsFilePath: connectionInfo.SecretsFilePath,
+		ShellSupported:  connectionInfo.ShellSupported,
+		AdminUISecured:  secrets.AdminUiPassword != "",
 	}, nil
 }
 
 func GetSQLInstructions(connectionDetails *ConnectionDetails) string {
-	uiURL := "https://" + net.JoinHostPort(connectionDetails.Hostname, connectionDetails.UIPort)
+	uiURL := "https://" + net.JoinHostPort(
+		displayHostname(connectionDetails),
+		connectionDetails.UIPort,
+	)
+	certificateLine := ""
+	if connectionDetails.CertFingerprint != "" {
+		certificateLine = "  - Certificate Fingerprint: " + connectionDetails.CertFingerprint + "\n"
+	} else if connectionDetails.InsecureSkipTLS {
+		certificateLine = "  - Certificate Validation: disable validation / " +
+			"use nocertcheck for the current deployment setup\n"
+	}
 
-	return `
+	adminUIInstructions := `
 === How to Connect from a Graphical SQL Client ===
 To connect using a client of your choice:
 1. Create a new database connection.
 2. Choose 'Exasol' as the driver.
 3. Enter the following values below in 'Database':
-  - Server: ` + connectionDetails.Hostname + `
+  - Server: ` + displayHostname(connectionDetails) + `
   - Port: ` + connectionDetails.DBPort + `
   - UserId: ` + connectionDetails.Username + `
-  - Certificate Fingerprint: ` + connectionDetails.CertFingerprint + `
-  - Password: <stored in ` + connectionDetails.SecretsFilePath + `>
+` + certificateLine + `  - Password: <stored in ` + connectionDetails.SecretsFilePath + `>
 
 === CLI Connection Instructions ===
 To connect using the CLI:
@@ -111,9 +119,30 @@ To connect using the CLI:
 === How to open the Administration UI ===
 1. Open the following URL in the browser: ` + uiURL + `
 2. Accept certificate if necessary
-3. Login with username "admin" and password stored in ` + connectionDetails.SecretsFilePath + `
 
-=== SSH Connection Instructions ===
+`
+	adminUIUsername := ""
+	if connectionDetails.AdminUISecured {
+		adminUIUsername = "admin"
+	}
+
+	if adminUIUsername != "" {
+		adminUIInstructions += fmt.Sprintf(
+			"3. Login with username %q and password stored in %s\n\n",
+			adminUIUsername,
+			connectionDetails.SecretsFilePath,
+		)
+	}
+
+	instructions := `
+
+` + adminUIInstructions
+
+	if !connectionDetails.ShellSupported {
+		return instructions
+	}
+
+	return instructions + `=== SSH Connection Instructions ===
   Public IP: ` + connectionDetails.PublicIp + `
   Primary admin shell (COS): exasol shell container
   Host shell (OS): exasol shell host
@@ -247,27 +276,32 @@ func printConnectionInsInJSONUnsafe(
 
 	encoder := json.NewEncoder(writer)
 	encoder.SetIndent("", "  ")
-
-	switch wfState {
-	case StatusRunning:
-		nodeDetails, err := config.ReadNodeDetails(deployment)
-		nodeDetails.DeploymentState = wfState
+	if wfState == StatusRunning || wfState == StatusStopped {
+		info, err := config.ReadDeploymentInfo(deployment)
 		if err != nil {
 			return err
 		}
+		info.DeploymentState = wfState
 
-		return encoder.Encode(nodeDetails)
-	case StatusStopped:
-		connectionDetails, err := getConnectionDetails(deployment)
-		if err != nil {
-			return err
-		}
-		details.DeploymentID = connectionDetails.DeploymentName
-		details.ClusterSize = connectionDetails.ClusterSize
-		details.ClusterState = connectionDetails.ClusterState
-
-		return encoder.Encode(details)
-	default:
-		return encoder.Encode(details)
+		return encoder.Encode(info)
 	}
+
+	return encoder.Encode(details)
+}
+
+func displayHostname(connectionDetails *ConnectionDetails) string {
+	if connectionDetails == nil {
+		return ""
+	}
+	if connectionDetails.DisplayHost != "" {
+		return connectionDetails.DisplayHost
+	}
+	if connectionDetails.Hostname != "" {
+		return connectionDetails.Hostname
+	}
+	if connectionDetails.PublicIp != "" {
+		return connectionDetails.PublicIp
+	}
+
+	return connectionDetails.Hostname
 }

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -15,20 +15,8 @@ import (
 	"github.com/exasol/exasol-personal/internal/presets"
 	"github.com/exasol/exasol-personal/internal/remote"
 	"github.com/exasol/exasol-personal/internal/task_runner"
-	"github.com/exasol/exasol-personal/internal/tofu"
 	"github.com/exasol/exasol-personal/internal/util"
 	"github.com/gobwas/glob"
-)
-
-// TofuLockfileMode controls whether OpenTofu is allowed to update .terraform.lock.hcl during init.
-//
-// This is an alias to the enum in the tofu package to avoid exposing internal/tofu details
-// to the CLI layer, while still using a strongly typed enum throughout the deploy pipeline.
-type TofuLockfileMode = tofu.LockfileMode
-
-const (
-	TofuLockfileReadonly = tofu.LockfileReadonly
-	TofuLockfileUpdate   = tofu.LockfileUpdate
 )
 
 const (
@@ -37,12 +25,32 @@ const (
 		"Fix the problem and run `deploy` again, or run `destroy` to clean up."
 )
 
-func appendDeployFailureResourceHint(err error) error {
+func appendDeployFailureHint(
+	deployment config.DeploymentDir,
+	err error,
+) error {
 	if err == nil {
 		return nil
 	}
 
-	return fmt.Errorf("%w\n\n%s", err, deployFailureResourceHint)
+	return fmt.Errorf(
+		"%w\n\nInspect launcher logs at %s for details. %s%s",
+		err,
+		deployment.Resolve("deployment.log"),
+		deployFailureResourceHint,
+		deployFailureResourceHintSuffix(deployment),
+	)
+}
+
+func deployFailureResourceHintSuffix(deployment config.DeploymentDir) string {
+	if _, statErr := os.Stat(deployment.NodeDetailsPath()); statErr == nil {
+		return fmt.Sprintf(
+			" Additional deployment diagnostics are stored in %s.",
+			deployment.NodeDetailsPath(),
+		)
+	}
+
+	return ""
 }
 
 //nolint:revive
@@ -145,6 +153,10 @@ func deployFromManifests(
 			if err != nil {
 				return err
 			}
+			backend, err := resolveBackendForManifest(infrastructureManifest)
+			if err != nil {
+				return err
+			}
 
 			installManifest, err := config.ReadInstallManifest(deployment)
 			if err != nil {
@@ -156,8 +168,7 @@ func deployFromManifests(
 				externalCommandOutput = os.Stderr
 			}
 
-			// Provision infrastructure via tofu when declared in infrastructure manifest
-			if err := runInfrastructureProvision(
+			if err := backend.Deploy(
 				ctx,
 				deployment,
 				infrastructureManifest,
@@ -167,7 +178,7 @@ func deployFromManifests(
 			); err != nil {
 				unregister()
 
-				deployErr := appendDeployFailureResourceHint(err)
+				deployErr := appendDeployFailureHint(deployment, err)
 				if stateErr := exasolState.SetWorkflowStateAndWrite(
 					&config.WorkflowStateDeploymentFailed{
 						Error: deployErr.Error(),
@@ -184,7 +195,7 @@ func deployFromManifests(
 			if err := runInstallSteps(ctx, deployment, installManifest,
 				externalCommandOutput, externalCommandOutput); err != nil {
 				unregister()
-				deployErr := appendDeployFailureResourceHint(err)
+				deployErr := appendDeployFailureHint(deployment, err)
 				if stateErr := exasolState.SetWorkflowStateAndWrite(
 					&config.WorkflowStateDeploymentFailed{
 						Error: deployErr.Error(),
@@ -317,73 +328,13 @@ func (builder *nodeListBuilder) getRemote(node string) (*remote.SSHConnectionOpt
 	}, nil
 }
 
-// Helpers to execute manifests
-
-func runInfrastructureProvision(
-	ctx context.Context,
-	deployment config.DeploymentDir,
-	manifest *presets.InfrastructureManifest,
-	out, outErr io.Writer,
-	tofuLockfileMode TofuLockfileMode,
-) error {
-	if manifest.Tofu == nil {
-		slog.Info("tofu: no configuration defined; skipping")
-		return nil
-	}
-
-	slog.Info("beginning deployment with tofu")
-
-	tofuCfg := tofu.NewTofuConfigFromDeployment(deployment.Root(), *manifest.Tofu)
-	logBuffer := task_runner.NewLogBuffer()
-	stdOutWriter := util.CombineWriters(logBuffer, out)
-	stdErrWriter := util.CombineWriters(logBuffer, outErr)
-
-	if err := tofu.Initialize(ctx, *tofuCfg,
-		stdOutWriter, stdErrWriter, tofuLockfileMode); err != nil {
-		logBuffer.ReplayLogMessages(ctx)
-		slog.Error("tofu: failed to init", "error", err)
-
-		return err
-	}
-
-	if err := tofu.Plan(ctx, *tofuCfg, stdOutWriter, stdErrWriter); err != nil {
-		logBuffer.ReplayLogMessages(ctx)
-		slog.Error("tofu: failed to plan")
-
-		return err
-	}
-
-	if err := tofu.ApplyPlan(ctx, *tofuCfg, stdOutWriter, stdErrWriter); err != nil {
-		logBuffer.ReplayLogMessages(ctx)
-		slog.Error("tofu: failed to apply")
-
-		return err
-	}
-
-	return nil
-}
-
-// Helpers to execute manifests
-
 func runInstallSteps(
 	ctx context.Context,
 	deployment config.DeploymentDir,
 	im *presets.InstallManifest,
 	out, outErr io.Writer,
 ) error {
-	// Translate remoteExec steps to tasks
-	tasks := []config.Task{}
-	for _, step := range im.Install {
-		if step.RemoteExec != nil {
-			// The filenames in the installation manifest are relative
-			// to the installation directory.
-			// Make them relative to the deployment directory here.
-			if step.RemoteExec.Filename != "" {
-				step.RemoteExec.Filename = filepath.Join("installation", step.RemoteExec.Filename)
-			}
-			tasks = append(tasks, config.Task{RemoteExec: step.RemoteExec})
-		}
-	}
+	tasks := buildInstallTasks(im)
 	if len(tasks) == 0 {
 		slog.Info("no installation steps defined; skipping")
 		return nil
@@ -394,4 +345,27 @@ func runInstallSteps(
 		&task_runner.RemoteScriptRunnerImpl{},
 		NewNodeLookup(deployment),
 	).RunTasks(ctx, tasks, deployment, out, outErr)
+}
+
+func buildInstallTasks(installManifest *presets.InstallManifest) []config.Task {
+	if installManifest == nil {
+		return nil
+	}
+
+	tasks := []config.Task{}
+	for _, step := range installManifest.Install {
+		if step.RemoteExec != nil {
+			remoteExec := *step.RemoteExec
+			if remoteExec.Filename != "" {
+				remoteExec.Filename = filepath.Join("installation", remoteExec.Filename)
+			}
+			tasks = append(tasks, config.Task{RemoteExec: &remoteExec})
+		}
+		if step.LocalCommand != nil {
+			localCommand := *step.LocalCommand
+			tasks = append(tasks, config.Task{LocalCommand: &localCommand})
+		}
+	}
+
+	return tasks
 }

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -7,16 +7,19 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
 )
 
-func TestAppendDeployFailureResourceHint(t *testing.T) {
+func TestAppendDeployFailureHint_AddsLauncherLogPath(t *testing.T) {
 	t.Parallel()
 
 	// Given
-	baseErr := errors.New("tofu apply failed")
+	baseErr := errors.New("deployment failed")
+	deployment := config.NewDeploymentDir(t.TempDir())
 
 	// When
-	err := appendDeployFailureResourceHint(baseErr)
+	err := appendDeployFailureHint(deployment, baseErr)
 
 	// Then
 	if err == nil {
@@ -25,18 +28,48 @@ func TestAppendDeployFailureResourceHint(t *testing.T) {
 	if !errors.Is(err, baseErr) {
 		t.Fatalf("expected wrapped error to match base error, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), deployFailureResourceHint) {
-		t.Fatalf("expected error to include resource hint, got: %q", err.Error())
+	if !strings.Contains(err.Error(), deployment.Resolve("deployment.log")) {
+		t.Fatalf("expected error to include deployment log path, got: %q", err.Error())
 	}
 }
 
-func TestAppendDeployFailureResourceHintNilInput(t *testing.T) {
+func TestAppendDeployFailureHint_AddsDeploymentInfoPathWhenPresent(t *testing.T) {
 	t.Parallel()
 
-	// Given/When
-	err := appendDeployFailureResourceHint(nil)
+	// Given
+	baseErr := errors.New("deployment failed")
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := config.WriteDeploymentInfo(deployment.Root(), &config.DeploymentInfo{
+		Backend:      "tofu",
+		DeploymentId: "dep-1",
+		Connection: &config.DeploymentConnection{
+			Host:           "example.local",
+			DisplayHost:    "example.local",
+			DBPort:         8563,
+			UIPort:         8443,
+			Username:       "sys",
+			ShellSupported: true,
+		},
+	}); err != nil {
+		t.Fatalf("failed to write deployment info: %v", err)
+	}
+
+	// When
+	err := appendDeployFailureHint(deployment, baseErr)
+
 	// Then
-	if err != nil {
+	if err == nil {
+		t.Fatal("expected non-nil error")
+	}
+	if !strings.Contains(err.Error(), deployment.NodeDetailsPath()) {
+		t.Fatalf("expected error to include deployment info path, got: %q", err.Error())
+	}
+}
+
+func TestAppendDeployFailureHintNilInput(t *testing.T) {
+	t.Parallel()
+
+	if err := appendDeployFailureHint(config.NewDeploymentDir(t.TempDir()), nil); err != nil {
 		t.Fatalf("expected nil, got: %v", err)
 	}
 }

--- a/internal/deploy/deploymentControl.go
+++ b/internal/deploy/deploymentControl.go
@@ -8,11 +8,8 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"time"
 
 	"github.com/exasol/exasol-personal/internal/config"
-	"github.com/exasol/exasol-personal/internal/task_runner"
-	"github.com/exasol/exasol-personal/internal/tofu"
 	"github.com/exasol/exasol-personal/internal/util"
 )
 
@@ -95,84 +92,28 @@ func Start(
 			// Fallback cleanup
 			defer unregister()
 
+			manifest, err := config.ReadInfrastructureManifest(deployment)
+			if err != nil {
+				return err
+			}
+			backend, err := resolveBackendForManifest(manifest)
+			if err != nil {
+				return err
+			}
+
 			var externalCommandOutput io.Writer
 			if verbose {
 				externalCommandOutput = os.Stderr
 			}
 
-			logBuffer := task_runner.NewLogBuffer()
-
-			err = applyAction(
+			if err := backend.Start(
 				ctx,
 				deployment,
-				"power_state=running",
-				util.CombineWriters(logBuffer, externalCommandOutput),
-				util.CombineWriters(logBuffer, externalCommandOutput),
-			)
-			if err != nil {
-				logBuffer.ReplayLogMessages(ctx)
-				slog.Error("failed to start deployment")
-
-				return err
-			}
-
-			// Attempt to refresh config/infrastructure
-			instPollCond := func(ctx context.Context) (bool, error) {
-				n11Details, err := Getn11Details(deployment)
-				if err != nil {
-					return false, err
-				}
-				if n11Details.Host != "" {
-					// Resources up-to-date
-					return true, nil
-				}
-				err = applyAction(
-					ctx,
-					deployment,
-					"", // No Arg needed for refresh
-					util.CombineWriters(logBuffer, externalCommandOutput),
-					util.CombineWriters(logBuffer, externalCommandOutput),
-				)
-				if err != nil {
-					logBuffer.ReplayLogMessages(ctx)
-					slog.Error("ApplyAction failed while refreshing", "error", err)
-
-					return false, err
-				}
-
-				return false, nil
-			}
-
-			waitCtx, cancel := context.WithTimeout(
-				ctx,
-				time.Duration(InstanceRefreshTimeoutSeconds)*time.Second,
-			)
-			defer cancel()
-
-			err = PollWithBackoff(waitCtx, instPollCond, WaitParams{
-				InitialBackoff: StartedInitialBackoff,
-				MaxBackoff:     StartedMaxBackoff,
-				LogPrefix:      "waiting to update EC2 Resources",
-			})
-			if err != nil {
-				slog.Error("Updated EC2 resources not available in time")
-				return err
-			}
-
-			// Use provided timeout if > 0; otherwise fallback to default (seconds)
-			if waitTimeoutSeconds <= 0 {
-				waitTimeoutSeconds = StartedDefaultTimeoutSeconds
-			}
-
-			// After starting the instance, wait until the database is ready for connections
-			// Enforce the provided timeout using a child context with deadline
-			waitCtx, cancel = context.WithTimeout(ctx,
-				time.Duration(waitTimeoutSeconds)*time.Second,
-			)
-			defer cancel()
-
-			if err := WaitForDatabaseStarted(waitCtx, deployment); err != nil {
-				slog.Error("database did not become operational with timeout", "error", err.Error())
+				manifest,
+				externalCommandOutput,
+				externalCommandOutput,
+				waitTimeoutSeconds,
+			); err != nil {
 				return err
 			}
 
@@ -276,24 +217,27 @@ func Stop(ctx context.Context, deployment config.DeploymentDir, verbose bool) er
 			// Fallback cleanup
 			defer unregister()
 
+			manifest, err := config.ReadInfrastructureManifest(deployment)
+			if err != nil {
+				return err
+			}
+			backend, err := resolveBackendForManifest(manifest)
+			if err != nil {
+				return err
+			}
+
 			var externalCommandOutput io.Writer
 			if verbose {
 				externalCommandOutput = os.Stderr
 			}
 
-			logBuffer := task_runner.NewLogBuffer()
-
-			err = applyAction(
+			if err := backend.Stop(
 				ctx,
 				deployment,
-				"power_state=stopped",
-				util.CombineWriters(logBuffer, externalCommandOutput),
-				util.CombineWriters(logBuffer, externalCommandOutput),
-			)
-			if err != nil {
-				logBuffer.ReplayLogMessages(ctx)
-				slog.Error("failed to stop the deployment")
-				// should this be a failure state that requires destroy?
+				manifest,
+				externalCommandOutput,
+				externalCommandOutput,
+			); err != nil {
 				return err
 			}
 
@@ -309,34 +253,4 @@ func Stop(ctx context.Context, deployment config.DeploymentDir, verbose bool) er
 
 			return nil
 		})
-}
-
-func applyAction(
-	ctx context.Context,
-	deployment config.DeploymentDir,
-	startStopArg string,
-	out, outErr io.Writer,
-) error {
-	manifest, err := config.ReadInfrastructureManifest(deployment)
-	if err != nil {
-		return err
-	}
-	if manifest.Tofu == nil {
-		slog.Info("no tofu configuration defined; skipping apply action")
-		return nil
-	}
-
-	tofuCfg := tofu.NewTofuConfigFromDeployment(deployment.Root(), *manifest.Tofu)
-	if err := tofu.ApplyAction(
-		ctx,
-		*tofuCfg,
-		startStopArg,
-		out,
-		outErr,
-	); err != nil {
-		slog.Error("Tofu Apply Failed:", "error", err.Error())
-		return err
-	}
-
-	return nil
 }

--- a/internal/deploy/destroy.go
+++ b/internal/deploy/destroy.go
@@ -11,8 +11,6 @@ import (
 	"os"
 
 	"github.com/exasol/exasol-personal/internal/config"
-	"github.com/exasol/exasol-personal/internal/task_runner"
-	"github.com/exasol/exasol-personal/internal/tofu"
 	"github.com/exasol/exasol-personal/internal/util"
 )
 
@@ -51,9 +49,9 @@ func Destroy(ctx context.Context, deployment config.DeploymentDir, verbose bool)
 			if err != nil {
 				return err
 			}
-			if manifest.Tofu == nil {
-				slog.Info("no tofu configuration defined; skipping destroy")
-				return nil
+			backend, err := resolveBackendForManifest(manifest)
+			if err != nil {
+				return err
 			}
 
 			var externalCommandStandardOut io.Writer
@@ -61,21 +59,14 @@ func Destroy(ctx context.Context, deployment config.DeploymentDir, verbose bool)
 				externalCommandStandardOut = os.Stderr
 			}
 
-			if manifest.Tofu != nil {
-				tofuCfg := tofu.NewTofuConfigFromDeployment(deployment.Root(), *manifest.Tofu)
-				logBuffer := task_runner.NewLogBuffer()
-				err = tofu.Destroy(
-					ctx,
-					*tofuCfg,
-					util.CombineWriters(logBuffer, externalCommandStandardOut),
-					util.CombineWriters(logBuffer, externalCommandStandardOut),
-				)
-				if err != nil {
-					logBuffer.ReplayLogMessages(ctx)
-					slog.Error("failed to destroy cloud resources")
-
-					return err
-				}
+			if err := backend.Destroy(
+				ctx,
+				deployment,
+				manifest,
+				externalCommandStandardOut,
+				externalCommandStandardOut,
+			); err != nil {
+				return err
 			}
 
 			// Stop handling interrupts before committing final initialized state

--- a/internal/deploy/diag_info.go
+++ b/internal/deploy/diag_info.go
@@ -22,7 +22,7 @@ func DumpDeploymentInfo(
 }
 
 func dumpDeploymentInfoUnsafe(deployment config.DeploymentDir, writer io.Writer) error {
-	details, err := config.ReadNodeDetails(deployment)
+	details, err := config.ReadDeploymentInfo(deployment)
 	if err != nil {
 		return err
 	}

--- a/internal/deploy/init.go
+++ b/internal/deploy/init.go
@@ -84,10 +84,7 @@ func InitDeployment(
 
 	// Proactively validate the preset selection to produce friendly errors.
 	slog.Info("validating presets")
-	if err := validateInfrastructurePreset(infrastructurePreset); err != nil {
-		return err
-	}
-	if err := validateInstallationPreset(installationPreset); err != nil {
+	if err := validatePresetSelection(infrastructurePreset, installationPreset); err != nil {
 		return err
 	}
 

--- a/internal/deploy/install_steps_test.go
+++ b/internal/deploy/install_steps_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/presets"
+)
+
+func TestBuildInstallTasks_PreservesRemoteAndLocalSteps(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	manifest := &presets.InstallManifest{
+		Install: presets.InstallSteps{
+			{
+				RemoteExec: &presets.RemoteExecTask{
+					Description: "remote",
+					Filename:    "monitor.sh",
+					Node:        "n11",
+				},
+			},
+			{
+				LocalCommand: &presets.LocalCommandTask{
+					Description: "local",
+					Command:     []string{"echo", "hello"},
+				},
+			},
+		},
+	}
+
+	// When
+	tasks := buildInstallTasks(manifest)
+
+	// Then
+	if len(tasks) != 2 {
+		t.Fatalf("expected 2 tasks, got %d", len(tasks))
+	}
+	if tasks[0].RemoteExec == nil {
+		t.Fatal("expected first task to be remoteExec")
+	}
+	if tasks[0].RemoteExec.Filename != filepath.Join("installation", "monitor.sh") {
+		t.Fatalf("unexpected remote filename: %q", tasks[0].RemoteExec.Filename)
+	}
+	if tasks[1].LocalCommand == nil {
+		t.Fatal("expected second task to be localCommand")
+	}
+	if got := tasks[1].LocalCommand.Command; len(got) != 2 || got[0] != "echo" ||
+		got[1] != "hello" {
+		t.Fatalf("unexpected local command: %#v", got)
+	}
+}

--- a/internal/deploy/preset_defaults.go
+++ b/internal/deploy/preset_defaults.go
@@ -1,0 +1,55 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/exasol/exasol-personal/internal/presets"
+)
+
+func ResolveDefaultInstallationPreset(infrastructurePreset PresetRef) (PresetRef, error) {
+	infrastructureManifest, err := readInfrastructureManifestFromPreset(infrastructurePreset)
+	if err != nil {
+		return PresetRef{}, fmt.Errorf(
+			"failed to load infrastructure preset %q: %w",
+			presetLabel(infrastructurePreset),
+			err,
+		)
+	}
+
+	for _, installName := range compatibleDefaultInstallationCandidates() {
+		installationPreset := PresetRef{Name: installName}
+		installManifest, err := readInstallManifestFromPreset(installationPreset)
+		if err != nil {
+			continue
+		}
+
+		if err := validatePresetCompatibility(
+			infrastructurePreset,
+			infrastructureManifest,
+			installationPreset,
+			installManifest,
+		); err == nil {
+			return installationPreset, nil
+		}
+	}
+
+	return PresetRef{}, fmt.Errorf(
+		"no compatible default installation preset found for infrastructure preset %q",
+		presetLabel(infrastructurePreset),
+	)
+}
+
+func compatibleDefaultInstallationCandidates() []string {
+	candidates := []string{presets.DefaultInstallation}
+	for _, name := range presets.ListEmbeddedInstallationsPresets() {
+		if !slices.Contains(candidates, name) {
+			candidates = append(candidates, name)
+		}
+	}
+
+	return candidates
+}

--- a/internal/deploy/preset_validation.go
+++ b/internal/deploy/preset_validation.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/exasol/exasol-personal/internal/presets"
+)
+
+func validatePresetSelection(
+	infrastructurePreset PresetRef,
+	installationPreset PresetRef,
+) error {
+	if err := validateInfrastructurePreset(infrastructurePreset); err != nil {
+		return err
+	}
+	if err := validateInstallationPreset(installationPreset); err != nil {
+		return err
+	}
+
+	infrastructureManifest, err := readInfrastructureManifestFromPreset(infrastructurePreset)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to load infrastructure preset %q: %w",
+			presetLabel(infrastructurePreset),
+			err,
+		)
+	}
+	if _, err := resolveBackendForManifest(infrastructureManifest); err != nil {
+		return err
+	}
+	backend, err := resolveBackendForManifest(infrastructureManifest)
+	if err != nil {
+		return err
+	}
+	if err := backend.ValidateEnvironment(); err != nil {
+		return err
+	}
+
+	installManifest, err := readInstallManifestFromPreset(installationPreset)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to load installation preset %q: %w",
+			presetLabel(installationPreset),
+			err,
+		)
+	}
+
+	return validatePresetCompatibility(
+		infrastructurePreset,
+		infrastructureManifest,
+		installationPreset,
+		installManifest,
+	)
+}
+
+func readInfrastructureManifestFromPreset(
+	infrastructurePreset PresetRef,
+) (*presets.InfrastructureManifest, error) {
+	if infrastructurePreset.IsPath() {
+		return presets.ReadInfrastructureManifestFromDir(infrastructurePreset.Path)
+	}
+
+	return presets.ReadInfrastructureManifest(infrastructurePreset.Name)
+}
+
+func readInstallManifestFromPreset(
+	installationPreset PresetRef,
+) (*presets.InstallManifest, error) {
+	if installationPreset.IsPath() {
+		return presets.ReadInstallManifestFromDir(installationPreset.Path)
+	}
+
+	return presets.ReadInstallManifest(installationPreset.Name)
+}
+
+func validatePresetCompatibility(
+	infrastructurePreset PresetRef,
+	infrastructureManifest *presets.InfrastructureManifest,
+	installationPreset PresetRef,
+	installManifest *presets.InstallManifest,
+) error {
+	required := installManifest.RequiredCapabilities()
+	if len(required) == 0 {
+		return nil
+	}
+
+	provided := infrastructureManifest.ProvidedCapabilities()
+	providedSet := make(map[string]struct{}, len(provided))
+	for _, capability := range provided {
+		providedSet[capability] = struct{}{}
+	}
+
+	missing := make([]string, 0, len(required))
+	for _, capability := range required {
+		if _, exists := providedSet[capability]; exists {
+			continue
+		}
+		missing = append(missing, capability)
+	}
+
+	if len(missing) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"installation preset %q is incompatible with infrastructure preset %q:"+
+			" missing capabilities [%s] (provided [%s])",
+		presetLabel(installationPreset),
+		presetLabel(infrastructurePreset),
+		strings.Join(missing, ", "),
+		strings.Join(provided, ", "),
+	)
+}

--- a/internal/deploy/preset_validation_test.go
+++ b/internal/deploy/preset_validation_test.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/presets"
+)
+
+func TestValidatePresetSelection_AcceptsDefaultEmbeddedPair(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	infrastructurePreset := PresetRef{Name: presets.DefaultInfrastructure}
+	installationPreset := PresetRef{Name: presets.DefaultInstallation}
+
+	// When
+	err := validatePresetSelection(infrastructurePreset, installationPreset)
+	// Then
+	if err != nil {
+		t.Fatalf("expected default preset pair to be valid, got %v", err)
+	}
+}
+
+func TestInitDeployment_RejectsIncompatiblePresetPairBeforeMutation(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	deploymentDir := t.TempDir()
+	infrastructureDir := t.TempDir()
+	installationDir := t.TempDir()
+
+	writeTestFile(t, filepath.Join(infrastructureDir, presets.InfrastructureManifestFilename), `
+name: Test Infrastructure
+description: test infrastructure
+backend: tofu
+compatibility:
+  provides:
+    - local-command
+`)
+	writeTestFile(t, filepath.Join(installationDir, presets.InstallationManifestFilename), `
+name: Test Installation
+description: test installation
+compatibility:
+  requires:
+    - remote-exec
+install: []
+`)
+
+	// When
+	err := InitDeployment(
+		context.Background(),
+		PresetRef{Path: infrastructureDir},
+		PresetRef{Path: installationDir},
+		map[string]string{},
+		map[string]string{},
+		config.NewDeploymentDir(deploymentDir),
+		false,
+		"0.0.0",
+	)
+
+	// Then
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "missing capabilities [remote-exec]") {
+		t.Fatalf("expected compatibility error, got %v", err)
+	}
+
+	entries, readErr := os.ReadDir(deploymentDir)
+	if readErr != nil {
+		t.Fatalf("expected to read deployment dir, got %v", readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf(
+			"expected deployment directory to remain untouched, found %d entries",
+			len(entries),
+		)
+	}
+}
+
+func TestResolveDefaultInstallationPreset_UsesCompatibleEmbeddedDefault(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	infrastructurePreset := PresetRef{Name: presets.DefaultInfrastructure}
+
+	// When
+	installationPreset, err := ResolveDefaultInstallationPreset(infrastructurePreset)
+	// Then
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if installationPreset.Name != presets.DefaultInstallation {
+		t.Fatalf("expected %q, got %#v", presets.DefaultInstallation, installationPreset)
+	}
+}
+
+func writeTestFile(t *testing.T, path string, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(strings.TrimSpace(content)+"\n"), 0o600); err != nil {
+		t.Fatalf("failed to write test file %s: %v", path, err)
+	}
+}

--- a/internal/deploy/ready.go
+++ b/internal/deploy/ready.go
@@ -14,14 +14,29 @@ import (
 	"github.com/exasol/exasol-personal/internal/connect"
 )
 
+var (
+	verifyDatabaseConnectionFn = verifyDatabaseConnection
+	newExasolConnectionFn      = connect.NewExasolConnection
+)
+
 // verifyDatabaseConnection checks if the database service is accepting connections
 // by attempting a connection with invalid credentials and expecting an authentication error.
 func verifyDatabaseConnection(ctx context.Context, deployment config.DeploymentDir) error {
 	var dbErr error
 	// Suppress driver noise only for this probe (invalid creds, transient failures expected).
 	probeErr := connect.WithSilencedDriverErrors(func() error {
-		database, err := connect.NewExasolConnection(
-			deployment, "invalid username", "invalid password", true)
+		connectionInfo, err := config.ResolveConnectionInfo(deployment)
+		if err != nil {
+			return err
+		}
+
+		database, err := newExasolConnectionFn(
+			deployment,
+			connectionInfo,
+			"invalid username",
+			"invalid password",
+			true,
+		)
 		if err != nil {
 			return err
 		}
@@ -80,7 +95,7 @@ func waitForDatabaseState(
 	params WaitParams,
 ) error {
 	return PollWithBackoff(ctx, func(ctx context.Context) (bool, error) {
-		err := verifyDatabaseConnection(ctx, deployment)
+		err := verifyDatabaseConnectionFn(ctx, deployment)
 		conditionMet := (params.ReadyMode && err == nil) || (!params.ReadyMode && err != nil)
 
 		return conditionMet, err

--- a/internal/deploy/shell.go
+++ b/internal/deploy/shell.go
@@ -22,26 +22,24 @@ func OpenHostShell(
 	selectedNode string,
 ) error {
 	return withDeploymentSharedLock(ctx, deployment, func(deployment config.DeploymentDir) error {
-		sshRemote, err := sshRemoteForNodeUnsafe(deployment, selectedNode)
+		backend, err := resolveBackendForDeployment(deployment)
 		if err != nil {
 			return err
 		}
 
-		return sshRemote.Shell(ctx, os.Stdout, os.Stderr)
+		return backend.OpenHostShell(ctx, deployment, selectedNode)
 	})
 }
 
 // OpenCOSShell opens an interactive COS session via the access node (n11).
 func OpenCOSShell(ctx context.Context, deployment config.DeploymentDir) error {
 	return withDeploymentSharedLock(ctx, deployment, func(deployment config.DeploymentDir) error {
-		sshRemote, err := sshRemoteForNodeUnsafe(deployment, "n11")
+		backend, err := resolveBackendForDeployment(deployment)
 		if err != nil {
 			return err
 		}
 
-		cosCommand := "/usr/bin/env bash /opt/exasol_launcher/scripts/connectCos.sh"
-
-		return sshRemote.RunInteractiveCommand(ctx, cosCommand, os.Stdout, os.Stderr)
+		return backend.OpenCOSShell(ctx, deployment)
 	})
 }
 

--- a/internal/deploy/tofu_backend.go
+++ b/internal/deploy/tofu_backend.go
@@ -1,0 +1,253 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/presets"
+	"github.com/exasol/exasol-personal/internal/task_runner"
+	"github.com/exasol/exasol-personal/internal/tofu"
+	"github.com/exasol/exasol-personal/internal/util"
+)
+
+type tofuBackend struct{}
+
+func (tofuBackend) ValidateEnvironment() error {
+	return nil
+}
+
+func (tofuBackend) OpenHostShell(
+	ctx context.Context,
+	deployment config.DeploymentDir,
+	selectedNode string,
+) error {
+	sshRemote, err := sshRemoteForNodeUnsafe(deployment, selectedNode)
+	if err != nil {
+		return err
+	}
+
+	return sshRemote.Shell(ctx, os.Stdout, os.Stderr)
+}
+
+func (tofuBackend) OpenCOSShell(ctx context.Context, deployment config.DeploymentDir) error {
+	sshRemote, err := sshRemoteForNodeUnsafe(deployment, "n11")
+	if err != nil {
+		return err
+	}
+
+	cosCommand := "/usr/bin/env bash /opt/exasol_launcher/scripts/connectCos.sh"
+
+	return sshRemote.RunInteractiveCommand(ctx, cosCommand, os.Stdout, os.Stderr)
+}
+
+func (tofuBackend) Deploy(
+	ctx context.Context,
+	deployment config.DeploymentDir,
+	manifest *presets.InfrastructureManifest,
+	out, outErr io.Writer,
+	tofuLockfileMode TofuLockfileMode,
+) error {
+	if manifest.Tofu == nil {
+		slog.Info("tofu: no configuration defined; skipping")
+		return nil
+	}
+
+	slog.Info("beginning deployment with tofu")
+
+	tofuCfg := tofu.NewTofuConfigFromDeployment(deployment.Root(), *manifest.Tofu)
+	logBuffer := task_runner.NewLogBuffer()
+	stdOutWriter := util.CombineWriters(logBuffer, out)
+	stdErrWriter := util.CombineWriters(logBuffer, outErr)
+
+	if err := tofu.Initialize(ctx, *tofuCfg,
+		stdOutWriter, stdErrWriter, tofuLockfileMode); err != nil {
+		logBuffer.ReplayLogMessages(ctx)
+		slog.Error("tofu: failed to init", "error", err)
+
+		return err
+	}
+
+	if err := tofu.Plan(ctx, *tofuCfg, stdOutWriter, stdErrWriter); err != nil {
+		logBuffer.ReplayLogMessages(ctx)
+		slog.Error("tofu: failed to plan")
+
+		return err
+	}
+
+	if err := tofu.ApplyPlan(ctx, *tofuCfg, stdOutWriter, stdErrWriter); err != nil {
+		logBuffer.ReplayLogMessages(ctx)
+		slog.Error("tofu: failed to apply")
+
+		return err
+	}
+
+	return nil
+}
+
+func (tofuBackend) Start(
+	ctx context.Context,
+	deployment config.DeploymentDir,
+	manifest *presets.InfrastructureManifest,
+	out, outErr io.Writer,
+	waitTimeoutSeconds int,
+) error {
+	logBuffer := task_runner.NewLogBuffer()
+	output := util.CombineWriters(logBuffer, out)
+	errOutput := util.CombineWriters(logBuffer, outErr)
+
+	if err := tofuApplyAction(
+		ctx,
+		deployment,
+		manifest,
+		"power_state=running",
+		output,
+		errOutput,
+	); err != nil {
+		logBuffer.ReplayLogMessages(ctx)
+		slog.Error("failed to start deployment")
+
+		return err
+	}
+
+	instPollCond := func(ctx context.Context) (bool, error) {
+		n11Details, err := Getn11Details(deployment)
+		if err != nil {
+			return false, err
+		}
+		if n11Details.Host != "" {
+			return true, nil
+		}
+
+		if err := tofuApplyAction(
+			ctx,
+			deployment,
+			manifest,
+			"",
+			output,
+			errOutput,
+		); err != nil {
+			logBuffer.ReplayLogMessages(ctx)
+			slog.Error("ApplyAction failed while refreshing", "error", err)
+
+			return false, err
+		}
+
+		return false, nil
+	}
+
+	waitCtx, cancel := context.WithTimeout(
+		ctx,
+		time.Duration(InstanceRefreshTimeoutSeconds)*time.Second,
+	)
+	defer cancel()
+
+	if err := PollWithBackoff(waitCtx, instPollCond, WaitParams{
+		InitialBackoff: StartedInitialBackoff,
+		MaxBackoff:     StartedMaxBackoff,
+		LogPrefix:      "waiting to update EC2 Resources",
+	}); err != nil {
+		slog.Error("Updated EC2 resources not available in time")
+		return err
+	}
+
+	if waitTimeoutSeconds <= 0 {
+		waitTimeoutSeconds = StartedDefaultTimeoutSeconds
+	}
+
+	waitCtx, cancel = context.WithTimeout(ctx, time.Duration(waitTimeoutSeconds)*time.Second)
+	defer cancel()
+
+	if err := WaitForDatabaseStarted(waitCtx, deployment); err != nil {
+		slog.Error("database did not become operational with timeout", "error", err.Error())
+		return err
+	}
+
+	return nil
+}
+
+func (tofuBackend) Stop(
+	ctx context.Context,
+	deployment config.DeploymentDir,
+	manifest *presets.InfrastructureManifest,
+	out, outErr io.Writer,
+) error {
+	logBuffer := task_runner.NewLogBuffer()
+
+	if err := tofuApplyAction(
+		ctx,
+		deployment,
+		manifest,
+		"power_state=stopped",
+		util.CombineWriters(logBuffer, out),
+		util.CombineWriters(logBuffer, outErr),
+	); err != nil {
+		logBuffer.ReplayLogMessages(ctx)
+		slog.Error("failed to stop the deployment")
+
+		return err
+	}
+
+	return nil
+}
+
+func (tofuBackend) Destroy(
+	ctx context.Context,
+	deployment config.DeploymentDir,
+	manifest *presets.InfrastructureManifest,
+	out, outErr io.Writer,
+) error {
+	if manifest.Tofu == nil {
+		slog.Info("no tofu configuration defined; skipping destroy")
+		return nil
+	}
+
+	tofuCfg := tofu.NewTofuConfigFromDeployment(deployment.Root(), *manifest.Tofu)
+	logBuffer := task_runner.NewLogBuffer()
+	if err := tofu.Destroy(
+		ctx,
+		*tofuCfg,
+		util.CombineWriters(logBuffer, out),
+		util.CombineWriters(logBuffer, outErr),
+	); err != nil {
+		logBuffer.ReplayLogMessages(ctx)
+		slog.Error("failed to destroy cloud resources")
+
+		return err
+	}
+
+	return nil
+}
+
+func tofuApplyAction(
+	ctx context.Context,
+	deployment config.DeploymentDir,
+	manifest *presets.InfrastructureManifest,
+	startStopArg string,
+	out, outErr io.Writer,
+) error {
+	if manifest.Tofu == nil {
+		slog.Info("no tofu configuration defined; skipping apply action")
+		return nil
+	}
+
+	tofuCfg := tofu.NewTofuConfigFromDeployment(deployment.Root(), *manifest.Tofu)
+	if err := tofu.ApplyAction(
+		ctx,
+		*tofuCfg,
+		startStopArg,
+		out,
+		outErr,
+	); err != nil {
+		slog.Error("Tofu Apply Failed:", "error", err.Error())
+		return err
+	}
+
+	return nil
+}

--- a/internal/deploy/tofu_lockfile.go
+++ b/internal/deploy/tofu_lockfile.go
@@ -1,0 +1,17 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import "github.com/exasol/exasol-personal/internal/tofu"
+
+// TofuLockfileMode controls whether OpenTofu is allowed to update .terraform.lock.hcl during init.
+//
+// This is an alias to the enum in the tofu package to avoid exposing internal/tofu details
+// to the CLI layer, while still using a strongly typed enum throughout the deploy pipeline.
+type TofuLockfileMode = tofu.LockfileMode
+
+const (
+	TofuLockfileReadonly = tofu.LockfileReadonly
+	TofuLockfileUpdate   = tofu.LockfileUpdate
+)

--- a/internal/presets/compatibility.go
+++ b/internal/presets/compatibility.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package presets
+
+import (
+	"slices"
+	"strings"
+)
+
+// Compatibility declares directional preset-composition metadata.
+//
+// Infrastructure presets use Provides, installation presets use Requires.
+type Compatibility struct {
+	Provides []string `yaml:"provides,omitempty"`
+	Requires []string `yaml:"requires,omitempty"`
+}
+
+func normalizedCapabilities(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	result := make([]string, 0, len(values))
+
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+
+	slices.Sort(result)
+
+	return result
+}

--- a/internal/presets/infrastructure_manifest.go
+++ b/internal/presets/infrastructure_manifest.go
@@ -22,9 +22,19 @@ type InfrastructureTofu struct {
 
 // InfrastructureManifest represents the infrastructure metadata and optional tofu configuration.
 type InfrastructureManifest struct {
-	Name        string              `yaml:"name"`
-	Description string              `yaml:"description"`
-	Tofu        *InfrastructureTofu `yaml:"tofu,omitempty"`
+	Name          string              `yaml:"name"`
+	Description   string              `yaml:"description"`
+	Backend       string              `yaml:"backend,omitempty"`
+	Compatibility *Compatibility      `yaml:"compatibility,omitempty"`
+	Tofu          *InfrastructureTofu `yaml:"tofu,omitempty"`
+}
+
+func (m *InfrastructureManifest) ProvidedCapabilities() []string {
+	if m == nil || m.Compatibility == nil {
+		return nil
+	}
+
+	return normalizedCapabilities(m.Compatibility.Provides)
 }
 
 var (

--- a/internal/presets/install_manifest.go
+++ b/internal/presets/install_manifest.go
@@ -19,10 +19,19 @@ import (
 // InstallManifest represents the installation preset workflow and metadata.
 // It is read from <deploymentDir>/installation/installation.yaml (extracted from assets).
 type InstallManifest struct {
-	Name        string       `yaml:"name"`
-	Description string       `yaml:"description"`
-	Variables   *Variables   `yaml:"variables"`
-	Install     InstallSteps `yaml:"install"`
+	Name          string         `yaml:"name"`
+	Description   string         `yaml:"description"`
+	Compatibility *Compatibility `yaml:"compatibility,omitempty"`
+	Variables     *Variables     `yaml:"variables"`
+	Install       InstallSteps   `yaml:"install"`
+}
+
+func (m *InstallManifest) RequiredCapabilities() []string {
+	if m == nil || m.Compatibility == nil {
+		return nil
+	}
+
+	return normalizedCapabilities(m.Compatibility.Requires)
 }
 
 // Variables defines installation-preset-owned variables.
@@ -221,14 +230,6 @@ type RemoteExecTask struct {
 	ExecuteInParallel bool        `yaml:"executeInParallel"`
 	Node              string      `yaml:"node"`
 	RegexLog          []*RegexLog `yaml:"regexLog"`
-}
-
-// LocalCommandTask describes a local command task.
-type LocalCommandTask struct {
-	Description string      `yaml:"description"`
-	Command     []string    `yaml:"command"`
-	Node        string      `yaml:"node"`
-	RegexLog    []*RegexLog `yaml:"regexLog"`
 }
 
 // ReadInstallManifest loads the installation manifest from embedded assets.

--- a/internal/presets/install_manifest.go
+++ b/internal/presets/install_manifest.go
@@ -114,9 +114,10 @@ func (d *VariableDef) EffectiveType() (string, error) {
 	}
 }
 
-// InstallStep supports remoteExec tasks.
+// InstallStep supports exactly one task type per step.
 type InstallStep struct {
-	RemoteExec *RemoteExecTask `yaml:"remoteExec"`
+	RemoteExec   *RemoteExecTask   `yaml:"remoteExec"`
+	LocalCommand *LocalCommandTask `yaml:"localCommand"`
 }
 
 // UnmarshalYAML allows InstallStep to be defined in two YAML styles:
@@ -139,7 +140,11 @@ func (s *InstallStep) UnmarshalYAML(value *yaml.Node) error {
 	}
 	*s = InstallStep(tmp)
 
-	if s.RemoteExec != nil {
+	if s.RemoteExec != nil && s.LocalCommand != nil {
+		return errors.New("install step must set exactly one task type")
+	}
+
+	if s.RemoteExec != nil || s.LocalCommand != nil {
 		return nil
 	}
 
@@ -230,6 +235,14 @@ type RemoteExecTask struct {
 	ExecuteInParallel bool        `yaml:"executeInParallel"`
 	Node              string      `yaml:"node"`
 	RegexLog          []*RegexLog `yaml:"regexLog"`
+}
+
+// LocalCommandTask describes a local command task.
+type LocalCommandTask struct {
+	Description string      `yaml:"description"`
+	Command     []string    `yaml:"command"`
+	Node        string      `yaml:"node"`
+	RegexLog    []*RegexLog `yaml:"regexLog"`
 }
 
 // ReadInstallManifest loads the installation manifest from embedded assets.

--- a/internal/presets/install_manifest_test.go
+++ b/internal/presets/install_manifest_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package presets
+
+import "testing"
+
+func TestParseInstallManifest_ReadsCompatibilityRequirements(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	manifestRaw := []byte(
+		"name: Test Install\n" +
+			"description: test install\n" +
+			"compatibility:\n" +
+			"  requires:\n" +
+			"    - remote-exec\n" +
+			"install:\n" +
+			"  - remoteExec:\n" +
+			"      description: run remotely\n" +
+			"      filename: monitor.sh\n",
+	)
+
+	// When
+	manifest, err := parseInstallManifest(manifestRaw)
+	// Then
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got := manifest.RequiredCapabilities(); len(got) != 1 || got[0] != "remote-exec" {
+		t.Fatalf("unexpected compatibility requirements: %#v", got)
+	}
+	if len(manifest.Install) != 1 {
+		t.Fatalf("expected 1 install step, got %d", len(manifest.Install))
+	}
+	if manifest.Install[0].RemoteExec == nil {
+		t.Fatal("expected remoteExec step to be populated")
+	}
+}

--- a/internal/presets/install_manifest_test.go
+++ b/internal/presets/install_manifest_test.go
@@ -37,3 +37,36 @@ func TestParseInstallManifest_ReadsCompatibilityRequirements(t *testing.T) {
 		t.Fatal("expected remoteExec step to be populated")
 	}
 }
+
+func TestParseInstallManifest_ReadsLocalCommandSteps(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	manifestRaw := []byte(
+		"name: Test Install\n" +
+			"description: test install\n" +
+			"compatibility:\n" +
+			"  requires:\n" +
+			"    - local-command\n" +
+			"install:\n" +
+			"  - localCommand:\n" +
+			"      description: run locally\n" +
+			"      command: [\"echo\", \"hello\"]\n",
+	)
+
+	// When
+	manifest, err := parseInstallManifest(manifestRaw)
+	// Then
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got := manifest.RequiredCapabilities(); len(got) != 1 || got[0] != "local-command" {
+		t.Fatalf("unexpected compatibility requirements: %#v", got)
+	}
+	if len(manifest.Install) != 1 {
+		t.Fatalf("expected 1 install step, got %d", len(manifest.Install))
+	}
+	if manifest.Install[0].LocalCommand == nil {
+		t.Fatal("expected localCommand step to be populated")
+	}
+}


### PR DESCRIPTION
## Description

Refactoring and prep work for Exasol Nano.
Local installation won’t be involving cloud operations and certainly not opentofu. So we needed to have an abstraction in place to differentiate how different kind of infrastructure deployment kinds would work.
Specifically we need a “local” backend that doesn’t involve cloud operations and a "tofu", "terraform" or "cloud" backend that serves the existing deployment presets.

This PR introduces the concept of different "backend" implementations into the launcher.
It is salvaged from the prototype here: https://github.com/exasol/exasol-personal/pull/94

## Related Issue

https://exasol.atlassian.net/browse/SPOT-30399

## Type of Change

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [x] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Introduced a generic deployment backend abstraction and extracted the existing tofu-based behavior behind that interface
- Added preset backend metadata and compatibility validation, including compatibility-aware default installation preset selection and CLI/help updates
- Normalized deployment connection info handling and install-step parsing, including generic support for connection metadata and mixed install task types
- Restored the tofu lockfile mode alias needed by the refactored deploy flow
- Updated and added tests to cover backend resolution, preset compatibility, deployment safety checks, connection info normalization, and install-step parsing


## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

Automatic and manual tests pass.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

This PR intentionally does **not** include:

- the OpenSpec repository scaffold
- any local backend implementation
- localruntime packaging/runtime code
- macOS `vz` integration
- local preset assets or release/signing pipeline changes

The salvaged changes were split into focused commits so the generic refactors can be reviewed and reverted independently if needed.
