### PR TITLE
fix: allow info for stopped deployments without host

### DIFF
--- a/internal/deploy/connection_instructions.go
+++ b/internal/deploy/connection_instructions.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/exasol/exasol-personal/internal/config"
 )
@@ -23,6 +24,8 @@ const (
 )
 
 type ConnectionDetails struct {
+	DeploymentOverview
+
 	Hostname        string
 	DisplayHost     string
 	DBPort          string
@@ -31,14 +34,18 @@ type ConnectionDetails struct {
 	CertFingerprint string
 	InsecureSkipTLS bool
 	SecretsFilePath string
-	DeploymentName  string
 	PublicIp        string
 	SSHCommand      string
 	SSHPort         string
-	ClusterState    string
-	ClusterSize     int
 	ShellSupported  bool
 	AdminUISecured  bool
+}
+
+type DeploymentOverview struct {
+	DeploymentName  string
+	DeploymentState string
+	ClusterState    string
+	ClusterSize     int
 }
 
 type DocumentationLink struct {
@@ -54,7 +61,7 @@ type Details struct {
 	Documentation   []DocumentationLink `json:"documentation"`
 }
 
-func getConnectionDetails(deployment config.DeploymentDir) (*ConnectionDetails, error) {
+func readConnectionDetails(deployment config.DeploymentDir) (*ConnectionDetails, error) {
 	deploymentInfo, err := config.ReadDeploymentInfo(deployment)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read deployment info: %w", err)
@@ -69,9 +76,11 @@ func getConnectionDetails(deployment config.DeploymentDir) (*ConnectionDetails, 
 	}
 
 	return &ConnectionDetails{
-		DeploymentName:  connectionInfo.DeploymentName,
-		ClusterSize:     connectionInfo.ClusterSize,
-		ClusterState:    connectionInfo.ClusterState,
+		DeploymentOverview: DeploymentOverview{
+			DeploymentName: connectionInfo.DeploymentName,
+			ClusterSize:    connectionInfo.ClusterSize,
+			ClusterState:   connectionInfo.ClusterState,
+		},
 		Hostname:        connectionInfo.Host,
 		DisplayHost:     connectionInfo.DisplayHost,
 		PublicIp:        connectionInfo.PublicIP,
@@ -160,13 +169,13 @@ Or visit %s for general information about Exasol products.
 `, SQLClientsDocURL, ProductDocURL)
 }
 
-func GetHeader(connectionDetails *ConnectionDetails, wfState string) string {
+func renderDeploymentOverview(overview DeploymentOverview) string {
 	return `
 Exasol Personal Deployment Overview
-Deployment Name: ` + connectionDetails.DeploymentName + `
-Deployment State: ` + wfState + `
-Cluster Size: ` + strconv.Itoa(connectionDetails.ClusterSize) + `
-Cluster State: ` + connectionDetails.ClusterState + `
+Deployment Name: ` + overview.DeploymentName + `
+Deployment State: ` + overview.DeploymentState + `
+Cluster Size: ` + strconv.Itoa(overview.ClusterSize) + `
+Cluster State: ` + overview.ClusterState + `
 `
 }
 
@@ -201,29 +210,52 @@ func getConnectionInstructionsTextUnsafe(
 
 	switch wfState {
 	case StatusRunning:
-		connectionDetails, err := getConnectionDetails(deployment)
+		connectionDetails, err := readConnectionDetails(deployment)
 		if err != nil {
 			return "", err
 		}
-		content := GetHeader(
-			connectionDetails,
-			wfState,
+		overview := connectionDetails.DeploymentOverview
+		overview.DeploymentState = wfState
+		content := renderDeploymentOverview(
+			overview,
 		) + GetSQLInstructions(
 			connectionDetails,
 		) + GetDocumentationLink()
 
 		return content, nil
 	case StatusStopped:
-		connectionDetails, err := getConnectionDetails(deployment)
+		overview, err := readDeploymentOverview(deployment, wfState)
 		if err != nil {
 			return "", err
 		}
-		content := GetHeader(connectionDetails, wfState) + GetDocumentationLink()
+		content := renderDeploymentOverview(overview) + GetDocumentationLink()
 
 		return content, nil
 	default:
 		return deploymentStatus.Message, nil
 	}
+}
+
+func readDeploymentOverview(
+	deployment config.DeploymentDir,
+	wfState string,
+) (DeploymentOverview, error) {
+	deploymentInfo, err := config.ReadDeploymentInfo(deployment)
+	if err != nil {
+		return DeploymentOverview{}, fmt.Errorf("failed to read deployment info: %w", err)
+	}
+
+	clusterState := strings.TrimSpace(deploymentInfo.ClusterState)
+	if clusterState == "" {
+		clusterState = wfState
+	}
+
+	return DeploymentOverview{
+		DeploymentName:  deploymentInfo.DeploymentId,
+		DeploymentState: wfState,
+		ClusterSize:     deploymentInfo.ClusterSize,
+		ClusterState:    clusterState,
+	}, nil
 }
 
 func writeConnectionInstructionsFile(deployment config.DeploymentDir, content string) error {

--- a/internal/deploy/connection_instructions_test.go
+++ b/internal/deploy/connection_instructions_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+)
+
+func TestGetConnectionInstructionsTextStoppedDoesNotRequireConnectionHost(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	deployment := config.NewDeploymentDir(t.TempDir())
+	writeStoppedWorkflowState(t, deployment)
+	writeDeploymentInfoWithoutConnectionHost(t, deployment)
+
+	// When
+	content, err := getConnectionInstructionsTextUnsafe(context.Background(), deployment)
+	// Then
+	if err != nil {
+		t.Fatalf("expected stopped deployment info to be rendered, got error: %v", err)
+	}
+	assertContains(t, content, "Deployment State: stopped")
+	assertContains(t, content, "Cluster Size: 1")
+	assertContains(t, content, "Cluster State: stopped")
+}
+
+func writeStoppedWorkflowState(t *testing.T, deployment config.DeploymentDir) {
+	t.Helper()
+
+	state := &config.ExasolPersonalState{}
+	err := state.SetWorkflowStateAndWrite(&config.WorkflowStateStopped{}, deployment)
+	if err != nil {
+		t.Fatalf("failed to write stopped workflow state: %v", err)
+	}
+}
+
+func writeDeploymentInfoWithoutConnectionHost(t *testing.T, deployment config.DeploymentDir) {
+	t.Helper()
+
+	if err := config.WriteDeploymentInfo(deployment.Root(), &config.DeploymentInfo{
+		DeploymentId: "test-deployment",
+		ClusterSize:  1,
+		ClusterState: "stopped",
+		Connection: &config.DeploymentConnection{
+			DBPort: 8563,
+			UIPort: 8443,
+		},
+	}); err != nil {
+		t.Fatalf("failed to write deployment info: %v", err)
+	}
+}
+
+func assertContains(t *testing.T, content string, expected string) {
+	t.Helper()
+
+	if !strings.Contains(content, expected) {
+		t.Fatalf("expected content to contain %q, got:\n%s", expected, content)
+	}
+}


### PR DESCRIPTION
## Description

Fix `exasol info` for stopped deployments whose connection host is unavailable after infrastructure stop. The command now renders the deployment overview for stopped deployments without resolving connection host, ports, or secrets that are only needed for connection instructions.

## Related Issue

None.

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Split the terminal overview data from running-only connection details.
- Render stopped deployment info from deployment metadata instead of connection details.
- Added a regression test for stopped `info` output when the deployment connection host is missing.

## Testing

- [ ] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

### Test Details

- `go test ./internal/deploy`
- `task fmt`
- `task lint`
- `task tests-unit`

CLI behavior:

```bash
exasol info --deployment-dir /tmp/exasol-launcher-hek0n8qx
```

For a stopped deployment with no active connection host, the command now succeeds and prints the overview instead of failing while resolving connection details:

```text
Exasol Personal Deployment Overview
Deployment Name: <deployment-id>
Deployment State: stopped
Cluster Size: 1
Cluster State: stopped
```

Connection instructions are still only rendered for running deployments.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

Deployment tests were not rerun locally in this branch.
