### PR TITLE
Cleanup Tool  UX improvements

### DIFF
--- a/tools/cleanup/README.md
+++ b/tools/cleanup/README.md
@@ -1,6 +1,6 @@
 # Exasol Cleanup (standalone)
 
-A small, standalone utility to discover and clean up Exasol Personal deployments on AWS.
+A small, standalone utility to discover and clean up Exasol Personal deployments across supported cloud providers.
 
 This internal tool is written and maintained almost exclusively using agentic AI. It's not part of any official release, not officially supported and purely internal.
 Feel free to use if you find it useful though.
@@ -13,23 +13,42 @@ Build:
 task build
 ```
 
+Provider selection uses `--provider=<name>[,<name>...]`. If omitted, all known providers are included. Location flags such as `--aws-region`, `--exoscale-zone`, and `--stackit-region` are multi-value too, so one provider can appear multiple times in the `Scope:` table - once per searched region or zone. Stackit cleanup also needs `--stackit-project-id` when the Stackit provider is selected. In command help, provider-specific flags are shown in separate provider option groups so they stay visually distinct from generic options such as `--owner`, `--json`, or `--verbose`.
+
 Discover deployments:
 
 ```
 ./bin/exasol-cleanup discover --owner=*
+./bin/exasol-cleanup discover --provider=aws --owner=*
+./bin/exasol-cleanup discover --provider=aws --aws-region=us-east-1,eu-central-1 --owner=*
+./bin/exasol-cleanup discover --provider=stackit --stackit-project-id=<project-id> --stackit-region=eu01
 ./bin/exasol-cleanup discover --legacy --owner=*
 ```
+
+`--owner` is a global flag. When omitted, AWS commands default to the caller identity. If you want to inspect or delete a deployment owned by somebody else, pass the matching `--owner` filter explicitly, for example `--owner=*`.
+
+`discover`, `show`, and `run` print a `Scope:` table first so you can always see every known provider, the effective location and owner filter for each one, a single status showing what happened with that provider, and an optional reason when something was skipped or failed.
 
 Show details:
 
 ```
 ./bin/exasol-cleanup show exasol-123ad553
+./bin/exasol-cleanup show exasol-123ad553 exasol-234bc664
+./bin/exasol-cleanup show --owner=* exasol-123ad553
+./bin/exasol-cleanup show --types=ec2-instance,ebs-volume exasol-123ad553
 ```
 
 Run cleanup (dry-run by default):
 
 ```
 ./bin/exasol-cleanup run exasol-123ad553 
+./bin/exasol-cleanup run exasol-123ad553 exasol-234bc664
 # To actually delete resources (dangerous):
 ./bin/exasol-cleanup run exasol-123ad553 --execute
