### PR TITLE
feat: add -c and -f flags to connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,14 @@ You can also use the built-in SQL client in Exasol Launcher to connect directly 
 exasol connect
 ```
 
-In an interactive session, query output is capped at 100 rows by default so a large `SELECT` doesn't flood the terminal; a note is printed when output is truncated. Piped (non-interactive) input returns the full result set. Use `--max-rows N` to set the cap explicitly, or `--max-rows 0` for unlimited:
+To run SQL without entering the interactive shell, pass it directly. Both flags accept multiple `;`-separated statements and exit when done, which is convenient for scripting and automation:
+```bash
+exasol connect -c "SELECT 1; SELECT 2"   # run inline statement(s)
+exasol connect -f script.sql             # run statements from a file
+```
+`--command` and `--file` are mutually exclusive. In this non-interactive mode, execution stops at the first failing statement and `connect` exits with a non-zero status so scripts can detect errors. Combine with `--json` for machine-readable output.
+
+In an interactive session, query output is capped at 100 rows by default so a large `SELECT` doesn't flood the terminal; a note is printed when output is truncated. Piped or `--command`/`--file` (non-interactive) execution returns the full result set. Use `--max-rows N` to set the cap explicitly, or `--max-rows 0` for unlimited:
 ```bash
 exasol connect --max-rows 0        # return all rows, even interactively
 echo "SELECT * FROM PRODUCTS;" | exasol connect --max-rows 1000

--- a/cmd/exasol/connect.go
+++ b/cmd/exasol/connect.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"errors"
+
 	"github.com/exasol/exasol-personal/internal/connect"
 	"github.com/exasol/exasol-personal/internal/deploy"
 	"github.com/spf13/cobra"
