### PR TITLE
fix: stabilize STACKIT cleanup resource deletion

### DIFF
--- a/tools/cleanup/internal/shared/types.go
+++ b/tools/cleanup/internal/shared/types.go
@@ -21,10 +21,11 @@ type DeploymentSummary struct {
 
 // ResourceRef identifies a resource found via tagging or relationship.
 type ResourceRef struct {
-	ARN    string       `json:"arn"`
-	Type   ResourceType `json:"type"`
-	Region string       `json:"region"`
-	ID     string       `json:"id"` // native ID (e.g., i-123, vol-abc)
+	ARN      string       `json:"arn"`
+	Type     ResourceType `json:"type"`
+	Region   string       `json:"region"`
+	ParentID string       `json:"parentId,omitempty"`
+	ID       string       `json:"id"` // native ID (e.g., i-123, vol-abc)
 }
 
 // ResourceMeta adds descriptive metadata used for planning & output.

--- a/tools/cleanup/internal/stackit/collect.go
+++ b/tools/cleanup/internal/stackit/collect.go
@@ -127,6 +127,25 @@ func CollectResources(ctx context.Context, projectId, region string, deploymentI
 				resources = append(resources, *meta)
 			}
 		}
+
+		for _, net := range networksResp.GetItems() {
+			nicsResp, err := iaasClient.DefaultAPI.ListNics(ctx, projectId, region, net.GetId()).Execute()
+			if err != nil {
+				slog.Debug("list network interfaces failed", "network_id", net.GetId(), "error", err)
+				continue
+			}
+
+			for _, nic := range nicsResp.GetItems() {
+				meta, err := ResourceMetaFromNIC(nic, projectId, region)
+				if err != nil {
+					return nil, err
+				}
+
+				if isDeployment(meta, deploymentId) {
+					resources = append(resources, *meta)
+				}
+			}
+		}
 	}
 
 	securityGroupsResp, err := iaasClient.DefaultAPI.ListSecurityGroups(ctx, projectId, region).Execute()