+./bin/exasol-cleanup run --owner=* exasol-123ad553 --execute
+./bin/exasol-cleanup run --types=ec2-instance,ebs-volume exasol-123ad553 --execute
 ```
+
+`show` and `run` are intentionally different: `show` lists the resources currently associated with each deployment, while `run` plans ordered cleanup actions and optionally executes them. Because `run` is destructive in execute mode, `--execute` remains the safety switch.
+
+In JSON mode, `show` and `run` always return a consistent batch-shaped envelope with a top-level `deployments` array, even when you request only a single deployment id.

--- a/tools/cleanup/cmd/cleanup/cleanup.go
+++ b/tools/cleanup/cmd/cleanup/cleanup.go
@@ -4,42 +4,66 @@
 package main
 
 import (
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+
 	"github.com/exasol/exasol-personal/tools/cleanup/internal/aws"
 	"github.com/exasol/exasol-personal/tools/cleanup/internal/exoscale"
 	"github.com/exasol/exasol-personal/tools/cleanup/internal/stackit"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
+const (
+	cleanupFlagGroupAnnotation = "exasol-cleanup/flag-group"
+	cleanupFlagGroupGeneric    = "Options"
+	cleanupFlagGroupAWS        = "AWS options"
+	cleanupFlagGroupExoscale   = "Exoscale options"
+	cleanupFlagGroupStackit    = "STACKIT options"
+)
+
+var cleanupFlagGroupOrder = []string{
+	cleanupFlagGroupGeneric,
+	cleanupFlagGroupAWS,
+	cleanupFlagGroupExoscale,
+	cleanupFlagGroupStackit,
+}
+
+type cleanupFlagOptions struct {
+	includeOwner bool
+	includeJSON  bool
+}
+
 var cleanupOpts = struct {
-	AWSRegion        string
-	ExoscaleZone     string
-	STACKITRegion    string
-	STACKITProjectId string
+	AWSRegions       []string
+	ExoscaleZones    []string
+	StackitRegions   []string
+	StackitProjectID string
+	Providers        []string
+	OwnerFilter      string
+	JSON             bool
 	Verbose          bool
-	AWS              bool
-	Exoscale         bool
-	STACKIT          bool
 }{}
 
+func allProviders() []string {
+	return []string{aws.ProviderName, exoscale.ProviderName, stackit.ProviderName}
+}
+
 // getSelectedProviders returns a list of provider names that should be used.
-// If no provider flags are set, returns all available providers.
-// If any provider flag is set, returns only those selected.
+// If no provider list is set, returns all available providers.
+// If any providers are set, returns only those selected.
 func getSelectedProviders() []string {
-	var selected []string
-
-	if cleanupOpts.AWS {
-		selected = append(selected, aws.ProviderName)
-	}
-	if cleanupOpts.Exoscale {
-		selected = append(selected, exoscale.ProviderName)
-	}
-	if cleanupOpts.STACKIT {
-		selected = append(selected, stackit.ProviderName)
+	if len(cleanupOpts.Providers) == 0 {
+		return allProviders()
 	}
 
-	// If none selected, use all available providers
-	if len(selected) == 0 {
-		return []string{aws.ProviderName, exoscale.ProviderName, stackit.ProviderName}
+	selected := make([]string, 0, len(cleanupOpts.Providers))
+	for _, provider := range cleanupOpts.Providers {
+		if !slices.Contains(selected, provider) {
+			selected = append(selected, provider)
+		}
 	}
 
 	return selected
@@ -56,38 +80,137 @@ func shouldUseProvider(providerName string) bool {
 	return false
 }
 
-// Register persistent flags on the root command since we expose top-level
-// subcommands (discover, show, run) without an intermediate "cleanup" group.
-func registerRootFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().
-		StringVar(&cleanupOpts.AWSRegion, "aws-region", "",
-			"AWS region containing the deployment resources")
-	cmd.PersistentFlags().
-		StringVar(&cleanupOpts.ExoscaleZone, "exoscale-zone", "ch-gva-2",
-			"Exoscale zone containing the deployment resources (default: ch-gva-2)")
-	cmd.PersistentFlags().
-		StringVar(&cleanupOpts.STACKITRegion, "stackit-region", "eu01",
-			"STACKIT region containing the deployment resources")
-	cmd.PersistentFlags().
-		StringVar(&cleanupOpts.STACKITProjectId, "stackit-project-id", "",
-			"STACKIT project containing the deployment resources")
-	cmd.PersistentFlags().
+func registerCommonFlags(cmd *cobra.Command, options cleanupFlagOptions) {
+	cmd.Flags().
+		StringSliceVar(&cleanupOpts.AWSRegions, "aws-region", nil,
+			"AWS regions containing deployment resources (repeat flag or use comma-separated values)")
+	setFlagGroup(cmd, "aws-region", cleanupFlagGroupAWS)
+	cmd.Flags().
+		StringSliceVar(&cleanupOpts.ExoscaleZones, "exoscale-zone", nil,
+			"Exoscale zones containing deployment resources (repeat flag or use comma-separated values; default: ch-gva-2)")
+	setFlagGroup(cmd, "exoscale-zone", cleanupFlagGroupExoscale)
+	cmd.Flags().
+		StringSliceVar(&cleanupOpts.StackitRegions, "stackit-region", nil,
+			"STACKIT regions containing deployment resources (repeat flag or use comma-separated values; default: eu01)")
+	setFlagGroup(cmd, "stackit-region", cleanupFlagGroupStackit)
+	cmd.Flags().
+		StringVar(&cleanupOpts.StackitProjectID, "stackit-project-id", "",
+			"STACKIT project containing deployment resources")
+	setFlagGroup(cmd, "stackit-project-id", cleanupFlagGroupStackit)
+	cmd.Flags().
 		BoolVar(&cleanupOpts.Verbose, "verbose", false,
 			"Enable verbose (debug) logging")
-	cmd.PersistentFlags().
-		BoolVar(&cleanupOpts.AWS, "aws", false,
-			"Use AWS provider")
-	cmd.PersistentFlags().
-		BoolVar(&cleanupOpts.Exoscale, "exoscale", false,
-			"Use Exoscale provider")
-	cmd.PersistentFlags().
-		BoolVar(&cleanupOpts.STACKIT, "stackit", false,
-			"Use STACKIT provider")
+	cmd.Flags().
+		StringSliceVar(&cleanupOpts.Providers, "provider", nil,
+			fmt.Sprintf("Providers to use (default: %s)", strings.Join(allProviders(), ",")))
 
-	cmd.MarkFlagsRequiredTogether("stackit", "stackit-project-id")
+	if options.includeOwner {
+		cmd.Flags().
+			StringVar(&cleanupOpts.OwnerFilter, "owner", "",
+				"Owner ARN/wildcard to filter (defaults AWS to caller; use * for any)")
+	}
+
+	if options.includeJSON {
+		cmd.Flags().
+			BoolVar(&cleanupOpts.JSON, "json", false,
+				"Output JSON")
+	}
 }
 
-// nolint: gochecknoinits
-func init() {
-	registerRootFlags(rootCmd)
+func setFlagGroup(cmd *cobra.Command, flagName, group string) {
+	flag := cmd.Flags().Lookup(flagName)
+	if flag == nil {
+		return
+	}
+	if flag.Annotations == nil {
+		flag.Annotations = map[string][]string{}
+	}
+	flag.Annotations[cleanupFlagGroupAnnotation] = []string{group}
+}
+
+func cleanupHelpFunc(cmd *cobra.Command, _ []string) {
+	writer := cmd.OutOrStdout()
+	if cmd.Long != "" {
+		_, _ = fmt.Fprintln(writer, strings.TrimSpace(cmd.Long))
+		_, _ = fmt.Fprintln(writer)
+	} else if cmd.Short != "" {
+		_, _ = fmt.Fprintln(writer, cmd.Short)
+		_, _ = fmt.Fprintln(writer)
+	}
+
+	if cmd.Runnable() || cmd.HasAvailableSubCommands() {
+		_, _ = fmt.Fprintln(writer, "Usage:")
+		_, _ = fmt.Fprintf(writer, "  %s\n\n", cmd.UseLine())
+	}
+
+	cmd.InitDefaultHelpCmd()
+	if cmd.HasAvailableSubCommands() {
+		_, _ = fmt.Fprintln(writer, "Available Commands:")
+		for _, subcommand := range cmd.Commands() {
+			if !subcommand.IsAvailableCommand() && subcommand.Name() != "help" {
+				continue
+			}
+			_, _ = fmt.Fprintf(writer, "  %-12s %s\n", subcommand.Name(), subcommand.Short)
+		}
+		_, _ = fmt.Fprintln(writer)
+	}
+
+	renderCleanupFlagGroups(writer, cmd)
+
+	if cmd.HasAvailableSubCommands() {
+		_, _ = fmt.Fprintf(writer, "Use \"%s [command] --help\" for more information about a command.\n", cmd.CommandPath())
+	}
+}
+
+func renderCleanupFlagGroups(writer io.Writer, cmd *cobra.Command) {
+	cmd.InitDefaultHelpFlag()
+	groups := map[string][]*pflag.Flag{}
+	cmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		if flag.Hidden {
+			return
+		}
+		group := flagGroup(flag)
+		groups[group] = append(groups[group], flag)
+	})
+
+	renderedGroups := map[string]bool{}
+	for _, group := range cleanupFlagGroupOrder {
+		renderFlagGroup(writer, group, groups[group])
+		renderedGroups[group] = true
+	}
+	for group, flags := range groups {
+		if renderedGroups[group] {
+			continue
+		}
+		renderFlagGroup(writer, group, flags)
+	}
+}
+
+func flagGroup(flag *pflag.Flag) string {
+	if flag.Annotations == nil {
+		return cleanupFlagGroupGeneric
+	}
+	groups := flag.Annotations[cleanupFlagGroupAnnotation]
+	if len(groups) == 0 || groups[0] == "" {
+		return cleanupFlagGroupGeneric
+	}
+
+	return groups[0]
+}
+
+func renderFlagGroup(writer io.Writer, title string, flags []*pflag.Flag) {
+	if len(flags) == 0 {
+		return
+	}
+
+	flagSet := pflag.NewFlagSet(title, pflag.ContinueOnError)
+	flagSet.SetOutput(io.Discard)
+	for _, flag := range flags {
+		flagCopy := *flag
+		flagSet.AddFlag(&flagCopy)
+	}
+
+	_, _ = fmt.Fprintf(writer, "%s:\n", title)
+	_, _ = fmt.Fprint(writer, flagSet.FlagUsagesWrapped(100))
+	_, _ = fmt.Fprintln(writer)
 }

--- a/tools/cleanup/cmd/cleanup/cleanup_collectors.go
+++ b/tools/cleanup/cmd/cleanup/cleanup_collectors.go
@@ -1,0 +1,439 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/exasol/exasol-personal/tools/cleanup/internal/aws"
+	"github.com/exasol/exasol-personal/tools/cleanup/internal/exoscale"
+	"github.com/exasol/exasol-personal/tools/cleanup/internal/shared"
+	"github.com/exasol/exasol-personal/tools/cleanup/internal/stackit"
+)
+
+const (
+	providerStatusSearched    = "searched"
+	providerStatusSkipped     = "skipped"
+	providerStatusUnavailable = "unavailable"
+	providerStatusError       = "error"
+
+	providerReasonNotSelected     = "not selected"
+	providerReasonCallerLookupErr = "failed to resolve caller identity"
+)
+
+var awsCollectorFactory = func(region, ownerFilter string, legacy bool) shared.ProviderCollector {
+	return aws.NewCollector(region, ownerFilter, legacy)
+}
+
+var exoscaleCollectorFactory = func(zone, ownerFilter string, legacy bool) shared.ProviderCollector {
+	return exoscale.NewCollector(zone, ownerFilter, legacy)
+}
+
+var stackitCollectorFactory = func(projectID, region, ownerFilter string) shared.ProviderCollector {
+	return stackit.NewCollector(projectID, region, ownerFilter)
+}
+
+var awsCallerIdentityARNLookup = func(ctx context.Context, region string) (string, bool) {
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	if err != nil {
+		return "", false
+	}
+
+	stsClient := sts.NewFromConfig(cfg)
+	idOut, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil || idOut.Arn == nil || *idOut.Arn == "" {
+		return "", false
+	}
+
+	return *idOut.Arn, true
+}
+
+type cleanupCommandError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type cleanupDiscoverySummary struct {
+	Count int `json:"count"`
+}
+
+type cleanupExecutionSummary struct {
+	Actions int `json:"actions"`
+}
+
+type cleanupExecutionInfo struct {
+	Mode  string   `json:"mode"`
+	Types []string `json:"types,omitempty"`
+}
+
+type cleanupResolved struct {
+	Deployment string `json:"deployment"`
+	Provider   string `json:"provider"`
+	Location   string `json:"location"`
+}
+
+type cleanupDiscoverJSONOutput struct {
+	Scope   cleanupScope               `json:"scope"`
+	Data    []shared.DeploymentSummary `json:"data,omitempty"`
+	Summary *cleanupDiscoverySummary   `json:"summary,omitempty"`
+	Error   *cleanupCommandError       `json:"error,omitempty"`
+}
+
+type cleanupShowJSONOutput struct {
+	Scope       cleanupScope                      `json:"scope"`
+	Deployments []cleanupShowDeploymentJSONOutput `json:"deployments"`
+	Error       *cleanupCommandError              `json:"error,omitempty"`
+}
+
+type cleanupRunJSONOutput struct {
+	Scope       cleanupScope                     `json:"scope"`
+	Execution   cleanupExecutionInfo             `json:"execution"`
+	Deployments []cleanupRunDeploymentJSONOutput `json:"deployments"`
+	Error       *cleanupCommandError             `json:"error,omitempty"`
+}
+
+type cleanupShowDeploymentJSONOutput struct {
+	Requested string                    `json:"requested"`
+	Resolved  *cleanupResolved          `json:"resolved,omitempty"`
+	Details   *shared.DeploymentDetails `json:"details,omitempty"`
+	Error     *cleanupCommandError      `json:"error,omitempty"`
+}
+
+type cleanupRunDeploymentJSONOutput struct {
+	Requested string                   `json:"requested"`
+	Resolved  *cleanupResolved         `json:"resolved,omitempty"`
+	Results   []shared.Result          `json:"results,omitempty"`
+	Summary   *cleanupExecutionSummary `json:"summary,omitempty"`
+	Error     *cleanupCommandError     `json:"error,omitempty"`
+}
+
+type cleanupScope struct {
+	Providers []cleanupScopeProvider `json:"providers"`
+}
+
+type cleanupScopeProvider struct {
+	Provider    string `json:"provider"`
+	Location    string `json:"location"`
+	Owner       string `json:"owner"`
+	OwnerSource string `json:"ownerSource,omitempty"`
+	Status      string `json:"status"`
+	Reason      string `json:"reason,omitempty"`
+}
+
+type cleanupOwnerResolution struct {
+	Filter  string
+	Display string
+	Source  string
+	Err     error
+}
+
+type cleanupProviderSpec struct {
+	Name           string
+	Locations      func() []string
+	ResolveOwner   func(context.Context, string) cleanupOwnerResolution
+	BuildCollector func(string, string, bool) shared.ProviderCollector
+}
+
+type cleanupScopedCollector struct {
+	Collector shared.ProviderCollector
+	Scope     *cleanupScopeProvider
+}
+
+type cleanupPlan struct {
+	Scope      cleanupScope
+	Collectors []cleanupScopedCollector
+}
+
+type cleanupLookupMatch struct {
+	Collector shared.ProviderCollector
+	Resolved  cleanupResolved
+}
+
+type cleanupLookupIndex struct {
+	Matches      map[string][]cleanupLookupMatch
+	SuccessCount int
+}
+
+func buildCleanupPlan(ctx context.Context, legacy bool) cleanupPlan {
+	plan := cleanupPlan{}
+	for _, spec := range cleanupProviderSpecs() {
+		selected := shouldUseProvider(spec.Name)
+		for _, location := range spec.Locations() {
+			owner := spec.ResolveOwner(ctx, location)
+			entry := cleanupScopeProvider{
+				Provider:    spec.Name,
+				Location:    location,
+				Owner:       owner.Display,
+				OwnerSource: owner.Source,
+				Status:      providerStatusSkipped,
+				Reason:      providerReasonNotSelected,
+			}
+
+			plan.Scope.Providers = append(plan.Scope.Providers, entry)
+			entryRef := &plan.Scope.Providers[len(plan.Scope.Providers)-1]
+			if !selected {
+				continue
+			}
+
+			if owner.Err != nil {
+				entryRef.Status = providerStatusUnavailable
+				entryRef.Reason = owner.Err.Error()
+				continue
+			}
+
+			collector := spec.BuildCollector(location, owner.Filter, legacy)
+			if _, err := collector.GetAccountInfo(ctx); err != nil {
+				entryRef.Status = providerStatusUnavailable
+				entryRef.Reason = err.Error()
+				continue
+			}
+
+			entryRef.Status = providerStatusSearched
+			entryRef.Reason = ""
+			plan.Collectors = append(plan.Collectors, cleanupScopedCollector{
+				Collector: collector,
+				Scope:     entryRef,
+			})
+		}
+	}
+
+	return plan
+}
+
+func lookupDeploymentInPlan(
+	ctx context.Context,
+	plan *cleanupPlan,
+	deploymentID string,
+) ([]cleanupLookupMatch, int) {
+	lookupIndex := collectLookupIndex(ctx, plan)
+
+	return lookupIndex.Matches[deploymentID], lookupIndex.SuccessCount
+}
+
+func collectLookupIndex(ctx context.Context, plan *cleanupPlan) cleanupLookupIndex {
+	lookupIndex := cleanupLookupIndex{
+		Matches: make(map[string][]cleanupLookupMatch),
+	}
+
+	for _, scopedCollector := range plan.Collectors {
+		summaries, err := scopedCollector.Collector.CollectDeploymentSummaries(ctx)
+		if err != nil {
+			scopedCollector.Scope.Status = providerStatusError
+			scopedCollector.Scope.Reason = err.Error()
+			continue
+		}
+
+		lookupIndex.SuccessCount++
+		scopedCollector.Scope.Status = providerStatusSearched
+		scopedCollector.Scope.Reason = ""
+		for _, summary := range summaries {
+			lookupIndex.Matches[summary.ID] = append(lookupIndex.Matches[summary.ID], cleanupLookupMatch{
+				Collector: scopedCollector.Collector,
+				Resolved: cleanupResolved{
+					Deployment: summary.ID,
+					Provider:   summary.Provider,
+					Location:   summary.Region,
+				},
+			})
+		}
+	}
+
+	return lookupIndex
+}
+
+func lookupMatchSummary(matches []cleanupLookupMatch) string {
+	parts := make([]string, 0, len(matches))
+	for _, match := range matches {
+		parts = append(parts, fmt.Sprintf("%s/%s", match.Resolved.Provider, match.Resolved.Location))
+	}
+
+	return strings.Join(parts, ", ")
+}
+
+func cleanupProviderSpecs() []cleanupProviderSpec {
+	return []cleanupProviderSpec{
+		{
+			Name:         aws.ProviderName,
+			Locations:    resolvedAWSRegions,
+			ResolveOwner: resolveAWSOwner,
+			BuildCollector: func(location, ownerFilter string, legacy bool) shared.ProviderCollector {
+				return awsCollectorFactory(location, ownerFilter, legacy)
+			},
+		},
+		{
+			Name:         exoscale.ProviderName,
+			Locations:    resolvedExoscaleZones,
+			ResolveOwner: resolveExoscaleOwner,
+			BuildCollector: func(location, ownerFilter string, legacy bool) shared.ProviderCollector {
+				return exoscaleCollectorFactory(location, ownerFilter, legacy)
+			},
+		},
+		{
+			Name:         stackit.ProviderName,
+			Locations:    resolvedStackitRegions,
+			ResolveOwner: resolveStackitOwner,
+			BuildCollector: func(location, ownerFilter string, _ bool) shared.ProviderCollector {
+				return stackitCollectorFactory(cleanupOpts.StackitProjectID, location, ownerFilter)
+			},
+		},
+	}
+}
+
+func resolveAWSOwner(ctx context.Context, region string) cleanupOwnerResolution {
+	if cleanupOpts.OwnerFilter != "" {
+		return cleanupOwnerResolution{Filter: cleanupOpts.OwnerFilter, Display: cleanupOpts.OwnerFilter, Source: "explicit"}
+	}
+
+	filter, ok := awsCallerIdentityARNLookup(ctx, region)
+	if !ok {
+		return cleanupOwnerResolution{
+			Display: "(caller)",
+			Source:  "default",
+			Err:     fmt.Errorf(providerReasonCallerLookupErr),
+		}
+	}
+
+	return cleanupOwnerResolution{Filter: filter, Display: "(caller)", Source: "default"}
+}
+
+func resolveExoscaleOwner(_ context.Context, _ string) cleanupOwnerResolution {
+	if cleanupOpts.OwnerFilter != "" {
+		return cleanupOwnerResolution{Filter: cleanupOpts.OwnerFilter, Display: cleanupOpts.OwnerFilter, Source: "explicit"}
+	}
+
+	return cleanupOwnerResolution{Display: "*", Source: "default"}
+}
+
+func resolveStackitOwner(_ context.Context, _ string) cleanupOwnerResolution {
+	if cleanupOpts.StackitProjectID == "" {
+		return cleanupOwnerResolution{
+			Display: "*",
+			Source:  "default",
+			Err:     fmt.Errorf("STACKIT project id is required; pass --stackit-project-id"),
+		}
+	}
+
+	if cleanupOpts.OwnerFilter != "" {
+		return cleanupOwnerResolution{Filter: cleanupOpts.OwnerFilter, Display: cleanupOpts.OwnerFilter, Source: "explicit"}
+	}
+
+	return cleanupOwnerResolution{Display: "*", Source: "default"}
+}
+
+func resolvedAWSRegions() []string {
+	return resolvedLocations(cleanupOpts.AWSRegions, []string{"us-east-1"})
+}
+
+func resolvedExoscaleZones() []string {
+	return resolvedLocations(cleanupOpts.ExoscaleZones, []string{"ch-gva-2"})
+}
+
+func resolvedStackitRegions() []string {
+	return resolvedLocations(cleanupOpts.StackitRegions, []string{"eu01"})
+}
+
+func resolvedLocations(explicit []string, defaults []string) []string {
+	if len(explicit) == 0 {
+		return append([]string(nil), defaults...)
+	}
+
+	locations := make([]string, 0, len(explicit))
+	for _, location := range explicit {
+		if location == "" || slices.Contains(locations, location) {
+			continue
+		}
+		locations = append(locations, location)
+	}
+
+	if len(locations) == 0 {
+		return append([]string(nil), defaults...)
+	}
+
+	return locations
+}
+
+func renderCleanupScope(writer io.Writer, scope cleanupScope) {
+	if len(scope.Providers) == 0 {
+		return
+	}
+
+	if _, err := fmt.Fprintln(writer, "Scope:"); err != nil {
+		return
+	}
+
+	rows := make([][]string, 0, len(scope.Providers))
+	for _, provider := range scope.Providers {
+		reason := provider.Reason
+		if reason == "" {
+			reason = "-"
+		}
+		rows = append(rows, []string{
+			provider.Provider,
+			provider.Location,
+			provider.Owner,
+			provider.Status,
+			reason,
+		})
+	}
+
+	shared.RenderTable(
+		writer,
+		[]string{"provider", "location", "owner", "status", "reason"},
+		[]int{12, 14, 28, 12, 40},
+		rows,
+	)
+	_, _ = fmt.Fprintln(writer)
+}
+
+func renderResolved(writer io.Writer, resolved cleanupResolved) {
+	_, _ = fmt.Fprintf(
+		writer,
+		"Resolved: deployment=%s provider=%s location=%s\n\n",
+		resolved.Deployment,
+		resolved.Provider,
+		resolved.Location,
+	)
+}
+
+func renderRequestedDeployment(writer io.Writer, deploymentID string) {
+	_, _ = fmt.Fprintf(writer, "Requested: deployment=%s\n\n", deploymentID)
+}
+
+func renderTypesFilter(writer io.Writer, types []string) {
+	typeDisplay := "(all)"
+	if len(types) > 0 {
+		typeDisplay = strings.Join(types, ",")
+	}
+	_, _ = fmt.Fprintf(writer, "Filters: types=%s\n\n", typeDisplay)
+}
+
+func renderExecutionInfo(writer io.Writer, execution cleanupExecutionInfo) {
+	typeDisplay := "(all)"
+	if len(execution.Types) > 0 {
+		typeDisplay = strings.Join(execution.Types, ",")
+	}
+	_, _ = fmt.Fprintf(writer, "Execution: mode=%s types=%s\n\n", execution.Mode, typeDisplay)
+}
+
+func encodeJSONOutput(writer io.Writer, payload any) error {
+	encoder := json.NewEncoder(writer)
+	encoder.SetIndent("", "  ")
+
+	return encoder.Encode(payload)
+}
+
+func commandError(code string, err error) *cleanupCommandError {
+	if err == nil {
+		return nil
+	}
+
+	return &cleanupCommandError{Code: code, Message: err.Error()}
+}

--- a/tools/cleanup/cmd/cleanup/cleanup_collectors_test.go
+++ b/tools/cleanup/cmd/cleanup/cleanup_collectors_test.go
@@ -1,0 +1,380 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/exasol/exasol-personal/tools/cleanup/internal/shared"
+)
+
+type stubProviderCollector struct {
+	name           string
+	accountInfo    string
+	accountInfoErr error
+}
+
+func (s stubProviderCollector) Name() string {
+	return s.name
+}
+
+func (stubProviderCollector) CollectDeploymentSummaries(context.Context) ([]shared.DeploymentSummary, error) {
+	return nil, nil
+}
+
+func (stubProviderCollector) IsAvailable(context.Context) bool {
+	return true
+}
+
+func (s stubProviderCollector) GetAccountInfo(context.Context) (string, error) {
+	if s.accountInfoErr != nil {
+		return "", s.accountInfoErr
+	}
+
+	return s.accountInfo, nil
+}
+
+func (stubProviderCollector) CollectDeploymentDetails(
+	context.Context,
+	string,
+) (*shared.DeploymentDetails, error) {
+	return nil, nil
+}
+
+func (stubProviderCollector) PlanActions(
+	*shared.DeploymentDetails,
+	[]shared.ResourceType,
+) ([]shared.Action, error) {
+	return nil, nil
+}
+
+func (stubProviderCollector) ExecuteActions(
+	context.Context,
+	[]shared.Action,
+	bool,
+) ([]shared.Result, error) {
+	return nil, nil
+}
+
+func TestBuildCleanupPlanUsesCallerOwnerOnlyForAWS(t *testing.T) {
+	originalOpts := cleanupOpts
+	originalAWSCollectorFactory := awsCollectorFactory
+	originalExoscaleCollectorFactory := exoscaleCollectorFactory
+	originalStackitCollectorFactory := stackitCollectorFactory
+	originalAWSCallerIdentityARNLookup := awsCallerIdentityARNLookup
+	t.Cleanup(func() {
+		cleanupOpts = originalOpts
+		awsCollectorFactory = originalAWSCollectorFactory
+		exoscaleCollectorFactory = originalExoscaleCollectorFactory
+		stackitCollectorFactory = originalStackitCollectorFactory
+		awsCallerIdentityARNLookup = originalAWSCallerIdentityARNLookup
+	})
+
+	cleanupOpts.Providers = []string{"aws", "exoscale"}
+	cleanupOpts.ExoscaleZones = []string{"ch-gva-2"}
+
+	var awsOwnerFilter string
+	var exoscaleOwnerFilter string
+	awsCollectorFactory = func(region, ownerFilter string, legacy bool) shared.ProviderCollector {
+		if region != "us-east-1" {
+			t.Fatalf("aws region = %q, want us-east-1", region)
+		}
+		awsOwnerFilter = ownerFilter
+		return stubProviderCollector{name: "aws", accountInfo: "123456789012"}
+	}
+	exoscaleCollectorFactory = func(zone, ownerFilter string, legacy bool) shared.ProviderCollector {
+		if zone != "ch-gva-2" {
+			t.Fatalf("exoscale zone = %q, want ch-gva-2", zone)
+		}
+		exoscaleOwnerFilter = ownerFilter
+		return stubProviderCollector{name: "exoscale", accountInfo: "org-id"}
+	}
+	stackitCollectorFactory = func(projectID, region, ownerFilter string) shared.ProviderCollector {
+		t.Fatalf("stackit collector should not be built when provider is not selected")
+		return nil
+	}
+	awsCallerIdentityARNLookup = func(context.Context, string) (string, bool) {
+		return "arn:aws:iam::123456789012:role/example", true
+	}
+
+	// Given a command without an explicit owner filter
+	// When the cleanup plan is built
+	plan := buildCleanupPlan(context.Background(), false)
+
+	// Then AWS defaults to the caller while Exoscale stays unfiltered
+	if len(plan.Collectors) != 2 {
+		t.Fatalf("collectors = %d, want 2", len(plan.Collectors))
+	}
+	if got := plan.Scope.Providers[0].Owner; got != "(caller)" {
+		t.Fatalf("aws owner display = %q, want (caller)", got)
+	}
+	if awsOwnerFilter != "arn:aws:iam::123456789012:role/example" {
+		t.Fatalf("aws owner filter = %q, want caller ARN", awsOwnerFilter)
+	}
+	if exoscaleOwnerFilter != "" {
+		t.Fatalf("exoscale owner filter = %q, want empty", exoscaleOwnerFilter)
+	}
+}
+
+func TestBuildCleanupPlanMarksUnavailableProvider(t *testing.T) {
+	originalOpts := cleanupOpts
+	originalAWSCollectorFactory := awsCollectorFactory
+	originalAWSCallerIdentityARNLookup := awsCallerIdentityARNLookup
+	t.Cleanup(func() {
+		cleanupOpts = originalOpts
+		awsCollectorFactory = originalAWSCollectorFactory
+		awsCallerIdentityARNLookup = originalAWSCallerIdentityARNLookup
+	})
+
+	cleanupOpts.Providers = []string{"aws"}
+
+	var awsOwnerFilter string
+	awsCollectorFactory = func(region, ownerFilter string, legacy bool) shared.ProviderCollector {
+		awsOwnerFilter = ownerFilter
+		return stubProviderCollector{name: "aws", accountInfoErr: errors.New("missing credentials")}
+	}
+	awsCallerIdentityARNLookup = func(context.Context, string) (string, bool) {
+		return "arn:aws:iam::123456789012:role/example", true
+	}
+
+	// Given a selected provider with broken credentials
+	// When the cleanup plan is built
+	plan := buildCleanupPlan(context.Background(), false)
+
+	// Then the scope reports the provider as unavailable and skips searching it
+	if len(plan.Collectors) != 0 {
+		t.Fatalf("collectors = %d, want 0", len(plan.Collectors))
+	}
+	if awsOwnerFilter != "arn:aws:iam::123456789012:role/example" {
+		t.Fatalf("aws owner filter = %q, want caller ARN", awsOwnerFilter)
+	}
+	if plan.Scope.Providers[0].Status != providerStatusUnavailable {
+		t.Fatalf("status = %q, want %q", plan.Scope.Providers[0].Status, providerStatusUnavailable)
+	}
+	if plan.Scope.Providers[0].Reason != "missing credentials" {
+		t.Fatalf("reason = %q, want missing credentials", plan.Scope.Providers[0].Reason)
+	}
+}
+
+func TestBuildCleanupPlanIncludesUnselectedProviders(t *testing.T) {
+	originalOpts := cleanupOpts
+	originalAWSCollectorFactory := awsCollectorFactory
+	originalExoscaleCollectorFactory := exoscaleCollectorFactory
+	originalStackitCollectorFactory := stackitCollectorFactory
+	originalAWSCallerIdentityARNLookup := awsCallerIdentityARNLookup
+	t.Cleanup(func() {
+		cleanupOpts = originalOpts
+		awsCollectorFactory = originalAWSCollectorFactory
+		exoscaleCollectorFactory = originalExoscaleCollectorFactory
+		stackitCollectorFactory = originalStackitCollectorFactory
+		awsCallerIdentityARNLookup = originalAWSCallerIdentityARNLookup
+	})
+
+	cleanupOpts.Providers = []string{"exoscale"}
+	cleanupOpts.ExoscaleZones = []string{"ch-gva-2"}
+	cleanupOpts.OwnerFilter = "owner-*"
+
+	var awsOwnerFilter string
+	var exoscaleOwnerFilter string
+	awsCollectorFactory = func(region, ownerFilter string, legacy bool) shared.ProviderCollector {
+		awsOwnerFilter = ownerFilter
+		return stubProviderCollector{name: "aws", accountInfo: "123456789012"}
+	}
+	exoscaleCollectorFactory = func(zone, ownerFilter string, legacy bool) shared.ProviderCollector {
+		exoscaleOwnerFilter = ownerFilter
+		return stubProviderCollector{name: "exoscale", accountInfo: "org-id"}
+	}
+	stackitCollectorFactory = func(projectID, region, ownerFilter string) shared.ProviderCollector {
+		t.Fatalf("stackit collector should not be built when provider is not selected")
+		return nil
+	}
+	awsCallerIdentityARNLookup = func(context.Context, string) (string, bool) {
+		return "arn:aws:iam::123456789012:role/example", true
+	}
+
+	// Given only Exoscale is selected with an explicit owner filter
+	// When the cleanup plan is built
+	plan := buildCleanupPlan(context.Background(), false)
+
+	// Then selected and unselected providers are both present in scope
+	if len(plan.Scope.Providers) != 3 {
+		t.Fatalf("providers = %d, want 3", len(plan.Scope.Providers))
+	}
+	if exoscaleOwnerFilter != "owner-*" {
+		t.Fatalf("exoscale owner filter = %q, want owner-*", exoscaleOwnerFilter)
+	}
+	if awsOwnerFilter != "" {
+		t.Fatalf("aws owner filter = %q, want empty because AWS was not selected", awsOwnerFilter)
+	}
+	if plan.Scope.Providers[0].Status != providerStatusSkipped {
+		t.Fatalf("aws status = %q, want %q", plan.Scope.Providers[0].Status, providerStatusSkipped)
+	}
+	if plan.Scope.Providers[0].Reason != providerReasonNotSelected {
+		t.Fatalf("aws reason = %q, want %q", plan.Scope.Providers[0].Reason, providerReasonNotSelected)
+	}
+	if plan.Scope.Providers[1].Status != providerStatusSearched {
+		t.Fatalf("exoscale status = %q, want %q", plan.Scope.Providers[1].Status, providerStatusSearched)
+	}
+	if plan.Scope.Providers[1].Reason != "" {
+		t.Fatalf("exoscale reason = %q, want empty", plan.Scope.Providers[1].Reason)
+	}
+	if plan.Scope.Providers[2].Status != providerStatusSkipped {
+		t.Fatalf("stackit status = %q, want %q", plan.Scope.Providers[2].Status, providerStatusSkipped)
+	}
+}
+
+func TestBuildCleanupPlanCreatesRowPerLocationTarget(t *testing.T) {
+	originalOpts := cleanupOpts
+	originalAWSCollectorFactory := awsCollectorFactory
+	originalExoscaleCollectorFactory := exoscaleCollectorFactory
+	originalStackitCollectorFactory := stackitCollectorFactory
+	originalAWSCallerIdentityARNLookup := awsCallerIdentityARNLookup
+	t.Cleanup(func() {
+		cleanupOpts = originalOpts
+		awsCollectorFactory = originalAWSCollectorFactory
+		exoscaleCollectorFactory = originalExoscaleCollectorFactory
+		stackitCollectorFactory = originalStackitCollectorFactory
+		awsCallerIdentityARNLookup = originalAWSCallerIdentityARNLookup
+	})
+
+	cleanupOpts.Providers = []string{"aws"}
+	cleanupOpts.AWSRegions = []string{"us-east-1", "eu-central-1"}
+
+	locations := make([]string, 0)
+	awsCollectorFactory = func(region, ownerFilter string, legacy bool) shared.ProviderCollector {
+		locations = append(locations, region)
+		return stubProviderCollector{name: "aws", accountInfo: "123456789012"}
+	}
+	exoscaleCollectorFactory = func(zone, ownerFilter string, legacy bool) shared.ProviderCollector {
+		return stubProviderCollector{name: "exoscale", accountInfo: "org-id"}
+	}
+	stackitCollectorFactory = func(projectID, region, ownerFilter string) shared.ProviderCollector {
+		t.Fatalf("stackit collector should not be built when provider is not selected")
+		return nil
+	}
+	awsCallerIdentityARNLookup = func(context.Context, string) (string, bool) {
+		return "arn:aws:iam::123456789012:role/example", true
+	}
+
+	plan := buildCleanupPlan(context.Background(), false)
+
+	if len(plan.Collectors) != 2 {
+		t.Fatalf("collectors = %d, want 2", len(plan.Collectors))
+	}
+	if len(plan.Scope.Providers) != 4 {
+		t.Fatalf("scope rows = %d, want 4", len(plan.Scope.Providers))
+	}
+	if locations[0] != "us-east-1" || locations[1] != "eu-central-1" {
+		t.Fatalf("locations = %v, want [us-east-1 eu-central-1]", locations)
+	}
+	if plan.Scope.Providers[0].Location != "us-east-1" || plan.Scope.Providers[1].Location != "eu-central-1" {
+		t.Fatalf("aws scope locations = %q,%q", plan.Scope.Providers[0].Location, plan.Scope.Providers[1].Location)
+	}
+	if plan.Scope.Providers[2].Status != providerStatusSkipped {
+		t.Fatalf("exoscale status = %q, want %q", plan.Scope.Providers[2].Status, providerStatusSkipped)
+	}
+	if plan.Scope.Providers[3].Status != providerStatusSkipped {
+		t.Fatalf("stackit status = %q, want %q", plan.Scope.Providers[3].Status, providerStatusSkipped)
+	}
+}
+
+func TestBuildCleanupPlanIncludesStackitTarget(t *testing.T) {
+	originalOpts := cleanupOpts
+	originalAWSCollectorFactory := awsCollectorFactory
+	originalExoscaleCollectorFactory := exoscaleCollectorFactory
+	originalStackitCollectorFactory := stackitCollectorFactory
+	originalAWSCallerIdentityARNLookup := awsCallerIdentityARNLookup
+	t.Cleanup(func() {
+		cleanupOpts = originalOpts
+		awsCollectorFactory = originalAWSCollectorFactory
+		exoscaleCollectorFactory = originalExoscaleCollectorFactory
+		stackitCollectorFactory = originalStackitCollectorFactory
+		awsCallerIdentityARNLookup = originalAWSCallerIdentityARNLookup
+	})
+
+	cleanupOpts.Providers = []string{"stackit"}
+	cleanupOpts.StackitProjectID = "project-1"
+	cleanupOpts.StackitRegions = []string{"eu01", "eu02"}
+	cleanupOpts.OwnerFilter = "owner-*"
+
+	stackitCalls := make([]string, 0)
+	stackitCollectorFactory = func(projectID, region, ownerFilter string) shared.ProviderCollector {
+		if projectID != "project-1" {
+			t.Fatalf("stackit project id = %q, want project-1", projectID)
+		}
+		if ownerFilter != "owner-*" {
+			t.Fatalf("stackit owner filter = %q, want owner-*", ownerFilter)
+		}
+		stackitCalls = append(stackitCalls, region)
+		return stubProviderCollector{name: "stackit", accountInfo: "project-name"}
+	}
+	awsCollectorFactory = func(region, ownerFilter string, legacy bool) shared.ProviderCollector {
+		t.Fatalf("aws collector should not be built when provider is not selected")
+		return nil
+	}
+	exoscaleCollectorFactory = func(zone, ownerFilter string, legacy bool) shared.ProviderCollector {
+		t.Fatalf("exoscale collector should not be built when provider is not selected")
+		return nil
+	}
+	awsCallerIdentityARNLookup = func(context.Context, string) (string, bool) {
+		return "", false
+	}
+
+	// Given only Stackit is selected across two regions
+	// When the cleanup plan is built
+	plan := buildCleanupPlan(context.Background(), false)
+
+	// Then both Stackit targets are searched and unselected providers remain visible in scope
+	if len(plan.Collectors) != 2 {
+		t.Fatalf("collectors = %d, want 2", len(plan.Collectors))
+	}
+	if len(stackitCalls) != 2 || stackitCalls[0] != "eu01" || stackitCalls[1] != "eu02" {
+		t.Fatalf("stackit calls = %v, want [eu01 eu02]", stackitCalls)
+	}
+	if len(plan.Scope.Providers) != 4 {
+		t.Fatalf("scope rows = %d, want 4", len(plan.Scope.Providers))
+	}
+	if plan.Scope.Providers[2].Provider != "stackit" || plan.Scope.Providers[2].Status != providerStatusSearched {
+		t.Fatalf("first stackit scope row = %#v, want searched", plan.Scope.Providers[2])
+	}
+	if plan.Scope.Providers[3].Provider != "stackit" || plan.Scope.Providers[3].Status != providerStatusSearched {
+		t.Fatalf("second stackit scope row = %#v, want searched", plan.Scope.Providers[3])
+	}
+}
+
+func TestBuildCleanupPlanMarksStackitMissingProjectUnavailable(t *testing.T) {
+	originalOpts := cleanupOpts
+	originalStackitCollectorFactory := stackitCollectorFactory
+	t.Cleanup(func() {
+		cleanupOpts = originalOpts
+		stackitCollectorFactory = originalStackitCollectorFactory
+	})
+
+	cleanupOpts.Providers = []string{"stackit"}
+	stackitCollectorFactory = func(projectID, region, ownerFilter string) shared.ProviderCollector {
+		t.Fatalf("stackit collector should not be built without project id")
+		return nil
+	}
+
+	// Given Stackit is selected without the required project id
+	// When the cleanup plan is built
+	plan := buildCleanupPlan(context.Background(), false)
+
+	// Then Stackit appears in scope as unavailable instead of failing flag parsing globally
+	if len(plan.Collectors) != 0 {
+		t.Fatalf("collectors = %d, want 0", len(plan.Collectors))
+	}
+	stackitScope := plan.Scope.Providers[2]
+	if stackitScope.Provider != "stackit" {
+		t.Fatalf("provider = %q, want stackit", stackitScope.Provider)
+	}
+	if stackitScope.Status != providerStatusUnavailable {
+		t.Fatalf("status = %q, want %q", stackitScope.Status, providerStatusUnavailable)
+	}
+	if stackitScope.Reason == "" {
+		t.Fatal("expected missing project reason")
+	}
+}

--- a/tools/cleanup/cmd/cleanup/cleanup_discover.go
+++ b/tools/cleanup/cmd/cleanup/cleanup_discover.go
@@ -4,28 +4,19 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"sort"
 	"strconv"
 	"strings"
 
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
-	"github.com/exasol/exasol-personal/tools/cleanup/internal/aws"
-	"github.com/exasol/exasol-personal/tools/cleanup/internal/exoscale"
 	"github.com/exasol/exasol-personal/tools/cleanup/internal/shared"
-	"github.com/exasol/exasol-personal/tools/cleanup/internal/stackit"
 	"github.com/spf13/cobra"
 )
 
 var cleanupDiscoverOpts = struct {
-	JSON           bool
-	OwnerFilter    string
-	Order          string
-	Legacy         bool
-	ownerIsDefault bool
+	Order  string
+	Legacy bool
 }{}
 
 const cleanupDiscoverShort = "List deployments discovered via Deployment tag"
@@ -38,51 +29,51 @@ var cleanupDiscoverCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cmd.SilenceUsage = true
 
-		var collectors []shared.ProviderCollector
-
-		// AWS Collector - default owner to caller identity
-		if shouldUseProvider(aws.ProviderName) {
-			awsRegion := cleanupOpts.AWSRegion
-			if awsRegion == "" {
-				awsRegion = "us-east-1" // Default region
+		plan := buildCleanupPlan(cmd.Context(), cleanupDiscoverOpts.Legacy)
+		res := make([]shared.DeploymentSummary, 0)
+		successCount := 0
+		for _, scopedCollector := range plan.Collectors {
+			summaries, err := scopedCollector.Collector.CollectDeploymentSummaries(cmd.Context())
+			if err != nil {
+				scopedCollector.Scope.Status = providerStatusError
+				scopedCollector.Scope.Reason = err.Error()
+				continue
 			}
 
-			awsOwnerFilter := cleanupDiscoverOpts.OwnerFilter
+			successCount++
+			scopedCollector.Scope.Status = providerStatusSearched
+			scopedCollector.Scope.Reason = ""
+			res = append(res, summaries...)
+		}
 
-			// AWS-specific default: use caller identity if no filter provided
-			if awsOwnerFilter == "" {
-				cfg, err := config.LoadDefaultConfig(cmd.Context())
-				if err == nil {
-					stsClient := sts.NewFromConfig(cfg)
-					idOut, err := stsClient.GetCallerIdentity(cmd.Context(), &sts.GetCallerIdentityInput{})
-					if err == nil && idOut.Arn != nil && *idOut.Arn != "" {
-						awsOwnerFilter = *idOut.Arn
-						cleanupDiscoverOpts.ownerIsDefault = true
-					}
+		if !cleanupOpts.JSON {
+			renderCleanupScope(cmd.OutOrStdout(), plan.Scope)
+		}
+
+		switch {
+		case len(plan.Collectors) == 0:
+			err := fmt.Errorf("no searchable providers available")
+			if cleanupOpts.JSON {
+				if encodeErr := encodeJSONOutput(cmd.OutOrStdout(), cleanupDiscoverJSONOutput{
+					Scope: plan.Scope,
+					Error: commandError("no_searchable_providers", err),
+				}); encodeErr != nil {
+					return encodeErr
 				}
 			}
 
-			collectors = append(collectors,
-				aws.NewCollector(awsRegion, awsOwnerFilter, cleanupDiscoverOpts.Legacy))
-		}
+			return err
+		case successCount == 0:
+			err := fmt.Errorf("all selected provider discovery attempts failed")
+			if cleanupOpts.JSON {
+				if encodeErr := encodeJSONOutput(cmd.OutOrStdout(), cleanupDiscoverJSONOutput{
+					Scope: plan.Scope,
+					Error: commandError("provider_discovery_failed", err),
+				}); encodeErr != nil {
+					return encodeErr
+				}
+			}
 
-		// Exoscale Collector - use provided owner filter or empty for all
-		if shouldUseProvider(exoscale.ProviderName) {
-			exoOwnerFilter := cleanupDiscoverOpts.OwnerFilter
-			// Exoscale default: empty means all deployments (no caller identity equivalent)
-
-			collectors = append(collectors,
-				exoscale.NewCollector(cleanupOpts.ExoscaleZone, exoOwnerFilter, cleanupDiscoverOpts.Legacy))
-		}
-
-		if shouldUseProvider(stackit.ProviderName) {
-			collectors = append(collectors,
-				stackit.NewCollector(cleanupOpts.STACKITProjectId, cleanupOpts.STACKITRegion))
-		}
-
-		// Collect from all providers
-		res, err := shared.CollectAllProviders(cmd.Context(), collectors)
-		if err != nil {
 			return err
 		}
 		// Support comma-separated ordering hierarchy, default to state
@@ -193,11 +184,14 @@ var cleanupDiscoverCmd = &cobra.Command{
 			// final tie-breaker: deployment id
 			return res[item1].ID < res[item2].ID
 		})
-		if cleanupDiscoverOpts.JSON {
-			enc := json.NewEncoder(cmd.OutOrStdout())
-			enc.SetIndent("", "  ")
-
-			return enc.Encode(res)
+		if cleanupOpts.JSON {
+			return encodeJSONOutput(cmd.OutOrStdout(), cleanupDiscoverJSONOutput{
+				Scope: plan.Scope,
+				Data:  res,
+				Summary: &cleanupDiscoverySummary{
+					Count: len(res),
+				},
+			})
 		}
 
 		// Prepare table rows
@@ -234,24 +228,7 @@ var cleanupDiscoverCmd = &cobra.Command{
 			fmt.Fprintf(cmd.OutOrStdout(), "\n")
 		}
 
-		// Build a concise summary of search parameters
-		mode := "project=exasol-personal"
-		if cleanupDiscoverOpts.Legacy {
-			mode = "legacy"
-		}
-		regionDisplay := cleanupOpts.AWSRegion
-		if regionDisplay == "" {
-			regionDisplay = "(default)"
-		}
-		if _, err := fmt.Fprintf(
-			cmd.OutOrStdout(),
-			"Total: %d deployments (owner=%s, region=%s, mode=%s, order=%s)\n",
-			len(res),
-			ownerFilterDisplay(cleanupDiscoverOpts.OwnerFilter),
-			regionDisplay,
-			mode,
-			order,
-		); err != nil {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Total: %d deployments\n", len(res)); err != nil {
 			// non-fatal: log to stderr-like output
 			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "write output failed:", err)
 		}
@@ -262,10 +239,6 @@ var cleanupDiscoverCmd = &cobra.Command{
 }
 
 func registerCleanupDiscoverFlags(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&cleanupDiscoverOpts.JSON, "json", false, "Output JSON")
-	cmd.Flags().
-		StringVar(&cleanupDiscoverOpts.OwnerFilter, "owner", "",
-			"Owner ARN/wildcard to filter (defaults to caller; use * for any)")
 	cmd.Flags().StringVar(&cleanupDiscoverOpts.Order, "order", "state,created,resources",
 		"Order by columns (comma-separated). Prefix +/- for asc/desc per field."+
 			" Fields: deployment,provider,owner,region,created,state,resources."+
@@ -274,20 +247,9 @@ func registerCleanupDiscoverFlags(cmd *cobra.Command) {
 		"Discover legacy deployments (ignore mandatory Project=exasol-personal)")
 }
 
-func ownerFilterDisplay(f string) string {
-	if cleanupDiscoverOpts.ownerIsDefault {
-		return "(caller)"
-	}
-
-	if f == "" {
-		return "(caller)"
-	}
-
-	return f
-}
-
 // nolint: gochecknoinits
 func init() {
 	rootCmd.AddCommand(cleanupDiscoverCmd)
+	registerCommonFlags(cleanupDiscoverCmd, cleanupFlagOptions{includeOwner: true, includeJSON: true})
 	registerCleanupDiscoverFlags(cleanupDiscoverCmd)
 }

--- a/tools/cleanup/cmd/cleanup/cleanup_flags_test.go
+++ b/tools/cleanup/cmd/cleanup/cleanup_flags_test.go
@@ -1,0 +1,163 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestRegisterCommonFlagsScopesOptionalFlags(t *testing.T) {
+	t.Parallel()
+
+	commandWithOwnerAndJSON := &cobra.Command{Use: "discover"}
+	registerCommonFlags(commandWithOwnerAndJSON, cleanupFlagOptions{includeOwner: true, includeJSON: true})
+
+	providersCommand := &cobra.Command{Use: "providers"}
+	registerCommonFlags(providersCommand, cleanupFlagOptions{})
+
+	// Given command-specific flag registration
+	// When optional flags are enabled only where needed
+	// Then owner/json are available on the intended command but absent on providers
+	if commandWithOwnerAndJSON.Flags().Lookup("owner") == nil {
+		t.Fatal("discover flags are missing owner")
+	}
+	if commandWithOwnerAndJSON.Flags().Lookup("json") == nil {
+		t.Fatal("discover flags are missing json")
+	}
+	if providersCommand.Flags().Lookup("owner") != nil {
+		t.Fatal("providers unexpectedly exposes owner")
+	}
+	if providersCommand.Flags().Lookup("json") != nil {
+		t.Fatal("providers unexpectedly exposes json")
+	}
+	if providersCommand.Flags().Lookup("provider") == nil {
+		t.Fatal("providers is missing shared provider-selection flag")
+	}
+}
+
+func TestCleanupHelpGroupsProviderFlags(t *testing.T) {
+	command := &cobra.Command{Use: "discover"}
+	registerCommonFlags(command, cleanupFlagOptions{includeOwner: true, includeJSON: true})
+
+	var output bytes.Buffer
+	renderCleanupFlagGroups(&output, command)
+	rendered := output.String()
+
+	// Given grouped flag rendering
+	// When a command has generic and provider-specific options
+	// Then provider flags are separated into provider option groups
+	options := sectionBetween(t, rendered, cleanupFlagGroupGeneric+":", cleanupFlagGroupAWS+":")
+	awsOptions := sectionBetween(t, rendered, cleanupFlagGroupAWS+":", cleanupFlagGroupExoscale+":")
+	exoscaleOptions := sectionBetween(t, rendered, cleanupFlagGroupExoscale+":", cleanupFlagGroupStackit+":")
+	stackitOptions := sectionAfter(t, rendered, cleanupFlagGroupStackit+":")
+
+	for _, expected := range []string{"--help", "--json", "--owner", "--provider", "--verbose"} {
+		if !strings.Contains(options, expected) {
+			t.Fatalf("generic options missing %q:\n%s", expected, rendered)
+		}
+	}
+	for _, unexpected := range []string{"--aws-region", "--exoscale-zone", "--stackit-project-id", "--stackit-region"} {
+		if strings.Contains(options, unexpected) {
+			t.Fatalf("generic options unexpectedly contain provider flag %q:\n%s", unexpected, rendered)
+		}
+	}
+	if !strings.Contains(awsOptions, "--aws-region") {
+		t.Fatalf("AWS options missing --aws-region:\n%s", rendered)
+	}
+	if !strings.Contains(exoscaleOptions, "--exoscale-zone") {
+		t.Fatalf("Exoscale options missing --exoscale-zone:\n%s", rendered)
+	}
+	for _, expected := range []string{"--stackit-project-id", "--stackit-region"} {
+		if !strings.Contains(stackitOptions, expected) {
+			t.Fatalf("STACKIT options missing %q:\n%s", expected, rendered)
+		}
+	}
+}
+
+func sectionBetween(t *testing.T, text, start, end string) string {
+	t.Helper()
+	startIndex := strings.Index(text, start)
+	if startIndex < 0 {
+		t.Fatalf("missing section %q in:\n%s", start, text)
+	}
+	sectionStart := startIndex + len(start)
+	endIndex := strings.Index(text[sectionStart:], end)
+	if endIndex < 0 {
+		t.Fatalf("missing section %q after %q in:\n%s", end, start, text)
+	}
+
+	return text[sectionStart : sectionStart+endIndex]
+}
+
+func sectionAfter(t *testing.T, text, start string) string {
+	t.Helper()
+	startIndex := strings.Index(text, start)
+	if startIndex < 0 {
+		t.Fatalf("missing section %q in:\n%s", start, text)
+	}
+
+	return text[startIndex+len(start):]
+}
+
+func TestGetSelectedProvidersDefaultsToAll(t *testing.T) {
+	t.Parallel()
+
+	originalOpts := cleanupOpts
+	t.Cleanup(func() { cleanupOpts = originalOpts })
+
+	cleanupOpts.Providers = nil
+
+	selected := getSelectedProviders()
+	if len(selected) != 3 {
+		t.Fatalf("selected = %v, want 3 providers", selected)
+	}
+	if selected[0] != "aws" || selected[1] != "exoscale" || selected[2] != "stackit" {
+		t.Fatalf("selected = %v, want [aws exoscale stackit]", selected)
+	}
+}
+
+func TestGetSelectedProvidersUsesExplicitListWithoutDuplicates(t *testing.T) {
+	t.Parallel()
+
+	originalOpts := cleanupOpts
+	t.Cleanup(func() { cleanupOpts = originalOpts })
+
+	cleanupOpts.Providers = []string{"exoscale", "aws", "exoscale"}
+
+	selected := getSelectedProviders()
+	if len(selected) != 2 {
+		t.Fatalf("selected = %v, want 2 providers", selected)
+	}
+	if selected[0] != "exoscale" || selected[1] != "aws" {
+		t.Fatalf("selected = %v, want [exoscale aws]", selected)
+	}
+}
+
+func TestResolvedLocationsDefaultsAndDeduplicates(t *testing.T) {
+	t.Parallel()
+
+	originalOpts := cleanupOpts
+	t.Cleanup(func() { cleanupOpts = originalOpts })
+
+	if got := resolvedAWSRegions(); len(got) != 1 || got[0] != "us-east-1" {
+		t.Fatalf("resolvedAWSRegions = %v, want [us-east-1]", got)
+	}
+
+	cleanupOpts.AWSRegions = []string{"eu-central-1", "eu-central-1", "", "us-east-1"}
+	if got := resolvedAWSRegions(); len(got) != 2 || got[0] != "eu-central-1" || got[1] != "us-east-1" {
+		t.Fatalf("resolvedAWSRegions = %v, want [eu-central-1 us-east-1]", got)
+	}
+
+	if got := resolvedExoscaleZones(); len(got) != 1 || got[0] != "ch-gva-2" {
+		t.Fatalf("resolvedExoscaleZones = %v, want [ch-gva-2]", got)
+	}
+
+	if got := resolvedStackitRegions(); len(got) != 1 || got[0] != "eu01" {
+		t.Fatalf("resolvedStackitRegions = %v, want [eu01]", got)
+	}
+}

--- a/tools/cleanup/cmd/cleanup/cleanup_providers.go
+++ b/tools/cleanup/cmd/cleanup/cleanup_providers.go
@@ -4,17 +4,21 @@
 package main
 
 import (
-	"fmt"
+	"encoding/json"
 	"log/slog"
 
-	"github.com/exasol/exasol-personal/tools/cleanup/internal/aws"
-	"github.com/exasol/exasol-personal/tools/cleanup/internal/exoscale"
 	"github.com/exasol/exasol-personal/tools/cleanup/internal/shared"
-	"github.com/exasol/exasol-personal/tools/cleanup/internal/stackit"
 	"github.com/spf13/cobra"
 )
 
 const cleanupProvidersShort = "List available providers and connection status"
+
+type providerStatus struct {
+	Provider  string `json:"provider"`
+	Location  string `json:"location"`
+	Connected bool   `json:"connected"`
+	Account   string `json:"account,omitempty"`
+}
 
 var cleanupProvidersCmd = &cobra.Command{
 	Use:    "providers",
@@ -24,61 +28,54 @@ var cleanupProvidersCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cmd.SilenceUsage = true
 
-		var collectors []shared.ProviderCollector
-
-		// AWS provider
-		if shouldUseProvider(aws.ProviderName) {
-			awsRegion := cleanupOpts.AWSRegion
-			if awsRegion == "" {
-				awsRegion = "us-east-1" // Default region for availability check
-			}
-			collectors = append(collectors, aws.NewCollector(awsRegion, "", false))
-		}
-
-		// Exoscale provider
-		if shouldUseProvider(exoscale.ProviderName) {
-			exoscaleZone := cleanupOpts.ExoscaleZone
-			if exoscaleZone == "" {
-				exoscaleZone = "ch-gva-2" // Already has default, but be explicit
-			}
-			collectors = append(collectors, exoscale.NewCollector(exoscaleZone, "", false))
-		}
-
-		if shouldUseProvider(stackit.ProviderName) {
-			collectors = append(collectors, stackit.NewCollector(cleanupOpts.STACKITProjectId, cleanupOpts.STACKITRegion))
-		}
-
-		for _, collector := range collectors {
-			providerName := collector.Name()
-			// Capitalize and pad provider name for alignment
-			displayName := providerName
-			if displayName == "aws" {
-				displayName = "AWS"
-			} else if displayName == "exoscale" {
-				displayName = "Exoscale"
-			} else if displayName == "stackit" {
-				displayName = "STACKIT"
-			}
-
-			// Pad to 11 characters for alignment
-			padded := fmt.Sprintf("%-11s", displayName)
-
-			if !collector.IsAvailable(cmd.Context()) {
-				fmt.Printf("%s Disconnected\n", padded)
-				slog.Debug("provider not available", "provider", providerName)
+		statuses := make([]providerStatus, 0)
+		for _, spec := range cleanupProviderSpecs() {
+			if !shouldUseProvider(spec.Name) {
 				continue
 			}
+			for _, location := range spec.Locations() {
+				collector := spec.BuildCollector(location, "", false)
+				status := providerStatus{Provider: spec.Name, Location: location, Connected: false}
+				accountInfo, err := collector.GetAccountInfo(cmd.Context())
+				if err != nil {
+					statuses = append(statuses, status)
+					slog.Debug("failed to get account info",
+						"provider", spec.Name,
+						"location", location,
+						"error", err)
+					continue
+				}
 
-			accountInfo, err := collector.GetAccountInfo(cmd.Context())
-			if err != nil {
-				fmt.Printf("%s Disconnected\n", padded)
-				slog.Debug("failed to get account info",
-					"provider", providerName,
-					"error", err)
-				continue
+				status.Connected = true
+				status.Account = accountInfo
+				statuses = append(statuses, status)
 			}
+		}
 
-			fmt.Printf("%s Connected    %s\n", padded, accountInfo)
+		if cleanupOpts.JSON {
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+
+			return enc.Encode(statuses)
+		}
+
+		rows := make([][]string, 0, len(statuses))
+		for _, status := range statuses {
+			connected := "disconnected"
+			account := "-"
+			if status.Connected {
+				connected = "connected"
+				account = status.Account
+			}
+			rows = append(rows, []string{status.Provider, status.Location, connected, account})
+		}
+		if len(rows) > 0 {
+			shared.RenderTable(
+				cmd.OutOrStdout(),
+				[]string{"provider", "location", "status", "account"},
+				[]int{12, 14, 12, 24},
+				rows,
+			)
 		}
 
 		return nil
@@ -88,4 +85,5 @@ var cleanupProvidersCmd = &cobra.Command{
 // nolint: gochecknoinits
 func init() {
 	rootCmd.AddCommand(cleanupProvidersCmd)
+	registerCommonFlags(cleanupProvidersCmd, cleanupFlagOptions{})
 }

--- a/tools/cleanup/cmd/cleanup/cleanup_run.go
+++ b/tools/cleanup/cmd/cleanup/cleanup_run.go
@@ -4,165 +4,242 @@
 package main
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
-	"github.com/exasol/exasol-personal/tools/cleanup/internal/aws"
-	"github.com/exasol/exasol-personal/tools/cleanup/internal/exoscale"
 	"github.com/exasol/exasol-personal/tools/cleanup/internal/shared"
-	"github.com/exasol/exasol-personal/tools/cleanup/internal/stackit"
 	"github.com/spf13/cobra"
 )
 
 var cleanupRunOpts = struct {
-	JSON    bool
 	Execute bool
 	Types   []string
 }{}
 
-const cleanupRunShort = "Run ordered cleanup (dry-run by default) for a deployment id"
+const cleanupRunShort = "Run ordered cleanup (dry-run by default) for one or more deployment ids"
 
 var cleanupRunCmd = &cobra.Command{
-	Use:    "run <deployment-id>",
+	Use:    "run <deployment-id>...",
 	Short:  cleanupRunShort,
-	Args:   cobra.ExactArgs(1),
+	Args:   cobra.MinimumNArgs(1),
 	PreRun: func(_ *cobra.Command, _ []string) { configureLogger() },
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		deploymentID := args[0]
 
-		var collectors []shared.ProviderCollector
+		plan := buildCleanupPlan(cmd.Context(), false)
+		lookupIndex := collectLookupIndex(cmd.Context(), &plan)
 
-		// AWS Collector - default owner to caller identity
-		if shouldUseProvider(aws.ProviderName) {
-			awsRegion := cleanupOpts.AWSRegion
-			if awsRegion == "" {
-				awsRegion = "us-east-1" // Default region
-			}
+		if !cleanupOpts.JSON {
+			renderCleanupScope(cmd.OutOrStdout(), plan.Scope)
+		}
 
-			awsOwnerFilter := ""
-			cfg, err := config.LoadDefaultConfig(cmd.Context())
-			if err == nil {
-				stsClient := sts.NewFromConfig(cfg)
-				idOut, err := stsClient.GetCallerIdentity(cmd.Context(), &sts.GetCallerIdentityInput{})
-				if err == nil && idOut.Arn != nil && *idOut.Arn != "" {
-					awsOwnerFilter = *idOut.Arn
+		execution := cleanupExecutionInfo{Mode: runMode(cleanupRunOpts.Execute), Types: cleanupRunOpts.Types}
+
+		switch {
+		case len(plan.Collectors) == 0:
+			err := fmt.Errorf("no searchable providers available")
+			if cleanupOpts.JSON {
+				if encodeErr := encodeJSONOutput(cmd.OutOrStdout(), cleanupRunJSONOutput{
+					Scope:       plan.Scope,
+					Execution:   execution,
+					Deployments: []cleanupRunDeploymentJSONOutput{},
+					Error:       commandError("no_searchable_providers", err),
+				}); encodeErr != nil {
+					return encodeErr
 				}
 			}
 
-			collectors = append(collectors,
-				aws.NewCollector(awsRegion, awsOwnerFilter, false))
-		}
+		case lookupIndex.SuccessCount == 0:
+			err := fmt.Errorf("all selected provider lookup attempts failed")
+			if cleanupOpts.JSON {
+				if encodeErr := encodeJSONOutput(cmd.OutOrStdout(), cleanupRunJSONOutput{
+					Scope:       plan.Scope,
+					Execution:   execution,
+					Deployments: []cleanupRunDeploymentJSONOutput{},
+					Error:       commandError("provider_lookup_failed", err),
+				}); encodeErr != nil {
+					return encodeErr
+				}
+			}
 
-		// Exoscale Collector
-		if shouldUseProvider(exoscale.ProviderName) {
-			collectors = append(collectors,
-				exoscale.NewCollector(cleanupOpts.ExoscaleZone, "", false))
-		}
-
-		if shouldUseProvider(stackit.ProviderName) {
-			collectors = append(collectors,
-				stackit.NewCollector(cleanupOpts.STACKITProjectId, cleanupOpts.STACKITRegion))
-		}
-
-		collector :=
-			stackit.NewCollector(cleanupOpts.STACKITProjectId, cleanupOpts.STACKITRegion)
-
-		// Find which provider has this deployment
-		// collector, err := shared.FindDeployment(cmd.Context(), collectors, deploymentID)
-		// if err != nil {
-		// 	return err
-		// }
-
-		// Use the found collector to get details
-		details, err := collector.CollectDeploymentDetails(cmd.Context(), deploymentID)
-		if err != nil {
 			return err
 		}
 
-		// Use resolved region from details to avoid empty display
-		region := details.Summary.Region
-		var typeFilter []shared.ResourceType
-		for _, t := range cleanupRunOpts.Types {
-			typeFilter = append(typeFilter, shared.ResourceType(t))
-		}
-		actions, err := collector.PlanActions(details, typeFilter)
-		if err != nil {
-			return err
-		}
-		results, err := collector.ExecuteActions(cmd.Context(), actions, cleanupRunOpts.Execute)
-		if err != nil {
-			return err
-		}
-		slog.Info(
-			"cleanup run",
-			"deployment",
-			deploymentID,
-			"region",
-			region,
-			"execute",
-			cleanupRunOpts.Execute,
-			"filtered_types",
-			cleanupRunOpts.Types,
-		)
-		if cleanupRunOpts.JSON {
-			enc := json.NewEncoder(cmd.OutOrStdout())
-			enc.SetIndent("", "  ")
+		results := make([]cleanupRunDeploymentJSONOutput, 0, len(args))
+		failureCount := 0
+		for i, deploymentID := range args {
+			if !cleanupOpts.JSON && i > 0 {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout())
+			}
 
-			return enc.Encode(results)
-		}
-		mode := "DRY-RUN"
-		if cleanupRunOpts.Execute {
-			mode = "EXECUTE"
-		}
-		if _, err := fmt.Fprintf(
-			cmd.OutOrStdout(),
-			"Cleanup %s Deployment %s Region %s Actions %d\n\n",
-			mode,
-			deploymentID,
-			region,
-			len(results),
-		); err != nil {
-			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "write output failed:", err)
-		}
-		rows := make([][]string, 0, len(results))
-		for _, result := range results {
-			rows = append(
-				rows,
-				[]string{
-					string(result.Action.Ref.Type),
-					result.Action.Ref.ID,
-					result.Action.Op,
-					result.Status,
-					result.Action.Reason,
-				},
+			result, err := loadCleanupRunResult(cmd.Context(), lookupIndex, deploymentID)
+			results = append(results, result)
+			if err != nil {
+				failureCount++
+				if !cleanupOpts.JSON {
+					renderRequestedDeployment(cmd.OutOrStdout(), deploymentID)
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Error: %s\n", err)
+				}
+				continue
+			}
+
+			if !cleanupOpts.JSON {
+				renderCleanupRunResult(cmd, *result.Resolved, result.Results, execution)
+			}
+			slog.Info(
+				"run complete",
+				"deployment",
+				deploymentID,
+				"actions",
+				result.Summary.Actions,
+				"execute",
+				cleanupRunOpts.Execute,
 			)
 		}
-		shared.RenderTable(
-			cmd.OutOrStdout(),
-			[]string{"type", "id", "op", "status", "reason"},
-			[]int{20, 25, 8, 10, 20},
-			rows,
-		)
-		slog.Info(
-			"run complete",
-			"deployment",
-			deploymentID,
-			"actions",
-			len(results),
-			"execute",
-			cleanupRunOpts.Execute,
-		)
+
+		if cleanupOpts.JSON {
+			payload := cleanupRunJSONOutput{
+				Scope:       plan.Scope,
+				Execution:   execution,
+				Deployments: results,
+			}
+			if failureCount > 0 {
+				payload.Error = commandError(
+					"deployment_requests_failed",
+					fmt.Errorf("%d deployment requests failed", failureCount),
+				)
+			}
+			if encodeErr := encodeJSONOutput(cmd.OutOrStdout(), payload); encodeErr != nil {
+				return encodeErr
+			}
+		}
+
+		if failureCount > 0 {
+			return fmt.Errorf("%d deployment requests failed", failureCount)
+		}
 
 		return nil
 	},
 }
 
+func loadCleanupRunResult(
+	ctx context.Context,
+	lookupIndex cleanupLookupIndex,
+	deploymentID string,
+) (cleanupRunDeploymentJSONOutput, error) {
+	result := cleanupRunDeploymentJSONOutput{Requested: deploymentID}
+	matches := lookupIndex.Matches[deploymentID]
+
+	switch {
+	case len(matches) == 0:
+		err := fmt.Errorf("deployment %s not found in searched providers", deploymentID)
+		result.Error = commandError("deployment_not_found", err)
+
+		return result, err
+	case len(matches) > 1:
+		err := fmt.Errorf(
+			"deployment %s matched multiple search targets: %s",
+			deploymentID,
+			lookupMatchSummary(matches),
+		)
+		result.Error = commandError("deployment_ambiguous", err)
+
+		return result, err
+	}
+
+	collector := matches[0].Collector
+	resolved := matches[0].Resolved
+	details, err := collector.CollectDeploymentDetails(ctx, deploymentID)
+	if err != nil {
+		result.Resolved = &resolved
+		result.Error = commandError("deployment_details_failed", err)
+
+		return result, err
+	}
+
+	typeFilter := resourceTypeFilter(cleanupRunOpts.Types)
+	actions, err := collector.PlanActions(details, typeFilter)
+	if err != nil {
+		result.Resolved = &resolved
+		result.Error = commandError("cleanup_plan_failed", err)
+
+		return result, err
+	}
+
+	results, err := collector.ExecuteActions(ctx, actions, cleanupRunOpts.Execute)
+	if err != nil {
+		result.Resolved = &resolved
+		result.Error = commandError("cleanup_execution_failed", err)
+
+		return result, err
+	}
+
+	result.Resolved = &resolved
+	result.Results = results
+	result.Summary = &cleanupExecutionSummary{Actions: len(results)}
+	slog.Info(
+		"cleanup run",
+		"deployment",
+		deploymentID,
+		"region",
+		details.Summary.Region,
+		"execute",
+		cleanupRunOpts.Execute,
+		"filtered_types",
+		cleanupRunOpts.Types,
+	)
+
+	return result, nil
+}
+
+func renderCleanupRunResult(
+	cmd *cobra.Command,
+	resolved cleanupResolved,
+	results []shared.Result,
+	execution cleanupExecutionInfo,
+) {
+	renderResolved(cmd.OutOrStdout(), resolved)
+	renderExecutionInfo(cmd.OutOrStdout(), execution)
+	mode := strings.ToUpper(execution.Mode)
+	if _, err := fmt.Fprintf(
+		cmd.OutOrStdout(),
+		"Cleanup %s Deployment %s Region %s Actions %d\n\n",
+		mode,
+		resolved.Deployment,
+		resolved.Location,
+		len(results),
+	); err != nil {
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "write output failed:", err)
+	}
+	rows := make([][]string, 0, len(results))
+	for _, result := range results {
+		rows = append(rows, []string{
+			string(result.Action.Ref.Type),
+			result.Action.Ref.ID,
+			result.Action.Op,
+			result.Status,
+			result.Action.Reason,
+		})
+	}
+	shared.RenderTable(
+		cmd.OutOrStdout(),
+		[]string{"type", "id", "op", "status", "reason"},
+		[]int{20, 25, 8, 10, 20},
+		rows,
+	)
+}
+
+func runMode(execute bool) string {
+	if execute {
+		return "execute"
+	}
+
+	return "dry-run"
+}
+
 func registerCleanupRunFlags(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&cleanupRunOpts.JSON, "json", false, "Output JSON")
 	cmd.Flags().
 		BoolVar(&cleanupRunOpts.Execute, "execute", false, "Execute deletions instead of dry-run")
 	cmd.Flags().
@@ -173,5 +250,6 @@ func registerCleanupRunFlags(cmd *cobra.Command) {
 // nolint: gochecknoinits
 func init() {
 	rootCmd.AddCommand(cleanupRunCmd)
+	registerCommonFlags(cleanupRunCmd, cleanupFlagOptions{includeOwner: true, includeJSON: true})
 	registerCleanupRunFlags(cleanupRunCmd)
 }

--- a/tools/cleanup/cmd/cleanup/cleanup_scope_test.go
+++ b/tools/cleanup/cmd/cleanup/cleanup_scope_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRenderCleanupScopeIncludesStatuses(t *testing.T) {
+	t.Parallel()
+
+	scope := cleanupScope{
+		Providers: []cleanupScopeProvider{
+			{
+				Provider: "aws",
+				Location: "us-east-1",
+				Owner:    "(caller)",
+				Status:   providerStatusSearched,
+				Reason:   "",
+			},
+			{
+				Provider: "aws",
+				Location: "eu-central-1",
+				Owner:    "(caller)",
+				Status:   providerStatusSearched,
+				Reason:   "",
+			},
+			{
+				Provider: "exoscale",
+				Location: "ch-gva-2",
+				Owner:    "*",
+				Status:   providerStatusSkipped,
+				Reason:   providerReasonNotSelected,
+			},
+		},
+	}
+
+	var output bytes.Buffer
+
+	// Given a built scope table
+	// When it is rendered for human-readable output
+	renderCleanupScope(&output, scope)
+
+	// Then it lists providers, status, and reason
+	rendered := strings.ToLower(output.String())
+	for _, expected := range []string{"scope:", "aws", "us-east-1", "eu-central-1", "exoscale", "searched", "skipped", "not selected"} {
+		if !strings.Contains(rendered, expected) {
+			t.Fatalf("rendered scope missing %q: %s", expected, output.String())
+		}
+	}
+}

--- a/tools/cleanup/cmd/cleanup/cleanup_show.go
+++ b/tools/cleanup/cmd/cleanup/cleanup_show.go
@@ -4,163 +4,226 @@
 package main
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
 	"log/slog"
 
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
-	"github.com/exasol/exasol-personal/tools/cleanup/internal/aws"
-	"github.com/exasol/exasol-personal/tools/cleanup/internal/exoscale"
 	"github.com/exasol/exasol-personal/tools/cleanup/internal/shared"
-	"github.com/exasol/exasol-personal/tools/cleanup/internal/stackit"
 	"github.com/spf13/cobra"
 )
 
 var cleanupShowOpts = struct {
-	JSON bool
+	Types []string
 }{}
 
-const cleanupShowShort = "Show resources for a deployment id"
+const cleanupShowShort = "Show resources for one or more deployment ids"
 
 var cleanupShowCmd = &cobra.Command{
-	Use:    "show <deployment-id>",
+	Use:    "show <deployment-id>...",
 	Short:  cleanupShowShort,
-	Args:   cobra.ExactArgs(1),
+	Args:   cobra.MinimumNArgs(1),
 	PreRun: func(_ *cobra.Command, _ []string) { configureLogger() },
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		deploymentID := args[0]
 
-		var collectors []shared.ProviderCollector
+		plan := buildCleanupPlan(cmd.Context(), false)
+		lookupIndex := collectLookupIndex(cmd.Context(), &plan)
 
-		// AWS Collector - default owner to caller identity
-		if shouldUseProvider(aws.ProviderName) {
-			awsRegion := cleanupOpts.AWSRegion
-			if awsRegion == "" {
-				awsRegion = "us-east-1" // Default region
-			}
+		if !cleanupOpts.JSON {
+			renderCleanupScope(cmd.OutOrStdout(), plan.Scope)
+		}
 
-			awsOwnerFilter := ""
-			cfg, err := config.LoadDefaultConfig(cmd.Context())
-			if err == nil {
-				stsClient := sts.NewFromConfig(cfg)
-				idOut, err := stsClient.GetCallerIdentity(cmd.Context(), &sts.GetCallerIdentityInput{})
-				if err == nil && idOut.Arn != nil && *idOut.Arn != "" {
-					awsOwnerFilter = *idOut.Arn
+		switch {
+		case len(plan.Collectors) == 0:
+			err := fmt.Errorf("no searchable providers available")
+			if cleanupOpts.JSON {
+				if encodeErr := encodeJSONOutput(cmd.OutOrStdout(), cleanupShowJSONOutput{
+					Scope:       plan.Scope,
+					Deployments: []cleanupShowDeploymentJSONOutput{},
+					Error:       commandError("no_searchable_providers", err),
+				}); encodeErr != nil {
+					return encodeErr
 				}
 			}
 
-			collectors = append(collectors,
-				aws.NewCollector(awsRegion, awsOwnerFilter, false))
-		}
+			return err
+		case lookupIndex.SuccessCount == 0:
+			err := fmt.Errorf("all selected provider lookup attempts failed")
+			if cleanupOpts.JSON {
+				if encodeErr := encodeJSONOutput(cmd.OutOrStdout(), cleanupShowJSONOutput{
+					Scope:       plan.Scope,
+					Deployments: []cleanupShowDeploymentJSONOutput{},
+					Error:       commandError("provider_lookup_failed", err),
+				}); encodeErr != nil {
+					return encodeErr
+				}
+			}
 
-		// Exoscale Collector
-		if shouldUseProvider(exoscale.ProviderName) {
-			collectors = append(collectors,
-				exoscale.NewCollector(cleanupOpts.ExoscaleZone, "", false))
-		}
-
-		if shouldUseProvider(stackit.ProviderName) {
-			collectors = append(collectors,
-				stackit.NewCollector(cleanupOpts.STACKITProjectId, cleanupOpts.STACKITRegion))
-		}
-
-		// Find which provider has this deployment
-		collector, err := shared.FindDeployment(cmd.Context(), collectors, deploymentID)
-		if err != nil {
 			return err
 		}
 
-		// Use the found collector to get details
-		details, err := collector.CollectDeploymentDetails(cmd.Context(), deploymentID)
-		if err != nil {
-			return err
-		}
-
-		if cleanupShowOpts.JSON {
-			enc := json.NewEncoder(cmd.OutOrStdout())
-			enc.SetIndent("", "  ")
-
-			return enc.Encode(details)
-		}
-		// Header removed; footer provides concise key=value summary instead
-		rows := make([][]string, 0, len(details.Resources))
-		for _, resource := range details.Resources {
-			owner := resource.Tags["Owner"]
-			if owner == "" {
-				owner = "-"
+		results := make([]cleanupShowDeploymentJSONOutput, 0, len(args))
+		failureCount := 0
+		for i, deploymentID := range args {
+			if !cleanupOpts.JSON && i > 0 {
+				_, _ = fmt.Fprintln(cmd.OutOrStdout())
 			}
-			when := "-"
-			if v, ok := resource.Attr["launchTime"]; ok {
-				when = fmt.Sprintf("%v", v)
-			}
-			if when == "-" {
-				if v, ok := resource.Attr["createTime"]; ok {
-					when = fmt.Sprintf("%v", v)
+
+			result, err := loadCleanupShowResult(cmd.Context(), lookupIndex, deploymentID)
+			results = append(results, result)
+			if err != nil {
+				failureCount++
+				if !cleanupOpts.JSON {
+					renderRequestedDeployment(cmd.OutOrStdout(), deploymentID)
+					_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Error: %s\n", err)
 				}
+				continue
 			}
-			if when == "-" {
-				if v, ok := resource.Attr["lastModified"]; ok {
-					when = fmt.Sprintf("%v", v)
-				}
+
+			if !cleanupOpts.JSON {
+				renderCleanupShowResult(cmd, *result.Resolved, result.Details)
 			}
-			state := "-"
-			if v, ok := resource.Attr["state"]; ok {
-				state = fmt.Sprintf("%v", v)
-			}
-			rows = append(
-				rows,
-				[]string{
-					string(resource.Ref.Type),
-					resource.Ref.ID,
-					owner,
-					when,
-					state,
-					resource.Ref.ARN,
-				},
-			)
-		}
-		if len(rows) > 0 {
-			shared.RenderTable(
-				cmd.OutOrStdout(),
-				[]string{"type", "id", "owner", "created", "state", "arn"},
-				[]int{15, 25, 50, 22, 10, 90},
-				rows,
-			)
-			fmt.Fprintf(cmd.OutOrStdout(), "\n")
-		}
-		// Footer summary in key=value style
-		created := "-"
-		if !details.Summary.CreatedAt.IsZero() {
-			created = details.Summary.CreatedAt.Format("2006-01-02 15:04")
-		}
-		if _, err := fmt.Fprintf(
-			cmd.OutOrStdout(),
-			"Summary: deployment=%s, owner=%s, provider=%s, region=%s, created=%s, state=%s, resources=%d\n",
-			details.Summary.ID,
-			details.Summary.Owner,
-			details.Summary.Provider,
-			details.Summary.Region,
-			created,
-			details.Summary.State,
-			details.Summary.Resources,
-		); err != nil {
-			_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "write output failed:", err)
+			slog.Info("show complete", "deployment", deploymentID)
 		}
 
-		slog.Info("show complete", "deployment", deploymentID)
+		if cleanupOpts.JSON {
+			payload := cleanupShowJSONOutput{
+				Scope:       plan.Scope,
+				Deployments: results,
+			}
+			if failureCount > 0 {
+				payload.Error = commandError(
+					"deployment_requests_failed",
+					fmt.Errorf("%d deployment requests failed", failureCount),
+				)
+			}
+			if encodeErr := encodeJSONOutput(cmd.OutOrStdout(), payload); encodeErr != nil {
+				return encodeErr
+			}
+		}
+
+		if failureCount > 0 {
+			return fmt.Errorf("%d deployment requests failed", failureCount)
+		}
 
 		return nil
 	},
 }
 
+func loadCleanupShowResult(
+	ctx context.Context,
+	lookupIndex cleanupLookupIndex,
+	deploymentID string,
+) (cleanupShowDeploymentJSONOutput, error) {
+	result := cleanupShowDeploymentJSONOutput{Requested: deploymentID}
+	matches := lookupIndex.Matches[deploymentID]
+
+	switch {
+	case len(matches) == 0:
+		err := fmt.Errorf("deployment %s not found in searched providers", deploymentID)
+		result.Error = commandError("deployment_not_found", err)
+
+		return result, err
+	case len(matches) > 1:
+		err := fmt.Errorf(
+			"deployment %s matched multiple search targets: %s",
+			deploymentID,
+			lookupMatchSummary(matches),
+		)
+		result.Error = commandError("deployment_ambiguous", err)
+
+		return result, err
+	}
+
+	collector := matches[0].Collector
+	resolved := matches[0].Resolved
+	details, err := collector.CollectDeploymentDetails(ctx, deploymentID)
+	if err != nil {
+		result.Resolved = &resolved
+		result.Error = commandError("deployment_details_failed", err)
+
+		return result, err
+	}
+
+	result.Resolved = &resolved
+	result.Details = filterDeploymentDetailsByTypes(details, cleanupShowOpts.Types)
+
+	return result, nil
+}
+
+func renderCleanupShowResult(cmd *cobra.Command, resolved cleanupResolved, details *shared.DeploymentDetails) {
+	renderResolved(cmd.OutOrStdout(), resolved)
+	renderTypesFilter(cmd.OutOrStdout(), cleanupShowOpts.Types)
+	rows := make([][]string, 0, len(details.Resources))
+	for _, resource := range details.Resources {
+		owner := resource.Tags["Owner"]
+		if owner == "" {
+			owner = "-"
+		}
+		when := "-"
+		if v, ok := resource.Attr["launchTime"]; ok {
+			when = fmt.Sprintf("%v", v)
+		}
+		if when == "-" {
+			if v, ok := resource.Attr["createTime"]; ok {
+				when = fmt.Sprintf("%v", v)
+			}
+		}
+		if when == "-" {
+			if v, ok := resource.Attr["lastModified"]; ok {
+				when = fmt.Sprintf("%v", v)
+			}
+		}
+		state := "-"
+		if v, ok := resource.Attr["state"]; ok {
+			state = fmt.Sprintf("%v", v)
+		}
+		rows = append(rows, []string{
+			string(resource.Ref.Type),
+			resource.Ref.ID,
+			owner,
+			when,
+			state,
+			resource.Ref.ARN,
+		})
+	}
+	if len(rows) > 0 {
+		shared.RenderTable(
+			cmd.OutOrStdout(),
+			[]string{"type", "id", "owner", "created", "state", "arn"},
+			[]int{15, 25, 50, 22, 10, 90},
+			rows,
+		)
+		_, _ = fmt.Fprintln(cmd.OutOrStdout())
+	}
+	created := "-"
+	if !details.Summary.CreatedAt.IsZero() {
+		created = details.Summary.CreatedAt.Format("2006-01-02 15:04")
+	}
+	if _, err := fmt.Fprintf(
+		cmd.OutOrStdout(),
+		"Summary: deployment=%s, owner=%s, provider=%s, region=%s, created=%s, state=%s, resources=%d\n",
+		details.Summary.ID,
+		details.Summary.Owner,
+		details.Summary.Provider,
+		details.Summary.Region,
+		created,
+		details.Summary.State,
+		details.Summary.Resources,
+	); err != nil {
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "write output failed:", err)
+	}
+}
+
 func registerCleanupShowFlags(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&cleanupShowOpts.JSON, "json", false, "Output JSON")
+	cmd.Flags().
+		StringSliceVar(&cleanupShowOpts.Types, "types", nil,
+			"Optional comma-separated resource types to limit (e.g. ec2-instance,ebs-volume)")
 }
 
 // nolint: gochecknoinits
 func init() {
 	rootCmd.AddCommand(cleanupShowCmd)
+	registerCommonFlags(cleanupShowCmd, cleanupFlagOptions{includeOwner: true, includeJSON: true})
 	registerCleanupShowFlags(cleanupShowCmd)
 }

--- a/tools/cleanup/cmd/cleanup/cleanup_show_run_test.go
+++ b/tools/cleanup/cmd/cleanup/cleanup_show_run_test.go
@@ -1,0 +1,359 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/exasol/exasol-personal/tools/cleanup/internal/shared"
+	"github.com/spf13/cobra"
+)
+
+type scenarioProviderCollector struct {
+	name                string
+	accountInfo         string
+	summaries           []shared.DeploymentSummary
+	detailsByDeployment map[string]*shared.DeploymentDetails
+	resultsByDeployment map[string][]shared.Result
+	planCalls           []string
+	executeCalls        []scenarioExecuteCall
+}
+
+func TestCleanupShowJSONAlwaysUsesDeploymentsArray(t *testing.T) {
+	originalOpts := cleanupOpts
+	originalShowOpts := cleanupShowOpts
+	originalAWSCollectorFactory := awsCollectorFactory
+	originalExoscaleCollectorFactory := exoscaleCollectorFactory
+	originalAWSCallerIdentityARNLookup := awsCallerIdentityARNLookup
+	t.Cleanup(func() {
+		cleanupOpts = originalOpts
+		cleanupShowOpts = originalShowOpts
+		awsCollectorFactory = originalAWSCollectorFactory
+		exoscaleCollectorFactory = originalExoscaleCollectorFactory
+		awsCallerIdentityARNLookup = originalAWSCallerIdentityARNLookup
+	})
+
+	collector := &scenarioProviderCollector{
+		name:        "aws",
+		accountInfo: "123456789012",
+		summaries:   []shared.DeploymentSummary{{ID: "dep-a", Provider: "aws", Region: "us-east-1", Owner: "alice", Resources: 1}},
+		detailsByDeployment: map[string]*shared.DeploymentDetails{
+			"dep-a": {Summary: shared.DeploymentSummary{ID: "dep-a", Provider: "aws", Region: "us-east-1", Owner: "alice", Resources: 1}},
+		},
+	}
+
+	cleanupOpts.JSON = true
+	cleanupOpts.Providers = []string{"aws"}
+	awsCollectorFactory = func(region, ownerFilter string, legacy bool) shared.ProviderCollector { return collector }
+	exoscaleCollectorFactory = func(zone, ownerFilter string, legacy bool) shared.ProviderCollector {
+		return stubProviderCollector{name: "exoscale", accountInfo: "org-id"}
+	}
+	awsCallerIdentityARNLookup = func(context.Context, string) (string, bool) {
+		return "arn:aws:iam::123456789012:role/example", true
+	}
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	// Given one deployment id in JSON mode
+	// When show runs
+	err := cleanupShowCmd.RunE(cmd, []string{"dep-a"})
+
+	// Then the response keeps the same array envelope as batch requests
+	if err != nil {
+		t.Fatalf("RunE returned error: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if _, ok := payload["resolved"]; ok {
+		t.Fatalf("payload unexpectedly contains legacy resolved field: %s", stdout.String())
+	}
+	if _, ok := payload["data"]; ok {
+		t.Fatalf("payload unexpectedly contains legacy data field: %s", stdout.String())
+	}
+	deployments, ok := payload["deployments"].([]any)
+	if !ok || len(deployments) != 1 {
+		t.Fatalf("deployments = %#v, want one item", payload["deployments"])
+	}
+	deployment, ok := deployments[0].(map[string]any)
+	if !ok {
+		t.Fatalf("deployment item = %#v, want object", deployments[0])
+	}
+	if _, ok := deployment["details"]; !ok {
+		t.Fatalf("deployment missing details: %s", stdout.String())
+	}
+}
+
+type scenarioExecuteCall struct {
+	deploymentID string
+	execute      bool
+}
+
+func TestCleanupRunJSONAlwaysUsesDeploymentsArray(t *testing.T) {
+	originalOpts := cleanupOpts
+	originalRunOpts := cleanupRunOpts
+	originalAWSCollectorFactory := awsCollectorFactory
+	originalExoscaleCollectorFactory := exoscaleCollectorFactory
+	originalAWSCallerIdentityARNLookup := awsCallerIdentityARNLookup
+	t.Cleanup(func() {
+		cleanupOpts = originalOpts
+		cleanupRunOpts = originalRunOpts
+		awsCollectorFactory = originalAWSCollectorFactory
+		exoscaleCollectorFactory = originalExoscaleCollectorFactory
+		awsCallerIdentityARNLookup = originalAWSCallerIdentityARNLookup
+	})
+
+	collector := &scenarioProviderCollector{
+		name:        "aws",
+		accountInfo: "123456789012",
+		summaries:   []shared.DeploymentSummary{{ID: "dep-a", Provider: "aws", Region: "us-east-1", Owner: "alice", Resources: 1}},
+		detailsByDeployment: map[string]*shared.DeploymentDetails{
+			"dep-a": {Summary: shared.DeploymentSummary{ID: "dep-a", Provider: "aws", Region: "us-east-1", Owner: "alice", Resources: 1}},
+		},
+		resultsByDeployment: map[string][]shared.Result{
+			"dep-a": {{Action: shared.Action{Ref: shared.ResourceRef{Type: "ec2-instance", ID: "i-a", ARN: "dep-a"}, Op: "delete", Reason: "ordered"}, Status: "planned"}},
+		},
+	}
+
+	cleanupOpts.JSON = true
+	cleanupOpts.Providers = []string{"aws"}
+	awsCollectorFactory = func(region, ownerFilter string, legacy bool) shared.ProviderCollector { return collector }
+	exoscaleCollectorFactory = func(zone, ownerFilter string, legacy bool) shared.ProviderCollector {
+		return stubProviderCollector{name: "exoscale", accountInfo: "org-id"}
+	}
+	awsCallerIdentityARNLookup = func(context.Context, string) (string, bool) {
+		return "arn:aws:iam::123456789012:role/example", true
+	}
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	// Given one deployment id in JSON mode
+	// When run executes in dry-run mode
+	err := cleanupRunCmd.RunE(cmd, []string{"dep-a"})
+
+	// Then the response stays in the batch envelope with results under deployments
+	if err != nil {
+		t.Fatalf("RunE returned error: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if _, ok := payload["resolved"]; ok {
+		t.Fatalf("payload unexpectedly contains legacy resolved field: %s", stdout.String())
+	}
+	if _, ok := payload["data"]; ok {
+		t.Fatalf("payload unexpectedly contains legacy data field: %s", stdout.String())
+	}
+	if _, ok := payload["summary"]; ok {
+		t.Fatalf("payload unexpectedly contains legacy summary field: %s", stdout.String())
+	}
+	deployments, ok := payload["deployments"].([]any)
+	if !ok || len(deployments) != 1 {
+		t.Fatalf("deployments = %#v, want one item", payload["deployments"])
+	}
+	deployment, ok := deployments[0].(map[string]any)
+	if !ok {
+		t.Fatalf("deployment item = %#v, want object", deployments[0])
+	}
+	if _, ok := deployment["results"]; !ok {
+		t.Fatalf("deployment missing results: %s", stdout.String())
+	}
+	if _, ok := deployment["summary"]; !ok {
+		t.Fatalf("deployment missing summary: %s", stdout.String())
+	}
+}
+
+func (s *scenarioProviderCollector) Name() string {
+	return s.name
+}
+
+func (s *scenarioProviderCollector) CollectDeploymentSummaries(context.Context) ([]shared.DeploymentSummary, error) {
+	return s.summaries, nil
+}
+
+func (*scenarioProviderCollector) IsAvailable(context.Context) bool {
+	return true
+}
+
+func (s *scenarioProviderCollector) GetAccountInfo(context.Context) (string, error) {
+	return s.accountInfo, nil
+}
+
+func (s *scenarioProviderCollector) CollectDeploymentDetails(
+	_ context.Context,
+	deploymentID string,
+) (*shared.DeploymentDetails, error) {
+	return s.detailsByDeployment[deploymentID], nil
+}
+
+func (s *scenarioProviderCollector) PlanActions(
+	details *shared.DeploymentDetails,
+	_ []shared.ResourceType,
+) ([]shared.Action, error) {
+	s.planCalls = append(s.planCalls, details.Summary.ID)
+	results := s.resultsByDeployment[details.Summary.ID]
+	actions := make([]shared.Action, 0, len(results))
+	for _, result := range results {
+		actions = append(actions, result.Action)
+	}
+
+	return actions, nil
+}
+
+func (s *scenarioProviderCollector) ExecuteActions(
+	_ context.Context,
+	actions []shared.Action,
+	execute bool,
+) ([]shared.Result, error) {
+	deploymentID := ""
+	if len(actions) > 0 {
+		deploymentID = actions[0].Ref.ARN
+	}
+	s.executeCalls = append(s.executeCalls, scenarioExecuteCall{deploymentID: deploymentID, execute: execute})
+
+	return s.resultsByDeployment[deploymentID], nil
+}
+
+func TestCleanupShowSupportsMultipleDeploymentIDs(t *testing.T) {
+	originalOpts := cleanupOpts
+	originalShowOpts := cleanupShowOpts
+	originalAWSCollectorFactory := awsCollectorFactory
+	originalExoscaleCollectorFactory := exoscaleCollectorFactory
+	originalAWSCallerIdentityARNLookup := awsCallerIdentityARNLookup
+	t.Cleanup(func() {
+		cleanupOpts = originalOpts
+		cleanupShowOpts = originalShowOpts
+		awsCollectorFactory = originalAWSCollectorFactory
+		exoscaleCollectorFactory = originalExoscaleCollectorFactory
+		awsCallerIdentityARNLookup = originalAWSCallerIdentityARNLookup
+	})
+
+	collector := &scenarioProviderCollector{
+		name:        "aws",
+		accountInfo: "123456789012",
+		summaries: []shared.DeploymentSummary{
+			{ID: "dep-a", Provider: "aws", Region: "us-east-1", Owner: "alice", CreatedAt: time.Unix(10, 0), State: "running", Resources: 1},
+			{ID: "dep-b", Provider: "aws", Region: "us-east-1", Owner: "bob", CreatedAt: time.Unix(20, 0), State: "stopped", Resources: 1},
+		},
+		detailsByDeployment: map[string]*shared.DeploymentDetails{
+			"dep-a": {
+				Summary:   shared.DeploymentSummary{ID: "dep-a", Provider: "aws", Region: "us-east-1", Owner: "alice", CreatedAt: time.Unix(10, 0), State: "running", Resources: 1},
+				Resources: []shared.ResourceMeta{{Ref: shared.ResourceRef{Type: "ec2-instance", ID: "i-a", ARN: "arn:a"}, Tags: map[string]string{"Owner": "alice"}, Attr: map[string]any{"state": "running"}}},
+			},
+			"dep-b": {
+				Summary:   shared.DeploymentSummary{ID: "dep-b", Provider: "aws", Region: "us-east-1", Owner: "bob", CreatedAt: time.Unix(20, 0), State: "stopped", Resources: 1},
+				Resources: []shared.ResourceMeta{{Ref: shared.ResourceRef{Type: "ec2-instance", ID: "i-b", ARN: "arn:b"}, Tags: map[string]string{"Owner": "bob"}, Attr: map[string]any{"state": "stopped"}}},
+			},
+		},
+	}
+
+	cleanupOpts.Providers = []string{"aws"}
+	awsCollectorFactory = func(region, ownerFilter string, legacy bool) shared.ProviderCollector { return collector }
+	exoscaleCollectorFactory = func(zone, ownerFilter string, legacy bool) shared.ProviderCollector {
+		return stubProviderCollector{name: "exoscale", accountInfo: "org-id"}
+	}
+	awsCallerIdentityARNLookup = func(context.Context, string) (string, bool) {
+		return "arn:aws:iam::123456789012:role/example", true
+	}
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	// Given two deployment ids in a single show invocation
+	// When the command runs
+	err := cleanupShowCmd.RunE(cmd, []string{"dep-a", "dep-b"})
+
+	// Then both deployments are rendered from one shared lookup pass
+	if err != nil {
+		t.Fatalf("RunE returned error: %v", err)
+	}
+	rendered := stdout.String()
+	for _, expected := range []string{"Scope:", "deployment=dep-a", "deployment=dep-b", "Summary: deployment=dep-a", "Summary: deployment=dep-b"} {
+		if !strings.Contains(rendered, expected) {
+			t.Fatalf("output missing %q: %s", expected, rendered)
+		}
+	}
+}
+
+func TestCleanupRunContinuesAcrossMultipleDeploymentIDs(t *testing.T) {
+	originalOpts := cleanupOpts
+	originalRunOpts := cleanupRunOpts
+	originalAWSCollectorFactory := awsCollectorFactory
+	originalExoscaleCollectorFactory := exoscaleCollectorFactory
+	originalAWSCallerIdentityARNLookup := awsCallerIdentityARNLookup
+	t.Cleanup(func() {
+		cleanupOpts = originalOpts
+		cleanupRunOpts = originalRunOpts
+		awsCollectorFactory = originalAWSCollectorFactory
+		exoscaleCollectorFactory = originalExoscaleCollectorFactory
+		awsCallerIdentityARNLookup = originalAWSCallerIdentityARNLookup
+	})
+
+	collector := &scenarioProviderCollector{
+		name:        "aws",
+		accountInfo: "123456789012",
+		summaries: []shared.DeploymentSummary{
+			{ID: "dep-a", Provider: "aws", Region: "us-east-1", Owner: "alice", Resources: 1},
+			{ID: "dep-b", Provider: "aws", Region: "us-east-1", Owner: "bob", Resources: 1},
+		},
+		detailsByDeployment: map[string]*shared.DeploymentDetails{
+			"dep-a": {Summary: shared.DeploymentSummary{ID: "dep-a", Provider: "aws", Region: "us-east-1", Owner: "alice", Resources: 1}},
+			"dep-b": {Summary: shared.DeploymentSummary{ID: "dep-b", Provider: "aws", Region: "us-east-1", Owner: "bob", Resources: 1}},
+		},
+		resultsByDeployment: map[string][]shared.Result{
+			"dep-a": {{Action: shared.Action{Ref: shared.ResourceRef{Type: "ec2-instance", ID: "i-a", ARN: "dep-a"}, Op: "delete", Reason: "ordered"}, Status: "planned"}},
+			"dep-b": {{Action: shared.Action{Ref: shared.ResourceRef{Type: "ec2-instance", ID: "i-b", ARN: "dep-b"}, Op: "delete", Reason: "ordered"}, Status: "planned"}},
+		},
+	}
+
+	cleanupOpts.Providers = []string{"aws"}
+	awsCollectorFactory = func(region, ownerFilter string, legacy bool) shared.ProviderCollector { return collector }
+	exoscaleCollectorFactory = func(zone, ownerFilter string, legacy bool) shared.ProviderCollector {
+		return stubProviderCollector{name: "exoscale", accountInfo: "org-id"}
+	}
+	awsCallerIdentityARNLookup = func(context.Context, string) (string, bool) {
+		return "arn:aws:iam::123456789012:role/example", true
+	}
+
+	var stdout bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	// Given multiple deployment ids including one missing id
+	// When the cleanup run executes in dry-run mode
+	err := cleanupRunCmd.RunE(cmd, []string{"dep-a", "missing", "dep-b"})
+
+	// Then successful deployments are still processed and the command reports a batch failure
+	if err == nil {
+		t.Fatal("RunE returned nil, want batch failure")
+	}
+	if err.Error() != "1 deployment requests failed" {
+		t.Fatalf("error = %q, want batch failure summary", err)
+	}
+	if len(collector.planCalls) != 2 {
+		t.Fatalf("planCalls = %v, want 2 successful deployments", collector.planCalls)
+	}
+	rendered := stdout.String()
+	for _, expected := range []string{"Cleanup DRY-RUN Deployment dep-a", "Cleanup DRY-RUN Deployment dep-b", "Requested: deployment=missing", "Error: deployment missing not found in searched providers"} {
+		if !strings.Contains(rendered, expected) {
+			t.Fatalf("output missing %q: %s", expected, rendered)
+		}
+	}
+}

--- a/tools/cleanup/cmd/cleanup/cleanup_types.go
+++ b/tools/cleanup/cmd/cleanup/cleanup_types.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import "github.com/exasol/exasol-personal/tools/cleanup/internal/shared"
+
+func resourceTypeFilter(typeNames []string) []shared.ResourceType {
+	if len(typeNames) == 0 {
+		return nil
+	}
+
+	typeFilter := make([]shared.ResourceType, 0, len(typeNames))
+	for _, typeName := range typeNames {
+		typeFilter = append(typeFilter, shared.ResourceType(typeName))
+	}
+
+	return typeFilter
+}
+
+func filterDeploymentDetailsByTypes(
+	details *shared.DeploymentDetails,
+	typeNames []string,
+) *shared.DeploymentDetails {
+	if len(typeNames) == 0 {
+		return details
+	}
+
+	allowedTypes := make(map[shared.ResourceType]struct{}, len(typeNames))
+	for _, typeName := range typeNames {
+		allowedTypes[shared.ResourceType(typeName)] = struct{}{}
+	}
+
+	filteredResources := make([]shared.ResourceMeta, 0, len(details.Resources))
+	for _, resource := range details.Resources {
+		if _, ok := allowedTypes[resource.Ref.Type]; ok {
+			filteredResources = append(filteredResources, resource)
+		}
+	}
+
+	filteredDetails := *details
+	filteredDetails.Resources = filteredResources
+	filteredDetails.Summary = details.Summary
+	filteredDetails.Summary.Resources = len(filteredResources)
+
+	return &filteredDetails
+}

--- a/tools/cleanup/cmd/cleanup/cleanup_types_test.go
+++ b/tools/cleanup/cmd/cleanup/cleanup_types_test.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"testing"
+
+	"github.com/exasol/exasol-personal/tools/cleanup/internal/shared"
+)
+
+func TestFilterDeploymentDetailsByTypes(t *testing.T) {
+	t.Parallel()
+
+	input := &shared.DeploymentDetails{
+		Summary: shared.DeploymentSummary{
+			ID:        "exasol-12345678",
+			Provider:  "aws",
+			Region:    "eu-central-1",
+			Owner:     "owner-1",
+			State:     shared.StateStopped,
+			Resources: 3,
+		},
+		Resources: []shared.ResourceMeta{
+			{Ref: shared.ResourceRef{Type: shared.ResourceType("ec2-instance"), ID: "i-1"}},
+			{Ref: shared.ResourceRef{Type: shared.ResourceType("ebs-volume"), ID: "vol-1"}},
+			{Ref: shared.ResourceRef{Type: shared.ResourceType("ssm-parameter"), ID: "param-1"}},
+		},
+	}
+
+	// Given deployment details with multiple resource types
+	// When a type filter is applied
+	filtered := filterDeploymentDetailsByTypes(input, []string{"ec2-instance", "ssm-parameter"})
+
+	// Then only the matching resources remain and the summary count matches
+	if filtered == input {
+		t.Fatal("filtered details reused original pointer")
+	}
+	if len(filtered.Resources) != 2 {
+		t.Fatalf("resources = %d, want 2", len(filtered.Resources))
+	}
+	if filtered.Resources[0].Ref.ID != "i-1" || filtered.Resources[1].Ref.ID != "param-1" {
+		t.Fatalf("filtered resources = %#v, want ec2-instance and ssm-parameter", filtered.Resources)
+	}
+	if filtered.Summary.Resources != 2 {
+		t.Fatalf("summary resources = %d, want 2", filtered.Summary.Resources)
+	}
+	if input.Summary.Resources != 3 {
+		t.Fatalf("original summary resources = %d, want 3", input.Summary.Resources)
+	}
+}

--- a/tools/cleanup/cmd/cleanup/main.go
+++ b/tools/cleanup/cmd/cleanup/main.go
@@ -16,13 +16,18 @@ import (
 const shortDescription = "Exasol Personal cleanup tool"
 
 const description = shortDescription + `