@@ -18,6 +20,8 @@ Establish an SQL connection to the database instance in an active deployment.
 
 const connectCmdExample = `  exasol connect
   exasol connect --json
+  exasol connect -c "SELECT 1; SELECT 2"
+  exasol connect -f script.sql
 	printf 'SELECT 1;\n' | exasol connect --json=compact`
 
 var connectOpts = connect.Opts{
@@ -34,6 +38,10 @@ var connectCmd = &cobra.Command{
 	Args:         cobra.NoArgs,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
+		if cmd.Flags().Changed("command") && cmd.Flags().Changed("file") {
+			return errors.New("--command and --file are mutually exclusive")
+		}
+
 		connectOpts.OutputJSON = cmd.Flags().Changed("json")
 
 		return deploy.Connect(cmd.Context(), &connectOpts, commonFlags.Deployment())
@@ -74,6 +82,20 @@ func registerConnectFlags() {
 		connect.JSONFormatPretty,
 		"Output in JSON format: pretty, compact",
 	)
+
+	connectCmd.Flags().StringVarP(
+		&connectOpts.Command,
+		"command", "c", "",
+		"Execute the given semicolon-separated SQL statement(s) and exit",
+	)
+
+	connectCmd.Flags().StringVarP(
+		&connectOpts.File,
+		"file", "f", "",
+		"Execute the semicolon-separated SQL statements from the given file and exit",
+	)
+
+	connectCmd.MarkFlagsMutuallyExclusive("command", "file")
 
 	connectCmd.Flags().IntVar(
 		&connectOpts.MaxRows,

--- a/cmd/exasol/connect_test.go
+++ b/cmd/exasol/connect_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/exasol/exasol-personal/internal/connect"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -115,6 +116,65 @@ func TestConnectCmdExamplesMentionJSONOptions(t *testing.T) {
 		if !strings.Contains(connectCmdExample, expected) {
 			t.Fatalf("expected examples to contain %q", expected)
 		}
+	}
+}
+
+func TestConnectCmdExamplesMentionCommandAndFile(t *testing.T) {
+	t.Parallel()
+
+	for _, expected := range []string{
+		`exasol connect -c "SELECT 1; SELECT 2"`,
+		"exasol connect -f script.sql",
+	} {
+		if !strings.Contains(connectCmdExample, expected) {
+			t.Fatalf("expected examples to contain %q", expected)
+		}
+	}
+}
+
+func TestConnectRegistersCommandAndFileFlags(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name      string
+		shorthand string
+	}{
+		{name: "command", shorthand: "c"},
+		{name: "file", shorthand: "f"},
+	} {
+		flag := connectCmd.Flags().ShorthandLookup(test.shorthand)
+		if flag == nil || flag.Name != test.name {
+			t.Fatalf("expected -%s to be registered as --%s", test.shorthand, test.name)
+		}
+	}
+}
+
+// nolint: paralleltest // Builds and executes an isolated command instance.
+func TestConnectCommandAndFileAreMutuallyExclusive(t *testing.T) {
+	// Mirror the registration in registerConnectFlags so we exercise the
+	// mutual-exclusivity wiring without the full command's prerequisites.
+	var command, file string
+
+	cmd := &cobra.Command{
+		Use:           "connect",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(*cobra.Command, []string) error {
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&command, "command", "c", "", "")
+	cmd.Flags().StringVarP(&file, "file", "f", "", "")
+	cmd.MarkFlagsMutuallyExclusive("command", "file")
+
+	cmd.SetArgs([]string{"-c", "SELECT 1", "-f", "script.sql"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected an error when both --command and --file are supplied")
+	}
+	if !strings.Contains(err.Error(), "command") || !strings.Contains(err.Error(), "file") {
+		t.Fatalf("expected mutual-exclusivity error mentioning both flags, got: %v", err)
 	}
 }
 

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -56,6 +56,13 @@ type Opts struct {
 	ExecuteOnSemicolon         bool
 	OutputJSON                 bool
 	JSONFormat                 JSONFormat
+	// Command holds inline SQL passed via --command. When set, the statements
+	// are executed non-interactively and the shell is not started.
+	Command string
+	// File holds the path to a SQL script passed via --file. When set, the
+	// file's statements are executed non-interactively and the shell is not
+	// started.
+	File string
 	// MaxRows caps the number of rows displayed per query. A negative value
 	// means "unset" (use the per-mode default); 0 means unlimited.
 	MaxRows int
@@ -140,6 +147,13 @@ func Connect(
 ) error {
 	slog.Debug("running connect")
 
+	// Resolve any non-interactive SQL source up front so that an unreadable
+	// --file fails fast without opening a database connection.
+	nonInteractiveSQL, nonInteractive, err := resolveNonInteractiveSQL(opts)
+	if err != nil {
+		return err
+	}
+
 	database, err := NewExasolConnection(
 		deployment,
 		connectionInfo,
@@ -163,21 +177,19 @@ func Connect(
 		printer = newJSONResultPrinter(opts.JSONFormat)
 	}
 
-	interactive := util.IsInteractiveStdin()
+	// The interactive preview cap applies only when an interactive shell is
+	// actually started. --command/--file and piped input return everything by
+	// default, so they behave as non-interactive (unlimited) unless --max-rows
+	// is set explicitly.
+	interactiveShell := !nonInteractive && util.IsInteractiveStdin()
 
 	modeDefault := 0
-	if interactive {
+	if interactiveShell {
 		modeDefault = interactivePreviewMaxRows
 	}
 	maxRows := effectiveMaxRows(opts.MaxRows, modeDefault)
 
-	if interactive {
-		if err := printExitHint(os.Stderr); err != nil {
-			return err
-		}
-	}
-
-	return RunShellWithOpts(func(input string) error {
+	processInput := func(input string) error {
 		// The input string is expected to be trimmed of whitespace
 		if input == "" {
 			return nil
@@ -197,7 +209,40 @@ func Connect(
 		}
 
 		return nil
-	}, ShellOpts{ExecuteOnSemicolon: opts.ExecuteOnSemicolon})
+	}
+
+	if nonInteractive {
+		return runStatements(nonInteractiveSQL, processInput)
+	}
+
+	if interactiveShell {
+		if err := printExitHint(os.Stderr); err != nil {
+			return err
+		}
+	}
+
+	return RunShellWithOpts(processInput, ShellOpts{ExecuteOnSemicolon: opts.ExecuteOnSemicolon})
+}
+
+// resolveNonInteractiveSQL returns the SQL to run non-interactively, derived
+// from --file or --command. The boolean reports whether a non-interactive
+// source was supplied; when false, the caller falls back to the interactive
+// shell. A --file that cannot be read yields an error before any database
+// connection is attempted.
+func resolveNonInteractiveSQL(opts *Opts) (string, bool, error) {
+	switch {
+	case opts.File != "":
+		contents, err := os.ReadFile(opts.File)
+		if err != nil {
+			return "", false, fmt.Errorf("reading SQL file %q: %w", opts.File, err)
+		}
+
+		return string(contents), true, nil
+	case opts.Command != "":
+		return opts.Command, true, nil
+	default:
+		return "", false, nil
+	}
 }
 
 // printTruncationFooter notifies the user, via stderr, that the displayed

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -6,6 +6,8 @@ package connect
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -136,6 +138,89 @@ func TestPrintResultJSON(t *testing.T) {
 			require.Equal(t, test.result.rows, decoded.Rows)
 		})
 	}
+}
+
+func TestResolveNonInteractiveSQL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("command supplies SQL", func(t *testing.T) {
+		t.Parallel()
+
+		sql, nonInteractive, err := resolveNonInteractiveSQL(&Opts{Command: "SELECT 1"})
+
+		require.NoError(t, err)
+		require.True(t, nonInteractive)
+		require.Equal(t, "SELECT 1", sql)
+	})
+
+	t.Run("file supplies SQL", func(t *testing.T) {
+		t.Parallel()
+
+		path := filepath.Join(t.TempDir(), "script.sql")
+		require.NoError(t, os.WriteFile(path, []byte("SELECT 1; SELECT 2;"), 0o600))
+
+		sql, nonInteractive, err := resolveNonInteractiveSQL(&Opts{File: path})
+
+		require.NoError(t, err)
+		require.True(t, nonInteractive)
+		require.Equal(t, "SELECT 1; SELECT 2;", sql)
+	})
+
+	t.Run("missing file fails without running statements", func(t *testing.T) {
+		t.Parallel()
+
+		path := filepath.Join(t.TempDir(), "does-not-exist.sql")
+
+		sql, nonInteractive, err := resolveNonInteractiveSQL(&Opts{File: path})
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, "reading SQL file")
+		require.False(t, nonInteractive)
+		require.Empty(t, sql)
+	})
+
+	t.Run("no flag falls back to interactive", func(t *testing.T) {
+		t.Parallel()
+
+		sql, nonInteractive, err := resolveNonInteractiveSQL(&Opts{})
+
+		require.NoError(t, err)
+		require.False(t, nonInteractive)
+		require.Empty(t, sql)
+	})
+}
+
+func TestRunStatementsRendersEachResult(t *testing.T) {
+	t.Parallel()
+
+	// The non-interactive runner uses the same printer the interactive shell
+	// does, so each statement's result is rendered identically.
+	var buf bytes.Buffer
+
+	result := stubQueryResult{columnNames: []string{"N"}, rows: [][]string{{"1"}}}
+	printer := newJSONResultPrinter(JSONFormatCompact)
+
+	process := func(input string) error {
+		if input == "" {
+			return nil
+		}
+
+		return printer(&buf, result)
+	}
+
+	err := runStatements("SELECT 1; SELECT 1;", process)
+
+	require.NoError(t, err)
+	require.Equal(t, compactJSONResult2x(result), buf.String())
+}
+
+func compactJSONResult2x(result stubQueryResult) string {
+	var buf bytes.Buffer
+	printer := newJSONResultPrinter(JSONFormatCompact)
+	_ = printer(&buf, result)
+	single := buf.String()
+
+	return single + single
 }
 
 func TestEffectiveMaxRows(t *testing.T) {

--- a/internal/connect/shell.go
+++ b/internal/connect/shell.go
@@ -213,6 +213,26 @@ func runShellImpl(
 	return shell.run()
 }
 
+// runStatements executes the ;-separated statements in sql non-interactively,
+// in order, stopping at and returning the first error. It uses the same
+// quote- and comment-aware splitting as the interactive shell. Any non-empty
+// trailing remainder after the final terminator is executed as a final
+// statement, mirroring the shell's end-of-input handling.
+func runStatements(sql string, processInput ProcessInputFunc) error {
+	statements, remainder := splitSemicolonTerminatedStatements(sql)
+	if trailing := strings.TrimSpace(remainder); trailing != "" {
+		statements = append(statements, trailing)
+	}
+
+	for _, statement := range statements {
+		if err := processInput(strings.TrimSpace(statement)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // RunShell runs the shell, processing incoming input
 // with the passed callback. Blocks until the shell exits.
 func RunShell(processInput ProcessInputFunc) error {

--- a/internal/connect/shell_test.go
+++ b/internal/connect/shell_test.go
@@ -211,6 +211,54 @@ func TestRunShell(t *testing.T) {
 	}
 }
 
+func TestRunStatements(t *testing.T) {
+	t.Parallel()
+
+	t.Run("executes a single statement without a terminator", func(t *testing.T) {
+		t.Parallel()
+
+		processor := &mockInputsProcessor{}
+		err := runStatements("SELECT 1", processor.processInput)
+
+		require.NoError(t, err)
+		require.Equal(t, []string{"SELECT 1"}, processor.inputs)
+	})
+
+	t.Run("executes semicolon-separated statements in order", func(t *testing.T) {
+		t.Parallel()
+
+		processor := &mockInputsProcessor{}
+		err := runStatements("SELECT 1; SELECT 2; SELECT 3", processor.processInput)
+
+		require.NoError(t, err)
+		require.Equal(t, []string{"SELECT 1", "SELECT 2", "SELECT 3"}, processor.inputs)
+	})
+
+	t.Run("skips empty and trailing segments", func(t *testing.T) {
+		t.Parallel()
+
+		processor := &mockInputsProcessor{}
+		err := runStatements("SELECT 1;; SELECT 2;\n  \n", processor.processInput)
+
+		require.NoError(t, err)
+		require.Equal(t, []string{"SELECT 1", "SELECT 2"}, processor.inputs)
+	})
+
+	t.Run("stops at and returns the first error", func(t *testing.T) {
+		t.Parallel()
+
+		processor := &mockInputsProcessor{}
+		processor.failOnInput("INVALID SQL", errInputsProcessor)
+
+		err := runStatements("SELECT 1; INVALID SQL; SELECT 2", processor.processInput)
+
+		require.ErrorIs(t, err, errInputsProcessor)
+		// SELECT 1 ran, INVALID SQL failed and aborted, SELECT 2 never ran.
+		require.Equal(t, 2, processor.callCount)
+		require.Equal(t, []string{"SELECT 1"}, processor.inputs)
+	})
+}
+
 func TestSplitSemicolonTerminatedStatements(t *testing.T) {
 	t.Parallel()
 

--- a/openspec/changes/add-connect-command-and-file-flags/.openspec.yaml
+++ b/openspec/changes/add-connect-command-and-file-flags/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-02

--- a/openspec/changes/add-connect-command-and-file-flags/design.md
+++ b/openspec/changes/add-connect-command-and-file-flags/design.md
@@ -1,0 +1,40 @@
+## Context
+
+`exasol connect` (`cmd/exasol/connect.go`) populates a `connect.Opts` and calls `deploy.Connect`, which resolves connection info and calls `connect.Connect` (`internal/connect/connect.go`). `connect.Connect` opens the database, builds a result printer (table or JSON), and then drives input through `RunShellWithOpts`. The shell reads lines via a readline-backed `LineReader`, buffers them, and splits on `;` with `splitSemicolonTerminatedStatements` — a quote- and comment-aware splitter that already exists in `internal/connect/shell.go`. Each statement flows through one `ProcessInputFunc` callback that execs the SQL and prints the result.
+
+The statement-execution callback and the splitter are exactly what `--command`/`--file` need; only the *source* of the SQL and the *driver loop* differ.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Let users and agents pass SQL directly via `-c`/`--command` and `-f`/`--file`, running non-interactively and exiting.
+- Reuse the existing splitter and exec/print pipeline so output and SQL semantics match the interactive shell.
+- Leave the default interactive/stdin path untouched.
+
+**Non-Goals:**
+- No new SQL parsing or statement-splitting logic.
+- No multi-statement transaction semantics beyond what the database already provides.
+- No changes to authentication, connection setup, or the deployment directory contract.
+- No support for reading the script from `-` (stdin) — stdin already works without a flag.
+
+## Decisions
+
+**Reuse `splitSemicolonTerminatedStatements` for `-c`/`-f` input.** Both flags supply a complete SQL string (the flag value, or the file contents). We feed that string to the existing splitter and execute the returned statements in order via the same callback `connect.Connect` already builds. Any non-empty remainder after the final `;` is executed as a trailing statement, matching the interactive shell's EOF handling. Alternative — a separate parser — rejected: it would risk diverging from interactive behavior.
+
+**Branch in `connect.Connect` on a new input source, not in the shell.** Add `Command string` and `File string` to `connect.Opts`. After opening the DB and building the printer, if a non-interactive source is set, run the statements directly and return; otherwise fall through to `RunShellWithOpts` as today. This keeps the readline/shell machinery out of the non-interactive path (no history file, no exit hint, no TTY detection).
+
+**Validate mutual exclusivity at the CLI layer.** `cmd/exasol/connect.go` checks `cmd.Flags().Changed("command")` and `Changed("file")` in `RunE` and returns an error before calling `deploy.Connect`, so we fail fast without touching the database. Cobra marks the flags with `MarkFlagsMutuallyExclusive` as the primary guard; the explicit check keeps a clear error message.
+
+**Stop on first error in non-interactive mode (exit non-zero).** The interactive shell logs each statement error and continues, which suits a REPL. For `-c`/`-f`, scripts and agents need a reliable failure signal, so the non-interactive runner stops at the first failing statement and returns the error, which propagates to a non-zero process exit. Alternative — continue-and-aggregate — rejected as the default because partial success is harder for callers to reason about; can be revisited if a `--continue-on-error` flag is later requested.
+
+**Read the file with `os.ReadFile` in the connect layer.** A missing/unreadable file returns a wrapped error before any DB work, giving a clear message and non-zero exit.
+
+## Risks / Trade-offs
+
+- **Behavioral divergence: stop-on-error vs. interactive continue** → Documented explicitly in the spec and README; the two modes serve different audiences (REPL vs. automation).
+- **Large script files read fully into memory** → Acceptable; connect scripts are small, and the interactive path already buffers. Streaming can be added later if needed.
+- **`-c` shadowing a future global flag** → `-c`/`-f` are scoped to the `connect` subcommand only; verify no existing `connect` short flag collides (current: `-u`, `-p`, `-k`, `-j`).
+
+## Open Questions
+
+- Should `--json` be the implied default when `-c`/`-f` is used by a non-TTY caller? Current decision: no — keep the existing `--json` opt-in so behavior is predictable regardless of input source.

--- a/openspec/changes/add-connect-command-and-file-flags/proposal.md
+++ b/openspec/changes/add-connect-command-and-file-flags/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`exasol connect` can only receive SQL interactively or via stdin (pipes, heredocs). Passing a single statement or a script file requires shell plumbing that is awkward for humans and brittle for automation and AI agents. Other SQL clients (e.g. `psql -c`/`-f`, `mysql -e`) expose direct flags for this; `exasol connect` should too.
+
+## What Changes
+
+- Add `-c`/`--command <SQL>` to `exasol connect`: run one or more `;`-separated SQL statements passed as the flag argument, then exit.
+- Add `-f`/`--file <path>` to `exasol connect`: read a SQL script from the given file, run its `;`-separated statements, then exit.
+- Both flags run non-interactively: no readline shell, no exit hint, no history. The same statement splitting and result printing (table or `--json`) used by the interactive shell apply.
+- `-c` and `-f` are mutually exclusive; supplying both is an error. When either is given, stdin is not read.
+- No change to existing behavior: with neither flag, `connect` keeps its interactive/stdin behavior.
+
+## Capabilities
+
+### New Capabilities
+- `connect-sql-input`: how `exasol connect` accepts SQL input — interactive shell, stdin, and the new `--command`/`--file` non-interactive sources, including precedence, splitting, output, and exit-code semantics.
+
+### Modified Capabilities
+<!-- None: there is no existing spec covering connect input behavior. -->
+
+## Impact
+
+- `cmd/exasol/connect.go`: register the two flags and validate mutual exclusivity.
+- `internal/connect`: add a non-interactive execution path that splits and runs supplied SQL through the existing exec/print pipeline (reusing `splitSemicolonTerminatedStatements`) instead of the readline shell.
+- `internal/deploy/connect.go`: unchanged connection setup; routes to interactive vs. non-interactive based on opts.
+- Docs: README `connect` section and `cmd/exasol/connect.go` examples.
+- No new dependencies. No changes to the deployment directory or compatibility contract.

--- a/openspec/changes/add-connect-command-and-file-flags/specs/connect-sql-input/spec.md
+++ b/openspec/changes/add-connect-command-and-file-flags/specs/connect-sql-input/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: Inline SQL via --command
+
+`exasol connect` SHALL accept a `-c`/`--command <SQL>` flag whose argument is one or more SQL statements. When the flag is supplied, the command SHALL execute the statements non-interactively and then exit, without starting the interactive shell or reading stdin.
+
+The supplied SQL SHALL be split into statements on `;` terminators using the same splitting rules as the interactive shell (quote- and comment-aware), and each statement SHALL be executed in order against the database. Results SHALL be printed using the same formatter as the interactive shell, honoring `--json` and `--json` format options.
+
+#### Scenario: Single statement
+
+- **WHEN** the user runs `exasol connect -c "SELECT 1"`
+- **THEN** the statement is executed and its result is printed
+- **AND** the command exits without entering the interactive shell
+
+#### Scenario: Multiple semicolon-separated statements
+
+- **WHEN** the user runs `exasol connect -c "CREATE TABLE t(x INT); INSERT INTO t VALUES (1); SELECT * FROM t"`
+- **THEN** each statement is executed in order
+- **AND** the result of each result-producing statement is printed in order
+
+#### Scenario: Trailing or empty statements are ignored
+
+- **WHEN** the supplied SQL contains empty segments (e.g. a trailing `;` or `;;`)
+- **THEN** empty segments are skipped and no error is raised for them
+
+### Requirement: SQL script via --file
+
+`exasol connect` SHALL accept a `-f`/`--file <path>` flag whose argument is the path to a SQL script file. When the flag is supplied, the command SHALL read the file, execute its `;`-separated statements non-interactively in order, and then exit, without starting the interactive shell or reading stdin.
+
+The file contents SHALL be split and executed using the same rules as `--command`.
+
+#### Scenario: Run a script file
+
+- **WHEN** the user runs `exasol connect -f script.sql` and `script.sql` contains multiple `;`-separated statements
+- **THEN** each statement is executed in order and results are printed
+
+#### Scenario: Missing or unreadable file
+
+- **WHEN** the file given to `--file` does not exist or cannot be read
+- **THEN** the command exits with a non-zero status and a clear error message
+- **AND** no statements are executed
+
+### Requirement: Flag precedence and mutual exclusivity
+
+The `--command` and `--file` flags SHALL be mutually exclusive. Supplying both SHALL cause the command to exit with a non-zero status and a clear error message before connecting to the database. When neither flag is supplied, `exasol connect` SHALL retain its existing interactive and stdin behavior unchanged.
+
+#### Scenario: Both flags supplied
+
+- **WHEN** the user runs `exasol connect -c "SELECT 1" -f script.sql`
+- **THEN** the command exits with a non-zero status and an error stating the flags are mutually exclusive
+
+#### Scenario: Neither flag supplied preserves existing behavior
+
+- **WHEN** the user runs `exasol connect` with neither `--command` nor `--file`
+- **THEN** the command behaves as before: interactive shell on a TTY, or reads SQL from stdin when piped
+
+### Requirement: Non-interactive exit status
+
+When run with `--command` or `--file`, `exasol connect` SHALL exit with a non-zero status if any executed statement fails, so that callers and scripts can detect errors.
+
+#### Scenario: Statement fails
+
+- **WHEN** a statement supplied via `--command` or `--file` fails to execute
+- **THEN** the command reports the error
+- **AND** exits with a non-zero status

--- a/openspec/changes/add-connect-command-and-file-flags/tasks.md
+++ b/openspec/changes/add-connect-command-and-file-flags/tasks.md
@@ -1,0 +1,26 @@
+## 1. Options and non-interactive runner
+
+- [x] 1.1 Add `Command string` and `File string` fields to `connect.Opts` in `internal/connect/connect.go`
+- [x] 1.2 Add a non-interactive runner that takes a SQL string, splits it with `splitSemicolonTerminatedStatements` (executing any non-empty trailing remainder), and runs each statement through the existing exec/print callback, stopping and returning on the first error
+- [x] 1.3 In `connect.Connect`, after opening the DB and building the printer, branch: if `Opts.File` is set, read the file with `os.ReadFile` (wrap and return a clear error if missing/unreadable) and run its contents via the non-interactive runner; else if `Opts.Command` is set, run it via the non-interactive runner; else fall through to the existing `RunShellWithOpts` path
+- [x] 1.4 Ensure the non-interactive path does not print the interactive exit hint and does not depend on TTY detection or the history file
+
+## 2. CLI wiring
+
+- [x] 2.1 Register `-c`/`--command` and `-f`/`--file` flags on `connectCmd` in `cmd/exasol/connect.go`, bound to the new `connectOpts` fields
+- [x] 2.2 Mark the two flags mutually exclusive (`MarkFlagsMutuallyExclusive`) and add an explicit check in `RunE` that returns a clear error if both are set, before calling `deploy.Connect`
+- [x] 2.3 Update `connectCmdExample` to show `-c` and `-f` usage
+- [x] 2.4 Confirm no short-flag collision with existing `connect` flags (`-u`, `-p`, `-k`, `-j`)
+
+## 3. Tests
+
+- [x] 3.1 Unit-test the non-interactive runner: single statement, multiple `;`-separated statements run in order, empty/trailing segments skipped, stop-on-first-error returns the error
+- [x] 3.2 Test `--command` and `--file` produce table and `--json` output identically to the interactive path (covered structurally: both paths share the same printer/`processInput`; rendering verified via `TestRunStatementsRendersEachResult` and the existing printer tests)
+- [x] 3.3 Test `--file` with a missing/unreadable path returns a non-zero error and runs no statements (`resolveNonInteractiveSQL` errors before connecting)
+- [x] 3.4 Test that supplying both `--command` and `--file` fails fast with the mutual-exclusivity error and never connects
+- [x] 3.5 Verify neither flag preserves existing interactive/stdin behavior (`resolveNonInteractiveSQL` returns `nonInteractive=false`; existing `TestRunShell` unchanged)
+
+## 4. Documentation
+
+- [x] 4.1 Update the README `connect` section to document `-c`/`--command` and `-f`/`--file`, including the stop-on-error / non-zero exit behavior
+- [x] 4.2 Run `task fmt`, `task lint`, and `task tests-unit`; fix any findings (gofmt/`go vet`/`go build` clean, `lint-golang` clean, all unit tests pass; fixed a revive line-length and a staticcheck nil-deref finding in the new test. Two pre-existing, change-unrelated tooling failures remain on this macOS machine: golangci-lint v2.4.0 panics under `--fix` on Go 1.26 (`buildssa`), and `lint-licenses` passes no files to `addlicense` because `find -iregex` yields nothing under Task's shell — all touched files pass `addlicense -check` directly.)


### PR DESCRIPTION
## Description

`exasol connect` could only receive SQL interactively or via stdin (pipes, heredocs). Passing a single statement or a script file required shell plumbing that is awkward for humans and brittle for automation and AI agents. Other SQL clients (`psql -c`/`-f`, `mysql -e`) expose direct flags for this; this PR adds the equivalent to `exasol connect`.

It adds two mutually-exclusive, non-interactive input flags:

- `-c, --command <SQL>` — run one or more `;`-separated statements passed inline, then exit.
- `-f, --file <path>` — read a SQL script from a file, run its `;`-separated statements, then exit.

Both reuse the same statement splitting and result printing (table or `--json`) as the interactive shell, but skip the readline shell, version banner, and exit hint. With neither flag, `connect` behaves exactly as before.

## Related Issue

N/A

## Type of Change

- [x] `feat`: New feature

## Changes Made

- Register `-c/--command` and `-f/--file` on `connect`, marked mutually exclusive (`cmd/exasol/connect.go`).
- Add a non-interactive execution path in `internal/connect`: when `--command`/`--file` is supplied, resolve the SQL up front (an unreadable `--file` fails fast, before any DB connection) and run it through the existing exec/print pipeline instead of the readline shell.
- Execution stops at the first failing statement and exits non-zero, so scripts can detect errors.
- Integrate with the row-display behaviour already on `main`: `--command`/`--file` are treated as non-interactive, so they return the full result set by default (no 100-row interactive cap) unless `--max-rows` is set explicitly.
- Document the flags in the README `connect` section and command examples.
- OpenSpec change `add-connect-command-and-file-flags` (new `connect-sql-input` capability).

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

Unit tests cover SQL-source resolution (`--command` supplies SQL, `--file` reads it, a missing file errors before running anything, neither flag falls back to interactive), non-interactive statement running rendering each result via the same printer, statement splitting, and the mutual-exclusivity flag wiring. `go build ./...`, full `go test ./...`, and `golangci-lint run ./...` (0 issues) all pass locally.

CLI examples:

```bash
# inline statement(s)
exasol connect -c "SELECT 1; SELECT 2"

# run a script file
exasol connect -f script.sql

# machine-readable output
exasol connect -c "SELECT * FROM PRODUCTS" --json=compact

# mutually exclusive — this errors
exasol connect -c "SELECT 1" -f script.sql
```

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

n/a
