### PR TITLE
docs: clarify agent contribution workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,5 +55,3 @@ Guidelines for AI agents working with documentation in this repository.
 **[doc/ci.md](doc/ci.md)** - CI/CD workflows, when they run, how to trigger them
 
 **[doc/release.md](doc/release.md)** - Release process, versioning, automation details
-
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,14 @@ Always read everything that is linked here at least once.
 
 **Testing** - Follow testing principles and patterns documented in [tests/README.md](tests/README.md). Apply those principles by inspecting existing test organization before adding new tests.
 
+## Repository Workflow
+
+Before creating a branch, committing, or opening a pull request, read [CONTRIBUTING.md](CONTRIBUTING.md) and follow the contribution process documented there.
+
+When preparing a branch or pull request, ask the user for a related Jira or GitHub issue ID if they have not already provided one; when provided, include it in the branch name and pull request description.
+
+For non-trivial changes, propose using OpenSpec even if the user has not asked for it; for OpenSpec-backed work, propose archiving the completed change before committing and opening a pull request.
+
 ## Documentation Guidelines
 
 Guidelines for AI agents working with documentation in this repository.
@@ -47,7 +55,5 @@ Guidelines for AI agents working with documentation in this repository.
 **[doc/ci.md](doc/ci.md)** - CI/CD workflows, when they run, how to trigger them
 
 **[doc/release.md](doc/release.md)** - Release process, versioning, automation details
-
-
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ Thank you for your interest in contributing! We welcome contributions from the c
 
 - **Keep PRs focused** - one feature or fix per PR
 - **Write clear descriptions** - explain what and why, not just how
+- **Use the [pull request template](.github/pull_request_template.md)** when submitting a pull request
 - **Use semantic commit messages** - follow [Conventional Commits](https://www.conventionalcommits.org/) format:
   - `feat:` new features
   - `fix:` bug fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ Thank you for your interest in contributing! We welcome contributions from the c
 
 - **Keep PRs focused** - one feature or fix per PR
 - **Write clear descriptions** - explain what and why, not just how
+- **Explain CLI changes with examples** - when changing CLI commands or behavior, describe the user-visible behavior in the PR description and include example invocations or output
 - **Use the [pull request template](.github/pull_request_template.md)** when submitting a pull request
 - **Use semantic commit messages** - follow [Conventional Commits](https://www.conventionalcommits.org/) format:
   - `feat:` new features


### PR DESCRIPTION
## Description

Clarifies the contribution workflow for AI agents by making them read the repository contribution process before branch, commit, and pull request work. The contribution guide now explicitly requires using the PR template and asks contributors to explain CLI command or behavior changes with examples in the PR description.

## Related Issue

Related: SPOT-30931

## Type of Change

- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [x] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Added agent guidance to read `CONTRIBUTING.md` before branch, commit, or PR work
- Added agent guidance to ask for a related Jira or GitHub issue ID and include it when provided
- Added contribution guidance to use the repository pull request template
- Added contribution guidance to explain CLI changes with examples in PR descriptions

## Testing

- [ ] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [ ] Manually tested the changes

### Test Details

- Ran `git diff --check`

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [ ] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [ ] Added/updated tests
- [ ] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

Documentation-only change.