-Specific providers can be targeted using the --aws, --exoscale, and --stackit flags. If no provider flags are set, all providers will be used.
+Specific providers can be targeted using --provider=<name>[,<name>...]. If no providers are specified, all known providers will be used.
 `
 
 var rootCmd = &cobra.Command{
 	Use:   "exasol-cleanup",
 	Short: shortDescription,
 	Long:  description,
+}
+
+// nolint: gochecknoinits
+func init() {
+	rootCmd.SetHelpFunc(cleanupHelpFunc)
 }
 
 func configureLogger() {

--- a/tools/cleanup/go.mod
+++ b/tools/cleanup/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.3
+	github.com/aws/aws-sdk-go-v2/credentials v1.19.3
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.275.1
 	github.com/aws/aws-sdk-go-v2/service/iam v1.51.0
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.3
@@ -14,8 +15,11 @@ require (
 	github.com/exoscale/egoscale/v3 v3.1.34
 	github.com/lmittmann/tint v1.1.3
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
+	github.com/stackitcloud/stackit-sdk-go/core v0.26.0
 	github.com/stackitcloud/stackit-sdk-go/services/iaas v1.11.1
 	github.com/stackitcloud/stackit-sdk-go/services/objectstorage v1.9.0
+	github.com/stackitcloud/stackit-sdk-go/services/resourcemanager v0.23.0
 	golang.org/x/term v0.41.0
 )
 
@@ -50,7 +54,6 @@ require (
 	github.com/ashanbrown/forbidigo/v2 v2.3.0 // indirect
 	github.com/ashanbrown/makezero/v2 v2.1.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
-	github.com/aws/aws-sdk-go-v2/credentials v1.19.3 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.15 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 // indirect
@@ -210,11 +213,8 @@ require (
 	github.com/sourcegraph/go-diff v0.7.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spf13/viper v1.18.2 // indirect
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
-	github.com/stackitcloud/stackit-sdk-go/core v0.26.0 // indirect
-	github.com/stackitcloud/stackit-sdk-go/services/resourcemanager v0.23.0 // indirect
 	github.com/stbenjam/no-sprintf-host-port v0.3.1 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect

--- a/tools/cleanup/internal/stackit/collect.go
+++ b/tools/cleanup/internal/stackit/collect.go
@@ -59,6 +59,10 @@ func createStackitClient(ctx context.Context) (*iaas.APIClient, *objectstorage.A
 }
 
 func GetAccountInfo(ctx context.Context, projectId string) (string, error) {
+	if projectId == "" {
+		return "", fmt.Errorf("STACKIT project id is required")
+	}
+
 	_, _, resourceManagerClient, err := createStackitClient(ctx)
 	if err != nil {
 		return "", err
@@ -66,10 +70,15 @@ func GetAccountInfo(ctx context.Context, projectId string) (string, error) {
 
 	projectResp, err := resourceManagerClient.DefaultAPI.GetProject(ctx, projectId).Execute()
 	if err != nil {
-		return projectResp.GetName(), nil
+		return "", fmt.Errorf("failed to get STACKIT project %s: %w", projectId, err)
 	}
 
-	return "[restricted]", nil
+	projectName := projectResp.GetName()
+	if projectName == "" {
+		return projectId, nil
+	}
+
+	return projectName, nil
 
 }
 
@@ -256,7 +265,8 @@ func CollectDeploymentDetails(
 func CollectDeploymentSummaries(
 	ctx context.Context,
 	projectId,
-	region string,
+	region,
+	ownerFilter string,
 ) ([]DeploymentSummary, error) {
 	resources, err := CollectResources(ctx, projectId, region, nil)
 	if err != nil {
@@ -274,7 +284,11 @@ func CollectDeploymentSummaries(
 	// Convert map to slice
 	result := make([]DeploymentSummary, 0, len(resourcesByDeployment))
 	for deploymentID, deploymentResources := range resourcesByDeployment {
-		result = append(result, summarizeDeploymentResources(deploymentID, region, deploymentResources))
+		summary := summarizeDeploymentResources(deploymentID, region, deploymentResources)
+		if !ownerMatchesFilter(summary.Owner, ownerFilter) {
+			continue
+		}
+		result = append(result, summary)
 	}
 
 	return result, nil
@@ -712,6 +726,20 @@ func firstStringAdditionalProperty(properties map[string]interface{}, keys ...st
 	}
 
 	return "", false
+}
+
+func ownerMatchesFilter(owner, filter string) bool {
+	if filter == "" || filter == "*" {
+		return true
+	}
+	pattern := "^" + regexp.QuoteMeta(filter) + "$"
+	pattern = strings.ReplaceAll(pattern, "\\*", ".*")
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return false
+	}
+
+	return re.MatchString(owner)
 }
 
 func serverStateToSimple(state string) string {

--- a/tools/cleanup/internal/stackit/collector.go
+++ b/tools/cleanup/internal/stackit/collector.go
@@ -15,14 +15,16 @@ const ProviderName = "stackit"
 
 // Collector implements shared.ProviderCollector for STACKIT.
 type Collector struct {
-	projectId string
-	region    string
+	projectId   string
+	region      string
+	ownerFilter string
 }
 
-func NewCollector(projectId, region string) *Collector {
+func NewCollector(projectId, region, ownerFilter string) *Collector {
 	return &Collector{
-		projectId: projectId,
-		region:    region,
+		projectId:   projectId,
+		region:      region,
+		ownerFilter: ownerFilter,
 	}
 }
 
@@ -41,7 +43,7 @@ func (c *Collector) GetAccountInfo(ctx context.Context) (string, error) {
 }
 
 func (c *Collector) CollectDeploymentSummaries(ctx context.Context) ([]shared.DeploymentSummary, error) {
-	return CollectDeploymentSummaries(ctx, c.projectId, c.region)
+	return CollectDeploymentSummaries(ctx, c.projectId, c.region, c.ownerFilter)
 }
 
 func (c *Collector) CollectDeploymentDetails(ctx context.Context, deploymentId string) (*shared.DeploymentDetails, error) {


### PR DESCRIPTION
## Description

Improve the standalone cleanup tool so provider selection and lookup behavior are clearer, more consistent, and easier to use.

This PR fixes the mismatch where a deployment could be discovered but not shown or cleaned up because `discover` and `show`/`run` resolved provider scope differently. It also refines the CLI UX by making scope explicit in command output, replacing provider booleans with `--provider`, supporting multiple locations per provider, allowing `show` and `run` to accept multiple deployment ids, and simplifying JSON output into a single consistent batch-oriented shape.

## Related Issue

SPOT-30911

## Type of Change

- [x] `fix`: Bug fix
- [x] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [x] `refactor`: Code refactoring
- [ ] `feat`: New feature
- [ ] `chore`: Maintenance tasks

## Changes Made

- Fixed cleanup lookup behavior so `show` and `run` use the same effective provider/owner scope model as `discover`
- Standardized shared cleanup flags:
  - `--owner` is shared where relevant
  - `--json` is shared for data-producing commands
  - `--types` is available on both `show` and `run`
- Replaced provider booleans like `--aws` / `--exoscale` with multi-value `--provider=<name>[,<name>...]`
- Added explicit `Scope:` output to `discover`, `show`, and `run`, including provider, location, owner, status, and reason
- Changed scope planning to operate on provider-location targets so one provider can appear multiple times for multiple regions/zones
- Added support for multi-value `--aws-region` and `--exoscale-zone`
- Added ambiguity detection when the same deployment id matches more than one searched target
- Added support for passing multiple deployment ids to `show` and `run`
- Kept `run` as dry-run by default and retained `--execute` as the explicit destructive switch
- Simplified `show --json` and `run --json` to always return a consistent batch-shaped envelope with a top-level `deployments` array
- Updated cleanup documentation and extended Go tests to cover the new lookup, scope, batch, and JSON behaviors

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

Ran the cleanup tool Go test suite from `tools/cleanup`:

This includes coverage for:
- shared cleanup flag registration
- provider owner resolution behavior
- provider/location scope planning
- multi-location scope rows
- multi-deployment `show` and `run`
- consistent batch-shaped JSON output for `show` and `run`

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

This PR intentionally updates the cleanup JSON shape without preserving backward compatibility because the JSON output is not yet relied on externally.

The resulting UX is:
- explicit provider and location scope before data output
- consistent provider selection via `--provider`
- multiple scope rows when multiple regions/zones are searched
- batch handling for `show` and `run`
- one consistent JSON envelope for single- and multi-deployment requests