### PR TITLE
docs: Improve STACKIT setup docs

### DIFF
--- a/HOWTO_SETUP_STACKIT_ACCOUNT.md
+++ b/HOWTO_SETUP_STACKIT_ACCOUNT.md
@@ -18,11 +18,15 @@ In the STACKIT portal, make sure you have an active organization with billing co
 
 ### 🔐 In the STACKIT Portal, do the following:
 
-1. Go to the resource manager.
+1. Go to the "Resource manager".
 2. Create a new project and enter it.
-3. Create a service account and select it.
-4. Create and download a service account key.
-5. Copy the project's UUID.
+3. Go to the "Service Accounts" menu in the "IAM" section.
+4. Create a service account and select it.
+5. Copy the service account's email.
+6. Create a service account key and download the JSON file.
+7. Go to the "Access" menu in the "IAM" section.
+8. Grant access to the service account using its email as the subject and give it the "Editor" role in the "Basic" section.
+9. Copy the project's UUID from the URL or the "Resource manager".
 
 ### 💻 On your local machine, do the following:
 


### PR DESCRIPTION
## Description

The STACKIT setup docs were missing some steps to give the service account permissions.

## Related Issue

[SPOT-30105](https://exasol.atlassian.net/browse/SPOT-30105)

## Type of Change

- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [x] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Modified the STACKIT setup docs.

## Testing

- [ ] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [ ] Manually tested the changes

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [ ] Added/updated tests
- [ ] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

[SPOT-30105]: https://exasol.atlassian.net/browse/SPOT-30105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