### PR TITLE
feat: add default deployment directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,7 @@ A cloud account on one of the supported platforms with permission to provision c
 curl https://downloads.exasol.com/exasol-personal/installer.sh | sh
 ```
 
-2. Create a deployment directory
-```bash
-mkdir deployment && cd deployment
-``` 
-3. Install on your cloud of choice
+2. Install on your cloud of choice
 
 ```bash
 exasol install aws        # Amazon Web Services
@@ -79,15 +75,9 @@ Read on for Windows instructions and full details.
 
    On Windows: download the Exasol Launcher from the [Exasol Download Portal](https://downloads.exasol.com/exasol-personal) and copy the `exasol` binary to a directory in your `PATH`.
 
-2. Create a new directory “deployment” and change into the directory:
-   ```bash
-   mkdir deployment
-   cd deployment
-   ```
+2. Configure authentication for your cloud provider. See the relevant account setup guide in [Prerequisites](#-prerequisites) for the environment variables and credentials required.
 
-3. Configure authentication for your cloud provider. See the relevant account setup guide in [Prerequisites](#-prerequisites) for the environment variables and credentials required.
-
-4. To install Exasol Personal, run the following command with the preset for your cloud provider:
+3. To install Exasol Personal, run the following command with the preset for your cloud provider:
    ```bash
    exasol install aws        # Amazon Web Services
    exasol install azure      # Microsoft Azure
@@ -103,13 +93,15 @@ Read on for Windows instructions and full details.
 
    When the deployment process has finished, you will see instructions on how to connect to your Exasol database using a client of your choice. You can also find this information at any time by using `exasol info` in the terminal.
 
-Most `exasol` commands must be run from the context of the deployment directory. Change into the deployment directory before you run any `exasol` commands.
+By default, Exasol Personal stores deployment state in `~/.exasol/personal/deployments/default`. If you run a command from an existing deployment directory, Exasol Personal uses that directory instead. Pass `--deployment-dir <path>` to choose a different deployment directory explicitly.
+
+Keep the deployment directory until cloud resources have been destroyed. Deleting the directory does not remove cloud resources and can make cleanup harder.
 
 ## 📊 Load Sample Data
 
 To get started quickly, Exasol provides two sample datasets hosted on S3 that you can import directly using SQL.
 
-You can load it directly by executing this command in the deployment directory:
+You can load it directly by executing this command:
 
 ```bash
 exasol connect < sample.sql
@@ -170,7 +162,7 @@ If the deployment process is interrupted, cloud resources that were already crea
 
 ## ⏯️ Start and stop Exasol Personal
 
-To save costs, you can temporarily stop Exasol Personal by using the following command (in the deployment directory):
+To save costs, you can temporarily stop Exasol Personal by using the following command:
 ```bash
 exasol stop
 ```
@@ -190,7 +182,7 @@ To completely remove an Exasol Personal deployment, use `exasol destroy`. This c
 
 To learn more about this command, use `exasol destroy --help`.
 
-Deleting the deployment directory and the Exasol Launcher will not remove the resources that were created in your cloud environment. To completely remove a deployment, you must use the `exasol destroy` command.
+Deleting the deployment directory and the Exasol Launcher will not remove the resources that were created in your cloud environment. To completely remove a deployment, you must use the `exasol destroy` command before deleting the deployment directory.
 
 If you have already deleted the deployment directory and the Exasol Launcher, you must remove the resources manually in your cloud provider’s console.
 

--- a/cmd/exasol/absdirvar.go
+++ b/cmd/exasol/absdirvar.go
@@ -18,7 +18,13 @@ type AbsDirValue struct {
 }
 
 func NewAbsDirValue(target *string, defaultValue string) *AbsDirValue {
+	if defaultValue == "" {
+		*target = ""
+		return &AbsDirValue{target: target}
+	}
+
 	*target, _ = filepath.Abs(defaultValue)
+
 	return &AbsDirValue{target: target}
 }
 

--- a/cmd/exasol/commonFlags.go
+++ b/cmd/exasol/commonFlags.go
@@ -60,10 +60,10 @@ func registerDeploymentDirFlag(cmd *cobra.Command, state *CommonFlags) {
 	AbsDirVar(
 		cmd.Flags(),
 		&state.DeploymentDir,
-		"deployment-dir",
+		deploymentDirFlagName,
 		"",
-		".",
-		"The directory to store deployment files",
+		"",
+		"Override the deployment directory selected automatically",
 	)
 }
 

--- a/cmd/exasol/connect_test.go
+++ b/cmd/exasol/connect_test.go
@@ -149,6 +149,8 @@ func TestConnectUsageShowsJSONFormatUnderFlags(t *testing.T) {
 	jsonFlag := connectCmd.LocalNonPersistentFlags().Lookup("json")
 	if jsonFlag == nil {
 		t.Fatal("expected --json to be a local non-persistent flag")
+
+		return
 	}
 	if jsonFlag.NoOptDefVal != connect.JSONFormatPretty.String() {
 		t.Fatalf(

--- a/cmd/exasol/deployment_dir_resolution.go
+++ b/cmd/exasol/deployment_dir_resolution.go
@@ -1,0 +1,126 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+const (
+	deploymentDirFlagName     = "deployment-dir"
+	legacyWorkflowStateMarker = ".workflowState.json"
+)
+
+type deploymentDirSource int
+
+const (
+	deploymentDirSourceNone deploymentDirSource = iota
+	deploymentDirSourceExplicit
+	deploymentDirSourceCurrent
+	deploymentDirSourceDefault
+)
+
+func resolveDeploymentDirForCommand(cmd *cobra.Command, state *CommonFlags) error {
+	deployment, source, err := resolveDeploymentDir(cmd, state)
+	if err != nil {
+		return err
+	}
+	if source == deploymentDirSourceNone {
+		return nil
+	}
+
+	state.DeploymentDir = deployment.Root()
+	if source == deploymentDirSourceDefault {
+		slog.Info("using default deployment directory", "path", deployment.Root())
+	}
+
+	return nil
+}
+
+func resolveDeploymentDir(
+	cmd *cobra.Command,
+	state *CommonFlags,
+) (config.DeploymentDir, deploymentDirSource, error) {
+	flag := deploymentDirFlag(cmd)
+	if flag == nil {
+		return state.Deployment(), deploymentDirSourceNone, nil
+	}
+	if flag.Changed {
+		return state.Deployment(), deploymentDirSourceExplicit, nil
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return config.DeploymentDir{}, deploymentDirSourceNone, fmt.Errorf(
+			"get current directory: %w",
+			err,
+		)
+	}
+	if recognized, err := isRecognizedDeploymentDir(cwd); err != nil {
+		return config.DeploymentDir{}, deploymentDirSourceNone, err
+	} else if recognized {
+		return config.NewDeploymentDir(cwd), deploymentDirSourceCurrent, nil
+	}
+
+	defaultDir, err := defaultDeploymentDir()
+	if err != nil {
+		return config.DeploymentDir{}, deploymentDirSourceNone, err
+	}
+
+	return config.NewDeploymentDir(defaultDir), deploymentDirSourceDefault, nil
+}
+
+func deploymentDirFlag(cmd *cobra.Command) *pflag.Flag {
+	if flag := cmd.Flags().Lookup(deploymentDirFlagName); flag != nil {
+		return flag
+	}
+
+	return cmd.InheritedFlags().Lookup(deploymentDirFlagName)
+}
+
+func defaultDeploymentDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory for default deployment directory: %w", err)
+	}
+
+	return filepath.Join(home, ".exasol", "personal", "deployments", "default"), nil
+}
+
+func isRecognizedDeploymentDir(path string) (bool, error) {
+	for _, marker := range []string{
+		config.ExasolPersonalStateFileName,
+		config.DeploymentVersionMarkerFileName,
+		legacyWorkflowStateMarker,
+	} {
+		exists, err := pathExists(filepath.Join(path, marker))
+		if err != nil {
+			return false, err
+		}
+		if exists {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func pathExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+
+	return false, err
+}

--- a/cmd/exasol/deployment_dir_resolution_test.go
+++ b/cmd/exasol/deployment_dir_resolution_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/spf13/cobra"
+)
+
+//nolint:paralleltest // t.Chdir changes process state.
+func TestResolveDeploymentDir_ExplicitFlagWins(t *testing.T) {
+	// Given: a current deployment directory and an explicit deployment directory flag.
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	writeTestMarker(t, filepath.Join(cwd, config.ExasolPersonalStateFileName))
+
+	explicit := filepath.Join(t.TempDir(), "explicit")
+	cmd, state := commandWithDeploymentDirFlag(t, explicit)
+
+	// When: deployment directory resolution runs.
+	deployment, source, err := resolveDeploymentDir(cmd, state)
+	// Then: the explicit flag value is used.
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if source != deploymentDirSourceExplicit {
+		t.Fatalf("expected explicit source, got %v", source)
+	}
+	if deployment.Root() != explicit {
+		t.Fatalf("expected %q, got %q", explicit, deployment.Root())
+	}
+}
+
+//nolint:paralleltest // t.Chdir changes process state.
+func TestResolveDeploymentDir_CurrentDeploymentDirWinsWhenFlagOmitted(t *testing.T) {
+	// Given: the current working directory is recognized as a deployment directory.
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	writeTestMarker(t, filepath.Join(cwd, config.DeploymentVersionMarkerFileName))
+	cmd, state := commandWithDeploymentDirFlag(t, "")
+
+	// When: deployment directory resolution runs.
+	deployment, source, err := resolveDeploymentDir(cmd, state)
+	// Then: the current working directory is used.
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if source != deploymentDirSourceCurrent {
+		t.Fatalf("expected current directory source, got %v", source)
+	}
+	if deployment.Root() != cwd {
+		t.Fatalf("expected %q, got %q", cwd, deployment.Root())
+	}
+}
+
+//nolint:paralleltest // t.Chdir changes process state.
+func TestResolveDeploymentDir_DefaultWinsWhenFlagOmittedOutsideDeploymentDir(t *testing.T) {
+	// Given: the current working directory is not recognized as a deployment directory.
+	home := t.TempDir()
+	cwd := t.TempDir()
+	setTestHome(t, home)
+	t.Chdir(cwd)
+	cmd, state := commandWithDeploymentDirFlag(t, "")
+
+	// When: deployment directory resolution runs.
+	deployment, source, err := resolveDeploymentDir(cmd, state)
+	// Then: the default deployment directory is used.
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if source != deploymentDirSourceDefault {
+		t.Fatalf("expected default source, got %v", source)
+	}
+	expected := filepath.Join(home, ".exasol", "personal", "deployments", "default")
+	if deployment.Root() != expected {
+		t.Fatalf("expected %q, got %q", expected, deployment.Root())
+	}
+}
+
+func setTestHome(t *testing.T, home string) {
+	t.Helper()
+
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HOMEDRIVE", "")
+	t.Setenv("HOMEPATH", "")
+}
+
+func TestResolveDeploymentDir_IgnoresCommandsWithoutDeploymentDirFlag(t *testing.T) {
+	t.Parallel()
+
+	// Given: a command that does not operate on deployment directories.
+	cmd := &cobra.Command{Use: "version"}
+	state := &CommonFlags{}
+
+	// When: deployment directory resolution runs.
+	_, source, err := resolveDeploymentDir(cmd, state)
+	// Then: no deployment directory source is selected.
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if source != deploymentDirSourceNone {
+		t.Fatalf("expected no source, got %v", source)
+	}
+}
+
+func commandWithDeploymentDirFlag(t *testing.T, value string) (*cobra.Command, *CommonFlags) {
+	t.Helper()
+
+	state := &CommonFlags{}
+	cmd := &cobra.Command{Use: "test"}
+	registerDeploymentDirFlag(cmd, state)
+	if value != "" {
+		if err := cmd.Flags().Set(deploymentDirFlagName, value); err != nil {
+			t.Fatalf("failed to set deployment-dir flag: %v", err)
+		}
+	}
+
+	return cmd, state
+}
+
+func writeTestMarker(t *testing.T, path string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte("test"), 0o600); err != nil {
+		t.Fatalf("failed to write marker: %v", err)
+	}
+}

--- a/cmd/exasol/init.go
+++ b/cmd/exasol/init.go
@@ -18,10 +18,12 @@ const (
 
 var initCmdShortDesc = `Initialize a new deployment directory`
 
-var initCmdLongDesc = initCmdShortDesc + `
-
-	Extracts the specified infrastructure and installation presets into the deployment directory.
-
+const (
+	deploymentDirectoryResolutionHelp = `
+	If --deployment-dir is not provided and the current directory is not a deployment directory,
+	uses ~/.exasol/personal/deployments/default.
+`
+	presetSelectionHelp = `
 	Preset arguments:
 	  - The first argument selects the infrastructure preset (required).
 	  - The optional second argument selects the installation preset.
@@ -31,6 +33,12 @@ var initCmdLongDesc = initCmdShortDesc + `
 
 	Tip: use "exasol presets" to discover and export presets.
 	`
+)
+
+var initCmdLongDesc = initCmdShortDesc + `
+
+	Extracts the specified infrastructure and installation presets into the deployment directory.` +
+	deploymentDirectoryResolutionHelp + presetSelectionHelp
 
 var initCmd = &cobra.Command{
 	Use:   "init <infra preset name-or-path> [install preset name-or-path]",

--- a/cmd/exasol/install.go
+++ b/cmd/exasol/install.go
@@ -17,17 +17,8 @@ var installCmdShortDesc = `Initialize and deploy Exasol in one step`
 
 var installCmdLongDesc = installCmdShortDesc + `
 
-	Extracts the specified infrastructure and installation presets into the deployment directory.
-
-	Preset arguments:
-	  - The first argument selects the infrastructure preset (required).
-	  - The optional second argument selects the installation preset.
-
-	Each argument can be either an embedded preset name (e.g. "aws") or a preset directory path.
-	To force path selection, pass a path-like value such as "./my-preset" or "/abs/path/to/preset".
-
-	Tip: use "exasol presets" to discover and export presets.
-	`
+	Initializes the deployment directory, prepares infrastructure, and installs Exasol.` +
+	deploymentDirectoryResolutionHelp + presetSelectionHelp
 
 var installCmd = &cobra.Command{
 	Use:   "install <infra preset name-or-path> [install preset name-or-path]",

--- a/cmd/exasol/root.go
+++ b/cmd/exasol/root.go
@@ -22,13 +22,14 @@ const (
 	rootCmdLongDesc = rootCmdShortDesc + `
 
 Getting Started:
-  Begin by creating a deployment directory, e.g., with "mkdir deployment", and then change
-  into that directory, e.g., with "cd deployment".
-
   To create and run an Exasol deployment, run "exasol install <infra preset name-or-path>".
 	This single command initializes your deployment directory, prepares the selected infrastructure,
 	and installs the database. It uses either a built-in infrastructure preset or a custom preset 
 	at a path you provide. Built-in presets are: aws, azure, and exoscale.
+
+	If you do not pass --deployment-dir and are not already inside a deployment directory,
+	Exasol Personal uses ~/.exasol/personal/deployments/default. Pass --deployment-dir
+	to override the active deployment directory.
 
 	Note: Cloud presets require provider credentials in your environment.
   Use "exasol init --help", "exasol install --help", or "exasol presets list" to see the preset
@@ -57,13 +58,16 @@ var rootCmd = &cobra.Command{
 	Example:       rootCmdExample,
 	SilenceErrors: true,
 	PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
-		deployment := commonFlags.Deployment()
 		// Root-level pre-run is the single place where we enforce cross-cutting concerns.
 		// Design decision: keep this centralized so individual commands don't have to
 		// remember to repeat it (and so user-visible behavior stays consistent).
 		if err := setupLogging(); err != nil {
 			return err
 		}
+		if err := resolveDeploymentDirForCommand(cmd, commonFlags); err != nil {
+			return err
+		}
+		deployment := commonFlags.Deployment()
 
 		// Deployment-directory compatibility is enforced centrally and only for commands
 		// that declare it via annotations.

--- a/cmd/exasol/status.go
+++ b/cmd/exasol/status.go
@@ -74,7 +74,6 @@ func registerStatusFlags() {
 // nolint: gochecknoinits
 func init() {
 	requireMinorVersionCompatibility(statusCmd, CurrentLauncherVersion)
-	requireInitializedDeploymentDir(statusCmd)
 	registerStatusFlags()
 	registerDeploymentDirFlag(statusCmd, commonFlags)
 	registerOutputFlags(statusCmd, commonFlags)

--- a/internal/deploy/status.go
+++ b/internal/deploy/status.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 
 	"github.com/exasol/exasol-personal/internal/config"
 )
@@ -26,9 +27,10 @@ const (
 )
 
 type StatusOutput struct {
-	Status  string `json:"status"`
-	Message string `json:"message,omitempty"`
-	Error   string `json:"error,omitempty"`
+	DeploymentDir string `json:"deploymentDir"`
+	Status        string `json:"status"`
+	Message       string `json:"message,omitempty"`
+	Error         string `json:"error,omitempty"`
 }
 
 func StatusJSONFormatter(status StatusOutput) (string, error) {
@@ -42,6 +44,7 @@ func StatusJSONFormatter(status StatusOutput) (string, error) {
 
 func StatusTextFormatter(status StatusOutput) (string, error) {
 	output := ""
+	output += fmt.Sprintf("Deployment directory: %s\n", status.DeploymentDir)
 	output += fmt.Sprintf("Status: %s\n", status.Status)
 
 	if status.Message != "" {
@@ -86,6 +89,7 @@ func statusWithFormatter(
 	if err != nil || status == nil {
 		return "", err
 	}
+	status.DeploymentDir = deployment.Root()
 
 	return format(*status)
 }
@@ -112,25 +116,35 @@ func GetStatusWithLock(
 		return getErr
 	})
 	if err != nil {
-		if errors.Is(err, ErrDeploymentDirectoryLocked) {
-			lockMessage := deploymentLockMessage(err)
-			if lockMessage == "" {
-				lockMessage = lockUnavailableMessage
-			}
-
-			return &StatusOutput{
-				Status:  StatusOperationInProgress,
-				Message: lockMessage,
-			}, nil
-		}
-		if errors.Is(err, context.Canceled) {
-			return nil, err
-		}
-
-		return nil, err
+		return statusFromLockError(err)
 	}
 
 	return status, nil
+}
+
+func statusFromLockError(err error) (*StatusOutput, error) {
+	if errors.Is(err, os.ErrNotExist) {
+		return notInitializedStatus(), nil
+	}
+	if errors.Is(err, ErrDeploymentDirectoryLocked) {
+		return operationInProgressStatus(deploymentLockMessage(err)), nil
+	}
+	if errors.Is(err, context.Canceled) {
+		return nil, err
+	}
+
+	return nil, err
+}
+
+func operationInProgressStatus(lockMessage string) *StatusOutput {
+	if lockMessage == "" {
+		lockMessage = lockUnavailableMessage
+	}
+
+	return &StatusOutput{
+		Status:  StatusOperationInProgress,
+		Message: lockMessage,
+	}
 }
 
 // nolint: revive
@@ -141,16 +155,16 @@ func GetStatus(
 ) (*StatusOutput, error) {
 	exasolState, err := config.ReadExasolPersonalState(deployment)
 	if err != nil {
+		if errors.Is(err, config.ErrMissingConfigFile) {
+			return notInitializedStatus(), nil
+		}
+
 		return nil, err
 	}
 
 	workflowState, err := exasolState.GetWorkflowState()
 	if errors.Is(err, config.ErrMissingConfigFile) {
-		return &StatusOutput{
-			Status: StatusNotInitialized,
-			Message: "No workflow state file was found. " +
-				"Run `init` or `install` to start a new deployment in this directory.",
-		}, nil
+		return notInitializedStatus(), nil
 	} else if err != nil {
 		return nil, err
 	}
@@ -237,6 +251,14 @@ func GetStatus(
 
 	default:
 		panic("unknown workflow state")
+	}
+}
+
+func notInitializedStatus() *StatusOutput {
+	return &StatusOutput{
+		Status: StatusNotInitialized,
+		Message: "No workflow state file was found. " +
+			"Run `init` or `install` to start a new deployment in this directory.",
 	}
 }
 

--- a/internal/deploy/status_test.go
+++ b/internal/deploy/status_test.go
@@ -1,0 +1,117 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/directorymutex"
+)
+
+func TestStatus_IncludesDeploymentDirInTextOutput(t *testing.T) {
+	t.Parallel()
+
+	// Given: an uninitialized deployment directory.
+	deployment := config.NewDeploymentDir(t.TempDir())
+
+	// When: status is rendered as text.
+	output, err := Status(context.Background(), deployment, StatusTextFormatter)
+	// Then: the output includes the active deployment directory and status.
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if !strings.Contains(output, "Deployment directory: "+deployment.Root()) {
+		t.Fatalf("expected deployment directory in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Status: "+StatusNotInitialized) {
+		t.Fatalf("expected not initialized status in output, got:\n%s", output)
+	}
+}
+
+func TestStatus_IncludesDeploymentDirInJSONOutput(t *testing.T) {
+	t.Parallel()
+
+	// Given: an uninitialized deployment directory.
+	deployment := config.NewDeploymentDir(t.TempDir())
+
+	// When: status is rendered as JSON.
+	output, err := Status(context.Background(), deployment, StatusJSONFormatter)
+	// Then: the JSON includes the active deployment directory and status.
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	var status StatusOutput
+	if err := json.Unmarshal([]byte(output), &status); err != nil {
+		t.Fatalf("expected valid JSON, got %q: %v", output, err)
+	}
+	if status.DeploymentDir != deployment.Root() {
+		t.Fatalf("expected deployment dir %q, got %q", deployment.Root(), status.DeploymentDir)
+	}
+	if status.Status != StatusNotInitialized {
+		t.Fatalf("expected status %q, got %q", StatusNotInitialized, status.Status)
+	}
+}
+
+func TestStatus_ReportsNotInitializedForMissingDirectory(t *testing.T) {
+	t.Parallel()
+
+	// Given: a deployment directory path that does not exist.
+	deployment := config.NewDeploymentDir(t.TempDir() + "/missing")
+
+	// When: status is requested.
+	output, err := Status(context.Background(), deployment, StatusJSONFormatter)
+	// Then: status reports not initialized instead of failing.
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	var status StatusOutput
+	if err := json.Unmarshal([]byte(output), &status); err != nil {
+		t.Fatalf("expected valid JSON, got %q: %v", output, err)
+	}
+	if status.Status != StatusNotInitialized {
+		t.Fatalf("expected status %q, got %q", StatusNotInitialized, status.Status)
+	}
+}
+
+func TestStatus_ReportsOperationInProgressWhenLockedBeforeStateFileExists(t *testing.T) {
+	t.Parallel()
+
+	// Given: an existing deployment directory locked exclusively before init writes state.
+	deployment := config.NewDeploymentDir(t.TempDir())
+	mutex, err := directorymutex.New(deployment.Root())
+	if err != nil {
+		t.Fatalf("expected mutex creation to succeed, got: %v", err)
+	}
+	if err := mutex.AcquireExclusive(context.Background()); err != nil {
+		t.Fatalf("expected exclusive lock to succeed, got: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = mutex.ReleaseExclusive(context.Background())
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	// When: status is requested while the init lock is still held.
+	output, err := Status(ctx, deployment, StatusJSONFormatter)
+	// Then: the deployment is reported as having an operation in progress.
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	var status StatusOutput
+	if err := json.Unmarshal([]byte(output), &status); err != nil {
+		t.Fatalf("expected valid JSON, got %q: %v", output, err)
+	}
+	if status.Status != StatusOperationInProgress {
+		t.Fatalf("expected status %q, got %q", StatusOperationInProgress, status.Status)
+	}
+	if status.Message == "" {
+		t.Fatal("expected operation-in-progress message, got empty message")
+	}
+}

--- a/openspec/changes/archive/2026-05-28-add-default-deployment-directory/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-28-add-default-deployment-directory/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-28

--- a/openspec/changes/archive/2026-05-28-add-default-deployment-directory/design.md
+++ b/openspec/changes/archive/2026-05-28-add-default-deployment-directory/design.md
@@ -1,0 +1,90 @@
+## Context
+
+Deployment-directory selection is currently implicit in the `--deployment-dir` flag default: commands that register the flag receive the current directory as their deployment directory unless the user overrides it. That makes the default journey require users to create or remember a directory before installing, and it also means the CLI cannot clearly distinguish an omitted flag from an explicit directory choice.
+
+The implementation is cross-cutting because deployment-directory selection affects command pre-run validation, compatibility checks, deployment file logging, version update checks, status formatting, and documentation. The deployment directory remains the local source of truth for state; this change only changes how the CLI chooses that directory when the user did not provide one.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make the default workflow use `~/.exasol/personal/deployments/default` when no explicit directory or recognized current deployment directory is available.
+- Preserve explicit `--deployment-dir` and multiple deployment directory workflows.
+- Keep the selected directory visible in user-facing output, especially `status`.
+- Let `status` report `not_initialized` for uninitialized resolved directories.
+- Keep commands that require initialized state failing with actionable path-aware errors.
+- Avoid breaking machine-readable JSON output with human-only diagnostic messages.
+
+**Non-Goals:**
+- Adding commands for deleting deployment directories.
+- Moving deployment state out of deployment directories.
+- Introducing a global registry of deployments.
+- Migrating existing deployment directories into the default directory.
+
+## Decisions
+
+### Resolve the deployment directory once in the command layer
+
+The CLI will resolve the active deployment directory during root pre-run before compatibility enforcement, deployment file logging, version update hints, and command execution. The resolved path is written back to the common command state so existing command implementations can continue using the common deployment accessor.
+
+Rationale:
+- Resolution is a CLI concern because it depends on command flags, current working directory, and user-facing diagnostics.
+- Resolving once prevents commands from independently making different choices.
+- Writing the resolved value back keeps the implementation localized and avoids threading a new parameter through all commands.
+
+Alternatives considered:
+- Resolve independently inside each command. Rejected because it would duplicate precedence logic and risk inconsistent behavior.
+- Move resolution into the lower-level deployment package. Rejected because that package should not depend on CLI flag semantics or terminal messaging.
+
+### Treat explicit `--deployment-dir` as the highest-precedence signal
+
+The resolver will detect whether the deployment directory flag was explicitly provided and use that path when present, even if the current directory is also a deployment directory.
+
+Rationale:
+- Existing scripts using `--deployment-dir` must remain stable.
+- Explicit command-line input should override ambient current-directory state.
+
+Alternatives considered:
+- Prefer the current deployment directory when already inside one. Rejected because it would make explicit flags unreliable.
+
+### Recognize current deployment directories by launcher-owned markers
+
+When no explicit flag is present, the resolver will use the current working directory if it contains launcher-owned deployment state or marker files. This includes current state markers and legacy markers so that incompatible or older directories still flow into compatibility checks and produce the intended errors instead of being silently ignored.
+
+Rationale:
+- Users who `cd` into an existing deployment continue to manage that deployment.
+- Broken or legacy deployment directories should not be hidden by falling back to the default directory.
+- Random empty directories should not capture the default workflow.
+
+Alternatives considered:
+- Treat any current directory as the deployment directory. Rejected because it preserves the friction this change is removing.
+- Treat only fully compatible deployment directories as current deployment directories. Rejected because it could silently bypass legacy or damaged deployment directories.
+
+### Keep the default directory transparent but not noisy in JSON stdout
+
+Commands that resolve to the default directory will emit a clear human-facing message containing the resolved path. The message should use stderr or the existing logging path rather than stdout payload output.
+
+Rationale:
+- Users must be able to see where state is stored.
+- JSON output needs to remain parseable by automation.
+
+Alternatives considered:
+- Print the default-directory message to stdout for all commands. Rejected because it would corrupt JSON output.
+- Only show the default path in `status`. Rejected because install and other operations should make the state location visible immediately.
+
+### Make `status` valid for uninitialized resolved directories
+
+The status command will no longer require an initialized deployment directory before it runs. It will include the active deployment directory in text and JSON output and report `not_initialized` when the resolved directory has no initialized deployment state.
+
+Rationale:
+- `status` is a discovery command; failing solely because initialization has not happened is less useful than reporting that state.
+- Showing the active path in `status` gives users a consistent way to learn which directory a command context points at.
+
+Alternatives considered:
+- Keep `status` requiring initialized state. Rejected because it conflicts with the goal that commands produce useful messages in all circumstances.
+
+## Risks / Trade-offs
+
+- [Users who create an empty directory and run `exasol install` without `--deployment-dir` will use the default directory] -> Document the new default journey and explain that `--deployment-dir .` explicitly selects the current empty directory.
+- [Default-directory diagnostics could break command output consumers] -> Emit human-facing diagnostics on stderr/logging and keep JSON stdout valid.
+- [A current directory with partial launcher state could be selected and then fail compatibility] -> Preserve that failure because it is safer than silently operating on a different deployment.
+- [Status on a missing default directory could accidentally create state] -> Prefer reporting `not_initialized` without creating the directory; creation remains owned by init/install flows.

--- a/openspec/changes/archive/2026-05-28-add-default-deployment-directory/proposal.md
+++ b/openspec/changes/archive/2026-05-28-add-default-deployment-directory/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Exasol Personal currently makes users create, choose, and remember a deployment directory before the product has shown value. This adds friction for local-first workflows and can create cloud cost risk when users lose the directory needed to manage or destroy resources.
+
+## What Changes
+
+- Add a transparent default deployment directory at `~/.exasol/personal/deployments/default`.
+- Resolve deployment directories using this precedence: explicit `--deployment-dir`, valid current working directory, then the default directory.
+- Automatically create the default directory for commands that initialize or install a deployment.
+- Keep support for explicit and multiple deployment directories.
+- Print a clear message whenever a command resolves to the default directory.
+- Include the active deployment directory in `exasol status` output.
+- Make `exasol status` report `not_initialized` for uninitialized resolved directories instead of failing only because initialization has not happened yet.
+- Keep commands that require an initialized deployment failing clearly when the resolved directory is not initialized, with errors that include the resolved path.
+- Update user-facing help and documentation for the default location, precedence, override behavior, and cloud cleanup implications.
+
+## Capabilities
+
+### New Capabilities
+- `deployment-directory-resolution`: The CLI resolves, reports, and uses a deployment directory without requiring users to manually choose one for the default workflow.
+
+### Modified Capabilities
+
+## Impact
+
+- Affected CLI command wiring for deployment-directory flags, root pre-run behavior, compatibility enforcement, deployment logging setup, and version update checks.
+- Affected status output format for both text and JSON status responses.
+- Affected initialization and install workflows when no deployment directory flag is provided.
+- Documentation and help text updates in end-user CLI guidance.
+- No new external dependencies and no removal of support for multiple deployment directories.

--- a/openspec/changes/archive/2026-05-28-add-default-deployment-directory/specs/deployment-directory-resolution/spec.md
+++ b/openspec/changes/archive/2026-05-28-add-default-deployment-directory/specs/deployment-directory-resolution/spec.md
@@ -1,0 +1,102 @@
+## ADDED Requirements
+
+### Requirement: CLI SHALL resolve an active deployment directory
+Commands that operate on a deployment directory SHALL resolve exactly one active deployment directory before command-specific execution.
+
+#### Scenario: Explicit deployment directory wins
+- **WHEN** a user invokes a deployment command with `--deployment-dir <path>`
+- **THEN** the CLI uses `<path>` as the active deployment directory
+- **AND** the CLI does not use the current working directory or default deployment directory for that command
+
+#### Scenario: Recognized current deployment directory wins when no flag is provided
+- **WHEN** a user invokes a deployment command without `--deployment-dir`
+- **AND** the current working directory contains launcher-owned deployment state or marker files
+- **THEN** the CLI uses the current working directory as the active deployment directory
+
+#### Scenario: Default deployment directory is used when no stronger source exists
+- **WHEN** a user invokes a deployment command without `--deployment-dir`
+- **AND** the current working directory is not recognized as a deployment directory
+- **THEN** the CLI uses `~/.exasol/personal/deployments/default` as the active deployment directory
+
+### Requirement: CLI SHALL keep the default deployment directory visible
+Commands that resolve to the default deployment directory SHALL emit a clear human-facing message containing the resolved path.
+
+#### Scenario: Default directory message is shown
+- **WHEN** a deployment command resolves to the default deployment directory
+- **THEN** the user sees a message containing the resolved default deployment directory path
+
+#### Scenario: JSON payload output remains parseable
+- **WHEN** a deployment command produces JSON output and resolves to the default deployment directory
+- **THEN** the command's stdout remains valid JSON
+- **AND** any human-facing default-directory message is emitted outside the JSON payload
+
+### Requirement: Init and install SHALL create the default deployment directory when needed
+Commands that initialize a deployment SHALL automatically create the default deployment directory when resolution selects it and it does not already exist.
+
+#### Scenario: Install creates the default deployment directory
+- **WHEN** a user runs `exasol install <preset>` outside a recognized deployment directory without `--deployment-dir`
+- **THEN** the CLI creates `~/.exasol/personal/deployments/default`
+- **AND** the install proceeds using that directory
+
+#### Scenario: Init creates the default deployment directory
+- **WHEN** a user runs `exasol init <preset>` outside a recognized deployment directory without `--deployment-dir`
+- **THEN** the CLI creates `~/.exasol/personal/deployments/default`
+- **AND** initialization proceeds using that directory
+
+### Requirement: Commands that require initialized state SHALL fail clearly for uninitialized directories
+Deployment commands that require an initialized deployment SHALL fail when the resolved active deployment directory is not initialized, and the error SHALL include the resolved path.
+
+#### Scenario: Required initialized command uses default directory but it is uninitialized
+- **WHEN** a user runs a command that requires initialized deployment state outside a recognized deployment directory without `--deployment-dir`
+- **AND** the default deployment directory is not initialized
+- **THEN** the command fails with a message that says the deployment directory is not initialized
+- **AND** the message includes the resolved default deployment directory path
+
+#### Scenario: Required initialized command uses explicit directory but it is uninitialized
+- **WHEN** a user runs a command that requires initialized deployment state with `--deployment-dir <path>`
+- **AND** `<path>` is not initialized
+- **THEN** the command fails with a message that says the deployment directory is not initialized
+- **AND** the message includes `<path>`
+
+### Requirement: Status SHALL report the active deployment directory
+The `status` command SHALL include the active deployment directory path in both text and JSON output.
+
+#### Scenario: Status reports explicit deployment directory
+- **WHEN** a user runs `exasol status --deployment-dir <path>`
+- **THEN** the status output includes `<path>` as the active deployment directory
+
+#### Scenario: Status reports current deployment directory
+- **WHEN** a user runs `exasol status` from a recognized deployment directory
+- **THEN** the status output includes the current working directory as the active deployment directory
+
+#### Scenario: Status reports default deployment directory
+- **WHEN** a user runs `exasol status` outside a recognized deployment directory without `--deployment-dir`
+- **THEN** the status output includes `~/.exasol/personal/deployments/default` as the active deployment directory
+
+### Requirement: Status SHALL report uninitialized resolved directories
+The `status` command SHALL report `not_initialized` for an uninitialized resolved deployment directory instead of failing only because initialization has not happened.
+
+#### Scenario: Status reports uninitialized default directory
+- **WHEN** a user runs `exasol status` outside a recognized deployment directory without `--deployment-dir`
+- **AND** the default deployment directory is not initialized
+- **THEN** the command succeeds
+- **AND** the status is `not_initialized`
+- **AND** the output includes the resolved default deployment directory path
+
+#### Scenario: Status reports uninitialized explicit directory
+- **WHEN** a user runs `exasol status --deployment-dir <path>`
+- **AND** `<path>` is not initialized
+- **THEN** the command succeeds
+- **AND** the status is `not_initialized`
+- **AND** the output includes `<path>` as the active deployment directory
+
+### Requirement: Documentation SHALL explain deployment directory behavior
+User-facing help and documentation SHALL explain the default deployment directory, precedence rules, override behavior, and cloud cleanup implications.
+
+#### Scenario: Help describes how to override the active deployment directory
+- **WHEN** a user reads command help for a deployment command
+- **THEN** the help explains that `--deployment-dir` overrides automatic deployment directory resolution
+
+#### Scenario: Documentation warns about preserving deployment directories for cloud cleanup
+- **WHEN** a user reads deployment documentation
+- **THEN** the documentation explains that cloud deployment directories should be kept until cloud resources are destroyed

--- a/openspec/changes/archive/2026-05-28-add-default-deployment-directory/tasks.md
+++ b/openspec/changes/archive/2026-05-28-add-default-deployment-directory/tasks.md
@@ -1,0 +1,28 @@
+## 1. Deployment Directory Resolution
+
+- [x] 1.1 Add a command-layer resolver for explicit flag, recognized current deployment directory, and default deployment directory precedence.
+- [x] 1.2 Update deployment directory flag handling so omitted and explicit values can be distinguished.
+- [x] 1.3 Wire resolution into root pre-run before compatibility checks, deployment file logging, version update hints, and command execution.
+- [x] 1.4 Emit a human-facing default-directory message on stderr/logging without corrupting JSON stdout.
+
+## 2. Command Behavior
+
+- [x] 2.1 Ensure `init` and `install` create and use the default deployment directory when resolution selects it.
+- [x] 2.2 Keep initialized-state enforcement for commands that require initialized deployments and include the resolved path in errors.
+- [x] 2.3 Change `status` so uninitialized resolved directories report `not_initialized` instead of failing solely because initialization is missing.
+- [x] 2.4 Add active deployment directory to status text and JSON output.
+
+## 3. Documentation and Help
+
+- [x] 3.1 Update root and command help text to explain the default directory and `--deployment-dir` override.
+- [x] 3.2 Update end-user documentation to describe precedence rules and the default workflow.
+- [x] 3.3 Update cloud cleanup guidance to explain why deployment directories should be kept until resources are destroyed.
+
+## 4. Tests and Verification
+
+- [x] 4.1 Add unit tests for explicit `--deployment-dir` precedence, recognized current directory precedence, and default fallback.
+- [x] 4.2 Add tests for default-directory creation during `init` or `install`.
+- [x] 4.3 Add tests for initialized-state errors including the resolved path.
+- [x] 4.4 Add tests for `status` output including active deployment directory in text and JSON.
+- [x] 4.5 Add tests for `status` reporting `not_initialized` on uninitialized explicit and default directories.
+- [x] 4.6 Run formatting, unit tests, and focused integration tests for deployment-directory and status behavior.

--- a/openspec/specs/deployment-directory-resolution/spec.md
+++ b/openspec/specs/deployment-directory-resolution/spec.md
@@ -1,0 +1,107 @@
+# deployment-directory-resolution Specification
+
+## Purpose
+Define how Exasol Personal resolves the active deployment directory so users can run deployment commands without first creating or changing into a directory, while preserving explicit overrides and existing deployment-directory workflows.
+
+## Requirements
+### Requirement: CLI SHALL resolve an active deployment directory
+Commands that operate on a deployment directory SHALL resolve exactly one active deployment directory before command-specific execution.
+
+#### Scenario: Explicit deployment directory wins
+- **WHEN** a user invokes a deployment command with `--deployment-dir <path>`
+- **THEN** the CLI uses `<path>` as the active deployment directory
+- **AND** the CLI does not use the current working directory or default deployment directory for that command
+
+#### Scenario: Recognized current deployment directory wins when no flag is provided
+- **WHEN** a user invokes a deployment command without `--deployment-dir`
+- **AND** the current working directory contains launcher-owned deployment state or marker files
+- **THEN** the CLI uses the current working directory as the active deployment directory
+
+#### Scenario: Default deployment directory is used when no stronger source exists
+- **WHEN** a user invokes a deployment command without `--deployment-dir`
+- **AND** the current working directory is not recognized as a deployment directory
+- **THEN** the CLI uses `~/.exasol/personal/deployments/default` as the active deployment directory
+
+### Requirement: CLI SHALL keep the default deployment directory visible
+Commands that resolve to the default deployment directory SHALL emit a clear human-facing message containing the resolved path.
+
+#### Scenario: Default directory message is shown
+- **WHEN** a deployment command resolves to the default deployment directory
+- **THEN** the user sees a message containing the resolved default deployment directory path
+
+#### Scenario: JSON payload output remains parseable
+- **WHEN** a deployment command produces JSON output and resolves to the default deployment directory
+- **THEN** the command's stdout remains valid JSON
+- **AND** any human-facing default-directory message is emitted outside the JSON payload
+
+### Requirement: Init and install SHALL create the default deployment directory when needed
+Commands that initialize a deployment SHALL automatically create the default deployment directory when resolution selects it and it does not already exist.
+
+#### Scenario: Install creates the default deployment directory
+- **WHEN** a user runs `exasol install <preset>` outside a recognized deployment directory without `--deployment-dir`
+- **THEN** the CLI creates `~/.exasol/personal/deployments/default`
+- **AND** the install proceeds using that directory
+
+#### Scenario: Init creates the default deployment directory
+- **WHEN** a user runs `exasol init <preset>` outside a recognized deployment directory without `--deployment-dir`
+- **THEN** the CLI creates `~/.exasol/personal/deployments/default`
+- **AND** initialization proceeds using that directory
+
+### Requirement: Commands that require initialized state SHALL fail clearly for uninitialized directories
+Deployment commands that require an initialized deployment SHALL fail when the resolved active deployment directory is not initialized, and the error SHALL include the resolved path.
+
+#### Scenario: Required initialized command uses default directory but it is uninitialized
+- **WHEN** a user runs a command that requires initialized deployment state outside a recognized deployment directory without `--deployment-dir`
+- **AND** the default deployment directory is not initialized
+- **THEN** the command fails with a message that says the deployment directory is not initialized
+- **AND** the message includes the resolved default deployment directory path
+
+#### Scenario: Required initialized command uses explicit directory but it is uninitialized
+- **WHEN** a user runs a command that requires initialized deployment state with `--deployment-dir <path>`
+- **AND** `<path>` is not initialized
+- **THEN** the command fails with a message that says the deployment directory is not initialized
+- **AND** the message includes `<path>`
+
+### Requirement: Status SHALL report the active deployment directory
+The `status` command SHALL include the active deployment directory path in both text and JSON output.
+
+#### Scenario: Status reports explicit deployment directory
+- **WHEN** a user runs `exasol status --deployment-dir <path>`
+- **THEN** the status output includes `<path>` as the active deployment directory
+
+#### Scenario: Status reports current deployment directory
+- **WHEN** a user runs `exasol status` from a recognized deployment directory
+- **THEN** the status output includes the current working directory as the active deployment directory
+
+#### Scenario: Status reports default deployment directory
+- **WHEN** a user runs `exasol status` outside a recognized deployment directory without `--deployment-dir`
+- **THEN** the status output includes `~/.exasol/personal/deployments/default` as the active deployment directory
+
+### Requirement: Status SHALL report uninitialized resolved directories
+The `status` command SHALL report `not_initialized` for an uninitialized resolved deployment directory instead of failing only because initialization has not happened.
+
+#### Scenario: Status reports uninitialized default directory
+- **WHEN** a user runs `exasol status` outside a recognized deployment directory without `--deployment-dir`
+- **AND** the default deployment directory is not initialized
+- **THEN** the command succeeds
+- **AND** the status is `not_initialized`
+- **AND** the output includes the resolved default deployment directory path
+
+#### Scenario: Status reports uninitialized explicit directory
+- **WHEN** a user runs `exasol status --deployment-dir <path>`
+- **AND** `<path>` is not initialized
+- **THEN** the command succeeds
+- **AND** the status is `not_initialized`
+- **AND** the output includes `<path>` as the active deployment directory
+
+### Requirement: Documentation SHALL explain deployment directory behavior
+User-facing help and documentation SHALL explain the default deployment directory, precedence rules, override behavior, and cloud cleanup implications.
+
+#### Scenario: Help describes how to override the active deployment directory
+- **WHEN** a user reads command help for a deployment command
+- **THEN** the help explains that `--deployment-dir` overrides automatic deployment directory resolution
+
+#### Scenario: Documentation warns about preserving deployment directories for cloud cleanup
+- **WHEN** a user reads deployment documentation
+- **THEN** the documentation explains that cloud deployment directories should be kept until cloud resources are destroyed
+

--- a/tests/tests/integration/test_deployment_directory_resolution.py
+++ b/tests/tests/integration/test_deployment_directory_resolution.py
@@ -1,0 +1,145 @@
+# Copyright 2026 Exasol AG
+# SPDX-License-Identifier: MIT
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+from .helpers import first_infrastructure_preset_id_or_skip
+
+
+def _env_with_home(home: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["USERPROFILE"] = str(home)
+    env["HOMEDRIVE"] = ""
+    env["HOMEPATH"] = ""
+    return env
+
+
+def _default_dir_logged(stderr: str, default_dir: Path) -> bool:
+    for line in stderr.splitlines():
+        try:
+            decoded: object = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(decoded, dict):
+            continue
+        if decoded.get("msg") != "using default deployment directory":
+            continue
+
+        logged_path = decoded.get("path")
+        if isinstance(logged_path, str) and Path(logged_path) == default_dir:
+            return True
+
+    return False
+
+
+def _assert_default_dir_logged(stderr: str, default_dir: Path) -> None:
+    assert _default_dir_logged(stderr, default_dir), (
+        f"expected default deployment directory {str(default_dir)!r} "
+        f"in stderr logs:\n{stderr}"
+    )
+
+
+def test_status_uses_default_deployment_dir_without_corrupting_json(
+    exasol_path: str, tmp_path: Path
+) -> None:
+    # Given a home directory without a default deployment directory
+    home = tmp_path / "home"
+    cwd = tmp_path / "work"
+    home.mkdir()
+    cwd.mkdir()
+    default_dir = home / ".exasol" / "personal" / "deployments" / "default"
+    launcher = str(Path(exasol_path).resolve())
+
+    # When status is invoked outside a deployment directory
+    result = subprocess.run(
+        [launcher, "status", "--json"],
+        cwd=cwd,
+        env=_env_with_home(home),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    # Then stdout stays parseable JSON and status reports the default directory
+    data = json.loads(result.stdout)
+    assert data["status"] == "not_initialized"
+    assert data["deploymentDir"] == str(default_dir)
+    _assert_default_dir_logged(result.stderr, default_dir)
+
+
+def test_status_reports_uninitialized_explicit_deployment_dir(
+    exasol_path: str, tmp_path: Path
+) -> None:
+    # Given an explicit uninitialized deployment directory
+    deployment_dir = tmp_path / "deployment"
+    deployment_dir.mkdir()
+    launcher = str(Path(exasol_path).resolve())
+
+    # When status is invoked for that directory
+    result = subprocess.run(
+        [launcher, "status", "--json", "--deployment-dir", str(deployment_dir)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    # Then it succeeds and reports not_initialized
+    data = json.loads(result.stdout)
+    assert data["status"] == "not_initialized"
+    assert data["deploymentDir"] == str(deployment_dir)
+
+
+def test_init_creates_default_deployment_dir(exasol_path: str, tmp_path: Path) -> None:
+    # Given no deployment directory flag and no recognized current deployment directory
+    home = tmp_path / "home"
+    cwd = tmp_path / "work"
+    home.mkdir()
+    cwd.mkdir()
+    default_dir = home / ".exasol" / "personal" / "deployments" / "default"
+    infra_id = first_infrastructure_preset_id_or_skip(exasol_path)
+    launcher = str(Path(exasol_path).resolve())
+
+    # When init is invoked
+    result = subprocess.run(
+        [launcher, "init", infra_id, "--no-launcher-version-check"],
+        cwd=cwd,
+        env=_env_with_home(home),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    # Then init creates and initializes the default deployment directory
+    assert (default_dir / ".exasolLauncherState.json").exists()
+    _assert_default_dir_logged(result.stderr, default_dir)
+
+
+def test_initialized_state_error_mentions_resolved_default_dir(
+    exasol_path: str, tmp_path: Path
+) -> None:
+    # Given no initialized deployment is available in the current or default directory
+    home = tmp_path / "home"
+    cwd = tmp_path / "work"
+    home.mkdir()
+    cwd.mkdir()
+    default_dir = home / ".exasol" / "personal" / "deployments" / "default"
+    launcher = str(Path(exasol_path).resolve())
+
+    # When a command requiring initialized state is invoked
+    result = subprocess.run(
+        [launcher, "info"],
+        cwd=cwd,
+        env=_env_with_home(home),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    # Then the error explains the resolved deployment directory
+    assert result.returncode != 0
+    assert "deployment directory is not initialized" in result.stderr.lower()
+    _assert_default_dir_logged(result.stderr, default_dir)


### PR DESCRIPTION
## Description

 Adds automatic deployment directory resolution so users can run `exasol install ...` without first creating or choosing a deployment directory.

  When `--deployment-dir` is omitted, Exasol Personal now resolves the active deployment directory in this order:

  1. Use `--deployment-dir` when provided.
  2. Use the current working directory when it is already a deployment directory.
  3. Otherwise use `~/.exasol/personal/deployments/default`.

  The default directory is shown to users when selected, and `exasol status` now reports the active deployment directory, including for uninitialized directories.


## Related Issue

Related: SPOT-30931

## Type of Change

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Added deployment directory resolution with precedence for explicit flag, recognized current directory, and default directory
- Made `exasol status` include the active deployment directory and report `not_initialized` for uninitialized resolved directories
- Updated help text, README, OpenSpec specs/archive, and focused unit/integration coverage

  ## CLI Examples

  Default install location:

  ```sh
  exasol install aws
  ```
  When run outside an existing deployment directory and without --deployment-dir, this initializes and installs using:  `~/.exasol/personal/deployments/default`

  Explicit override:
  ```sh
  exasol install aws --deployment-dir ./my-deployment
  ```
  
  Existing deployment directory workflow:
  ```sh
  cd ./my-existing-deployment
  exasol status
  ```
  
  Status now shows the active deployment directory:
  ```sh
  Deployment directory: /home/user/.exasol/personal/deployments/default
  Status: not_initialized
  Message: No workflow state file was found. Run `init` or `install` to start a new deployment in this directory.
  ``` 
  JSON status remains parseable:
  ```sh 
  exasol status --json

  {
    "deploymentDir": "/home/user/.exasol/personal/deployments/default",
    "status": "not_initialized",
    "message": "No workflow state file was found. Run `init` or `install` to start a new deployment in this directory."
  }
  ```

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

- Ran all tests

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

OpenSpec change archived as `openspec/changes/archive/2026-05-28-add-default-deployment-directory`.