@@ -135,6 +154,22 @@ func CollectResources(ctx context.Context, projectId, region string, deploymentI
 	} else {
 		for _, sg := range securityGroupsResp.GetItems() {
 			meta, err := ResourceMetaFromSecurityGroup(sg, projectId, region)
+			if err != nil {
+				return nil, err
+			}
+
+			if isDeployment(meta, deploymentId) {
+				resources = append(resources, *meta)
+			}
+		}
+	}
+
+	publicIPsResp, err := iaasClient.DefaultAPI.ListPublicIPs(ctx, projectId, region).Execute()
+	if err != nil {
+		slog.Debug("list public IPs failed", "error", err)
+	} else {
+		for _, publicIP := range publicIPsResp.GetItems() {
+			meta, err := ResourceMetaFromPublicIP(publicIP, projectId, region)
 			if err != nil {
 				return nil, err
 			}
@@ -210,61 +245,8 @@ func CollectDeploymentDetails(
 	}
 
 	details := &DeploymentDetails{
-		Summary: DeploymentSummary{
-			ID:        deploymentId,
-			Provider:  "stackit",
-			Region:    region,
-			Owner:     "",
-			CreatedAt: time.Time{},
-			State:     StateUnknown,
-		},
+		Summary:   summarizeDeploymentResources(deploymentId, region, resources),
 		Resources: resources,
-	}
-
-	var earliest *time.Time
-	hasInstances := false
-	hasActive := false
-	hasStopped := false
-
-	for _, meta := range resources {
-		if meta.Ref.Type == ResourceServer {
-			state := meta.Attr["status"].(string)
-			switch state {
-			case StateActive:
-				hasActive = true
-			case StateStopped:
-				hasStopped = true
-			}
-		}
-
-		createdAt, ok := meta.Attr["createdAt"].(time.Time)
-		if ok && !createdAt.IsZero() && createdAt.Before(*earliest) {
-			earliest = &createdAt
-		}
-	}
-
-	// Update summary
-	details.Summary.Resources = len(details.Resources)
-	if earliest != nil {
-		details.Summary.CreatedAt = *earliest
-	}
-
-	// Determine state
-	if hasInstances {
-		switch {
-		case hasActive:
-			details.Summary.State = StateActive
-		case hasStopped:
-			details.Summary.State = StateStopped
-		case details.Summary.Resources > 0:
-			details.Summary.State = StateTerminated
-		}
-	} else if details.Summary.Resources > 0 {
-		details.Summary.State = "orphaned"
-	}
-
-	if details.Summary.Owner == "" {
-		details.Summary.Owner = "-"
 	}
 
 	return details, nil
@@ -281,60 +263,121 @@ func CollectDeploymentSummaries(
 		return nil, err
 	}
 
-	summaries := make(map[string]*DeploymentSummary)
+	resourcesByDeployment := make(map[string][]ResourceMeta)
 	for _, meta := range resources {
 		depId, ok := getDeploymentId(&meta)
 		if ok {
-			sum, ok := summaries[depId]
-			if !ok {
-				sum = &DeploymentSummary{
-					ID:        depId,
-					Provider:  "stackit",
-					Region:    region,
-					Owner:     "",
-					CreatedAt: time.Time{},
-					State:     StateUnknown,
-				}
-
-				summaries[depId] = sum
-			}
-
-			sum.Resources++
-
-			if meta.Ref.Type == ResourceServer {
-				state := meta.Attr["state"].(string)
-				switch state {
-				case StateActive:
-					if sum.State != StateActive {
-						sum.State = StateActive
-					}
-				case StateStopped:
-					if sum.State != StateActive {
-						sum.State = StateStopped
-					}
-				}
-			}
-
-			createdAt, ok := meta.Attr["createdAt"].(time.Time)
-			if ok && !createdAt.IsZero() && createdAt.Before(sum.CreatedAt) {
-				sum.CreatedAt = createdAt
-			}
+			resourcesByDeployment[depId] = append(resourcesByDeployment[depId], meta)
 		}
 	}
 
 	// Convert map to slice
-	result := make([]DeploymentSummary, 0, len(summaries))
-	for _, s := range summaries {
-		if s.Owner == "" {
-			s.Owner = "-"
-		}
-		result = append(result, *s)
+	result := make([]DeploymentSummary, 0, len(resourcesByDeployment))
+	for deploymentID, deploymentResources := range resourcesByDeployment {
+		result = append(result, summarizeDeploymentResources(deploymentID, region, deploymentResources))
 	}
 
 	return result, nil
 }
 
 // Helper functions
+
+func summarizeDeploymentResources(
+	deploymentID string,
+	region string,
+	resources []ResourceMeta,
+) DeploymentSummary {
+	summary := DeploymentSummary{
+		ID:        deploymentID,
+		Provider:  "stackit",
+		Region:    region,
+		Owner:     "",
+		CreatedAt: time.Time{},
+		State:     StateUnknown,
+		Resources: len(resources),
+	}
+
+	var earliest *time.Time
+	hasInstances := false
+	hasActive := false
+	hasProvisioning := false
+	hasStopped := false
+
+	for _, meta := range resources {
+		if summary.Owner == "" {
+			if owner := firstNonEmpty(meta.Tags["Owner"], meta.Tags["owner"]); owner != "" {
+				summary.Owner = owner
+			}
+		}
+
+		if meta.Ref.Type == ResourceServer {
+			hasInstances = true
+			if state, ok := meta.Attr["state"].(string); ok {
+				switch state {
+				case StateActive:
+					hasActive = true
+				case StateProvisioning:
+					hasProvisioning = true
+				case StateStopped:
+					hasStopped = true
+				}
+			}
+		}
+
+		if createdAt, ok := meta.Attr["createdAt"].(time.Time); ok && !createdAt.IsZero() {
+			earliest = preferEarlierTime(earliest, createdAt)
+		}
+	}
+
+	if earliest != nil {
+		summary.CreatedAt = *earliest
+	}
+
+	if hasInstances {
+		switch {
+		case hasActive:
+			summary.State = StateActive
+		case hasProvisioning:
+			summary.State = StateProvisioning
+		case hasStopped:
+			summary.State = StateStopped
+		case summary.Resources > 0:
+			summary.State = StateTerminated
+		}
+	} else if summary.Resources > 0 {
+		summary.State = "orphaned"
+	}
+
+	if summary.Owner == "" {
+		summary.Owner = "-"
+	}
+
+	return summary
+}
+
+func preferEarlierTime(existing *time.Time, candidate time.Time) *time.Time {
+	if candidate.IsZero() {
+		return existing
+	}
+
+	if existing == nil || candidate.Before(*existing) {
+		candidateCopy := candidate
+
+		return &candidateCopy
+	}
+
+	return existing
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+
+	return ""
+}
 
 func ResourceMetaFromServer(server iaas.Server, projectId, region string) (*ResourceMeta, error) {
 	labels, err := toStringMap(server.GetLabels())
@@ -425,6 +468,68 @@ func ResourceMetaFromNetwork(net iaas.Network, projectId, region string) (*Resou
 	return &meta, nil
 }
 
+func ResourceMetaFromNIC(nic iaas.NIC, projectId, region string) (*ResourceMeta, error) {
+	labels, err := toStringMap(nic.GetLabels())
+	if err != nil {
+		return nil, err
+	}
+
+	id := nic.GetId()
+	name := nic.GetName()
+	networkID := nic.GetNetworkId()
+	device := nic.GetDevice()
+	ipv4 := nic.GetIpv4()
+	status := strings.ToLower(nic.GetStatus())
+
+	meta := ResourceMeta{
+		Ref: ResourceRef{
+			ARN:      nicARN(region, projectId, networkID, id),
+			Type:     ResourceNetworkInterface,
+			Region:   region,
+			ParentID: networkID,
+			ID:       id,
+		},
+		Tags: labels,
+		Attr: map[string]any{
+			"name":      name,
+			"networkId": networkID,
+			"device":    device,
+			"ipv4":      ipv4,
+			"state":     status,
+		},
+	}
+
+	return &meta, nil
+}
+
+func ResourceMetaFromPublicIP(publicIP iaas.PublicIp, projectId, region string) (*ResourceMeta, error) {
+	labels, err := toStringMap(publicIP.GetLabels())
+	if err != nil {
+		return nil, err
+	}
+
+	id := publicIP.GetId()
+	ip := publicIP.GetIp()
+	networkInterfaceID := publicIP.GetNetworkInterface()
+
+	meta := ResourceMeta{
+		Ref: ResourceRef{
+			ARN:    publicIPARN(region, projectId, id),
+			Type:   ResourcePublicIP,
+			Region: region,
+			ID:     id,
+		},
+		Tags: labels,
+		Attr: map[string]any{
+			"name":             ip,
+			"ip":               ip,
+			"networkInterface": networkInterfaceID,
+		},
+	}
+
+	return &meta, nil
+}
+
 func ResourceMetaFromSecurityGroup(sg iaas.SecurityGroup, projectId, region string) (*ResourceMeta, error) {
 	labels, err := toStringMap(sg.GetLabels())
 	if err != nil {
@@ -476,27 +581,42 @@ func ResourceMetaFromAccessKey(key objectstorage.AccessKey, projectId, region st
 
 	id := key.GetKeyId()
 	name := key.GetDisplayName()
+	expires := key.GetExpires()
+	credentialsGroupID, _ := firstStringAdditionalProperty(key.AdditionalProperties, "credentialsGroupId", "credentialsGroupID", "groupId")
 
 	meta := ResourceMeta{
 		Ref: ResourceRef{
-			ARN:    credentialARN(region, projectId, id),
-			Type:   ResourceObjectStorageCredential,
-			Region: region,
-			ID:     id,
+			ARN:      credentialARN(region, projectId, id),
+			Type:     ResourceObjectStorageCredential,
+			Region:   region,
+			ParentID: credentialsGroupID,
+			ID:       id,
 		},
 		Tags: map[string]string{},
 		Attr: map[string]any{
-			"name": name,
+			"name":    name,
+			"expires": expires,
 		},
+	}
+
+	for _, keyName := range []string{"credentialsGroupId", "credentialsGroupID", "credentialsGroupName", "groupId", "groupName", "userUrn", "userURN", "urn"} {
+		if value, ok := stringAdditionalProperty(key.AdditionalProperties, keyName); ok {
+			meta.Attr[keyName] = value
+		}
 	}
 
 	return &meta, nil
 }
 
-func ResourceMetaFromCredentialsGroup(cg objectstorage.CredentialsGroup, projectId, region string) (*ResourceMeta, error) {
+func ResourceMetaFromCredentialsGroup(
+	cg objectstorage.CredentialsGroup,
+	projectId,
+	region string,
+) (*ResourceMeta, error) {
 
 	id := cg.GetCredentialsGroupId()
 	name := cg.GetDisplayName()
+	urn := cg.GetUrn()
 
 	meta := ResourceMeta{
 		Ref: ResourceRef{
@@ -508,6 +628,7 @@ func ResourceMetaFromCredentialsGroup(cg objectstorage.CredentialsGroup, project
 		Tags: map[string]string{},
 		Attr: map[string]any{
 			"name": name,
+			"urn":  urn,
 		},
 	}
 
@@ -523,7 +644,7 @@ func isDeployment(meta *ResourceMeta, deploymentId *string) bool {
 		return true
 	}
 
-	if name, ok := meta.Attr["name"]; ok && (strings.HasPrefix(name.(string), *deploymentId+"-") || name == *deploymentId) {
+	if name, ok := meta.Attr["name"].(string); ok && (strings.HasPrefix(name, *deploymentId+"-") || name == *deploymentId) {
 		return true
 	}
 
@@ -565,6 +686,34 @@ func toStringMap(m map[string]interface{}) (map[string]string, error) {
 	return result, nil
 }
 
+func stringAdditionalProperty(properties map[string]interface{}, key string) (string, bool) {
+	if properties == nil {
+		return "", false
+	}
+
+	value, ok := properties[key]
+	if !ok {
+		return "", false
+	}
+
+	stringValue, ok := value.(string)
+	if !ok || stringValue == "" {
+		return "", false
+	}
+
+	return stringValue, true
+}
+
+func firstStringAdditionalProperty(properties map[string]interface{}, keys ...string) (string, bool) {
+	for _, key := range keys {
+		if value, ok := stringAdditionalProperty(properties, key); ok {
+			return value, true
+		}
+	}
+
+	return "", false
+}
+
 func serverStateToSimple(state string) string {
 	switch state {
 	case "ACTIVE", "BACKING-UP", "SNAPSHOTTING", "STARTING":
@@ -600,6 +749,14 @@ func serverARN(region, projectId, id string) string {
 
 func volumeARN(region, projectId, id string) string {
 	return fmt.Sprintf("stackit:%s:project:%s:volume:%s", region, projectId, id)
+}
+
+func publicIPARN(region, projectId, id string) string {
+	return fmt.Sprintf("stackit:%s:project:%s:public-ip:%s", region, projectId, id)
+}
+
+func nicARN(region, projectId, networkID, id string) string {
+	return fmt.Sprintf("stackit:%s:project:%s:network:%s:nic:%s", region, projectId, networkID, id)
 }
 
 func networkARN(region, projectId, id string) string {

--- a/tools/cleanup/internal/stackit/collect_test.go
+++ b/tools/cleanup/internal/stackit/collect_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package stackit
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSummarizeDeploymentResourcesUsesEarliestTimestampAndActiveState(t *testing.T) {
+	t.Parallel()
+
+	createdLater := time.Date(2026, time.January, 2, 10, 0, 0, 0, time.UTC)
+	createdEarlier := time.Date(2026, time.January, 1, 8, 30, 0, 0, time.UTC)
+
+	resources := []ResourceMeta{
+		{
+			Ref:  ResourceRef{Type: ResourceServer},
+			Tags: map[string]string{"owner": "qa-team"},
+			Attr: map[string]any{
+				"name":      "exasol-251a4801-node-1",
+				"state":     StateActive,
+				"createdAt": createdLater,
+			},
+		},
+		{
+			Ref:  ResourceRef{Type: ResourceVolume},
+			Tags: map[string]string{},
+			Attr: map[string]any{
+				"name":      "exasol-251a4801-volume",
+				"createdAt": createdEarlier,
+			},
+		},
+	}
+
+	// Given a deployment with multiple resources and mixed timestamps
+	// When the summary is derived from the resource list
+	summary := summarizeDeploymentResources("exasol-251a4801", "eu01", resources)
+
+	// Then it keeps the earliest timestamp and marks the deployment active
+	if summary.CreatedAt != createdEarlier {
+		t.Fatalf("expected earliest createdAt %v, got %v", createdEarlier, summary.CreatedAt)
+	}
+	if summary.State != StateActive {
+		t.Fatalf("expected state %q, got %q", StateActive, summary.State)
+	}
+	if summary.Owner != "qa-team" {
+		t.Fatalf("expected owner %q, got %q", "qa-team", summary.Owner)
+	}
+	if summary.Resources != len(resources) {
+		t.Fatalf("expected %d resources, got %d", len(resources), summary.Resources)
+	}
+}
+
+func TestSummarizeDeploymentResourcesMarksProvisioningServers(t *testing.T) {
+	t.Parallel()
+
+	resources := []ResourceMeta{
+		{
+			Ref:  ResourceRef{Type: ResourceServer},
+			Tags: map[string]string{},
+			Attr: map[string]any{
+				"name":  "exasol-251a4801-node-1",
+				"state": StateProvisioning,
+			},
+		},
+	}
+
+	// Given a deployment with a server still coming up
+	// When the summary is derived from the resource list
+	summary := summarizeDeploymentResources("exasol-251a4801", "eu01", resources)
+
+	// Then the deployment stays in provisioning instead of looking terminated
+	if summary.State != StateProvisioning {
+		t.Fatalf("expected state %q, got %q", StateProvisioning, summary.State)
+	}
+	if summary.Owner != "-" {
+		t.Fatalf("expected fallback owner %q, got %q", "-", summary.Owner)
+	}
+
+}
+
+func TestSummarizeDeploymentResourcesMarksOrphanedWithoutServers(t *testing.T) {
+	t.Parallel()
+
+	resources := []ResourceMeta{
+		{
+			Ref:  ResourceRef{Type: ResourceObjectStorageBucket},
+			Tags: map[string]string{},
+			Attr: map[string]any{"name": "exasol-251a4801"},
+		},
+	}
+
+	// Given a deployment that only has non-server resources left
+	// When the summary is derived from the resource list
+	summary := summarizeDeploymentResources("exasol-251a4801", "eu01", resources)
+
+	// Then it is reported as orphaned and no panic occurs
+	if summary.State != "orphaned" {
+		t.Fatalf("expected state %q, got %q", "orphaned", summary.State)
+	}
+	if !summary.CreatedAt.IsZero() {
+		t.Fatalf("expected zero createdAt, got %v", summary.CreatedAt)
+	}
+}

--- a/tools/cleanup/internal/stackit/handlers.go
+++ b/tools/cleanup/internal/stackit/handlers.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	iaas "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api"
 	iaasWait "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api/wait"
@@ -16,6 +17,13 @@ import (
 )
 
 var ErrUnsupportedResource = errors.New("unsupported resource type for deletion")
+
+const (
+	stackitDeleteRetryCount = 15
+	stackitDeleteRetryDelay = 2 * time.Second
+	stackitBucketRetryCount = 3
+	stackitBucketRetryDelay = 2 * time.Second
+)
 
 var iaasClient *iaas.APIClient
 var objectStorageClient *objectstorage.APIClient
@@ -36,6 +44,8 @@ func deleteResource(ctx context.Context, projectId, region string, ref ResourceR
 	deleters := map[ResourceType]func(context.Context, ResourceRef) error{
 		ResourceServer:                        h.DeleteServer,
 		ResourceVolume:                        h.DeleteVolume,
+		ResourcePublicIP:                      h.DeletePublicIP,
+		ResourceNetworkInterface:              h.DeleteNetworkInterface,
 		ResourceNetwork:                       h.DeleteNetwork,
 		ResourceSecurityGroup:                 h.DeleteSecurityGroup,
 		ResourceObjectStorageBucket:           h.DeleteObjectStorageBucket,
@@ -59,17 +69,21 @@ type handler struct {
 }
 
 func (h *handler) DeleteServer(ctx context.Context, ref ResourceRef) error {
-	err := h.iaasClient.DefaultAPI.DeleteServer(context.Background(), h.projectId, h.region, ref.ID).Execute()
+	deleted, err := deleteWithRetry(ctx, stackitDeleteRetryCount, stackitDeleteRetryDelay, func() error {
+		return h.iaasClient.DefaultAPI.DeleteServer(ctx, h.projectId, h.region, ref.ID).Execute()
+	})
 	if err != nil {
-		// Treat not found as success for idempotent cleanup
-		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
-			return nil
-		}
 		return fmt.Errorf("failed to delete server: %w", err)
 	}
+	if !deleted {
+		return nil
+	}
 
-	_, err = iaasWait.DeleteServerWaitHandler(context.Background(), h.iaasClient.DefaultAPI, h.projectId, h.region, ref.ID).WaitWithContext(context.Background())
+	_, err = iaasWait.DeleteServerWaitHandler(ctx, h.iaasClient.DefaultAPI, h.projectId, h.region, ref.ID).WaitWithContext(ctx)
 	if err != nil {
+		if isNotFoundError(err) {
+			return nil
+		}
 		return fmt.Errorf("failed to wait for server deletion: %w", err)
 	}
 
@@ -77,30 +91,58 @@ func (h *handler) DeleteServer(ctx context.Context, ref ResourceRef) error {
 }
 
 func (h *handler) DeleteVolume(ctx context.Context, ref ResourceRef) error {
-	err := h.iaasClient.DefaultAPI.DeleteVolume(context.Background(), h.projectId, h.region, ref.ID).Execute()
+	deleted, err := deleteWithRetry(ctx, stackitDeleteRetryCount, stackitDeleteRetryDelay, func() error {
+		return h.iaasClient.DefaultAPI.DeleteVolume(ctx, h.projectId, h.region, ref.ID).Execute()
+	})
 	if err != nil {
-		// Treat not found as success for idempotent cleanup
-		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
-			return nil
-		}
 		return fmt.Errorf("failed to delete volume: %w", err)
 	}
+	if !deleted {
+		return nil
+	}
 
-	_, err = iaasWait.DeleteVolumeWaitHandler(context.Background(), h.iaasClient.DefaultAPI, h.projectId, h.region, ref.ID).WaitWithContext(context.Background())
+	_, err = iaasWait.DeleteVolumeWaitHandler(ctx, h.iaasClient.DefaultAPI, h.projectId, h.region, ref.ID).WaitWithContext(ctx)
 	if err != nil {
+		if isNotFoundError(err) {
+			return nil
+		}
 		return fmt.Errorf("failed to wait for volume deletion: %w", err)
 	}
 
 	return nil
 }
 
-func (h *handler) DeleteSecurityGroup(ctx context.Context, ref ResourceRef) error {
-	err := h.iaasClient.DefaultAPI.DeleteSecurityGroup(context.Background(), h.projectId, h.region, ref.ID).Execute()
+func (h *handler) DeletePublicIP(ctx context.Context, ref ResourceRef) error {
+	_, err := deleteWithRetry(ctx, stackitDeleteRetryCount, stackitDeleteRetryDelay, func() error {
+		return h.iaasClient.DefaultAPI.DeletePublicIP(ctx, h.projectId, h.region, ref.ID).Execute()
+	})
 	if err != nil {
-		// Treat not found as success for idempotent cleanup
-		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
-			return nil
-		}
+		return fmt.Errorf("failed to delete public IP: %w", err)
+	}
+
+	return nil
+}
+
+func (h *handler) DeleteNetworkInterface(ctx context.Context, ref ResourceRef) error {
+	if ref.ParentID == "" {
+		return errors.New("failed to delete network interface: missing parent network id")
+	}
+
+	_, err := deleteWithRetry(ctx, stackitDeleteRetryCount, stackitDeleteRetryDelay, func() error {
+		return h.iaasClient.DefaultAPI.DeleteNic(ctx, h.projectId, h.region, ref.ParentID, ref.ID).Execute()
+	})
+	if err != nil {
+		return fmt.Errorf("failed to delete network interface: %w", err)
+	}
+
+	return nil
+}
+
+func (h *handler) DeleteSecurityGroup(ctx context.Context, ref ResourceRef) error {
+	_, err := deleteWithRetry(ctx, stackitDeleteRetryCount, stackitDeleteRetryDelay, func() error {
+		return h.iaasClient.DefaultAPI.DeleteSecurityGroup(ctx, h.projectId, h.region, ref.ID).Execute()
+	})
+	if err != nil {
 		return fmt.Errorf("failed to delete security group: %w", err)
 	}
 
@@ -108,17 +150,21 @@ func (h *handler) DeleteSecurityGroup(ctx context.Context, ref ResourceRef) erro
 }
 
 func (h *handler) DeleteNetwork(ctx context.Context, ref ResourceRef) error {
-	err := h.iaasClient.DefaultAPI.DeleteNetwork(context.Background(), h.projectId, h.region, ref.ID).Execute()
+	deleted, err := deleteWithRetry(ctx, stackitDeleteRetryCount, stackitDeleteRetryDelay, func() error {
+		return h.iaasClient.DefaultAPI.DeleteNetwork(ctx, h.projectId, h.region, ref.ID).Execute()
+	})
 	if err != nil {
-		// Treat not found as success for idempotent cleanup
-		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
-			return nil
-		}
-		return fmt.Errorf("failed to delete volume: %w", err)
+		return fmt.Errorf("failed to delete network: %w", err)
+	}
+	if !deleted {
+		return nil
 	}
 
-	_, err = iaasWait.DeleteNetworkWaitHandler(context.Background(), h.iaasClient.DefaultAPI, h.projectId, h.region, ref.ID).WaitWithContext(context.Background())
+	_, err = iaasWait.DeleteNetworkWaitHandler(ctx, h.iaasClient.DefaultAPI, h.projectId, h.region, ref.ID).WaitWithContext(ctx)
 	if err != nil {
+		if isNotFoundError(err) {
+			return nil
+		}
 		return fmt.Errorf("failed to wait for network deletion: %w", err)
 	}
 
@@ -126,44 +172,205 @@ func (h *handler) DeleteNetwork(ctx context.Context, ref ResourceRef) error {
 }
 
 func (h *handler) DeleteObjectStorageBucket(ctx context.Context, ref ResourceRef) error {
-	_, err := h.objectStorageClient.DefaultAPI.DeleteBucket(context.Background(), h.projectId, h.region, ref.ID).Execute()
-	if err != nil {
-		// Treat not found as success for idempotent cleanup
-		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
-			return nil
-		}
+	err := h.deleteObjectStorageBucketOnce(ctx, ref.ID)
+	if err == nil {
+		return nil
+	}
+	if !isBucketNotEmptyError(err) {
 		return fmt.Errorf("failed to delete bucket: %w", err)
 	}
 
-	_, err = objectstorageWait.DeleteBucketWaitHandler(context.Background(), h.objectStorageClient.DefaultAPI, h.projectId, h.region, ref.ID).WaitWithContext(context.Background())
+	s3Client, cleanup, err := h.newTemporaryObjectStorageS3Client(ctx)
 	if err != nil {
+		return fmt.Errorf("failed to prepare temporary object storage credentials: %w", err)
+	}
+	defer cleanup()
+
+	for attempt := 0; attempt < stackitBucketRetryCount; attempt++ {
+		if err := emptyObjectStorageBucket(ctx, s3Client, ref.ID); err != nil {
+			return fmt.Errorf("failed to empty bucket: %w", err)
+		}
+
+		deleteErr := h.deleteObjectStorageBucketOnce(ctx, ref.ID)
+		if deleteErr == nil {
+			return nil
+		}
+
+		if !isBucketNotEmptyError(deleteErr) || attempt == stackitBucketRetryCount-1 {
+			return fmt.Errorf("failed to delete bucket: %w", deleteErr)
+		}
+
+		if err := sleepWithContext(ctx, stackitBucketRetryDelay); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (h *handler) deleteObjectStorageBucketOnce(ctx context.Context, bucketName string) error {
+	deleted, err := deleteWithRetry(ctx, stackitDeleteRetryCount, stackitDeleteRetryDelay, func() error {
+		_, err := h.objectStorageClient.DefaultAPI.DeleteBucket(ctx, h.projectId, h.region, bucketName).Execute()
+		return err
+	})
+	if err != nil {
+		return err
+	}
+	if !deleted {
+		return nil
+	}
+
+	_, err = objectstorageWait.DeleteBucketWaitHandler(ctx, h.objectStorageClient.DefaultAPI, h.projectId, h.region, bucketName).WaitWithContext(ctx)
+	if err != nil && !isNotFoundError(err) {
 		return fmt.Errorf("failed to wait for bucket deletion: %w", err)
 	}
+
 	return nil
 }
 
 func (h *handler) DeleteObjectStorageCredential(ctx context.Context, ref ResourceRef) error {
-	_, err := h.objectStorageClient.DefaultAPI.DeleteAccessKey(context.Background(), h.projectId, h.region, ref.ID).Execute()
+	err := h.deleteObjectStorageAccessKey(ctx, ref.ID, ref.ParentID)
 	if err != nil {
-		// Treat not found as success for idempotent cleanup
-		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
-			return nil
-		}
-		return fmt.Errorf("failed to delete bucket: %w", err)
+		return fmt.Errorf("failed to delete object storage credential: %w", err)
 	}
 
 	return nil
 }
 
 func (h *handler) DeleteObjectStorageCredentialsGroup(ctx context.Context, ref ResourceRef) error {
-	_, err := h.objectStorageClient.DefaultAPI.DeleteCredentialsGroup(context.Background(), h.projectId, h.region, ref.ID).Execute()
-	if err != nil {
-		// Treat not found as success for idempotent cleanup
-		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
-			return nil
-		}
-		return fmt.Errorf("failed to delete bucket: %w", err)
+	_, err := h.objectStorageClient.DefaultAPI.DeleteCredentialsGroup(ctx, h.projectId, h.region, ref.ID).Execute()
+	if err == nil || isNotFoundError(err) {
+		return nil
+	}
+
+	if !isActiveAccessKeysError(err) {
+		return fmt.Errorf("failed to delete object storage credential group: %w", err)
+	}
+
+	deletedCount, cleanupErr := h.deleteMatchingCredentialsGroupAccessKeys(ctx, ref.ID)
+	if cleanupErr != nil {
+		return fmt.Errorf("failed to delete object storage credential group: %w", errors.Join(err, cleanupErr))
+	}
+	if deletedCount == 0 {
+		return fmt.Errorf("failed to delete object storage credential group: %w", err)
+	}
+
+	_, err = h.objectStorageClient.DefaultAPI.DeleteCredentialsGroup(ctx, h.projectId, h.region, ref.ID).Execute()
+	if err != nil && !isNotFoundError(err) {
+		return fmt.Errorf("failed to delete object storage credential group: %w", err)
 	}
 
 	return nil
+}
+
+func (h *handler) deleteMatchingCredentialsGroupAccessKeys(ctx context.Context, groupID string) (int, error) {
+	accessKeysResp, err := h.objectStorageClient.DefaultAPI.ListAccessKeys(ctx, h.projectId, h.region).
+		CredentialsGroup(groupID).
+		Execute()
+	if err != nil {
+		if isNotFoundError(err) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("failed to list object storage credentials: %w", err)
+	}
+
+	deletedCount := 0
+	for _, accessKey := range accessKeysResp.GetAccessKeys() {
+		err := h.deleteObjectStorageAccessKey(ctx, accessKey.GetKeyId(), groupID)
+		if err != nil {
+			return deletedCount, fmt.Errorf("failed to delete object storage credential %s: %w", accessKey.GetKeyId(), err)
+		}
+
+		deletedCount++
+	}
+
+	return deletedCount, nil
+}
+
+func (h *handler) deleteObjectStorageAccessKey(ctx context.Context, keyID, groupID string) error {
+	request := h.objectStorageClient.DefaultAPI.DeleteAccessKey(ctx, h.projectId, h.region, keyID)
+	if groupID != "" {
+		request = request.CredentialsGroup(groupID)
+	}
+
+	_, err := request.Execute()
+	if err != nil && !isNotFoundError(err) {
+		return err
+	}
+
+	return nil
+}
+
+func deleteWithRetry(
+	ctx context.Context,
+	attempts int,
+	delay time.Duration,
+	deleter func() error,
+) (bool, error) {
+	for attempt := 0; attempt < attempts; attempt++ {
+		err := deleter()
+		if err == nil {
+			return true, nil
+		}
+		if isNotFoundError(err) {
+			return false, nil
+		}
+		if !isConflictError(err) || attempt == attempts-1 {
+			return false, err
+		}
+
+		if err := sleepWithContext(ctx, delay); err != nil {
+			return false, err
+		}
+	}
+
+	return false, nil
+}
+
+func isNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "404") || strings.Contains(message, "not found")
+}
+
+func isConflictError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "409") || strings.Contains(message, "conflict") || strings.Contains(message, "still in use") || strings.Contains(message, " in use")
+}
+
+func isBucketNotEmptyError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "bucket.not_empty") || strings.Contains(message, "bucket is not empty")
+}
+
+func isActiveAccessKeysError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "active_access_keys") || strings.Contains(message, "actively used access keys")
+}
+
+func sleepWithContext(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }

--- a/tools/cleanup/internal/stackit/objectstorage_s3.go
+++ b/tools/cleanup/internal/stackit/objectstorage_s3.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package stackit
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	awssdk "github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	objectstorage "github.com/stackitcloud/stackit-sdk-go/services/objectstorage/v2api"
+)
+
+const (
+	s3BatchDeleteSize                   = 1000
+	stackitTempBucketCredsMaxNameLength = 32
+	stackitTempBucketCredsPrefix        = "exa-cln-"
+)
+
+func (h *handler) newTemporaryObjectStorageS3Client(ctx context.Context) (*s3.Client, func(), error) {
+	temporaryGroupName := temporaryObjectStorageCredentialsGroupName(time.Now())
+	groupPayload := objectstorage.NewCreateCredentialsGroupPayload(temporaryGroupName)
+	groupResp, err := h.objectStorageClient.DefaultAPI.CreateCredentialsGroup(ctx, h.projectId, h.region).
+		CreateCredentialsGroupPayload(*groupPayload).
+		Execute()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create temporary credentials group: %w", err)
+	}
+
+	credentialsGroup := groupResp.GetCredentialsGroup()
+	groupID := credentialsGroup.GetCredentialsGroupId()
+	accessKeyPayload := objectstorage.NewCreateAccessKeyPayload()
+	accessKeyResp, err := h.objectStorageClient.DefaultAPI.CreateAccessKey(ctx, h.projectId, h.region).
+		CreateAccessKeyPayload(*accessKeyPayload).
+		CredentialsGroup(groupID).
+		Execute()
+	if err != nil {
+		_, _ = h.objectStorageClient.DefaultAPI.DeleteCredentialsGroup(context.Background(), h.projectId, h.region, groupID).Execute()
+		return nil, nil, fmt.Errorf("failed to create temporary access key: %w", err)
+	}
+
+	endpoint := fmt.Sprintf("https://object.storage.%s.onstackit.cloud", h.region)
+	cfg, err := awsconfig.LoadDefaultConfig(ctx,
+		awsconfig.WithRegion(h.region),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			accessKeyResp.GetAccessKey(),
+			accessKeyResp.GetSecretAccessKey(),
+			"",
+		)),
+		awsconfig.WithEndpointResolverWithOptions(awssdk.EndpointResolverWithOptionsFunc(
+			func(service, region string, options ...interface{}) (awssdk.Endpoint, error) {
+				return awssdk.Endpoint{
+					URL:               endpoint,
+					HostnameImmutable: true,
+					SigningRegion:     h.region,
+				}, nil
+			},
+		)),
+	)
+	if err != nil {
+		_ = h.deleteObjectStorageAccessKey(context.Background(), accessKeyResp.GetKeyId(), groupID)
+		_, _ = h.objectStorageClient.DefaultAPI.DeleteCredentialsGroup(context.Background(), h.projectId, h.region, groupID).Execute()
+		return nil, nil, fmt.Errorf("failed to configure temporary S3 client: %w", err)
+	}
+
+	client := s3.NewFromConfig(cfg, func(options *s3.Options) {
+		options.UsePathStyle = true
+	})
+
+	cleanup := func() {
+		cleanupCtx := context.Background()
+		_ = h.deleteObjectStorageAccessKey(cleanupCtx, accessKeyResp.GetKeyId(), groupID)
+		_, _ = h.objectStorageClient.DefaultAPI.DeleteCredentialsGroup(cleanupCtx, h.projectId, h.region, groupID).Execute()
+	}
+
+	return client, cleanup, nil
+}
+
+func temporaryObjectStorageCredentialsGroupName(now time.Time) string {
+	name := fmt.Sprintf("%s%x", stackitTempBucketCredsPrefix, now.UTC().UnixNano())
+	if len(name) <= stackitTempBucketCredsMaxNameLength {
+		return name
+	}
+
+	return name[:stackitTempBucketCredsMaxNameLength]
+}
+
+func emptyObjectStorageBucket(ctx context.Context, client *s3.Client, bucket string) error {
+	continuationToken := (*string)(nil)
+	for {
+		listInput := &s3.ListObjectsV2Input{Bucket: awssdk.String(bucket)}
+		if continuationToken != nil {
+			listInput.ContinuationToken = continuationToken
+		}
+
+		listResp, err := client.ListObjectsV2(ctx, listInput)
+		if err != nil {
+			if isS3NotFoundError(err) {
+				return nil
+			}
+			return fmt.Errorf("failed to list bucket objects: %w", err)
+		}
+
+		objects := make([]s3types.ObjectIdentifier, 0, len(listResp.Contents))
+		for _, object := range listResp.Contents {
+			if object.Key != nil {
+				objects = append(objects, s3types.ObjectIdentifier{Key: object.Key})
+			}
+		}
+
+		for start := 0; start < len(objects); start += s3BatchDeleteSize {
+			end := start + s3BatchDeleteSize
+			if end > len(objects) {
+				end = len(objects)
+			}
+
+			_, err := client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+				Bucket: awssdk.String(bucket),
+				Delete: &s3types.Delete{Objects: objects[start:end], Quiet: awssdk.Bool(true)},
+			})
+			if err != nil {
+				return fmt.Errorf("failed to delete bucket objects: %w", err)
+			}
+		}
+
+		if !awssdk.ToBool(listResp.IsTruncated) || listResp.NextContinuationToken == nil {
+			return nil
+		}
+
+		continuationToken = listResp.NextContinuationToken
+	}
+}
+
+func isS3NotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "nosuchbucket") || strings.Contains(message, "not found")
+}

--- a/tools/cleanup/internal/stackit/run.go
+++ b/tools/cleanup/internal/stackit/run.go
@@ -23,6 +23,8 @@ func BuildPlan() CleanupPlan {
 	return CleanupPlan{Phases: []Phase{
 		{Name: "servers", Types: []ResourceType{ResourceServer}},
 		{Name: "volumes", Types: []ResourceType{ResourceVolume}},
+		{Name: "public-ips", Types: []ResourceType{ResourcePublicIP}},
+		{Name: "network-interfaces", Types: []ResourceType{ResourceNetworkInterface}},
 		{Name: "networks", Types: []ResourceType{ResourceNetwork}},
 		{Name: "security-groups", Types: []ResourceType{ResourceSecurityGroup}},
 		{Name: "objectstorage-buckets", Types: []ResourceType{ResourceObjectStorageBucket}},

--- a/tools/cleanup/internal/stackit/run_test.go
+++ b/tools/cleanup/internal/stackit/run_test.go
@@ -1,0 +1,196 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package stackit
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	objectstorage "github.com/stackitcloud/stackit-sdk-go/services/objectstorage/v2api"
+)
+
+func TestPlanActionsOrdersStackitNetworkDependencies(t *testing.T) {
+	t.Parallel()
+
+	// Given a deployment with dependent STACKIT networking resources
+	details := &DeploymentDetails{
+		Resources: []ResourceMeta{
+			{Ref: ResourceRef{Type: ResourceNetwork, ID: "network-1"}},
+			{Ref: ResourceRef{Type: ResourceNetworkInterface, ID: "nic-1", ParentID: "network-1"}},
+			{Ref: ResourceRef{Type: ResourcePublicIP, ID: "public-ip-1"}},
+			{Ref: ResourceRef{Type: ResourceSecurityGroup, ID: "sg-1"}},
+			{Ref: ResourceRef{Type: ResourceServer, ID: "server-1"}},
+		},
+	}
+
+	// When cleanup actions are planned
+	actions, err := PlanActions(details, nil)
+	if err != nil {
+		t.Fatalf("unexpected error planning actions: %v", err)
+	}
+
+	// Then public IPs and NICs are deleted before networks and security groups
+	got := make([]ResourceType, 0, len(actions))
+	for _, action := range actions {
+		got = append(got, action.Ref.Type)
+	}
+
+	want := []ResourceType{
+		ResourceServer,
+		ResourcePublicIP,
+		ResourceNetworkInterface,
+		ResourceNetwork,
+		ResourceSecurityGroup,
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("expected %d actions, got %d", len(want), len(got))
+	}
+	for index := range want {
+		if got[index] != want[index] {
+			t.Fatalf("expected action %d to be %q, got %q", index, want[index], got[index])
+		}
+	}
+}
+
+func TestDeleteMatchingCredentialsGroupAccessKeysUsesCredentialsGroupFilter(t *testing.T) {
+	t.Parallel()
+
+	// Given a STACKIT handler with objectstorage mocks
+	deletedKeyIDs := []string{}
+	deletedKeyGroups := []string{}
+	listAccessKeysExecute := func(r objectstorage.ApiListAccessKeysRequest) (*objectstorage.ListAccessKeysResponse, error) {
+		filter := reflect.ValueOf(r).FieldByName("credentialsGroup")
+		if !filter.IsValid() || filter.IsNil() {
+			t.Fatal("expected credentials-group filter to be set")
+		}
+		if got := filter.Elem().String(); got != "group-1" {
+			t.Fatalf("expected credentials-group filter %q, got %q", "group-1", got)
+		}
+
+		accessKey := objectstorage.AccessKey{}
+		accessKey.SetKeyId("key-1")
+		return objectstorage.NewListAccessKeysResponse([]objectstorage.AccessKey{accessKey}, "project-1"), nil
+	}
+	deleteAccessKeyExecute := func(r objectstorage.ApiDeleteAccessKeyRequest) (*objectstorage.DeleteAccessKeyResponse, error) {
+		deletedKeyIDs = append(deletedKeyIDs, reflect.ValueOf(r).FieldByName("keyId").String())
+		groupField := reflect.ValueOf(r).FieldByName("credentialsGroup")
+		if !groupField.IsValid() || groupField.IsNil() {
+			t.Fatal("expected credentials-group filter to be set on delete")
+		}
+		deletedKeyGroups = append(deletedKeyGroups, groupField.Elem().String())
+		return objectstorage.NewDeleteAccessKeyResponse("key-1", "project-1"), nil
+	}
+
+	h := handler{
+		objectStorageClient: &objectstorage.APIClient{DefaultAPI: objectstorage.DefaultAPIServiceMock{
+			ListAccessKeysExecuteMock:  &listAccessKeysExecute,
+			DeleteAccessKeyExecuteMock: &deleteAccessKeyExecute,
+		}},
+		projectId: "project-1",
+		region:    "eu01",
+	}
+
+	// When credential-group access keys are deleted
+	deletedCount, err := h.deleteMatchingCredentialsGroupAccessKeys(context.Background(), "group-1")
+	if err != nil {
+		t.Fatalf("unexpected error deleting access keys: %v", err)
+	}
+
+	// Then only the filtered group's keys are deleted
+	if deletedCount != 1 {
+		t.Fatalf("expected 1 deleted access key, got %d", deletedCount)
+	}
+	if len(deletedKeyIDs) != 1 || deletedKeyIDs[0] != "key-1" {
+		t.Fatalf("expected deleted key IDs [key-1], got %v", deletedKeyIDs)
+	}
+	if len(deletedKeyGroups) != 1 || deletedKeyGroups[0] != "group-1" {
+		t.Fatalf("expected deleted key groups [group-1], got %v", deletedKeyGroups)
+	}
+}
+
+func TestDeleteObjectStorageCredentialUsesParentCredentialsGroup(t *testing.T) {
+	t.Parallel()
+
+	// Given a credential resource that knows its parent credentials group
+	var deletedKeyGroup string
+	deleteAccessKeyExecute := func(r objectstorage.ApiDeleteAccessKeyRequest) (*objectstorage.DeleteAccessKeyResponse, error) {
+		groupField := reflect.ValueOf(r).FieldByName("credentialsGroup")
+		if !groupField.IsValid() || groupField.IsNil() {
+			t.Fatal("expected credentials-group filter to be set on delete")
+		}
+		deletedKeyGroup = groupField.Elem().String()
+		return objectstorage.NewDeleteAccessKeyResponse("key-1", "project-1"), nil
+	}
+
+	h := handler{
+		objectStorageClient: &objectstorage.APIClient{DefaultAPI: objectstorage.DefaultAPIServiceMock{
+			DeleteAccessKeyExecuteMock: &deleteAccessKeyExecute,
+		}},
+		projectId: "project-1",
+		region:    "eu01",
+	}
+
+	// When the direct credential delete runs
+	err := h.DeleteObjectStorageCredential(context.Background(), ResourceRef{
+		Type:     ResourceObjectStorageCredential,
+		ID:       "key-1",
+		ParentID: "group-1",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error deleting object storage credential: %v", err)
+	}
+
+	// Then the delete request carries the parent credentials group
+	if deletedKeyGroup != "group-1" {
+		t.Fatalf("expected delete to use credentials group %q, got %q", "group-1", deletedKeyGroup)
+	}
+}
+
+func TestResourceMetaFromAccessKeyStoresCredentialsGroupAsParent(t *testing.T) {
+	t.Parallel()
+
+	// Given an access key returned with group metadata
+	accessKey := objectstorage.AccessKey{}
+	accessKey.SetDisplayName("key-1")
+	accessKey.SetExpires("")
+	accessKey.SetKeyId("key-1")
+	accessKey.AdditionalProperties = map[string]interface{}{
+		"credentialsGroupId": "group-1",
+	}
+
+	// When resource metadata is derived from the access key
+	meta, err := ResourceMetaFromAccessKey(accessKey, "project-1", "eu01")
+	if err != nil {
+		t.Fatalf("unexpected error building access-key metadata: %v", err)
+	}
+
+	// Then the resource keeps the group relationship for deletion
+	if meta.Ref.ParentID != "group-1" {
+		t.Fatalf("expected parent credentials group %q, got %q", "group-1", meta.Ref.ParentID)
+	}
+}
+
+func TestTemporaryObjectStorageCredentialsGroupNameFitsApiLimit(t *testing.T) {
+	t.Parallel()
+
+	// Given a deterministic timestamp
+	now := time.Unix(0, 1780070569901435109)
+
+	// When a temporary credentials-group name is generated
+	name := temporaryObjectStorageCredentialsGroupName(now)
+
+	// Then the generated name is valid for the STACKIT API limit
+	if len(name) > stackitTempBucketCredsMaxNameLength {
+		t.Fatalf("expected name length <= %d, got %d (%q)", stackitTempBucketCredsMaxNameLength, len(name), name)
+	}
+	if name == "" {
+		t.Fatal("expected non-empty temporary credentials-group name")
+	}
+	if got, want := name[:len(stackitTempBucketCredsPrefix)], stackitTempBucketCredsPrefix; got != want {
+		t.Fatalf("expected name prefix %q, got %q", want, got)
+	}
+}

--- a/tools/cleanup/internal/stackit/types.go
+++ b/tools/cleanup/internal/stackit/types.go
@@ -26,6 +26,7 @@ type ResourceType = shared.ResourceType
 const (
 	ResourceServer                        ResourceType = "stackit-server"
 	ResourceVolume                        ResourceType = "stackit-volume"
+	ResourcePublicIP                      ResourceType = "stackit-public-ip"
 	ResourceNetworkInterface              ResourceType = "stackit-network-interface"
 	ResourceNetwork                       ResourceType = "stackit-network"
 	ResourceSecurityGroup                 ResourceType = "stackit-security-group"


### PR DESCRIPTION
## Description

Fix STACKIT cleanup failures in `tools/cleanup` by making discovery and deletion follow actual resource dependencies and object-storage API requirements.

This resolves the earlier STACKIT cleanup panic and the follow-up failures around public IP / NIC ordering, non-empty object-storage buckets, and credential-group access-key deletion.

Example user-visible cleanup invocation:

`./exasol-cleanup run --execute --stackit --stackit-project-id 0e9fde0e-4f99-44e5-ae61-fa9899843b0d exasol-251a4801`

## Related Issue

Fixes SPOT-30098

## Type of Change

- [x] `fix`: Bug fix
- [ ] `feat`: New feature
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- add STACKIT public IP and NIC discovery/deletion and order them before network and security-group cleanup
- make deployment summary derivation nil-safe and add regression coverage for active, provisioning, and orphaned deployments
- handle object-storage cleanup more robustly by deleting group-scoped access keys correctly and emptying non-empty buckets only when needed

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

- ran `task fmt`
- ran `task lint`
- ran `task all`
- ran focused Go tests for `tools/cleanup/internal/stackit`
- manually verified STACKIT cleanup with the command shown above, including the previously failing object-storage credential-group cleanup

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

- this PR is intentionally focused on the `tools/cleanup` STACKIT flow
- object-storage key deletion now includes the `credentials-group` context required by the STACKIT API for group-managed access keys
