### PR TITLE
feat: Add per-user artifact cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Keep the deployment directory until cloud resources have been destroyed. Deletin
 
 An initialized deployment directory is tied to the selected infrastructure and installation presets. Rerun `exasol install <preset>` with the same presets to retry a failed deployment safely, or use `exasol config get`, `exasol config set`, and `exasol config reset` to inspect or change parameters for the existing presets without deleting local state. To switch presets in the same deployment directory, run `exasol destroy --remove` before initializing again, or run `exasol remove` if the cloud resources are already gone.
 
+Runtime tools such as OpenTofu are downloaded on demand and reused from a per-user runtime artifact cache. Use `exasol cache list` to inspect cached artifacts, `exasol cache clean` to remove stale artifacts, `exasol cache clean --invalid` to remove artifacts that fail integrity checks, `exasol cache clean --partial-downloads` to remove staged partial downloads, `exasol cache clean --all` to wipe cached artifacts, and `exasol diag cache` to inspect cache health without changing it. Add `--dry-run` to a cleanup command to preview what would be removed.
+
 ## 📊 Load Sample Data
 
 To get started quickly, Exasol provides two sample datasets hosted on S3 that you can import directly using SQL.

--- a/cmd/exasol/cache.go
+++ b/cmd/exasol/cache.go
@@ -1,0 +1,301 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/exasol/exasol-personal/internal/runtimeartifacts"
+	"github.com/spf13/cobra"
+)
+
+const cacheCmdShortDesc = "Manage the runtime artifact cache"
+
+const cacheCmdLongDesc = cacheCmdShortDesc + `
+
+Runtime artifacts are launcher-managed tools and files that are downloaded on demand
+and reused across deployments.
+`
+
+var cacheCleanOpts = struct {
+	Invalid          bool
+	All              bool
+	PartialDownloads bool
+	DryRun           bool
+}{}
+
+var cacheCmd = &cobra.Command{
+	Use:   "cache",
+	Short: cacheCmdShortDesc,
+	Long:  cacheCmdLongDesc,
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return cmd.Help()
+	},
+}
+
+var cacheListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List cached runtime artifacts",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		cmd.SilenceUsage = true
+		artifactCache, err := runtimeartifacts.NewDefaultCache()
+		if err != nil {
+			return err
+		}
+		entries, err := artifactCache.List(cmd.Context())
+		if err != nil {
+			return err
+		}
+		if commonFlags.OutputJson {
+			return renderCacheListJSON(cmd.OutOrStdout(), entries)
+		}
+
+		return renderCacheListText(cmd.OutOrStdout(), artifactCache.Root(), entries)
+	},
+}
+
+var cacheCleanCmd = &cobra.Command{
+	Use:   "clean",
+	Short: "Clean cached runtime artifacts",
+	Long: `Clean cached runtime artifacts.
+
+With no selector, this removes artifacts older than the configured retention period.
+Use --invalid to remove artifacts that fail integrity checks.
+Use --all to remove every cached runtime artifact.
+Use --partial-downloads to remove staged partial downloads.
+Use --dry-run to preview a cleanup without removing files.
+`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		cmd.SilenceUsage = true
+		if selectedCacheCleanupSelectorCount() > 1 {
+			return errors.New("--invalid, --all, and --partial-downloads are mutually exclusive")
+		}
+		artifactCache, err := runtimeartifacts.NewDefaultCache()
+		if err != nil {
+			return err
+		}
+		summary, err := artifactCache.Clean(cmd.Context(), runtimeartifacts.CleanOptions{
+			Mode:   selectedCacheCleanupMode(),
+			DryRun: cacheCleanOpts.DryRun,
+		})
+		if err != nil {
+			return err
+		}
+
+		return renderCacheCleanText(cmd.OutOrStdout(), summary)
+	},
+}
+
+var cacheUnlockCmd = &cobra.Command{
+	Use:   "unlock",
+	Short: "Clear a stale runtime artifact cache lock",
+	Long: `Clear a stale runtime artifact cache lock.
+
+Only use this command when you are certain that no launcher process is currently
+using the runtime artifact cache.
+`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		cmd.SilenceUsage = true
+		artifactCache, err := runtimeartifacts.NewDefaultCache()
+		if err != nil {
+			return err
+		}
+		if err := artifactCache.Unlock(); err != nil {
+			return err
+		}
+		_, err = fmt.Fprintln(cmd.OutOrStdout(), "Runtime artifact cache lock cleared.")
+
+		return err
+	},
+}
+
+func renderCacheListJSON(
+	writer io.Writer,
+	entries []runtimeartifacts.CacheEntryInfo,
+) error {
+	encoder := json.NewEncoder(writer)
+	encoder.SetIndent("", "  ")
+
+	return encoder.Encode(entries)
+}
+
+func renderCacheListText(
+	writer io.Writer,
+	cacheRoot string,
+	entries []runtimeartifacts.CacheEntryInfo,
+) error {
+	if _, err := fmt.Fprintf(writer, "Runtime artifact cache: %s\n", cacheRoot); err != nil {
+		return err
+	}
+	if len(entries) == 0 {
+		_, err := fmt.Fprintln(writer, "No cached runtime artifacts.")
+		return err
+	}
+	for _, entry := range entries {
+		if _, err := fmt.Fprintf(
+			writer,
+			"%s %s last_used=%s size=%s path=%s\n",
+			entry.ResourceID,
+			entry.Platform,
+			entry.LastUsedAt.Format("2006-01-02T15:04:05Z07:00"),
+			formatByteSize(entry.SizeBytes),
+			entry.ResolvedPath,
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func selectedCacheCleanupMode() runtimeartifacts.CleanupMode {
+	if cacheCleanOpts.Invalid {
+		return runtimeartifacts.CleanupModeInvalid
+	}
+	if cacheCleanOpts.All {
+		return runtimeartifacts.CleanupModeAll
+	}
+	if cacheCleanOpts.PartialDownloads {
+		return runtimeartifacts.CleanupModePartialDownloads
+	}
+
+	return runtimeartifacts.CleanupModeStale
+}
+
+func selectedCacheCleanupSelectorCount() int {
+	count := 0
+	if cacheCleanOpts.Invalid {
+		count++
+	}
+	if cacheCleanOpts.All {
+		count++
+	}
+	if cacheCleanOpts.PartialDownloads {
+		count++
+	}
+
+	return count
+}
+
+func renderCacheCleanText(
+	writer io.Writer,
+	summary runtimeartifacts.CleanSummary,
+) error {
+	action := "Removed"
+	if summary.DryRun {
+		action = "Would remove"
+	}
+	subject := "runtime artifact(s)"
+	if summary.Mode == runtimeartifacts.CleanupModePartialDownloads {
+		subject = "partial download(s)"
+	}
+	if _, err := fmt.Fprintf(
+		writer,
+		"%s %d %s, %s (mode: %s).\n",
+		action,
+		summary.RemovedEntries,
+		subject,
+		formatByteSize(summary.RemovedBytes),
+		summary.Mode,
+	); err != nil {
+		return err
+	}
+	if summary.InvalidEntries > 0 {
+		_, err := fmt.Fprintf(writer, "Invalid artifacts: %d\n", summary.InvalidEntries)
+		return err
+	}
+
+	return nil
+}
+
+func formatCachePath(cacheRoot, pathValue string) string {
+	if cacheRoot == "" || pathValue == "" {
+		return pathValue
+	}
+
+	rel, err := filepath.Rel(filepath.Clean(cacheRoot), filepath.Clean(pathValue))
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return pathValue
+	}
+
+	return filepath.ToSlash(rel)
+}
+
+func formatByteSize(sizeBytes int64) string {
+	const unit = 1024
+	if sizeBytes < unit {
+		return fmt.Sprintf("%d B", sizeBytes)
+	}
+
+	for _, sizeUnit := range []struct {
+		label string
+		bytes int64
+	}{
+		{label: "GB", bytes: unit * unit * unit},
+		{label: "MB", bytes: unit * unit},
+		{label: "KB", bytes: unit},
+	} {
+		if sizeBytes >= sizeUnit.bytes {
+			if sizeBytes%sizeUnit.bytes == 0 {
+				return fmt.Sprintf("%d %s", sizeBytes/sizeUnit.bytes, sizeUnit.label)
+			}
+
+			size := float64(sizeBytes) / float64(sizeUnit.bytes)
+
+			return fmt.Sprintf("%.1f %s", size, sizeUnit.label)
+		}
+	}
+
+	return fmt.Sprintf("%d B", sizeBytes)
+}
+
+func registerCacheCommands() {
+	cacheListCmd.Flags().SortFlags = false
+	registerOutputFlags(cacheListCmd, commonFlags)
+
+	cacheCleanCmd.Flags().BoolVar(
+		&cacheCleanOpts.Invalid,
+		"invalid",
+		false,
+		"Remove cached artifacts that fail integrity checks",
+	)
+	cacheCleanCmd.Flags().BoolVar(
+		&cacheCleanOpts.All,
+		"all",
+		false,
+		"Remove all cached runtime artifacts",
+	)
+	cacheCleanCmd.Flags().BoolVar(
+		&cacheCleanOpts.PartialDownloads,
+		"partial-downloads",
+		false,
+		"Remove staged partial downloads",
+	)
+	cacheCleanCmd.Flags().BoolVar(
+		&cacheCleanOpts.DryRun,
+		"dry-run",
+		false,
+		"Preview cleanup without removing files",
+	)
+	cacheCleanCmd.MarkFlagsMutuallyExclusive("invalid", "all", "partial-downloads")
+
+	cacheCmd.AddCommand(cacheListCmd)
+	cacheCmd.AddCommand(cacheCleanCmd)
+	cacheCmd.AddCommand(cacheUnlockCmd)
+}
+
+// nolint: gochecknoinits
+func init() {
+	registerCacheCommands()
+	rootCmd.AddCommand(cacheCmd)
+}

--- a/cmd/exasol/cache_test.go
+++ b/cmd/exasol/cache_test.go
@@ -1,0 +1,302 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/runtimeartifacts"
+	"github.com/spf13/cobra"
+)
+
+func TestCacheCommandsDoNotUseDeploymentDirectoryConcerns(t *testing.T) {
+	t.Parallel()
+
+	commands := map[string]*cobra.Command{
+		"cache":        cacheCmd,
+		"cache list":   cacheListCmd,
+		"cache clean":  cacheCleanCmd,
+		"cache unlock": cacheUnlockCmd,
+	}
+	for name, cmd := range commands {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if deploymentFileLoggingIsRequired(cmd) {
+				t.Fatalf("expected %s to not require deployment file logging", name)
+			}
+			if deploymentCompatibilityIsRequired(cmd) {
+				t.Fatalf("expected %s to not require deployment compatibility", name)
+			}
+			if deploymentDirMustBeInitialized(cmd) {
+				t.Fatalf("expected %s to not require initialized deployment dir", name)
+			}
+		})
+	}
+}
+
+//nolint:paralleltest // modifies process environment and global flag state.
+func TestCacheListCommandInitializesConfig(t *testing.T) {
+	home := t.TempDir()
+	cacheHome := t.TempDir()
+	setCacheCommandTestEnv(t, home, cacheHome)
+	oldOutputJSON := commonFlags.OutputJson
+	commonFlags.OutputJson = false
+	t.Cleanup(func() {
+		commonFlags.OutputJson = oldOutputJSON
+	})
+
+	cmd := *cacheListCmd
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	if err := cmd.RunE(&cmd, nil); err != nil {
+		t.Fatalf("expected cache list to succeed, got %v", err)
+	}
+
+	expectedConfig := filepath.Join(config.LauncherDirPath(home), "runtime-artifacts.yaml")
+	if _, err := os.Stat(expectedConfig); err != nil {
+		t.Fatalf("expected cache config to be created, got %v", err)
+	}
+	userCacheDir, err := os.UserCacheDir()
+	if err != nil {
+		t.Fatalf("failed to resolve user cache dir: %v", err)
+	}
+	expectedCacheRoot := filepath.Join(
+		config.LauncherDirPath(userCacheDir),
+		"runtime-artifacts",
+	)
+	if !strings.Contains(buf.String(), "Runtime artifact cache: "+expectedCacheRoot) {
+		t.Fatalf("expected cache root in output, got %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), "No cached runtime artifacts.") {
+		t.Fatalf("expected empty-cache message, got %q", buf.String())
+	}
+}
+
+func TestCacheListCommandRegistersJSONFlag(t *testing.T) {
+	t.Parallel()
+
+	if cacheListCmd.Flags().Lookup("json") == nil {
+		t.Fatal("expected cache list to register json output flag")
+	}
+}
+
+func TestCacheCleanCommandRegistersCleanupFlags(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"invalid", "all", "partial-downloads", "dry-run"} {
+		if cacheCleanCmd.Flags().Lookup(name) == nil {
+			t.Fatalf("expected cache clean to register --%s", name)
+		}
+	}
+	for _, name := range []string{"invalid", "all", "partial-downloads"} {
+		flag := cacheCleanCmd.Flags().Lookup(name)
+		annotations := flag.Annotations["cobra_annotation_mutually_exclusive"]
+		if len(annotations) != 1 || annotations[0] != "invalid all partial-downloads" {
+			t.Fatalf(
+				"expected --%s mutually exclusive with cleanup selectors, got %+v",
+				name,
+				annotations,
+			)
+		}
+	}
+}
+
+//nolint:paralleltest // modifies global clean option state.
+func TestCacheCleanRejectsMultipleCleanupSelectors(t *testing.T) {
+	oldOpts := cacheCleanOpts
+	cacheCleanOpts.Invalid = true
+	cacheCleanOpts.All = false
+	cacheCleanOpts.PartialDownloads = true
+	cacheCleanOpts.DryRun = true
+	t.Cleanup(func() {
+		cacheCleanOpts = oldOpts
+	})
+
+	cmd := &cobra.Command{Use: "clean"}
+	err := cacheCleanCmd.RunE(cmd, nil)
+
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("expected mutually exclusive flag error, got %v", err)
+	}
+}
+
+func TestCacheUnlockHelpWarnsAboutActiveLauncherProcesses(t *testing.T) {
+	t.Parallel()
+
+	if !strings.Contains(cacheUnlockCmd.Long, "no launcher process") {
+		t.Fatalf("expected cache unlock warning, got %q", cacheUnlockCmd.Long)
+	}
+}
+
+func TestRenderCacheListJSON(t *testing.T) {
+	t.Parallel()
+
+	entries := []runtimeartifacts.CacheEntryInfo{cacheEntryInfoFixture()}
+	var buf bytes.Buffer
+
+	if err := renderCacheListJSON(&buf, entries); err != nil {
+		t.Fatalf("expected json render to succeed, got %v", err)
+	}
+
+	var decoded []runtimeartifacts.CacheEntryInfo
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("expected valid json, got %v: %s", err, buf.String())
+	}
+	if len(decoded) != 1 ||
+		decoded[0].ResourceID != "tofu" ||
+		decoded[0].ArtifactPath != "artifacts/tofu/download.tgz" ||
+		decoded[0].ResolvedPath != "artifacts/tofu" {
+		t.Fatalf("unexpected decoded entries: %+v", decoded)
+	}
+}
+
+func TestRenderCacheListTextIncludesLastUsedTimestamp(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	if err := renderCacheListText(&buf, "/cache", []runtimeartifacts.CacheEntryInfo{
+		cacheEntryInfoFixture(),
+	}); err != nil {
+		t.Fatalf("expected text render to succeed, got %v", err)
+	}
+
+	output := buf.String()
+	for _, expected := range []string{
+		"Runtime artifact cache: /cache",
+		"tofu linux/amd64",
+		"last_used=2026-06-08T12:00:00Z",
+		"size=1.5 KB",
+		"path=artifacts/tofu",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("expected %q in output, got %q", expected, output)
+		}
+	}
+}
+
+func TestRenderCacheCleanTextUsesDryRunAndInvalidWording(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	err := renderCacheCleanText(&buf, runtimeartifacts.CleanSummary{
+		Mode:           "invalid",
+		DryRun:         true,
+		RemovedEntries: 2,
+		RemovedBytes:   2 * 1024 * 1024,
+		InvalidEntries: 2,
+	})
+	if err != nil {
+		t.Fatalf("expected clean summary render to succeed, got %v", err)
+	}
+
+	output := buf.String()
+	for _, expected := range []string{
+		"Would remove 2 runtime artifact(s), 2 MB (mode: invalid).",
+		"Invalid artifacts: 2",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("expected %q in output, got %q", expected, output)
+		}
+	}
+}
+
+func TestFormatCachePathReturnsRelativePathsInsideCacheRoot(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		cacheRoot string
+		pathValue string
+		expected  string
+	}{
+		{
+			name:      "inside root",
+			cacheRoot: "/cache",
+			pathValue: "/cache/artifacts/tofu/download.tgz",
+			expected:  "artifacts/tofu/download.tgz",
+		},
+		{
+			name:      "outside root",
+			cacheRoot: "/cache",
+			pathValue: "/config/runtime-artifacts.yaml",
+			expected:  "/config/runtime-artifacts.yaml",
+		},
+		{
+			name:      "already relative",
+			cacheRoot: "/cache",
+			pathValue: "artifacts/tofu",
+			expected:  "artifacts/tofu",
+		},
+	}
+	for _, test := range tests {
+		if actual := formatCachePath(test.cacheRoot, test.pathValue); actual != test.expected {
+			t.Fatalf("%s: expected %q, got %q", test.name, test.expected, actual)
+		}
+	}
+}
+
+func TestFormatByteSizeUsesHumanFriendlyUnits(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		size     int64
+		expected string
+	}{
+		{size: 42, expected: "42 B"},
+		{size: 1024, expected: "1 KB"},
+		{size: 1536, expected: "1.5 KB"},
+		{size: 2 * 1024 * 1024, expected: "2 MB"},
+		{size: 5*1024*1024 + 512*1024, expected: "5.5 MB"},
+		{size: 3 * 1024 * 1024 * 1024, expected: "3 GB"},
+	}
+	for _, test := range tests {
+		if actual := formatByteSize(test.size); actual != test.expected {
+			t.Fatalf("expected %d bytes to render as %q, got %q", test.size, test.expected, actual)
+		}
+	}
+}
+
+func cacheEntryInfoFixture() runtimeartifacts.CacheEntryInfo {
+	return runtimeartifacts.CacheEntryInfo{
+		ID:           "identity",
+		ResourceID:   "tofu",
+		Platform:     "linux/amd64",
+		URL:          "https://example.com/tofu",
+		Sha256:       strings.Repeat("a", 64),
+		ArtifactPath: "artifacts/tofu/download.tgz",
+		ResolvedPath: "artifacts/tofu",
+		CreatedAt:    time.Date(2026, 6, 8, 11, 0, 0, 0, time.UTC),
+		LastUsedAt:   time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC),
+		SizeBytes:    1536,
+	}
+}
+
+func setCacheCommandTestEnv(t *testing.T, home, cacheHome string) {
+	t.Helper()
+
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HOMEDRIVE", "")
+	t.Setenv("HOMEPATH", "")
+	switch runtime.GOOS {
+	case "windows":
+		t.Setenv("LOCALAPPDATA", cacheHome)
+	case "darwin":
+		t.Setenv("HOME", home)
+	default:
+		t.Setenv("XDG_CACHE_HOME", cacheHome)
+	}
+}

--- a/cmd/exasol/cache_test.go
+++ b/cmd/exasol/cache_test.go
@@ -26,6 +26,7 @@ func TestCacheCommandsDoNotUseDeploymentDirectoryConcerns(t *testing.T) {
 		"cache list":   cacheListCmd,
 		"cache clean":  cacheCleanCmd,
 		"cache unlock": cacheUnlockCmd,
+		"diag cache":   diagCacheCmd,
 	}
 	for name, cmd := range commands {
 		t.Run(name, func(t *testing.T) {
@@ -139,6 +140,16 @@ func TestCacheUnlockHelpWarnsAboutActiveLauncherProcesses(t *testing.T) {
 	}
 }
 
+func TestDiagCacheHelpDescribesReadOnlyBehavior(t *testing.T) {
+	t.Parallel()
+
+	if !strings.Contains(diagCacheCmd.Long, "without removing artifacts") ||
+		!strings.Contains(diagCacheCmd.Long, "rewriting metadata") ||
+		!strings.Contains(diagCacheCmd.Long, "clearing cache locks") {
+		t.Fatalf("expected read-only diagnostic help, got %q", diagCacheCmd.Long)
+	}
+}
+
 func TestRenderCacheListJSON(t *testing.T) {
 	t.Parallel()
 
@@ -206,6 +217,57 @@ func TestRenderCacheCleanTextUsesDryRunAndInvalidWording(t *testing.T) {
 	for _, expected := range []string{
 		"Would remove 2 runtime artifact(s), 2 MB (mode: invalid).",
 		"Invalid artifacts: 2",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("expected %q in output, got %q", expected, output)
+		}
+	}
+}
+
+func TestRenderCacheDiagnosticsTextIncludesCacheState(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	report := runtimeartifacts.DiagnosticReport{
+		CacheRoot:        "/cache",
+		ConfigPath:       "/config/runtime-artifacts.yaml",
+		ConfigExists:     true,
+		RetentionDays:    30,
+		IndexPath:        "/cache/index.json",
+		IndexExists:      true,
+		Lock:             runtimeartifacts.CacheLockStatus{Locked: true, Mode: "exclusive"},
+		ArtifactCount:    1,
+		TotalBytes:       3 * 1024 * 1024 * 1024,
+		StaleCandidates:  1,
+		InvalidArtifacts: 1,
+		MissingFiles:     []string{"/cache/missing"},
+		UnexpectedPaths:  []string{"/cache/unexpected"},
+		Entries: []runtimeartifacts.DiagnosticEntry{
+			{
+				CacheEntryInfo:  cacheEntryInfoFixture(),
+				Stale:           true,
+				IntegrityStatus: "mismatch",
+			},
+		},
+	}
+
+	if err := renderCacheDiagnosticsText(&buf, report); err != nil {
+		t.Fatalf("expected diagnostics render to succeed, got %v", err)
+	}
+
+	output := buf.String()
+	for _, expected := range []string{
+		"Cache root: /cache",
+		"Config file: /config/runtime-artifacts.yaml",
+		"Index file: index.json",
+		"Config status: ok (retention_days=30)",
+		"Index status: ok",
+		"Lock status: locked (exclusive)",
+		"Total size: 3 GB",
+		"Invalid artifacts: 1",
+		"tofu linux/amd64 integrity=mismatch stale=true path=artifacts/tofu",
+		"Missing: missing",
+		"Unexpected: unexpected",
 	} {
 		if !strings.Contains(output, expected) {
 			t.Fatalf("expected %q in output, got %q", expected, output)

--- a/cmd/exasol/deployment_dir_resolution.go
+++ b/cmd/exasol/deployment_dir_resolution.go
@@ -104,12 +104,7 @@ func deploymentDirFlag(cmd *cobra.Command) *pflag.Flag {
 }
 
 func defaultDeploymentDir() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("resolve home directory for default deployment directory: %w", err)
-	}
-
-	return filepath.Join(home, ".exasol", "personal", "deployments", "default"), nil
+	return config.DefaultDeploymentDirPath()
 }
 
 func isRecognizedDeploymentDir(path string) (bool, error) {

--- a/cmd/exasol/deployment_dir_resolution_test.go
+++ b/cmd/exasol/deployment_dir_resolution_test.go
@@ -76,7 +76,7 @@ func TestResolveDeploymentDir_DefaultWinsWhenFlagOmittedOutsideDeploymentDir(t *
 	if source != deploymentDirSourceDefault {
 		t.Fatalf("expected default source, got %v", source)
 	}
-	expected := filepath.Join(home, ".exasol", "personal", "deployments", "default")
+	expected := filepath.Join(config.LauncherDirPath(home), "deployments", "default")
 	if deployment.Root() != expected {
 		t.Fatalf("expected %q, got %q", expected, deployment.Root())
 	}

--- a/cmd/exasol/diagCache.go
+++ b/cmd/exasol/diagCache.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/exasol/exasol-personal/internal/runtimeartifacts"
+	"github.com/spf13/cobra"
+)
+
+var diagCacheCmd = &cobra.Command{
+	Use:   "cache",
+	Short: "Inspect the runtime artifact cache",
+	Long: `Inspect the runtime artifact cache.
+
+This command reports cache state without removing artifacts, rewriting metadata,
+or clearing cache locks.
+`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		cmd.SilenceUsage = true
+		artifactCache, err := runtimeartifacts.NewDefaultCache()
+		if err != nil {
+			return err
+		}
+
+		return renderCacheDiagnosticsText(cmd.OutOrStdout(), artifactCache.Diagnose())
+	},
+}
+
+func renderCacheDiagnosticsText(
+	writer io.Writer,
+	report runtimeartifacts.DiagnosticReport,
+) error {
+	lines := []string{
+		"Cache root: " + report.CacheRoot,
+		"Config file: " + report.ConfigPath,
+		cacheConfigStatusLine(report),
+		"Index file: " + formatCachePath(report.CacheRoot, report.IndexPath),
+		cacheIndexStatusLine(report),
+		cacheLockStatusLine(report.Lock),
+		fmt.Sprintf("Artifacts: %d", report.ArtifactCount),
+		"Total size: " + formatByteSize(report.TotalBytes),
+		fmt.Sprintf("Stale candidates: %d", report.StaleCandidates),
+		fmt.Sprintf("Invalid artifacts: %d", report.InvalidArtifacts),
+	}
+	for _, entry := range report.Entries {
+		lines = append(
+			lines,
+			fmt.Sprintf(
+				"%s %s integrity=%s stale=%t path=%s",
+				entry.ResourceID,
+				entry.Platform,
+				entry.IntegrityStatus,
+				entry.Stale,
+				formatCachePath(report.CacheRoot, entry.ResolvedPath),
+			),
+		)
+	}
+	for _, missing := range report.MissingFiles {
+		lines = append(lines, "Missing: "+formatCachePath(report.CacheRoot, missing))
+	}
+	for _, unexpected := range report.UnexpectedPaths {
+		lines = append(lines, "Unexpected: "+formatCachePath(report.CacheRoot, unexpected))
+	}
+
+	return writeLines(writer, lines)
+}
+
+func cacheConfigStatusLine(report runtimeartifacts.DiagnosticReport) string {
+	if report.ConfigError != "" {
+		return "Config status: error: " + report.ConfigError
+	}
+	if report.ConfigExists {
+		return fmt.Sprintf("Config status: ok (retention_days=%d)", report.RetentionDays)
+	}
+
+	return fmt.Sprintf("Config status: default (retention_days=%d)", report.RetentionDays)
+}
+
+func cacheIndexStatusLine(report runtimeartifacts.DiagnosticReport) string {
+	if report.IndexError != "" {
+		return "Index status: error: " + report.IndexError
+	}
+	if report.IndexExists {
+		return "Index status: ok"
+	}
+
+	return "Index status: missing"
+}
+
+func cacheLockStatusLine(lock runtimeartifacts.CacheLockStatus) string {
+	if lock.Error != "" {
+		return "Lock status: error: " + lock.Error
+	}
+	if lock.Locked {
+		return fmt.Sprintf("Lock status: locked (%s)", lock.Mode)
+	}
+
+	return "Lock status: unlocked"
+}
+
+func writeLines(writer io.Writer, lines []string) error {
+	for _, line := range lines {
+		if _, err := fmt.Fprintln(writer, line); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// nolint: gochecknoinits
+func init() {
+	diagCmd.AddCommand(diagCacheCmd)
+}

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -46,7 +46,7 @@ The Exasol Personal tool (`exasol`) is a command-line application that automates
 **Self-Contained**
 - Single binary with no external dependencies
 - Infrastructure-as-Code templates embedded in the binary
-- Runtime resources stored in the deployment directory
+- Runtime artifacts resolved on demand and cached per user
 
 **Safety**
 - Explicit commands for destructive operations
@@ -95,7 +95,6 @@ The `init` command prepares a deployment directory:
 1. Create deployment directory structure
 2. Extract the selected infrastructure and installation presets
 3. Write infrastructure variables (for example, a `.tfvars` file) and workflow state
-4. Resolve runtime resources needed by the selected infrastructure preset
 
 **Output:** A self-contained deployment directory ready for provisioning.
 
@@ -227,6 +226,12 @@ The deployment directory is the central artifact containing everything needed to
 - `deployment.json` - Deployment information (IPs, connection details)
 - `secrets.json` - Credentials required by the launcher (sensitive)
 - SSH private key referenced by `deployment.json:nodes[*].ssh.keyFile` (current presets use `node_access.pem`)
+
+### Runtime Artifact Cache
+
+Launcher-managed runtime artifacts are resolved on demand and stored in a per-user cache so they can be reused across deployments. Cache metadata records source information, validation data, size, and last-use timestamps; cleanup uses the launcher cache retention configuration, with a built-in default when no user configuration exists.
+
+Users can inspect and maintain the cache with `exasol cache list`, `exasol cache clean`, `exasol cache clean --invalid`, `exasol cache clean --partial-downloads`, `exasol cache clean --all`, `exasol cache unlock`, and `exasol diag cache`. Diagnostics are read-only and include cache, lock, metadata, and checksum state.
 
 **Key characteristics:**
 - Self-contained (portable to another machine if needed)

--- a/doc/development.md
+++ b/doc/development.md
@@ -83,8 +83,6 @@ GOOS=windows GOARCH=amd64 task build
 GOOS=darwin GOARCH=arm64 task build
 ```
 
-**Note:** The launcher now resolves OpenTofu at runtime through the embedded resource manager, so `task build` no longer needs platform-specific OpenTofu downloads. Cross-compilation only needs the usual Go environment variables.
-
 ### Building Without Task
 
 If you prefer to use Go commands directly (or Task is unavailable):
@@ -208,7 +206,8 @@ See [Best Practices](best_practices.md) for project-specific coding guidelines a
 ## Common Issues
 
 **OpenTofu binary not found:**
-- OpenTofu is resolved at runtime through the embedded resource manager.
+- OpenTofu is resolved at runtime through the per-user runtime artifact cache.
+- Use `exasol diag cache` to inspect cache state, `exasol cache clean --invalid` to remove artifacts that fail integrity checks, and `exasol cache clean --partial-downloads` to remove interrupted downloads.
 - For direct tofu invocations in development workflows, use `task fmt-terraform` or `go run ./tools/tofu/main.go ...`.
 
 **Windows fails with `tofu init -lockfile=readonly` due to missing hashes in `.terraform.lock.hcl`:**

--- a/internal/config/deployment_dir.go
+++ b/internal/config/deployment_dir.go
@@ -4,9 +4,18 @@
 package config
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/exasol/exasol-personal/internal/presets"
+)
+
+const (
+	launcherRootDirName      = ".exasol"
+	launcherPersonalDirName  = "personal"
+	deploymentsDirName       = "deployments"
+	defaultDeploymentDirName = "default"
 )
 
 // DeploymentDir represents the root of a deployment directory.
@@ -28,6 +37,29 @@ func NewDeploymentDir(path string) DeploymentDir {
 	}
 
 	return DeploymentDir{root: root}
+}
+
+func DefaultDeploymentDirPath() (string, error) {
+	rootDir, err := LauncherRootDirPath()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(rootDir, deploymentsDirName, defaultDeploymentDirName), nil
+}
+
+func LauncherRootDirPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory for launcher root directory: %w", err)
+	}
+
+	return LauncherDirPath(home), nil
+}
+
+// LauncherDirPath returns the launcher-owned directory below baseDir.
+func LauncherDirPath(baseDir string) string {
+	return filepath.Join(baseDir, launcherRootDirName, launcherPersonalDirName)
 }
 
 func (d DeploymentDir) Root() string {

--- a/internal/deploy/locking.go
+++ b/internal/deploy/locking.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/exasol/exasol-personal/internal/config"
 	"github.com/exasol/exasol-personal/internal/directorymutex"
-	"github.com/exasol/exasol-personal/internal/util"
 )
 
 const lockUnavailableMessage = "Deployment directory is locked by another operation. " +
@@ -65,53 +64,29 @@ func withDeploymentLock(
 		return err
 	}
 
+	wrapped := func(any) error {
+		return function(deployment)
+	}
+
 	if exclusive {
-		err = mutex.AcquireExclusive(ctx)
+		err = mutex.WithExclusive(ctx, nil, wrapped)
 	} else {
-		err = mutex.AcquireShared(ctx)
+		err = mutex.WithShared(ctx, nil, wrapped)
 	}
 
 	if err != nil {
-		return mapLockAcquireError(ctx, deployment, err)
+		return mapDeploymentLockError(deployment, err)
 	}
 
-	releaseCtx := context.WithoutCancel(ctx)
-	release := func() error {
-		if exclusive {
-			return mutex.ReleaseExclusive(releaseCtx)
-		}
-
-		return mutex.ReleaseShared(releaseCtx)
-	}
-	releaseOnce := releaseOnInterruptOnce(release)
-
-	var callbackErr error
-	defer func() {
-		releaseErr := releaseOnce()
-		if releaseErr == nil {
-			return
-		}
-		if callbackErr == nil {
-			callbackErr = releaseErr
-			return
-		}
-		callbackErr = errors.Join(callbackErr, releaseErr)
-	}()
-
-	callbackErr = callWithPanicSafetyError(function, deployment)
-
-	return callbackErr
+	return nil
 }
 
-func mapLockAcquireError(ctx context.Context, deployment config.DeploymentDir, err error) error {
+func mapDeploymentLockError(deployment config.DeploymentDir, err error) error {
 	if errors.Is(err, context.Canceled) {
 		return err
 	}
 	if !errors.Is(err, directorymutex.ErrAcquireTimeout) {
 		return err
-	}
-	if ctx == nil {
-		return &deploymentDirectoryLockedError{message: lockUnavailableMessage}
 	}
 
 	if operation := lockedOperationName(deployment); operation != "" {
@@ -144,34 +119,6 @@ func activeOperationInProgressMessage(operation string) string {
 	return "Operation '" + operation + "' is currently in progress. Please wait. " +
 		"Do not use `unlock` unless you are certain that no other exasol " +
 		"launcher instance is running."
-}
-
-func callWithPanicSafetyError(
-	function func(deployment config.DeploymentDir) error,
-	deployment config.DeploymentDir,
-) error {
-	defer func() {
-		if recovered := recover(); recovered != nil {
-			panic(recovered)
-		}
-	}()
-
-	return function(deployment)
-}
-
-func releaseOnInterruptOnce(release func() error) func() error {
-	// Run the release function no matter what
-	unregister, _ := util.RegisterOnceSignalHandler(func() {
-		_ = release()
-	})
-
-	return func() error {
-		if unregister() {
-			return release()
-		}
-
-		return nil
-	}
 }
 
 func deploymentLockMessage(err error) string {

--- a/internal/deploy/reconfiguration_test.go
+++ b/internal/deploy/reconfiguration_test.go
@@ -70,7 +70,7 @@ func TestSetDeploymentConfiguration_UpdatesVariablesAndPreservesStateFiles(t *te
 	if err := os.WriteFile(statePath, []byte("state"), 0o600); err != nil {
 		t.Fatalf("write state file failed: %v", err)
 	}
-	tofuBinaryPath, err := tofu.ResolveBinaryPath(context.Background(), deployment.Root())
+	tofuBinaryPath, err := tofu.ResolveBinaryPath(context.Background())
 	if err != nil {
 		t.Fatalf("resolve tofu binary path failed: %v", err)
 	}

--- a/internal/directorymutex/directorymutex.go
+++ b/internal/directorymutex/directorymutex.go
@@ -12,6 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/exasol/exasol-personal/internal/util"
 )
 
 var (
@@ -102,6 +104,38 @@ func (m *DirectoryMutex) ReleaseExclusive(ctx context.Context) error {
 	return m.release(ctx, modeExclusive)
 }
 
+func (m *DirectoryMutex) WithShared(ctx context.Context, arg any, function func(any) error) error {
+	return m.withLock(ctx, arg, function, modeShared)
+}
+
+func (m *DirectoryMutex) WithExclusive(
+	ctx context.Context,
+	arg any,
+	function func(any) error,
+) error {
+	return m.withLock(ctx, arg, function, modeExclusive)
+}
+
+// ClearLock force-removes the current marker file if one exists.
+func (m *DirectoryMutex) ClearLock() error {
+	marker, err := m.findMarker()
+	if err != nil {
+		return err
+	}
+	if marker == nil {
+		return nil
+	}
+	if err := os.Remove(marker.path); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	return nil
+}
+
 // Status reports the current observed lock state.
 func (m *DirectoryMutex) Status() (Status, error) {
 	marker, err := m.findMarker()
@@ -129,26 +163,6 @@ func (m *DirectoryMutex) Status() (Status, error) {
 	}
 
 	return status, nil
-}
-
-// ClearLock force-removes the current marker file if one exists.
-func (m *DirectoryMutex) ClearLock() error {
-	marker, err := m.findMarker()
-	if err != nil {
-		return err
-	}
-	if marker == nil {
-		return nil
-	}
-	if err := os.Remove(marker.path); err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-
-		return err
-	}
-
-	return nil
 }
 
 type markerInfo struct {
@@ -401,6 +415,82 @@ func withTimeoutIfMissing(
 	}
 
 	return context.WithTimeout(ctx, timeout)
+}
+
+func (m *DirectoryMutex) withLock(
+	ctx context.Context,
+	arg any,
+	function func(any) error,
+	mode lockMode,
+) error {
+	var err error
+
+	switch mode {
+	case modeExclusive:
+		err = m.AcquireExclusive(ctx)
+	case modeShared:
+		err = m.AcquireShared(ctx)
+	default:
+	}
+
+	if err != nil {
+		return err
+	}
+
+	releaseCtx := context.WithoutCancel(ctx)
+	release := func() error {
+		switch mode {
+		case modeExclusive:
+			return m.ReleaseExclusive(releaseCtx)
+		case modeShared:
+			return m.ReleaseShared(releaseCtx)
+		default:
+			return nil
+		}
+	}
+	releaseOnce := releaseOnInterruptOnce(release)
+
+	var callbackErr error
+	defer func() {
+		releaseErr := releaseOnce()
+		if releaseErr == nil {
+			return
+		}
+		if callbackErr == nil {
+			callbackErr = releaseErr
+			return
+		}
+		callbackErr = errors.Join(callbackErr, releaseErr)
+	}()
+
+	callbackErr = callWithPanicSafetyError(function, arg)
+
+	return callbackErr
+}
+
+func callWithPanicSafetyError(function func(any) error, arg any) error {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			panic(recovered)
+		}
+	}()
+
+	return function(arg)
+}
+
+func releaseOnInterruptOnce(release func() error) func() error {
+	// Run the release function no matter what
+	unregister, _ := util.RegisterOnceSignalHandler(func() {
+		_ = release()
+	})
+
+	return func() error {
+		if unregister() {
+			return release()
+		}
+
+		return nil
+	}
 }
 
 func sleepWithContext(ctx context.Context, duration time.Duration) error {

--- a/internal/runtimeartifacts/cache.go
+++ b/internal/runtimeartifacts/cache.go
@@ -95,6 +95,15 @@ type CleanSummary struct {
 	Entries        []CacheEntryInfo `json:"entries"`
 }
 
+type CacheLockStatus struct {
+	CacheExists bool   `json:"cacheExists"`
+	Locked      bool   `json:"locked"`
+	Mode        string `json:"mode,omitempty"`
+	SharedCount int    `json:"sharedCount,omitempty"`
+	MarkerPath  string `json:"markerPath,omitempty"`
+	Error       string `json:"error,omitempty"`
+}
+
 type cleanupPlan struct {
 	mode           CleanupMode
 	dryRun         bool

--- a/internal/runtimeartifacts/cache.go
+++ b/internal/runtimeartifacts/cache.go
@@ -1,0 +1,531 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package runtimeartifacts
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/directorymutex"
+	"go.yaml.in/yaml/v3"
+)
+
+const (
+	runtimeArtifactsDirName    = "runtime-artifacts"
+	artifactsDirName           = "artifacts"
+	downloadsDirName           = "downloads"
+	cacheIndexFileName         = "index.json"
+	cacheConfigFileName        = "runtime-artifacts.yaml"
+	cacheIndexVersion          = 1
+	defaultRetentionDays       = 30
+	automaticCleanupInterval   = 24 * time.Hour
+	defaultCacheAcquireTimeout = 5 * time.Minute
+	integrityStatusOK          = "ok"
+	integrityStatusMissing     = "missing"
+	integrityStatusMismatch    = "mismatch"
+	integrityStatusReadError   = "read_error"
+)
+
+var (
+	ErrInvalidCacheConfig = errors.New("invalid runtime artifact cache configuration")
+	ErrCacheLocked        = errors.New("runtime artifact cache is locked")
+)
+
+type clock interface {
+	Now() time.Time
+}
+
+type systemClock struct{}
+
+func (systemClock) Now() time.Time {
+	return time.Now().UTC()
+}
+
+type CacheConfig struct {
+	//nolint:tagliatelle // YAML config uses snake_case field names.
+	RetentionDays int `json:"retentionDays" yaml:"retention_days"`
+}
+
+type Cache struct {
+	root       string
+	configPath string
+	clock      clock
+}
+
+type CacheEntryInfo struct {
+	ID           string    `json:"id"`
+	ResourceID   string    `json:"resourceId"`
+	Platform     string    `json:"platform"`
+	URL          string    `json:"url"`
+	Sha256       string    `json:"sha256"`
+	ArtifactPath string    `json:"artifactPath"`
+	ResolvedPath string    `json:"resolvedPath"`
+	CreatedAt    time.Time `json:"createdAt"`
+	LastUsedAt   time.Time `json:"lastUsedAt"`
+	SizeBytes    int64     `json:"sizeBytes"`
+}
+
+type CleanupMode string
+
+const (
+	CleanupModeStale            CleanupMode = "stale"
+	CleanupModeInvalid          CleanupMode = "invalid"
+	CleanupModeAll              CleanupMode = "all"
+	CleanupModePartialDownloads CleanupMode = "partial-downloads"
+)
+
+type CleanOptions struct {
+	Mode   CleanupMode
+	DryRun bool
+}
+
+type CleanSummary struct {
+	Mode           CleanupMode      `json:"mode"`
+	DryRun         bool             `json:"dryRun"`
+	RemovedEntries int              `json:"removedEntries"`
+	RemovedBytes   int64            `json:"removedBytes"`
+	InvalidEntries int              `json:"invalidEntries,omitempty"`
+	Entries        []CacheEntryInfo `json:"entries"`
+}
+
+type cleanupPlan struct {
+	mode           CleanupMode
+	dryRun         bool
+	removedBytes   int64
+	invalidEntries int
+	candidates     []cleanupCandidate
+}
+
+type cleanupCandidate struct {
+	id    string
+	entry cacheIndexEntry
+	info  CacheEntryInfo
+}
+
+type partialDownloadPlan struct {
+	removedBytes int64
+	candidates   []partialDownloadCandidate
+}
+
+type partialDownloadCandidate struct {
+	path string
+}
+
+func DefaultCacheRoot() (string, error) {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user cache directory: %w", err)
+	}
+
+	return filepath.Join(config.LauncherDirPath(cacheDir), runtimeArtifactsDirName), nil
+}
+
+func DefaultConfigPath() (string, error) {
+	rootDir, err := config.LauncherRootDirPath()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(rootDir, cacheConfigFileName), nil
+}
+
+func NewDefaultCache() (*Cache, error) {
+	root, err := DefaultCacheRoot()
+	if err != nil {
+		return nil, err
+	}
+	configPath, err := DefaultConfigPath()
+	if err != nil {
+		return nil, err
+	}
+
+	return NewCache(root, configPath), nil
+}
+
+func NewCache(root, configPath string) *Cache {
+	return newCacheWithClock(root, configPath, systemClock{})
+}
+
+func newCacheWithClock(root, configPath string, clk clock) *Cache {
+	return &Cache{root: filepath.Clean(root), configPath: filepath.Clean(configPath), clock: clk}
+}
+
+func (c *Cache) Root() string {
+	return c.root
+}
+
+func (c *Cache) ConfigPath() string {
+	return c.configPath
+}
+
+func (c *Cache) IndexPath() string {
+	return filepath.Join(c.root, cacheIndexFileName)
+}
+
+func DefaultCacheConfig() CacheConfig {
+	return CacheConfig{RetentionDays: defaultRetentionDays}
+}
+
+func LoadCacheConfig(path string) (CacheConfig, bool, error) {
+	cfg := DefaultCacheConfig()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return cfg, false, nil
+		}
+
+		return cfg, false, err
+	}
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return cfg, true, err
+	}
+	if err := validateCacheConfig(cfg); err != nil {
+		return cfg, true, err
+	}
+
+	return cfg, true, nil
+}
+
+func EnsureCacheConfig(path string) (CacheConfig, error) {
+	cfg, exists, err := LoadCacheConfig(path)
+	if err != nil || exists {
+		return cfg, err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), dirPerm); err != nil {
+		return cfg, err
+	}
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return cfg, err
+	}
+
+	return cfg, os.WriteFile(path, data, filePerm)
+}
+
+func validateCacheConfig(cfg CacheConfig) error {
+	if cfg.RetentionDays <= 0 {
+		return fmt.Errorf("%w: retention_days must be positive", ErrInvalidCacheConfig)
+	}
+
+	return nil
+}
+
+func (c *Cache) List(ctx context.Context) ([]CacheEntryInfo, error) {
+	var entries []CacheEntryInfo
+	err := c.withExclusiveLock(ctx, func() error {
+		if _, err := EnsureCacheConfig(c.configPath); err != nil {
+			return err
+		}
+		index, _, err := c.readIndex()
+		if err != nil {
+			return err
+		}
+		entries = c.listEntries(index)
+
+		return nil
+	})
+
+	return entries, err
+}
+
+func (c *Cache) Clean(ctx context.Context, opts CleanOptions) (CleanSummary, error) {
+	mode, err := normalizeCleanupMode(opts.Mode)
+	if err != nil {
+		return CleanSummary{}, err
+	}
+	opts.Mode = mode
+
+	var summary CleanSummary
+	err = c.withExclusiveLock(ctx, func() error {
+		cfg, err := EnsureCacheConfig(c.configPath)
+		if err != nil {
+			return err
+		}
+		if opts.Mode == CleanupModePartialDownloads {
+			plan, planErr := c.planPartialDownloadCleanup()
+			summary = plan.summary(opts.DryRun)
+			if planErr != nil || opts.DryRun {
+				return planErr
+			}
+
+			return removePartialDownloads(plan)
+		}
+
+		index, _, err := c.readIndex()
+		if err != nil {
+			// If we can't read the cache index, we treat it as empty so we can
+			// still wipe the cache.
+			index = emptyCacheIndex()
+		}
+		plan, err := c.planCleanup(index, cfg, opts)
+		summary = plan.summary()
+		if err == nil && !opts.DryRun {
+			if opts.Mode == CleanupModeAll {
+				err = c.wipeCacheContents(&index)
+			} else {
+				err = c.removeEntries(&index, plan)
+			}
+		}
+		if err != nil || opts.DryRun {
+			return err
+		}
+		index.LastCleanup = c.clock.Now().UTC()
+
+		return c.writeIndex(index)
+	})
+
+	return summary, err
+}
+
+func (c *Cache) Unlock() error {
+	return c.clearLock()
+}
+
+func (c *Cache) listEntries(index cacheIndex) []CacheEntryInfo {
+	entries := make([]CacheEntryInfo, 0, len(index.Entries))
+	for _, entryID := range sortedEntryIDs(index) {
+		info, err := c.entryInfo(entryID, index.Entries[entryID])
+		if err == nil {
+			entries = append(entries, info)
+		}
+	}
+
+	return entries
+}
+
+func (c *Cache) entryInfo(entryID string, entry cacheIndexEntry) (CacheEntryInfo, error) {
+	if _, err := c.pathFromRelative(entry.EntryPath, "entryPath"); err != nil {
+		return CacheEntryInfo{}, err
+	}
+	if _, err := c.pathFromRelative(entry.ArtifactPath, "artifactPath"); err != nil {
+		return CacheEntryInfo{}, err
+	}
+	if _, err := c.pathFromRelative(entry.ResolvedPath, "resolvedPath"); err != nil {
+		return CacheEntryInfo{}, err
+	}
+
+	return CacheEntryInfo{
+		ID:           entryID,
+		ResourceID:   entry.ResourceID,
+		Platform:     entry.Platform,
+		URL:          entry.URL,
+		Sha256:       entry.Sha256,
+		ArtifactPath: entry.ArtifactPath,
+		ResolvedPath: entry.ResolvedPath,
+		CreatedAt:    entry.CreatedAt,
+		LastUsedAt:   entry.LastUsedAt,
+		SizeBytes:    entry.SizeBytes,
+	}, nil
+}
+
+func (c *Cache) planCleanup(
+	index cacheIndex,
+	cfg CacheConfig,
+	opts CleanOptions,
+) (cleanupPlan, error) {
+	plan := cleanupPlan{mode: opts.Mode, dryRun: opts.DryRun}
+	now := c.clock.Now()
+	for _, entryID := range sortedEntryIDs(index) {
+		entry := index.Entries[entryID]
+		invalid := false
+		var remove bool
+		switch opts.Mode {
+		case CleanupModeAll:
+			remove = true
+		case CleanupModeInvalid:
+			check := c.checkIntegrity(entry)
+			invalid = check.Status != integrityStatusOK
+			remove = invalid
+		case CleanupModeStale:
+			remove = isEntryStale(entry, cfg, now)
+		case CleanupModePartialDownloads:
+			remove = false
+		default:
+			remove = isEntryStale(entry, cfg, now)
+		}
+		if !remove {
+			continue
+		}
+		info, err := c.entryInfo(entryID, entry)
+		if err != nil {
+			return plan, err
+		}
+		size, err := directorySize(c.absolutePath(entry.EntryPath))
+		if err == nil {
+			info.SizeBytes = size
+		}
+		plan.removedBytes += info.SizeBytes
+		if invalid {
+			plan.invalidEntries++
+		}
+		plan.candidates = append(plan.candidates, cleanupCandidate{
+			id:    entryID,
+			entry: entry,
+			info:  info,
+		})
+	}
+
+	return plan, nil
+}
+
+func (p cleanupPlan) summary() CleanSummary {
+	entries := make([]CacheEntryInfo, 0, len(p.candidates))
+	for _, candidate := range p.candidates {
+		entries = append(entries, candidate.info)
+	}
+
+	return CleanSummary{
+		Mode:           p.mode,
+		DryRun:         p.dryRun,
+		RemovedEntries: len(p.candidates),
+		RemovedBytes:   p.removedBytes,
+		InvalidEntries: p.invalidEntries,
+		Entries:        entries,
+	}
+}
+
+func normalizeCleanupMode(mode CleanupMode) (CleanupMode, error) {
+	if mode == "" {
+		return CleanupModeStale, nil
+	}
+	switch mode {
+	case CleanupModeStale, CleanupModeInvalid, CleanupModeAll, CleanupModePartialDownloads:
+		return mode, nil
+	default:
+		return "", fmt.Errorf("unsupported cache cleanup mode %q", mode)
+	}
+}
+
+func isEntryStale(entry cacheIndexEntry, cfg CacheConfig, now time.Time) bool {
+	if entry.LastUsedAt.IsZero() {
+		return true
+	}
+	cutoff := now.Add(-time.Duration(cfg.RetentionDays) * 24 * time.Hour)
+
+	return entry.LastUsedAt.Before(cutoff)
+}
+
+func (c *Cache) cleanupStaleIfDue(index *cacheIndex) error {
+	if !index.LastCleanup.IsZero() &&
+		c.clock.Now().Sub(index.LastCleanup) < automaticCleanupInterval {
+		return nil
+	}
+	cfg, _, err := LoadCacheConfig(c.configPath)
+	if err != nil {
+		return err
+	}
+	plan, err := c.planCleanup(*index, cfg, CleanOptions{Mode: CleanupModeStale})
+	if err != nil {
+		return err
+	}
+	if err := c.removeEntries(index, plan); err != nil {
+		return err
+	}
+	index.LastCleanup = c.clock.Now().UTC()
+
+	return nil
+}
+
+func (c *Cache) removeEntries(index *cacheIndex, plan cleanupPlan) error {
+	for _, candidate := range plan.candidates {
+		if err := os.RemoveAll(c.absolutePath(candidate.entry.EntryPath)); err != nil {
+			return err
+		}
+		delete(index.Entries, candidate.id)
+	}
+
+	return nil
+}
+
+func (p partialDownloadPlan) summary(dryRun bool) CleanSummary {
+	return CleanSummary{
+		Mode:           CleanupModePartialDownloads,
+		DryRun:         dryRun,
+		RemovedEntries: len(p.candidates),
+		RemovedBytes:   p.removedBytes,
+	}
+}
+
+func removePartialDownloads(plan partialDownloadPlan) error {
+	for _, candidate := range plan.candidates {
+		if err := os.RemoveAll(candidate.path); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *Cache) planPartialDownloadCleanup() (partialDownloadPlan, error) {
+	plan := partialDownloadPlan{}
+	root := c.downloadsRoot()
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return plan, nil
+		}
+
+		return plan, err
+	}
+	sort.Slice(entries, func(left, right int) bool {
+		return entries[left].Name() < entries[right].Name()
+	})
+
+	plan.candidates = make([]partialDownloadCandidate, 0, len(entries))
+	for _, entry := range entries {
+		path := filepath.Join(root, entry.Name())
+		size, err := directorySize(path)
+		if err != nil {
+			return partialDownloadPlan{}, err
+		}
+		plan.removedBytes += size
+		plan.candidates = append(plan.candidates, partialDownloadCandidate{path: path})
+	}
+
+	return plan, nil
+}
+
+// wipeCacheContents removes cache contents, including unindexed files, while
+// preserving lock state for the running operation and resetting artifact
+// metadata.
+func (c *Cache) wipeCacheContents(index *cacheIndex) error {
+	entries, err := os.ReadDir(c.root)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			index.Entries = map[string]cacheIndexEntry{}
+			return nil
+		}
+
+		return err
+	}
+
+	for _, entry := range entries {
+		if directorymutex.IsMarkerName(entry.Name()) {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(c.root, entry.Name())); err != nil {
+			return err
+		}
+	}
+	index.Entries = map[string]cacheIndexEntry{}
+
+	return nil
+}
+
+func sortedEntryIDs(index cacheIndex) []string {
+	keys := make([]string, 0, len(index.Entries))
+	for key := range index.Entries {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	return keys
+}

--- a/internal/runtimeartifacts/cache.go
+++ b/internal/runtimeartifacts/cache.go
@@ -18,19 +18,18 @@ import (
 )
 
 const (
-	runtimeArtifactsDirName    = "runtime-artifacts"
-	artifactsDirName           = "artifacts"
-	downloadsDirName           = "downloads"
-	cacheIndexFileName         = "index.json"
-	cacheConfigFileName        = "runtime-artifacts.yaml"
-	cacheIndexVersion          = 1
-	defaultRetentionDays       = 30
-	automaticCleanupInterval   = 24 * time.Hour
-	defaultCacheAcquireTimeout = 5 * time.Minute
-	integrityStatusOK          = "ok"
-	integrityStatusMissing     = "missing"
-	integrityStatusMismatch    = "mismatch"
-	integrityStatusReadError   = "read_error"
+	runtimeArtifactsDirName  = "runtime-artifacts"
+	artifactsDirName         = "artifacts"
+	downloadsDirName         = "downloads"
+	cacheIndexFileName       = "index.json"
+	cacheConfigFileName      = "runtime-artifacts.yaml"
+	cacheIndexVersion        = 1
+	defaultRetentionDays     = 30
+	automaticCleanupInterval = 24 * time.Hour
+	integrityStatusOK        = "ok"
+	integrityStatusMissing   = "missing"
+	integrityStatusMismatch  = "mismatch"
+	integrityStatusReadError = "read_error"
 )
 
 var (

--- a/internal/runtimeartifacts/cache_core.go
+++ b/internal/runtimeartifacts/cache_core.go
@@ -35,6 +35,10 @@ import (
 // - filesystem primitives (`directorySize`) provide size inspection without
 //   mutating the cache.
 
+// This timeout should be long enough for another launcher to download and
+// extract whatever resource it is going to use.
+const acquireTimeout = 5 * time.Minute
+
 type cacheIndex struct {
 	Version     int                        `json:"version"`
 	LastCleanup time.Time                  `json:"lastCleanupAt,omitempty"`
@@ -132,7 +136,7 @@ func (c *Cache) lockStatus() CacheLockStatus {
 }
 
 //nolint:contextcheck // Lock release must outlive caller cancellation.
-func (c *Cache) withExclusiveLock(ctx context.Context, function func() error) (callbackErr error) {
+func (c *Cache) withExclusiveLock(ctx context.Context, function func() error) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -144,33 +148,15 @@ func (c *Cache) withExclusiveLock(ctx context.Context, function func() error) (c
 		return err
 	}
 
-	lockCtx, cancel := cacheLockContext(ctx)
+	waitCtx, cancel := context.WithTimeout(ctx, acquireTimeout)
 	defer cancel()
-	if err := mutex.AcquireExclusive(lockCtx); err != nil {
+
+	err = mutex.WithExclusive(waitCtx, nil, func(any) error { return function() })
+	if err != nil {
 		return mapCacheLockError(err)
 	}
 
-	releaseCtx := context.WithoutCancel(ctx)
-	defer func() {
-		releaseErr := mutex.ReleaseExclusive(releaseCtx)
-		if callbackErr == nil {
-			callbackErr = releaseErr
-		} else if releaseErr != nil {
-			callbackErr = errors.Join(callbackErr, releaseErr)
-		}
-	}()
-
-	callbackErr = function()
-
-	return callbackErr
-}
-
-func cacheLockContext(ctx context.Context) (context.Context, context.CancelFunc) {
-	if _, ok := ctx.Deadline(); ok {
-		return ctx, func() {}
-	}
-
-	return context.WithTimeout(ctx, defaultCacheAcquireTimeout)
+	return nil
 }
 
 func mapCacheLockError(err error) error {

--- a/internal/runtimeartifacts/cache_core.go
+++ b/internal/runtimeartifacts/cache_core.go
@@ -1,0 +1,390 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package runtimeartifacts
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/exasol/exasol-personal/internal/directorymutex"
+)
+
+// Primitive groups and semantics:
+// - lock primitives (`withExclusiveLock`, `clearLock`) create the cache root
+//   before constructing directorymutex, serialize cache reads and mutations
+//   with exclusive locks, map contention to cache-specific errors, and release
+//   locks with a cancellation-independent context.
+// - index primitives (`readIndex`, `readIndexRaw`, `writeIndex`) treat a
+//   missing index as an empty cache, reject unsupported schema versions,
+//   validate relative cache paths for normal operations, and write metadata
+//   atomically through a temporary file.
+// - path primitives (`pathWithinRoot`, `pathFromRelative`, `relativePath`,
+//   `absolutePath`) normalize cache-relative paths and convert them to absolute
+//   filesystem paths while rejecting values that escape their root.
+// - integrity primitives (`checkIntegrity`) validate the cached downloaded
+//   artifact against the expected checksum and do not inspect extracted
+//   contents.
+// - filesystem primitives (`directorySize`) provide size inspection without
+//   mutating the cache.
+
+type cacheIndex struct {
+	Version     int                        `json:"version"`
+	LastCleanup time.Time                  `json:"lastCleanupAt,omitempty"`
+	Entries     map[string]cacheIndexEntry `json:"entries"`
+}
+
+type cacheIndexEntry struct {
+	ResourceID   string    `json:"resourceId"`
+	Platform     string    `json:"platform"`
+	URL          string    `json:"url"`
+	Sha256       string    `json:"sha256"`
+	Extract      bool      `json:"extract"`
+	DownloadPath string    `json:"downloadPath,omitempty"`
+	ResourcePath string    `json:"resourcePath,omitempty"`
+	EntryPath    string    `json:"entryPath"`
+	ArtifactPath string    `json:"artifactPath"`
+	ResolvedPath string    `json:"resolvedPath"`
+	CreatedAt    time.Time `json:"createdAt"`
+	LastUsedAt   time.Time `json:"lastUsedAt"`
+	SizeBytes    int64     `json:"sizeBytes"`
+}
+
+type integrityCheck struct {
+	Status string
+	Actual string
+	Error  string
+}
+
+type cacheLockedError struct {
+	message string
+}
+
+func (e *cacheLockedError) Error() string {
+	return e.message
+}
+
+func (*cacheLockedError) Is(target error) bool {
+	return target == ErrCacheLocked
+}
+
+func (c *Cache) artifactsRoot() string {
+	return filepath.Join(c.root, artifactsDirName)
+}
+
+func (c *Cache) downloadsRoot() string {
+	return filepath.Join(c.root, downloadsDirName)
+}
+
+func (c *Cache) clearLock() error {
+	if err := os.MkdirAll(c.root, dirPerm); err != nil {
+		return err
+	}
+	mutex, err := directorymutex.New(c.root)
+	if err != nil {
+		return err
+	}
+
+	return mutex.ClearLock()
+}
+
+//nolint:contextcheck // Lock release must outlive caller cancellation.
+func (c *Cache) withExclusiveLock(ctx context.Context, function func() error) (callbackErr error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := os.MkdirAll(c.root, dirPerm); err != nil {
+		return err
+	}
+	mutex, err := directorymutex.New(c.root)
+	if err != nil {
+		return err
+	}
+
+	lockCtx, cancel := cacheLockContext(ctx)
+	defer cancel()
+	if err := mutex.AcquireExclusive(lockCtx); err != nil {
+		return mapCacheLockError(err)
+	}
+
+	releaseCtx := context.WithoutCancel(ctx)
+	defer func() {
+		releaseErr := mutex.ReleaseExclusive(releaseCtx)
+		if callbackErr == nil {
+			callbackErr = releaseErr
+		} else if releaseErr != nil {
+			callbackErr = errors.Join(callbackErr, releaseErr)
+		}
+	}()
+
+	callbackErr = function()
+
+	return callbackErr
+}
+
+func cacheLockContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}
+	}
+
+	return context.WithTimeout(ctx, defaultCacheAcquireTimeout)
+}
+
+func mapCacheLockError(err error) error {
+	if errors.Is(err, context.Canceled) {
+		return err
+	}
+	if errors.Is(err, directorymutex.ErrAcquireTimeout) {
+		return &cacheLockedError{
+			message: "Runtime artifact cache is locked by another operation. " +
+				"Please wait. Run `exasol cache unlock` only if no launcher " +
+				"process is using the cache.",
+		}
+	}
+
+	return err
+}
+
+func emptyCacheIndex() cacheIndex {
+	return cacheIndex{
+		Version: cacheIndexVersion,
+		Entries: map[string]cacheIndexEntry{},
+	}
+}
+
+func (c *Cache) readIndex() (cacheIndex, bool, error) {
+	index, exists, err := c.readIndexRaw()
+	if err != nil || !exists {
+		return index, exists, err
+	}
+	if err := c.validateIndex(index); err != nil {
+		return index, true, err
+	}
+
+	return index, true, nil
+}
+
+func (c *Cache) readIndexRaw() (cacheIndex, bool, error) {
+	index := emptyCacheIndex()
+	data, err := os.ReadFile(c.IndexPath())
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return index, false, nil
+		}
+
+		return index, false, err
+	}
+	if err := json.Unmarshal(data, &index); err != nil {
+		return index, true, err
+	}
+	if index.Version == 0 {
+		index.Version = cacheIndexVersion
+	}
+	if index.Version != cacheIndexVersion {
+		return index, true, fmt.Errorf(
+			"unsupported runtime artifact cache index version %d",
+			index.Version,
+		)
+	}
+	if index.Entries == nil {
+		index.Entries = map[string]cacheIndexEntry{}
+	}
+
+	return index, true, nil
+}
+
+func (c *Cache) validateIndex(index cacheIndex) error {
+	for entryID, entry := range index.Entries {
+		for field, value := range map[string]string{
+			"entryPath":    entry.EntryPath,
+			"artifactPath": entry.ArtifactPath,
+			"resolvedPath": entry.ResolvedPath,
+		} {
+			if strings.TrimSpace(value) == "" {
+				return fmt.Errorf("cache entry %q has empty %s", entryID, field)
+			}
+			if _, err := c.pathFromRelative(value, field); err != nil {
+				return fmt.Errorf("cache entry %q: %w", entryID, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *Cache) writeIndex(index cacheIndex) error {
+	if index.Entries == nil {
+		index.Entries = map[string]cacheIndexEntry{}
+	}
+	index.Version = cacheIndexVersion
+	if err := os.MkdirAll(c.root, dirPerm); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(index, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	tmpFile, err := os.CreateTemp(c.root, cacheIndexFileName+".tmp-")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmpFile.Name()
+	closed := false
+	removeTemp := true
+	defer func() {
+		if !closed {
+			_ = tmpFile.Close()
+		}
+		if removeTemp {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if _, err := tmpFile.Write(data); err != nil {
+		return err
+	}
+	if err := tmpFile.Chmod(filePerm); err != nil {
+		return err
+	}
+	if err := tmpFile.Sync(); err != nil {
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		closed = true
+		return err
+	}
+	closed = true
+
+	if err := os.Rename(tmpPath, c.IndexPath()); err != nil {
+		return err
+	}
+	removeTemp = false
+
+	return nil
+}
+
+func (c *Cache) checkIntegrity(entry cacheIndexEntry) integrityCheck {
+	artifactPath, err := c.pathFromRelative(entry.ArtifactPath, "artifactPath")
+	if err != nil {
+		return integrityCheck{Status: integrityStatusReadError, Error: err.Error()}
+	}
+	if _, err := os.Stat(artifactPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return integrityCheck{Status: integrityStatusMissing, Error: err.Error()}
+		}
+
+		return integrityCheck{Status: integrityStatusReadError, Error: err.Error()}
+	}
+	actual, err := sha256OfFile(artifactPath)
+	if err != nil {
+		return integrityCheck{Status: integrityStatusReadError, Error: err.Error()}
+	}
+	if actual != entry.Sha256 {
+		return integrityCheck{Status: integrityStatusMismatch, Actual: actual}
+	}
+
+	return integrityCheck{Status: integrityStatusOK, Actual: actual}
+}
+
+func (c *Cache) pathFromRelative(value, field string) (string, error) {
+	return pathWithinRoot(c.root, value, field)
+}
+
+func (c *Cache) relativePath(pathValue string) (string, error) {
+	rel, err := filepath.Rel(c.root, pathValue)
+	if err != nil {
+		return "", err
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q must stay within %s", pathValue, c.root)
+	}
+
+	return filepath.ToSlash(rel), nil
+}
+
+func (c *Cache) absolutePath(rel string) string {
+	return filepath.Join(c.root, filepath.FromSlash(rel))
+}
+
+func pathWithinRoot(root, value, field string) (string, error) {
+	cleanValue, err := cleanRelativePath(value, field)
+	if err != nil {
+		return "", err
+	}
+
+	candidate := filepath.Join(root, filepath.FromSlash(cleanValue))
+	rel, err := filepath.Rel(root, candidate)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("%s %q must stay within %s", field, value, root)
+	}
+
+	return candidate, nil
+}
+
+func cleanOptionalRelativePath(value, field string) (string, error) {
+	if strings.TrimSpace(value) == "" {
+		return "", nil
+	}
+
+	return cleanRelativePath(value, field)
+}
+
+func cleanRelativePath(value, field string) (string, error) {
+	cleanValue := filepath.Clean(filepath.FromSlash(value))
+	if cleanValue == "." || cleanValue == ".." || filepath.IsAbs(cleanValue) ||
+		strings.HasPrefix(cleanValue, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("%s %q must stay within cache entry", field, value)
+	}
+
+	return filepath.ToSlash(cleanValue), nil
+}
+
+func safePathSegment(value string) string {
+	var builder strings.Builder
+	for _, char := range value {
+		switch {
+		case char >= 'a' && char <= 'z',
+			char >= 'A' && char <= 'Z',
+			char >= '0' && char <= '9',
+			char == '-', char == '_', char == '.':
+			_, _ = builder.WriteRune(char)
+		default:
+			_ = builder.WriteByte('_')
+		}
+	}
+	if builder.Len() == 0 {
+		return "_"
+	}
+
+	return builder.String()
+}
+
+func directorySize(path string) (int64, error) {
+	var size int64
+	err := filepath.WalkDir(path, func(_ string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		size += info.Size()
+
+		return nil
+	})
+
+	return size, err
+}

--- a/internal/runtimeartifacts/cache_core.go
+++ b/internal/runtimeartifacts/cache_core.go
@@ -17,10 +17,11 @@ import (
 )
 
 // Primitive groups and semantics:
-// - lock primitives (`withExclusiveLock`, `clearLock`) create the cache root
-//   before constructing directorymutex, serialize cache reads and mutations
-//   with exclusive locks, map contention to cache-specific errors, and release
-//   locks with a cancellation-independent context.
+// - lock primitives (`withExclusiveLock`, `lockStatus`, `clearLock`) create the
+//   cache root before constructing directorymutex, serialize cache reads and
+//   mutations with exclusive locks, map contention to cache-specific errors,
+//   report lock state without acquiring the lock, and release locks with a
+//   cancellation-independent context.
 // - index primitives (`readIndex`, `readIndexRaw`, `writeIndex`) treat a
 //   missing index as an empty cache, reject unsupported schema versions,
 //   validate relative cache paths for normal operations, and write metadata
@@ -92,6 +93,42 @@ func (c *Cache) clearLock() error {
 	}
 
 	return mutex.ClearLock()
+}
+
+func (c *Cache) lockStatus() CacheLockStatus {
+	status := CacheLockStatus{}
+	info, err := os.Stat(c.root)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return status
+		}
+		status.Error = err.Error()
+
+		return status
+	}
+	status.CacheExists = true
+	if !info.IsDir() {
+		status.Error = c.root + " is not a directory"
+		return status
+	}
+
+	mutex, err := directorymutex.New(c.root)
+	if err != nil {
+		status.Error = err.Error()
+		return status
+	}
+	lockStatus, err := mutex.Status()
+	if err != nil {
+		status.Error = err.Error()
+		return status
+	}
+
+	status.Locked = lockStatus.Locked
+	status.Mode = lockStatus.Mode
+	status.SharedCount = lockStatus.SharedCount
+	status.MarkerPath = lockStatus.MarkerPath
+
+	return status
 }
 
 //nolint:contextcheck // Lock release must outlive caller cancellation.

--- a/internal/runtimeartifacts/cache_diagnosis.go
+++ b/internal/runtimeartifacts/cache_diagnosis.go
@@ -1,0 +1,190 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package runtimeartifacts
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const defaultUnexpectedReportSize = 50
+
+type DiagnosticReport struct {
+	CacheRoot        string            `json:"cacheRoot"`
+	ConfigPath       string            `json:"configPath"`
+	ConfigExists     bool              `json:"configExists"`
+	ConfigError      string            `json:"configError,omitempty"`
+	RetentionDays    int               `json:"retentionDays"`
+	IndexPath        string            `json:"indexPath"`
+	IndexExists      bool              `json:"indexExists"`
+	IndexError       string            `json:"indexError,omitempty"`
+	Lock             CacheLockStatus   `json:"lock"`
+	ArtifactCount    int               `json:"artifactCount"`
+	TotalBytes       int64             `json:"totalBytes"`
+	StaleCandidates  int               `json:"staleCandidates"`
+	InvalidArtifacts int               `json:"invalidArtifacts"`
+	MissingFiles     []string          `json:"missingFiles,omitempty"`
+	UnexpectedPaths  []string          `json:"unexpectedPaths,omitempty"`
+	Entries          []DiagnosticEntry `json:"entries"`
+}
+
+type DiagnosticEntry struct {
+	CacheEntryInfo
+
+	Stale           bool   `json:"stale"`
+	IntegrityStatus string `json:"integrityStatus"`
+	ExpectedSha256  string `json:"expectedSha256,omitempty"`
+	ActualSha256    string `json:"actualSha256,omitempty"`
+	Error           string `json:"error,omitempty"`
+}
+
+type diagnosticEntryResult struct {
+	entry             DiagnosticEntry
+	expectedEntryRoot string
+	sizeBytes         int64
+	counted           bool
+	stale             bool
+	invalid           bool
+	missingFiles      []string
+}
+
+func (c *Cache) Diagnose() DiagnosticReport {
+	report := DiagnosticReport{
+		CacheRoot:  c.root,
+		ConfigPath: c.configPath,
+		IndexPath:  c.IndexPath(),
+		Lock:       c.lockStatus(),
+	}
+
+	cfg, configExists, configErr := LoadCacheConfig(c.configPath)
+	report.ConfigExists = configExists
+	report.RetentionDays = cfg.RetentionDays
+	if configErr != nil {
+		report.ConfigError = configErr.Error()
+		cfg = DefaultCacheConfig()
+	}
+
+	index, indexExists, indexErr := c.readIndexRaw()
+	report.IndexExists = indexExists
+	if indexErr != nil {
+		report.IndexError = indexErr.Error()
+		return report
+	}
+
+	expectedEntryRoots := map[string]struct{}{}
+	now := c.clock.Now()
+	for _, entryID := range sortedEntryIDs(index) {
+		entry := index.Entries[entryID]
+		result := c.diagnoseEntry(entryID, entry, cfg, now)
+		if result.expectedEntryRoot != "" {
+			expectedEntryRoots[result.expectedEntryRoot] = struct{}{}
+		}
+		if result.counted {
+			report.ArtifactCount++
+		}
+		report.TotalBytes += result.sizeBytes
+		if result.stale {
+			report.StaleCandidates++
+		}
+		if result.invalid {
+			report.InvalidArtifacts++
+		}
+		report.MissingFiles = append(report.MissingFiles, result.missingFiles...)
+		report.Entries = append(report.Entries, result.entry)
+	}
+	report.UnexpectedPaths = c.unexpectedEntryRoots(expectedEntryRoots)
+
+	return report
+}
+
+func (c *Cache) diagnoseEntry(
+	entryID string,
+	entry cacheIndexEntry,
+	cfg CacheConfig,
+	now time.Time,
+) diagnosticEntryResult {
+	info, err := c.entryInfo(entryID, entry)
+	diag := DiagnosticEntry{CacheEntryInfo: info, ExpectedSha256: entry.Sha256}
+	if err != nil {
+		diag.ID = entryID
+		diag.ResourceID = entry.ResourceID
+		diag.Platform = entry.Platform
+		diag.IntegrityStatus = integrityStatusReadError
+		diag.Error = err.Error()
+
+		return diagnosticEntryResult{entry: diag, invalid: true}
+	}
+
+	result := diagnosticEntryResult{
+		entry:             diag,
+		expectedEntryRoot: filepath.Clean(entry.EntryPath),
+		counted:           true,
+	}
+	result.sizeBytes, _ = directorySize(c.absolutePath(entry.EntryPath))
+	if isEntryStale(entry, cfg, now) {
+		result.entry.Stale = true
+		result.stale = true
+	}
+	check := c.checkIntegrity(entry)
+	result.entry.IntegrityStatus = check.Status
+	result.entry.ActualSha256 = check.Actual
+	if check.Error != "" {
+		result.entry.Error = check.Error
+	}
+	if check.Status != integrityStatusOK {
+		result.invalid = true
+		if check.Status == integrityStatusMissing {
+			result.missingFiles = append(result.missingFiles, info.ArtifactPath)
+		}
+	}
+	if entry.ResolvedPath != "" {
+		if _, err := os.Stat(c.absolutePath(entry.ResolvedPath)); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				result.missingFiles = append(result.missingFiles, info.ResolvedPath)
+			}
+		}
+	}
+
+	return result
+}
+
+func (c *Cache) unexpectedEntryRoots(expected map[string]struct{}) []string {
+	root := c.artifactsRoot()
+	var unexpected []string
+	_ = filepath.WalkDir(root, func(pathValue string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !entry.IsDir() || pathValue == root {
+			return nil
+		}
+		rel, err := filepath.Rel(root, pathValue)
+		if err != nil {
+			return err
+		}
+		const cacheEntryPathDepth = 3
+		if len(strings.Split(filepath.ToSlash(rel), "/")) != cacheEntryPathDepth {
+			return nil
+		}
+		cacheRel, err := c.relativePath(pathValue)
+		if err != nil {
+			return err
+		}
+		if _, ok := expected[filepath.Clean(cacheRel)]; !ok {
+			unexpected = append(unexpected, filepath.ToSlash(cacheRel))
+		}
+
+		return filepath.SkipDir
+	})
+	sort.Strings(unexpected)
+	if len(unexpected) > defaultUnexpectedReportSize {
+		return unexpected[:defaultUnexpectedReportSize]
+	}
+
+	return unexpected
+}

--- a/internal/runtimeartifacts/cache_test.go
+++ b/internal/runtimeartifacts/cache_test.go
@@ -374,6 +374,138 @@ func TestCacheCleanAllWipesCacheContentsAndResetsMetadata(t *testing.T) {
 	}
 }
 
+func TestCacheDiagnoseReportsChecksumMismatchAndUnexpectedPaths(t *testing.T) {
+	t.Parallel()
+
+	now := testNow()
+	cache := newTestCache(t, now)
+	writeTestCacheConfig(t, cache, 5)
+	index := emptyCacheIndex()
+	seedCacheEntry(t, cache, &index, "valid", "valid", checksumString("valid"), now)
+	seedCacheEntry(
+		t,
+		cache,
+		&index,
+		"invalid",
+		"invalid",
+		checksumString("expected"),
+		now.AddDate(0, 0, -10),
+	)
+	writeTestIndex(t, cache, index)
+	unexpected := filepath.Join(
+		cache.artifactsRoot(),
+		"unexpected",
+		"linux_amd64",
+		"orphan",
+		"file",
+	)
+	if err := os.MkdirAll(filepath.Dir(unexpected), dirPerm); err != nil {
+		t.Fatalf("failed to create unexpected entry: %v", err)
+	}
+	if err := os.WriteFile(unexpected, []byte("orphan"), filePerm); err != nil {
+		t.Fatalf("failed to write unexpected entry: %v", err)
+	}
+
+	report := cache.Diagnose()
+
+	if report.ConfigError != "" || report.IndexError != "" {
+		t.Fatalf(
+			"expected clean diagnostic read, got config=%q index=%q",
+			report.ConfigError,
+			report.IndexError,
+		)
+	}
+	if report.ArtifactCount != 2 || report.InvalidArtifacts != 1 || report.StaleCandidates != 1 {
+		t.Fatalf("unexpected diagnostic counts: %+v", report)
+	}
+	statuses := map[string]string{}
+	for _, entry := range report.Entries {
+		statuses[entry.ID] = entry.IntegrityStatus
+	}
+	if statuses["valid"] != integrityStatusOK {
+		t.Fatalf("expected valid entry to be ok, got %q", statuses["valid"])
+	}
+	if statuses["invalid"] != integrityStatusMismatch {
+		t.Fatalf("expected invalid entry mismatch, got %q", statuses["invalid"])
+	}
+	expectedUnexpected := filepath.ToSlash(filepath.Join(
+		artifactsDirName,
+		"unexpected",
+		"linux_amd64",
+		"orphan",
+	))
+	if len(report.UnexpectedPaths) != 1 || report.UnexpectedPaths[0] != expectedUnexpected {
+		t.Fatalf("expected unexpected entry root, got %+v", report.UnexpectedPaths)
+	}
+}
+
+func TestCacheDiagnoseContinuesWhenOneEntryHasInvalidPath(t *testing.T) {
+	t.Parallel()
+
+	now := testNow()
+	cache := newTestCache(t, now)
+	index := emptyCacheIndex()
+	seedCacheEntry(t, cache, &index, "valid", "valid", checksumString("valid"), now)
+	index.Entries["bad"] = cacheIndexEntry{
+		ResourceID:   "bad-resource",
+		Platform:     "linux/amd64",
+		Sha256:       checksumString("bad"),
+		EntryPath:    "../bad",
+		ArtifactPath: "artifacts/bad/file",
+		ResolvedPath: "artifacts/bad/file",
+		LastUsedAt:   now,
+	}
+	writeTestIndex(t, cache, index)
+
+	report := cache.Diagnose()
+
+	if report.IndexError != "" {
+		t.Fatalf("expected diagnostics to continue past bad entry, got %q", report.IndexError)
+	}
+	if report.ArtifactCount != 1 || report.InvalidArtifacts != 1 {
+		t.Fatalf("unexpected diagnostic counts: %+v", report)
+	}
+	statuses := map[string]string{}
+	for _, entry := range report.Entries {
+		statuses[entry.ID] = entry.IntegrityStatus
+	}
+	if statuses["valid"] != integrityStatusOK {
+		t.Fatalf("expected valid entry to be ok, got %q", statuses["valid"])
+	}
+	if statuses["bad"] != integrityStatusReadError {
+		t.Fatalf("expected bad entry read error, got %q", statuses["bad"])
+	}
+}
+
+func TestCacheLockStatusAndUnlockUseDirectoryMutex(t *testing.T) {
+	t.Parallel()
+
+	cache := newTestCache(t, testNow())
+	if err := os.MkdirAll(cache.Root(), dirPerm); err != nil {
+		t.Fatalf("failed to create cache root: %v", err)
+	}
+	mutex, err := directorymutex.New(cache.Root())
+	if err != nil {
+		t.Fatalf("failed to create mutex: %v", err)
+	}
+	if err := mutex.AcquireExclusive(context.Background()); err != nil {
+		t.Fatalf("failed to acquire mutex: %v", err)
+	}
+
+	status := cache.lockStatus()
+	if !status.Locked || status.Mode != "exclusive" {
+		t.Fatalf("expected exclusive lock status, got %+v", status)
+	}
+
+	if err := cache.Unlock(); err != nil {
+		t.Fatalf("expected unlock to clear marker, got %v", err)
+	}
+	status = cache.lockStatus()
+	if status.Locked || status.Error != "" {
+		t.Fatalf("expected unlocked cache, got %+v", status)
+	}
+}
+
 func TestCacheLockContentionReturnsUserFacingError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runtimeartifacts/cache_test.go
+++ b/internal/runtimeartifacts/cache_test.go
@@ -1,0 +1,500 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package runtimeartifacts
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/directorymutex"
+)
+
+type testClock struct {
+	now time.Time
+}
+
+func (c *testClock) Now() time.Time {
+	return c.now
+}
+
+func TestDefaultCacheRootUsesLauncherRuntimeArtifactsNamespace(t *testing.T) {
+	t.Parallel()
+
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		t.Fatalf("failed to resolve user cache dir: %v", err)
+	}
+
+	root, err := DefaultCacheRoot()
+	if err != nil {
+		t.Fatalf("expected cache root, got error: %v", err)
+	}
+
+	expected := filepath.Join(config.LauncherDirPath(cacheDir), runtimeArtifactsDirName)
+	if root != expected {
+		t.Fatalf("expected %q, got %q", expected, root)
+	}
+}
+
+//nolint:paralleltest // home-directory environment is process-global.
+func TestDefaultConfigPathUsesLauncherRootDirectory(t *testing.T) {
+	home := t.TempDir()
+	setRuntimeArtifactsTestHome(t, home)
+
+	path, err := DefaultConfigPath()
+	if err != nil {
+		t.Fatalf("expected config path, got error: %v", err)
+	}
+
+	expected := filepath.Join(config.LauncherDirPath(home), cacheConfigFileName)
+	if path != expected {
+		t.Fatalf("expected %q, got %q", expected, path)
+	}
+}
+
+func TestEnsureCacheConfigCreatesDefaultAndRejectsInvalidRetention(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config", cacheConfigFileName)
+
+	cfg, err := EnsureCacheConfig(configPath)
+	if err != nil {
+		t.Fatalf("expected default config creation, got error: %v", err)
+	}
+	if cfg.RetentionDays != defaultRetentionDays {
+		t.Fatalf("expected default retention %d, got %d", defaultRetentionDays, cfg.RetentionDays)
+	}
+	content, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("expected config file to exist: %v", err)
+	}
+	if !strings.Contains(string(content), "retention_days: 30") {
+		t.Fatalf("expected retention_days in config, got: %s", string(content))
+	}
+
+	if err := os.WriteFile(configPath, []byte("retention_days: 0\n"), filePerm); err != nil {
+		t.Fatalf("failed to write invalid config: %v", err)
+	}
+	_, _, err = LoadCacheConfig(configPath)
+	if !errors.Is(err, ErrInvalidCacheConfig) {
+		t.Fatalf("expected invalid config error, got %v", err)
+	}
+}
+
+func TestCacheIndexReadWriteRoundTripAndRejectsEscapingPaths(t *testing.T) {
+	t.Parallel()
+
+	cache := newTestCache(t, testNow())
+	index := emptyCacheIndex()
+	entry := seedCacheEntry(
+		t,
+		cache,
+		&index,
+		"artifact",
+		"payload",
+		checksumString("payload"),
+		testNow(),
+	)
+
+	if err := cache.writeIndex(index); err != nil {
+		t.Fatalf("expected index write, got error: %v", err)
+	}
+	if _, err := os.Stat(cache.IndexPath() + ".tmp"); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected temporary index file to be absent, got %v", err)
+	}
+
+	read, exists, err := cache.readIndex()
+	if err != nil {
+		t.Fatalf("expected index read, got error: %v", err)
+	}
+	if !exists {
+		t.Fatal("expected index to exist")
+	}
+	if read.Entries["artifact"].ArtifactPath != entry.ArtifactPath {
+		t.Fatalf(
+			"expected artifact path %q, got %q",
+			entry.ArtifactPath,
+			read.Entries["artifact"].ArtifactPath,
+		)
+	}
+
+	malicious := `{
+		"version":1,
+		"entries":{
+			"bad":{
+				"entryPath":"../bad",
+				"artifactPath":"artifacts/bad/file",
+				"resolvedPath":"artifacts/bad/file"
+			}
+		}
+	}`
+	if err := os.WriteFile(cache.IndexPath(), []byte(malicious), filePerm); err != nil {
+		t.Fatalf("failed to write malicious index: %v", err)
+	}
+	_, _, err = cache.readIndex()
+	if err == nil || !strings.Contains(err.Error(), "must stay within") {
+		t.Fatalf("expected containment error, got %v", err)
+	}
+}
+
+func TestArtifactIdentityChangesWhenArtifactMetadataChanges(t *testing.T) {
+	t.Parallel()
+
+	base, err := artifactIdentity(
+		"tofu",
+		"linux/amd64",
+		false,
+		ArtifactSpec{
+			URL:    "https://example.com/tofu.tgz",
+			Sha256: strings.Repeat("A", 64),
+		},
+		"tofu.tgz",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("expected identity, got error: %v", err)
+	}
+	changed, err := artifactIdentity(
+		"tofu",
+		"linux/amd64",
+		false,
+		ArtifactSpec{
+			URL:    "https://example.com/tofu-v2.tgz",
+			Sha256: strings.Repeat("A", 64),
+		},
+		"tofu.tgz",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("expected changed identity, got error: %v", err)
+	}
+	if base == changed {
+		t.Fatal("expected URL change to produce a distinct artifact identity")
+	}
+}
+
+func TestCacheCleanRemovesStaleEntriesAndKeepsRecentEntries(t *testing.T) {
+	t.Parallel()
+
+	now := testNow()
+	cache := newTestCache(t, now)
+	writeTestCacheConfig(t, cache, 10)
+	index := emptyCacheIndex()
+	stale := seedCacheEntry(
+		t,
+		cache,
+		&index,
+		"stale",
+		"old",
+		checksumString("old"),
+		now.AddDate(0, 0, -30),
+	)
+	recent := seedCacheEntry(
+		t,
+		cache,
+		&index,
+		"recent",
+		"new",
+		checksumString("new"),
+		now.AddDate(0, 0, -1),
+	)
+	writeTestIndex(t, cache, index)
+
+	summary, err := cache.Clean(context.Background(), CleanOptions{})
+	if err != nil {
+		t.Fatalf("expected clean to succeed, got %v", err)
+	}
+
+	if summary.Mode != CleanupModeStale || summary.RemovedEntries != 1 {
+		t.Fatalf("unexpected cleanup summary: %+v", summary)
+	}
+	if _, err := os.Stat(cache.absolutePath(stale.EntryPath)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected stale entry to be removed, got %v", err)
+	}
+	if _, err := os.Stat(cache.absolutePath(recent.EntryPath)); err != nil {
+		t.Fatalf("expected recent entry to remain, got %v", err)
+	}
+	read, _, err := cache.readIndex()
+	if err != nil {
+		t.Fatalf("failed to read index: %v", err)
+	}
+	if _, ok := read.Entries["stale"]; ok {
+		t.Fatal("expected stale metadata to be removed")
+	}
+	if _, ok := read.Entries["recent"]; !ok {
+		t.Fatal("expected recent metadata to remain")
+	}
+}
+
+func TestCacheCleanDryRunDoesNotMutateFilesOrMetadata(t *testing.T) {
+	t.Parallel()
+
+	now := testNow()
+	cache := newTestCache(t, now)
+	writeTestCacheConfig(t, cache, 1)
+	index := emptyCacheIndex()
+	entry := seedCacheEntry(
+		t,
+		cache,
+		&index,
+		"stale",
+		"old",
+		checksumString("old"),
+		now.AddDate(0, 0, -10),
+	)
+	writeTestIndex(t, cache, index)
+
+	summary, err := cache.Clean(context.Background(), CleanOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("expected dry-run clean to succeed, got %v", err)
+	}
+
+	if !summary.DryRun || summary.RemovedEntries != 1 {
+		t.Fatalf("unexpected dry-run summary: %+v", summary)
+	}
+	if _, err := os.Stat(cache.absolutePath(entry.EntryPath)); err != nil {
+		t.Fatalf("expected dry-run to keep files, got %v", err)
+	}
+	read, _, err := cache.readIndex()
+	if err != nil {
+		t.Fatalf("failed to read index: %v", err)
+	}
+	if !read.LastCleanup.Equal(index.LastCleanup) {
+		t.Fatalf("expected dry-run to preserve last cleanup, got %s", read.LastCleanup)
+	}
+	if _, ok := read.Entries["stale"]; !ok {
+		t.Fatal("expected dry-run to keep metadata")
+	}
+}
+
+func TestCacheCleanInvalidRemovesChecksumMismatches(t *testing.T) {
+	t.Parallel()
+
+	cache := newTestCache(t, testNow())
+	index := emptyCacheIndex()
+	good := seedCacheEntry(t, cache, &index, "good", "good", checksumString("good"), testNow())
+	bad := seedCacheEntry(t, cache, &index, "bad", "bad", checksumString("expected"), testNow())
+	writeTestIndex(t, cache, index)
+
+	summary, err := cache.Clean(context.Background(), CleanOptions{Mode: CleanupModeInvalid})
+	if err != nil {
+		t.Fatalf("expected invalid clean to succeed, got %v", err)
+	}
+
+	if summary.Mode != CleanupModeInvalid ||
+		summary.RemovedEntries != 1 ||
+		summary.InvalidEntries != 1 {
+		t.Fatalf("unexpected invalid cleanup summary: %+v", summary)
+	}
+	if _, err := os.Stat(cache.absolutePath(bad.EntryPath)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected invalid entry to be removed, got %v", err)
+	}
+	if _, err := os.Stat(cache.absolutePath(good.EntryPath)); err != nil {
+		t.Fatalf("expected valid entry to remain, got %v", err)
+	}
+}
+
+func TestCacheCleanAllWipesCacheContentsAndResetsMetadata(t *testing.T) {
+	t.Parallel()
+
+	cache := newTestCache(t, testNow())
+	index := emptyCacheIndex()
+	seedCacheEntry(
+		t,
+		cache,
+		&index,
+		"artifact",
+		"payload",
+		checksumString("payload"),
+		testNow(),
+	)
+	writeTestIndex(t, cache, index)
+	unexpected := filepath.Join(
+		cache.artifactsRoot(),
+		"unexpected",
+		"linux_amd64",
+		"orphan",
+		"file",
+	)
+	if err := os.MkdirAll(filepath.Dir(unexpected), dirPerm); err != nil {
+		t.Fatalf("failed to create unexpected entry: %v", err)
+	}
+	if err := os.WriteFile(unexpected, []byte("orphan"), filePerm); err != nil {
+		t.Fatalf("failed to write unexpected entry: %v", err)
+	}
+	partialDownload := filepath.Join(cache.downloadsRoot(), ".tmp-partial", "download.bin")
+	if err := os.MkdirAll(filepath.Dir(partialDownload), dirPerm); err != nil {
+		t.Fatalf("failed to create partial download directory: %v", err)
+	}
+	if err := os.WriteFile(partialDownload, []byte("partial"), filePerm); err != nil {
+		t.Fatalf("failed to write partial download: %v", err)
+	}
+	rootUnexpected := filepath.Join(cache.root, "orphan-root")
+	if err := os.WriteFile(rootUnexpected, []byte("root-orphan"), filePerm); err != nil {
+		t.Fatalf("failed to write root-level unexpected content: %v", err)
+	}
+
+	summary, err := cache.Clean(context.Background(), CleanOptions{Mode: CleanupModeAll})
+	if err != nil {
+		t.Fatalf("expected full clean to succeed, got %v", err)
+	}
+
+	if summary.Mode != CleanupModeAll || summary.RemovedEntries != 1 {
+		t.Fatalf("unexpected full cleanup summary: %+v", summary)
+	}
+	if _, err := os.Stat(cache.artifactsRoot()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected artifact tree to be removed, got %v", err)
+	}
+	if _, err := os.Stat(cache.downloadsRoot()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected downloads tree to be removed, got %v", err)
+	}
+	if _, err := os.Stat(rootUnexpected); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected root-level unexpected content to be removed, got %v", err)
+	}
+	read, _, err := cache.readIndex()
+	if err != nil {
+		t.Fatalf("failed to read index: %v", err)
+	}
+	if len(read.Entries) != 0 {
+		t.Fatalf("expected metadata reset, got %+v", read.Entries)
+	}
+	if _, err := os.Stat(cache.configPath); err != nil {
+		t.Fatalf("expected cache configuration to be preserved, got %v", err)
+	}
+}
+
+func TestCacheLockContentionReturnsUserFacingError(t *testing.T) {
+	t.Parallel()
+
+	cache := newTestCache(t, testNow())
+	if err := os.MkdirAll(cache.Root(), dirPerm); err != nil {
+		t.Fatalf("failed to create cache root: %v", err)
+	}
+	mutex, err := directorymutex.New(cache.Root())
+	if err != nil {
+		t.Fatalf("failed to create mutex: %v", err)
+	}
+	if err := mutex.AcquireExclusive(context.Background()); err != nil {
+		t.Fatalf("failed to acquire mutex: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = mutex.ReleaseExclusive(context.Background())
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	_, err = cache.Clean(ctx, CleanOptions{})
+
+	if !errors.Is(err, ErrCacheLocked) {
+		t.Fatalf("expected cache locked error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "exasol cache unlock") {
+		t.Fatalf("expected user-facing unlock hint, got %v", err)
+	}
+}
+
+func setRuntimeArtifactsTestHome(t *testing.T, home string) {
+	t.Helper()
+
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HOMEDRIVE", "")
+	t.Setenv("HOMEPATH", "")
+	if runtime.GOOS == "windows" {
+		t.Setenv("LOCALAPPDATA", home)
+	}
+}
+
+func newTestCache(t *testing.T, now time.Time) *Cache {
+	t.Helper()
+
+	clk := &testClock{now: now}
+	root := filepath.Join(t.TempDir(), "cache")
+	configPath := filepath.Join(t.TempDir(), "config", cacheConfigFileName)
+
+	return newCacheWithClock(root, configPath, clk)
+}
+
+func writeTestCacheConfig(t *testing.T, cache *Cache, retentionDays int) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(cache.configPath), dirPerm); err != nil {
+		t.Fatalf("failed to create config directory: %v", err)
+	}
+	content := "retention_days: " + strconv.Itoa(retentionDays) + "\n"
+	if err := os.WriteFile(cache.configPath, []byte(content), filePerm); err != nil {
+		t.Fatalf("failed to write cache config: %v", err)
+	}
+}
+
+func writeTestIndex(t *testing.T, cache *Cache, index cacheIndex) {
+	t.Helper()
+
+	if err := cache.writeIndex(index); err != nil {
+		t.Fatalf("failed to write cache index: %v", err)
+	}
+}
+
+func seedCacheEntry(
+	t *testing.T,
+	cache *Cache,
+	index *cacheIndex,
+	artifactID, content, expectedSha string,
+	lastUsedAt time.Time,
+) cacheIndexEntry {
+	t.Helper()
+
+	entryPath := filepath.Join(cache.artifactsRoot(), "resource", "linux_amd64", artifactID)
+	artifactPath := filepath.Join(entryPath, "artifact.bin")
+	if err := os.MkdirAll(filepath.Dir(artifactPath), dirPerm); err != nil {
+		t.Fatalf("failed to create artifact directory: %v", err)
+	}
+	if err := os.WriteFile(artifactPath, []byte(content), filePerm); err != nil {
+		t.Fatalf("failed to write artifact: %v", err)
+	}
+	entryRelPath, err := cache.relativePath(entryPath)
+	if err != nil {
+		t.Fatalf("failed to resolve entry rel path: %v", err)
+	}
+	artifactRelPath, err := cache.relativePath(artifactPath)
+	if err != nil {
+		t.Fatalf("failed to resolve artifact rel path: %v", err)
+	}
+
+	entry := cacheIndexEntry{
+		ResourceID:   "resource",
+		Platform:     "linux/amd64",
+		URL:          "https://example.com/" + artifactID,
+		Sha256:       expectedSha,
+		EntryPath:    entryRelPath,
+		ArtifactPath: artifactRelPath,
+		ResolvedPath: artifactRelPath,
+		CreatedAt:    lastUsedAt.Add(-time.Hour),
+		LastUsedAt:   lastUsedAt,
+		SizeBytes:    int64(len(content)),
+	}
+	index.Entries[artifactID] = entry
+
+	return entry
+}
+
+func checksumString(content string) string {
+	sum := sha256.Sum256([]byte(content))
+
+	return hex.EncodeToString(sum[:])
+}
+
+func testNow() time.Time {
+	return time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+}

--- a/internal/runtimeartifacts/download.go
+++ b/internal/runtimeartifacts/download.go
@@ -177,7 +177,7 @@ func downloadFile(ctx context.Context, url, destPath string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("download %s: %s", url, resp.Status)
+		return fmt.Errorf("failed to fetch %s (%s)", url, resp.Status)
 	}
 
 	out, err := os.Create(destPath)

--- a/internal/runtimeartifacts/manager.go
+++ b/internal/runtimeartifacts/manager.go
@@ -5,9 +5,12 @@ package runtimeartifacts
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"os"
 	"path"
@@ -17,10 +20,8 @@ import (
 )
 
 const (
-	resourceDirName = "resources"
-	cacheFileName   = "resources.json"
-	dirPerm         = 0o700
-	filePerm        = 0o600
+	dirPerm  = 0o700
+	filePerm = 0o600
 )
 
 type Platform struct {
@@ -29,36 +30,98 @@ type Platform struct {
 }
 
 type Manager struct {
-	spec        ResourceSpec
-	resourceDir string
-	cachePath   string
-	platform    Platform
-}
-
-type cacheFile struct {
-	Resources map[string]cacheEntry `json:"resources"`
-}
-
-type cacheEntry struct {
-	URL    string `json:"url"`
-	Sha256 string `json:"sha256"`
+	spec     ResourceSpec
+	cache    *Cache
+	platform Platform
 }
 
 type artifactRequest struct {
-	artifactPath string
-	resolvedPath string
-	extract      bool
+	cacheKey        string
+	platform        string
+	entryRelPath    string
+	artifactRelPath string
+	resolvedRelPath string
+	downloadPath    string
+	resourcePath    string
+	extract         bool
 }
 
-func NewResourceManager(spec ResourceSpec, deploymentDir string) *Manager {
-	return NewResourceManagerForPlatform(spec, deploymentDir, runtime.GOOS, runtime.GOARCH)
+func (r artifactRequest) entryPath(cache *Cache) string {
+	return cache.absolutePath(r.entryRelPath)
 }
 
-func NewResourceManagerForPlatform(spec ResourceSpec, deploymentDir, goos, goarch string) *Manager {
+func (r artifactRequest) artifactPath(cache *Cache) string {
+	return cache.absolutePath(r.artifactRelPath)
+}
+
+func (r artifactRequest) resolvedPath(cache *Cache) string {
+	return cache.absolutePath(r.resolvedRelPath)
+}
+
+func (r artifactRequest) withEntryPath(cache *Cache, entryPath string) (artifactRequest, error) {
+	var err error
+	r.entryRelPath, err = cache.relativePath(entryPath)
+	if err != nil {
+		return artifactRequest{}, err
+	}
+	artifactPath, err := pathWithinRoot(entryPath, r.downloadPath, "download_path")
+	if err != nil {
+		return artifactRequest{}, err
+	}
+	r.artifactRelPath, err = cache.relativePath(artifactPath)
+	if err != nil {
+		return artifactRequest{}, err
+	}
+	r.resolvedRelPath = r.artifactRelPath
+	if r.extract {
+		extractedRoot, err := archiveExtractionRoot(r.artifactPath(cache))
+		if err != nil {
+			return artifactRequest{}, err
+		}
+		resolvedPath, err := extractedResourcePath(extractedRoot, r.resourcePath)
+		if err != nil {
+			return artifactRequest{}, err
+		}
+		r.resolvedRelPath, err = cache.relativePath(resolvedPath)
+		if err != nil {
+			return artifactRequest{}, err
+		}
+	}
+
+	return r, nil
+}
+
+type artifactIdentityPayload struct {
+	ResourceID   string `json:"resourceId"`
+	Platform     string `json:"platform"`
+	URL          string `json:"url"`
+	Sha256       string `json:"sha256"`
+	Extract      bool   `json:"extract"`
+	DownloadPath string `json:"downloadPath"`
+	ResourcePath string `json:"resourcePath"`
+}
+
+func NewResourceManager(spec ResourceSpec) (*Manager, error) {
+	cache, err := NewDefaultCache()
+	if err != nil {
+		return nil, err
+	}
+
+	return NewResourceManagerWithCache(spec, cache), nil
+}
+
+func NewResourceManagerWithCache(spec ResourceSpec, cache *Cache) *Manager {
+	return NewResourceManagerWithCacheForPlatform(spec, cache, runtime.GOOS, runtime.GOARCH)
+}
+
+func NewResourceManagerWithCacheForPlatform(
+	spec ResourceSpec,
+	cache *Cache,
+	goos, goarch string,
+) *Manager {
 	return &Manager{
-		spec:        spec,
-		resourceDir: filepath.Join(deploymentDir, resourceDirName),
-		cachePath:   filepath.Join(deploymentDir, cacheFileName),
+		spec:  spec,
+		cache: cache,
 		platform: Platform{
 			GOOS:   goos,
 			GOARCH: goarch,
@@ -66,10 +129,19 @@ func NewResourceManagerForPlatform(spec ResourceSpec, deploymentDir, goos, goarc
 	}
 }
 
+func NewResourceManagerForPlatform(spec ResourceSpec, cacheRoot, goos, goarch string) *Manager {
+	return NewResourceManagerWithCacheForPlatform(
+		spec,
+		NewCache(cacheRoot, filepath.Join(cacheRoot, cacheConfigFileName)),
+		goos,
+		goarch,
+	)
+}
+
 func (m *Manager) Request(ctx context.Context, resourceID string) (string, error) {
 	def, ok := m.spec[resourceID]
 	if !ok {
-		return "", fmt.Errorf("unknown runtime resource %q", resourceID)
+		return "", fmt.Errorf("unknown runtime artifact %q", resourceID)
 	}
 
 	artifact, err := def.Resolve(m.platform.GOOS, m.platform.GOARCH)
@@ -81,103 +153,126 @@ func (m *Manager) Request(ctx context.Context, resourceID string) (string, error
 		return "", err
 	}
 
-	cache, err := m.readCache()
+	var resolvedPath string
+	err = m.cache.withExclusiveLock(ctx, func() error {
+		index, _, err := m.cache.readIndex()
+		if err != nil {
+			return err
+		}
+
+		path, reused, err := m.reuseCacheEntry(&index, artifact, target)
+		if err != nil {
+			return err
+		}
+		if reused {
+			resolvedPath = path
+			slog.Debug("found resource in cache", "id", resourceID, "path", resolvedPath)
+
+			return nil
+		}
+
+		path, err = m.refresh(ctx, resourceID, artifact, target, &index)
+		if err != nil {
+			return err
+		}
+		if err := m.writeIndexAfterCleanup(&index); err != nil {
+			return err
+		}
+		resolvedPath = path
+		slog.Debug("downloaded resource", "id", resourceID, "path", resolvedPath)
+
+		return nil
+	})
 	if err != nil {
-		return "", err
-	}
-
-	if entry, ok := cache.Resources[resourceID]; ok {
-		if resolvedPath, err := validateCacheEntry(entry, artifact, target); err == nil {
-			return resolvedPath, nil
-		}
-	}
-
-	return m.refresh(ctx, resourceID, artifact, target, cache)
-}
-
-func (m *Manager) resourcePath(resourceID string) string {
-	return filepath.Join(m.resourceDir, resourceID)
-}
-
-func (m *Manager) readCache() (cacheFile, error) {
-	cache := cacheFile{Resources: map[string]cacheEntry{}}
-
-	data, err := os.ReadFile(m.cachePath)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return cache, nil
-		}
-
-		return cache, err
-	}
-
-	if err := json.Unmarshal(data, &cache); err != nil {
-		return cache, err
-	}
-	if cache.Resources == nil {
-		cache.Resources = map[string]cacheEntry{}
-	}
-
-	return cache, nil
-}
-
-func (m *Manager) writeCache(cache cacheFile) error {
-	if err := os.MkdirAll(filepath.Dir(m.cachePath), dirPerm); err != nil {
-		return err
-	}
-
-	data, err := json.MarshalIndent(cache, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	tmpPath := m.cachePath + ".tmp"
-	if err := os.WriteFile(tmpPath, data, filePerm); err != nil {
-		return err
-	}
-
-	_ = os.Remove(m.cachePath)
-
-	return os.Rename(tmpPath, m.cachePath)
-}
-
-func validateCacheEntry(
-	entry cacheEntry,
-	artifact ArtifactSpec,
-	target artifactRequest,
-) (string, error) {
-	artifactPath := target.artifactPath
-	resolvedPath := target.resolvedPath
-	extract := target.extract
-
-	if entry.URL != artifact.URL {
-		return "", errors.New("url changed")
-	}
-	if entry.Sha256 != strings.ToLower(strings.TrimSpace(artifact.Sha256)) {
-		return "", errors.New("checksum changed")
-	}
-
-	if _, err := os.Stat(artifactPath); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return "", errors.New("artifact missing")
-		}
-
-		return "", err
-	}
-
-	if !extract {
-		return artifactPath, nil
-	}
-
-	if _, err := os.Stat(resolvedPath); err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return "", errors.New("extracted output missing")
-		}
-
 		return "", err
 	}
 
 	return resolvedPath, nil
+}
+
+func (m *Manager) reuseCacheEntry(
+	index *cacheIndex,
+	artifact ArtifactSpec,
+	target artifactRequest,
+) (string, bool, error) {
+	entry, ok := index.Entries[target.cacheKey]
+	if !ok {
+		return "", false, nil
+	}
+	resolvedPath, reusable, err := cacheEntryPathIfReusable(entry, artifact, target, m.cache)
+	if err != nil {
+		return "", false, err
+	}
+	if !reusable {
+		return "", false, nil
+	}
+
+	entry.LastUsedAt = m.cache.clock.Now().UTC()
+	if size, statErr := directorySize(target.entryPath(m.cache)); statErr == nil {
+		entry.SizeBytes = size
+	}
+	index.Entries[target.cacheKey] = entry
+	if err := m.writeIndexAfterCleanup(index); err != nil {
+		return "", false, err
+	}
+
+	return resolvedPath, true, nil
+}
+
+func (m *Manager) cleanupStaleBestEffort(index *cacheIndex) {
+	if err := m.cache.cleanupStaleIfDue(index); err != nil {
+		slog.Warn("failed to clean runtime artifact cache; continuing", "error", err)
+	}
+}
+
+func (m *Manager) writeIndexAfterCleanup(index *cacheIndex) error {
+	m.cleanupStaleBestEffort(index)
+
+	return m.cache.writeIndex(*index)
+}
+
+func cacheEntryPathIfReusable(
+	entry cacheIndexEntry,
+	artifact ArtifactSpec,
+	target artifactRequest,
+	cache *Cache,
+) (string, bool, error) {
+	expected := normalizeSha256(artifact.Sha256)
+	if entry.URL != artifact.URL {
+		return "", false, nil
+	}
+	if entry.Sha256 != expected {
+		return "", false, nil
+	}
+	if entry.EntryPath != target.entryRelPath ||
+		entry.ArtifactPath != target.artifactRelPath ||
+		entry.ResolvedPath != target.resolvedRelPath {
+		return "", false, nil
+	}
+
+	artifactPath := target.artifactPath(cache)
+	if _, err := os.Stat(artifactPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", false, nil
+		}
+
+		return "", false, err
+	}
+
+	if !target.extract {
+		return artifactPath, true, nil
+	}
+
+	resolvedPath := target.resolvedPath(cache)
+	if _, err := os.Stat(resolvedPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", false, nil
+		}
+
+		return "", false, err
+	}
+
+	return resolvedPath, true, nil
 }
 
 func (m *Manager) refresh(
@@ -185,45 +280,100 @@ func (m *Manager) refresh(
 	resourceID string,
 	artifact ArtifactSpec,
 	target artifactRequest,
-	cache cacheFile,
+	index *cacheIndex,
 ) (string, error) {
-	resourceDir := m.resourcePath(resourceID)
-	if err := os.RemoveAll(resourceDir); err != nil {
+	stage, cleanup, err := m.stageArtifactRequest(target)
+	if err != nil {
 		return "", err
 	}
+	committed := false
+	defer func() {
+		if !committed {
+			cleanup()
+		}
+	}()
+
 	if err := downloadArtifact(
 		ctx,
 		resourceID,
 		artifact.URL,
-		target.artifactPath,
+		stage.artifactPath(m.cache),
 		artifact.Sha256,
 	); err != nil {
+		slog.Error("failed to download resource", "id", resourceID, "error", err)
 		return "", err
 	}
 
-	if target.extract {
-		extractedPath, err := extractArtifact(target.artifactPath, artifact.ResourcePath)
+	if stage.extract {
+		_, err := extractArtifact(stage.artifactPath(m.cache), artifact.ResourcePath)
 		if err != nil {
 			return "", err
 		}
-		target.resolvedPath = extractedPath
 	}
 
-	expected := strings.ToLower(strings.TrimSpace(artifact.Sha256))
-	entry := cacheEntry{
-		URL:    artifact.URL,
-		Sha256: expected,
-	}
-	cache.Resources[resourceID] = entry
-	if err := m.writeCache(cache); err != nil {
+	size, err := directorySize(stage.entryPath(m.cache))
+	if err != nil {
 		return "", err
+	}
+	if err := os.RemoveAll(target.entryPath(m.cache)); err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(target.entryPath(m.cache)), dirPerm); err != nil {
+		return "", err
+	}
+	if err := os.Rename(stage.entryPath(m.cache), target.entryPath(m.cache)); err != nil {
+		return "", err
+	}
+	committed = true
+
+	now := m.cache.clock.Now().UTC()
+	index.Entries[target.cacheKey] = cacheIndexEntry{
+		ResourceID:   resourceID,
+		Platform:     target.platform,
+		URL:          artifact.URL,
+		Sha256:       normalizeSha256(artifact.Sha256),
+		Extract:      target.extract,
+		DownloadPath: target.downloadPath,
+		ResourcePath: target.resourcePath,
+		EntryPath:    target.entryRelPath,
+		ArtifactPath: target.artifactRelPath,
+		ResolvedPath: target.resolvedRelPath,
+		CreatedAt:    now,
+		LastUsedAt:   now,
+		SizeBytes:    size,
 	}
 
 	if target.extract {
-		return target.resolvedPath, nil
+		return target.resolvedPath(m.cache), nil
 	}
 
-	return target.artifactPath, nil
+	return target.artifactPath(m.cache), nil
+}
+
+func (m *Manager) stageArtifactRequest(target artifactRequest) (artifactRequest, func(), error) {
+	parent := m.cache.downloadsRoot()
+	if err := os.MkdirAll(parent, dirPerm); err != nil {
+		return artifactRequest{}, nil, err
+	}
+	stageEntryPath, err := os.MkdirTemp(parent, ".tmp-"+target.cacheKey+"-")
+	if err != nil {
+		return artifactRequest{}, nil, err
+	}
+	staged := false
+	defer func() {
+		if !staged {
+			_ = os.RemoveAll(stageEntryPath)
+		}
+	}()
+
+	stage, err := target.withEntryPath(m.cache, stageEntryPath)
+	if err != nil {
+		return artifactRequest{}, nil, err
+	}
+
+	staged = true
+
+	return stage, func() { _ = os.RemoveAll(stageEntryPath) }, nil
 }
 
 func (a ArtifactSpec) downloadPath() (string, error) {
@@ -256,26 +406,71 @@ func (m *Manager) resolveArtifactRequest(
 	if err != nil {
 		return artifactRequest{}, err
 	}
-
-	resourceDir := m.resourcePath(resourceID)
-	downloadPath, err = pathWithinRoot(resourceDir, downloadPath, "download_path")
+	downloadPath, err = cleanRelativePath(downloadPath, "download_path")
 	if err != nil {
 		return artifactRequest{}, err
 	}
-	target := artifactRequest{artifactPath: downloadPath, resolvedPath: downloadPath}
+
+	resourcePath := ""
 	if def.Extract {
-		extractedRoot, err := archiveExtractionRoot(target.artifactPath)
+		resourcePath, err = cleanOptionalRelativePath(artifact.ResourcePath, "resource_path")
 		if err != nil {
 			return artifactRequest{}, err
 		}
-		target.resolvedPath, err = extractedResourcePath(extractedRoot, artifact.ResourcePath)
-		if err != nil {
-			return artifactRequest{}, err
-		}
-		target.extract = true
 	}
 
-	return target, nil
+	platform := platformKey(m.platform.GOOS, m.platform.GOARCH)
+	cacheKey, err := artifactIdentity(
+		resourceID,
+		platform,
+		def.Extract,
+		artifact,
+		downloadPath,
+		resourcePath,
+	)
+	if err != nil {
+		return artifactRequest{}, err
+	}
+	entryPath := filepath.Join(
+		m.cache.artifactsRoot(),
+		safePathSegment(resourceID),
+		safePathSegment(platform),
+		cacheKey,
+	)
+
+	target := artifactRequest{
+		cacheKey:     cacheKey,
+		platform:     platform,
+		downloadPath: downloadPath,
+		resourcePath: resourcePath,
+		extract:      def.Extract,
+	}
+
+	return target.withEntryPath(m.cache, entryPath)
+}
+
+func artifactIdentity(
+	resourceID, platform string,
+	extract bool,
+	artifact ArtifactSpec,
+	downloadPath, resourcePath string,
+) (string, error) {
+	payload := artifactIdentityPayload{
+		ResourceID:   resourceID,
+		Platform:     platform,
+		URL:          artifact.URL,
+		Sha256:       normalizeSha256(artifact.Sha256),
+		Extract:      extract,
+		DownloadPath: downloadPath,
+		ResourcePath: resourcePath,
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(data)
+
+	return hex.EncodeToString(sum[:]), nil
 }
 
 func extractedResourcePath(extractedRoot, resourcePath string) (string, error) {
@@ -286,20 +481,6 @@ func extractedResourcePath(extractedRoot, resourcePath string) (string, error) {
 	return pathWithinRoot(extractedRoot, resourcePath, "resource_path")
 }
 
-func pathWithinRoot(root, value, field string) (string, error) {
-	cleanValue := filepath.Clean(filepath.FromSlash(value))
-	if cleanValue == "." || cleanValue == ".." || filepath.IsAbs(cleanValue) {
-		return "", fmt.Errorf("%s %q must stay within %s", field, value, root)
-	}
-
-	candidate := filepath.Join(root, cleanValue)
-	rel, err := filepath.Rel(root, candidate)
-	if err != nil {
-		return "", err
-	}
-	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return "", fmt.Errorf("%s %q must stay within %s", field, value, root)
-	}
-
-	return candidate, nil
+func normalizeSha256(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
 }

--- a/internal/runtimeartifacts/manager_test.go
+++ b/internal/runtimeartifacts/manager_test.go
@@ -15,7 +15,9 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 type tarFixtureEntry struct {
@@ -92,12 +94,60 @@ func TestManager_RequestUsesDownloadPathFallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	expectedPath := filepath.Join(deploymentDir, "resources", "artifact", "artifact.tar.gz")
-	if path != expectedPath {
-		t.Fatalf("expected artifact path %q, got %q", expectedPath, path)
-	}
+	assertPathInCache(t, deploymentDir, path, "artifact", "linux_amd64", "artifact.tar.gz")
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("expected artifact path to exist, got %v", err)
+	}
+}
+
+func TestManager_StagesArtifactRequestsUnderDownloadsRoot(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	cache := newCacheWithClock(
+		filepath.Join(t.TempDir(), "cache"),
+		filepath.Join(t.TempDir(), cacheConfigFileName),
+		systemClock{},
+	)
+	def := ResourceDefinition{
+		Extract: false,
+		Artifact: map[string]ArtifactSpec{
+			"linux/amd64": {
+				URL:          "https://example.com/artifact.bin",
+				Sha256:       strings.Repeat("a", 64),
+				DownloadPath: "artifact.bin",
+			},
+		},
+	}
+	artifact := def.Artifact["linux/amd64"]
+	manager := NewResourceManagerWithCacheForPlatform(
+		ResourceSpec{"artifact": def},
+		cache,
+		"linux",
+		"amd64",
+	)
+	target, err := manager.resolveArtifactRequest("artifact", def, artifact)
+	if err != nil {
+		t.Fatalf("failed to resolve artifact request: %v", err)
+	}
+
+	// When
+	stage, cleanup, err := manager.stageArtifactRequest(target)
+	if err != nil {
+		t.Fatalf("expected staging to succeed, got %v", err)
+	}
+	defer cleanup()
+
+	// Then
+	stageEntryPath := stage.entryPath(cache)
+	if !strings.HasPrefix(stageEntryPath, cache.downloadsRoot()+string(filepath.Separator)) {
+		t.Fatalf("expected stage entry under downloads root, got %q", stageEntryPath)
+	}
+	if strings.HasPrefix(stageEntryPath, cache.artifactsRoot()+string(filepath.Separator)) {
+		t.Fatalf("expected stage entry to not be under artifacts root, got %q", stageEntryPath)
+	}
+	if !strings.HasPrefix(stage.artifactPath(cache), stageEntryPath+string(filepath.Separator)) {
+		t.Fatalf("expected staged artifact under stage entry, got %q", stage.artifactPath(cache))
 	}
 }
 
@@ -191,33 +241,22 @@ func TestManager_RequestUsesPlatformVariantAndCachesIt(t *testing.T) {
 	if path1 == "" {
 		t.Fatal("expected resolved path")
 	}
-	expectedPath := filepath.Join(deploymentDir, "resources", "artifact", "artifact", "tool")
-	if path1 != expectedPath {
-		t.Fatalf("expected extracted file path %q, got %q", expectedPath, path1)
-	}
+	assertPathInCache(
+		t,
+		deploymentDir,
+		path1,
+		"artifact",
+		"linux_amd64",
+		filepath.Join("artifact", "tool"),
+	)
 	if _, err := os.Stat(path1); err != nil {
 		t.Fatalf("expected resolved path to exist, got %v", err)
 	}
-	readmePath := filepath.Join(
-		deploymentDir,
-		"resources",
-		"artifact",
-		"artifact",
-		"nested",
-		"README",
-	)
+	readmePath := filepath.Join(filepath.Dir(path1), "nested", "README")
 	if _, err := os.Stat(readmePath); err != nil {
 		t.Fatalf("expected extracted nested README to exist, got %v", err)
 	}
-	configPath := filepath.Join(
-		deploymentDir,
-		"resources",
-		"artifact",
-		"artifact",
-		"nested",
-		"config",
-		"x",
-	)
+	configPath := filepath.Join(filepath.Dir(path1), "nested", "config", "x")
 	if _, err := os.Stat(configPath); err != nil {
 		t.Fatalf("expected extracted nested config file to exist, got %v", err)
 	}
@@ -228,6 +267,22 @@ func TestManager_RequestUsesPlatformVariantAndCachesIt(t *testing.T) {
 	if toolInfo.Mode().Perm() != 0o640 {
 		t.Fatalf("expected extracted tool mode 0640, got %v", toolInfo.Mode().Perm())
 	}
+	index, _, err := manager.cache.readIndex()
+	if err != nil {
+		t.Fatalf("failed to read cache index: %v", err)
+	}
+	entry := onlyCacheEntry(t, index)
+	expectedSize, err := directorySize(manager.cache.absolutePath(entry.EntryPath))
+	if err != nil {
+		t.Fatalf("failed to calculate cache entry size: %v", err)
+	}
+	if entry.SizeBytes != expectedSize || entry.SizeBytes <= int64(len(archiveData)) {
+		t.Fatalf(
+			"expected size to include archive and extracted contents, got %d; archive size is %d",
+			entry.SizeBytes,
+			len(archiveData),
+		)
+	}
 
 	// When
 	path2, err := manager.Request(context.Background(), "artifact")
@@ -237,6 +292,189 @@ func TestManager_RequestUsesPlatformVariantAndCachesIt(t *testing.T) {
 	}
 	if path2 != path1 {
 		t.Fatalf("expected cache hit to return same path, got %q and %q", path1, path2)
+	}
+}
+
+func TestManager_RequestUpdatesLastUsedAtOnCacheHit(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	clock := &testClock{now: testNow()}
+	cache := newCacheWithClock(
+		filepath.Join(t.TempDir(), "cache"),
+		filepath.Join(t.TempDir(), cacheConfigFileName),
+		clock,
+	)
+	data := []byte("artifact")
+	server, requests := newCountingArtifactServer(t, "artifact.bin", data)
+	spec := ResourceSpec{
+		"artifact": {
+			Extract: false,
+			Artifact: map[string]ArtifactSpec{
+				"linux/amd64": {
+					URL:          server.URL + "/artifact.bin",
+					Sha256:       checksumString(string(data)),
+					DownloadPath: "artifact.bin",
+				},
+			},
+		},
+	}
+	manager := NewResourceManagerWithCacheForPlatform(spec, cache, "linux", "amd64")
+
+	// When
+	path1, err := manager.Request(context.Background(), "artifact")
+	// Then
+	if err != nil {
+		t.Fatalf("expected first request to succeed, got %v", err)
+	}
+	index, _, err := cache.readIndex()
+	if err != nil {
+		t.Fatalf("failed to read cache index: %v", err)
+	}
+	entry := onlyCacheEntry(t, index)
+	if !entry.CreatedAt.Equal(clock.now) || !entry.LastUsedAt.Equal(clock.now) {
+		t.Fatalf("unexpected initial timestamps: %+v", entry)
+	}
+
+	// When
+	clock.now = clock.now.Add(2 * time.Hour)
+	path2, err := manager.Request(context.Background(), "artifact")
+	// Then
+	if err != nil {
+		t.Fatalf("expected cache hit to succeed, got %v", err)
+	}
+	if path2 != path1 {
+		t.Fatalf("expected cache hit to reuse %q, got %q", path1, path2)
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("expected cache hit to avoid a second download, got %d requests", requests.Load())
+	}
+	index, _, err = cache.readIndex()
+	if err != nil {
+		t.Fatalf("failed to read cache index: %v", err)
+	}
+	entry = onlyCacheEntry(t, index)
+	if !entry.CreatedAt.Equal(testNow()) {
+		t.Fatalf("expected created timestamp to remain unchanged, got %s", entry.CreatedAt)
+	}
+	if !entry.LastUsedAt.Equal(clock.now) {
+		t.Fatalf("expected last-used timestamp %s, got %s", clock.now, entry.LastUsedAt)
+	}
+}
+
+func TestManager_RequestRefreshesMissingCachedFile(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	clock := &testClock{now: testNow()}
+	cache := newCacheWithClock(
+		filepath.Join(t.TempDir(), "cache"),
+		filepath.Join(t.TempDir(), cacheConfigFileName),
+		clock,
+	)
+	data := []byte("artifact")
+	server, requests := newCountingArtifactServer(t, "artifact.bin", data)
+	spec := ResourceSpec{
+		"artifact": {
+			Extract: false,
+			Artifact: map[string]ArtifactSpec{
+				"linux/amd64": {
+					URL:          server.URL + "/artifact.bin",
+					Sha256:       checksumString(string(data)),
+					DownloadPath: "artifact.bin",
+				},
+			},
+		},
+	}
+	manager := NewResourceManagerWithCacheForPlatform(spec, cache, "linux", "amd64")
+	path1, err := manager.Request(context.Background(), "artifact")
+	if err != nil {
+		t.Fatalf("expected first request to succeed, got %v", err)
+	}
+	if err := os.Remove(path1); err != nil {
+		t.Fatalf("failed to remove cached artifact: %v", err)
+	}
+
+	// When
+	clock.now = clock.now.Add(time.Hour)
+	path2, err := manager.Request(context.Background(), "artifact")
+	// Then
+	if err != nil {
+		t.Fatalf("expected missing file refresh to succeed, got %v", err)
+	}
+	if path2 != path1 {
+		t.Fatalf("expected refresh to reuse identity path %q, got %q", path1, path2)
+	}
+	if requests.Load() != 2 {
+		t.Fatalf(
+			"expected missing file to trigger a second download, got %d requests",
+			requests.Load(),
+		)
+	}
+	if _, err := os.Stat(path2); err != nil {
+		t.Fatalf("expected refreshed artifact file, got %v", err)
+	}
+}
+
+func TestManager_RequestRunsAutomaticStaleCleanupWhenDue(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	clock := &testClock{now: testNow()}
+	cache := newCacheWithClock(
+		filepath.Join(t.TempDir(), "cache"),
+		filepath.Join(t.TempDir(), cacheConfigFileName),
+		clock,
+	)
+	writeTestCacheConfig(t, cache, 1)
+	index := emptyCacheIndex()
+	stale := seedCacheEntry(
+		t,
+		cache,
+		&index,
+		"stale",
+		"old",
+		checksumString("old"),
+		clock.now.AddDate(0, 0, -10),
+	)
+	writeTestIndex(t, cache, index)
+	data := []byte("artifact")
+	server := newArtifactServer(t, "artifact.bin", data)
+	spec := ResourceSpec{
+		"artifact": {
+			Extract: false,
+			Artifact: map[string]ArtifactSpec{
+				"linux/amd64": {
+					URL:          server.URL + "/artifact.bin",
+					Sha256:       checksumString(string(data)),
+					DownloadPath: "artifact.bin",
+				},
+			},
+		},
+	}
+	manager := NewResourceManagerWithCacheForPlatform(spec, cache, "linux", "amd64")
+
+	// When
+	_, err := manager.Request(context.Background(), "artifact")
+	// Then
+	if err != nil {
+		t.Fatalf("expected request to succeed, got %v", err)
+	}
+	if _, err := os.Stat(cache.absolutePath(stale.EntryPath)); !os.IsNotExist(err) {
+		t.Fatalf("expected stale entry to be removed, got %v", err)
+	}
+	read, _, err := cache.readIndex()
+	if err != nil {
+		t.Fatalf("failed to read index: %v", err)
+	}
+	if _, ok := read.Entries["stale"]; ok {
+		t.Fatal("expected stale metadata to be removed")
+	}
+	if len(read.Entries) != 1 {
+		t.Fatalf("expected only refreshed artifact metadata, got %+v", read.Entries)
+	}
+	if !read.LastCleanup.Equal(clock.now) {
+		t.Fatalf("expected automatic cleanup timestamp %s, got %s", clock.now, read.LastCleanup)
 	}
 }
 
@@ -338,8 +576,8 @@ func TestManager_RequestRefreshesWhenChecksumChanges(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected checksum refresh to succeed, got %v", err)
 	}
-	if path2 != path1 {
-		t.Fatalf("expected refresh to reuse the same cache path, got %q and %q", path1, path2)
+	if path2 == path1 {
+		t.Fatalf("expected changed checksum to use a new cache path, got %q", path2)
 	}
 	data, err := os.ReadFile(path2)
 	if err != nil {
@@ -347,6 +585,21 @@ func TestManager_RequestRefreshesWhenChecksumChanges(t *testing.T) {
 	}
 	if string(data) != string(secondData) {
 		t.Fatal("expected refreshed artifact content to change")
+	}
+}
+
+func assertPathInCache(
+	t *testing.T,
+	cacheRoot, actualPath, resourceID, platformDir, suffix string,
+) {
+	t.Helper()
+
+	prefix := filepath.Join(cacheRoot, artifactsDirName, resourceID, platformDir)
+	if !strings.HasPrefix(actualPath, prefix+string(filepath.Separator)) {
+		t.Fatalf("expected path under %q, got %q", prefix, actualPath)
+	}
+	if !strings.HasSuffix(actualPath, suffix) {
+		t.Fatalf("expected path to end with %q, got %q", suffix, actualPath)
 	}
 }
 
@@ -479,6 +732,35 @@ func newArtifactServer(t *testing.T, artifactName string, data []byte) *httptest
 	return server
 }
 
+func newCountingArtifactServer(
+	t *testing.T,
+	artifactName string,
+	data []byte,
+) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+
+	requests := &atomic.Int64{}
+	handler := func(writer http.ResponseWriter, request *http.Request) {
+		requests.Add(1)
+		expectedPath := "/"
+		if artifactName != "" {
+			expectedPath = "/" + artifactName
+		}
+		if request.URL.Path != expectedPath {
+			http.NotFound(writer, request)
+			return
+		}
+
+		writer.WriteHeader(http.StatusOK)
+		_, _ = writer.Write(data)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	t.Cleanup(server.Close)
+
+	return server, requests
+}
+
 func newMutableArtifactServer(t *testing.T, artifactName string, data *[]byte) *httptest.Server {
 	t.Helper()
 
@@ -500,4 +782,19 @@ func newMutableArtifactServer(t *testing.T, artifactName string, data *[]byte) *
 	t.Cleanup(server.Close)
 
 	return server
+}
+
+func onlyCacheEntry(t *testing.T, index cacheIndex) cacheIndexEntry {
+	t.Helper()
+
+	if len(index.Entries) != 1 {
+		t.Fatalf("expected one cache entry, got %+v", index.Entries)
+	}
+	for _, entry := range index.Entries {
+		return entry
+	}
+
+	t.Fatal("expected one cache entry")
+
+	return cacheIndexEntry{}
 }

--- a/internal/tofu/config.go
+++ b/internal/tofu/config.go
@@ -115,7 +115,7 @@ func (c *Config) TofuBinaryPath(ctx context.Context) (string, error) {
 		return "", errors.New("tofu deployment root is not configured")
 	}
 
-	binaryPath, err := ResolveBinaryPath(ctx, c.deploymentRoot)
+	binaryPath, err := ResolveBinaryPath(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/internal/tofu/resource.go
+++ b/internal/tofu/resource.go
@@ -10,14 +10,17 @@ import (
 	"github.com/exasol/exasol-personal/internal/runtimeartifacts"
 )
 
-// ResolveBinaryPath resolves the runtime tofu binary path for the given deployment directory.
-func ResolveBinaryPath(ctx context.Context, deploymentRoot string) (string, error) {
+// ResolveBinaryPath resolves the runtime tofu binary path.
+func ResolveBinaryPath(ctx context.Context) (string, error) {
 	spec, err := runtimeartifacts.ParseSpec(resources.ResourcesYAML)
 	if err != nil {
 		return "", err
 	}
 
-	manager := runtimeartifacts.NewResourceManager(spec, deploymentRoot)
+	manager, err := runtimeartifacts.NewResourceManager(spec)
+	if err != nil {
+		return "", err
+	}
 
 	return manager.Request(ctx, "tofu")
 }

--- a/openspec/changes/add-runtime-artifact-cache/.openspec.yaml
+++ b/openspec/changes/add-runtime-artifact-cache/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-08

--- a/openspec/changes/add-runtime-artifact-cache/design.md
+++ b/openspec/changes/add-runtime-artifact-cache/design.md
@@ -1,0 +1,247 @@
+## Context
+
+The launcher currently resolves runtime artifacts through `internal/runtimeartifacts`.
+The manager receives a deployment directory, stores artifacts below that deployment, and records cache metadata in a deployment-local `resources.json`. OpenTofu is the current runtime artifact, resolved by `internal/tofu.ResolveBinaryPath` from the embedded `assets/resources/resources.yaml`.
+
+That design works, but it duplicates the same downloaded and extracted artifact across deployments. It also gives users no central way to see which runtime artifacts exist, when they were last used, or how much cache space they consume.
+
+This change turns runtime artifact storage into a per-user cache. The existing resource-definition model remains the source of truth for which artifact is required for the current platform. The cache becomes the place where materialized artifacts and their use metadata live.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Store runtime artifacts in a per-user cache rooted under a launcher-owned directory in the operating system user cache location.
+- Use the term `runtime-artifacts` for the cache namespace to align with the existing `runtimeartifacts` package.
+- Track last-use timestamps for all cached runtime artifacts.
+- Clean stale artifacts based on a per-user retention configuration.
+- Detect cached artifacts whose downloaded artifact no longer matches the expected checksum.
+- Provide user-facing cache management commands for listing, cleaning, and unlocking the cache.
+- Provide a diagnostic command that reports cache state without mutating it.
+- Coordinate concurrent launcher processes that may resolve or clean the shared cache.
+- Preserve checksum validation, platform selection, archive extraction, and artifact-refresh semantics.
+
+**Non-Goals:**
+- Do not introduce generalized package management for arbitrary third-party tools.
+- Do not add support for artifacts beyond the existing runtime artifact definition model.
+- Do not change deployment-directory compatibility or deployment state semantics.
+- Do not move unrelated cache data, such as SQL shell history, as part of this change.
+
+## Decisions
+
+### Use a named per-user cache namespace
+
+Runtime artifact cache data will live under the operating system user cache directory, inside a `.exasol/personal/runtime-artifacts` namespace. The concrete root is resolved at runtime with `os.UserCacheDir()` and path joining, so platform-specific cache base locations remain delegated to Go and the host operating system.
+
+Inside that namespace:
+- `index.json` stores cache metadata.
+- `artifacts/` stores materialized artifacts.
+- `downloads/` stores in-progress artifact downloads and extraction staging.
+- directory mutex marker files may appear while an operation holds the cache lock.
+
+Rationale:
+- `.exasol/personal` mirrors the launcher-owned durable configuration layout while staying under the operating system cache location.
+- `runtime-artifacts` aligns with the existing package and feature vocabulary.
+- The namespace leaves room for other launcher cache data later without mixing it with runtime artifact metadata.
+
+Alternative considered: store artifacts directly under the user cache directory. Rejected because it makes the cache harder to identify and leaves no clean namespace for future cache data.
+
+### Store retention settings in launcher configuration
+
+Cache retention configuration will live in the launcher's durable local root directory. The implementation should reuse the same root-directory helper used to derive the default deployment directory rather than using `os.UserConfigDir()`. The cache data remains in the operating system user cache directory, but user settings should not live in a directory that the operating system or a user may purge as disposable cache data.
+
+The configuration file will contain a positive retention value:
+
+```yaml
+retention_days: 30
+```
+
+The initial default is 30 days. If the configuration file is missing, cache management will use the default and create the default file when appropriate. Invalid configuration is reported clearly by explicit cache commands. Runtime artifact resolution should not fail solely because automatic cleanup configuration is invalid; in that case, artifact resolution should proceed and skip automatic cleanup with a warning.
+
+Rationale:
+- `retention_days` is shorter than `cleanup_after_days` while still describing the cache policy and making the unit explicit.
+- An integer day count is easy for users to edit and avoids ambiguity in duration parsing.
+- Go's built-in duration parser does not support day units, so a field such as `cleanup_after: 30d` would require custom parsing.
+- Keeping configuration outside the cache prevents a cache purge from erasing user preferences.
+- Using the launcher root directory keeps launcher-owned configuration near the launcher's existing durable local state.
+
+Alternative considered: place `config.yaml` inside the runtime artifact cache directory. Rejected because cache directories are disposable by convention.
+
+Alternative key names considered:
+- `max_age_days`: concise, but emphasizes deletion threshold more than cache policy.
+- `expire_after_days`: clear, but still fairly verbose.
+- `keep_days`: short, but less precise about whether it means minimum or maximum retention.
+- `ttl_days`: concise, but more technical and less friendly for end users.
+- `retention`: shortest, but would either hide the unit or require a custom duration parser.
+
+### Key cache entries by artifact identity
+
+The cache index will store entries keyed by a stable artifact identity derived from:
+- logical runtime artifact ID
+- platform
+- source URL
+- expected checksum
+- extraction flag
+- download path override
+- resource path within an archive
+
+The key should be a filesystem-safe digest rather than raw user-visible metadata. Artifact files should be stored under a layout grouped by logical artifact ID and platform, with the digest as the final identity component.
+
+Rationale:
+- A shared cache can hold multiple versions of the same logical artifact at the same time.
+- URL or checksum changes produce a distinct cache entry, preserving the current behavior that artifact metadata changes refresh the artifact.
+- Grouping by logical ID and platform keeps manual inspection understandable while avoiding path collisions.
+
+Alternative considered: key only by logical artifact ID. Rejected because different platforms, versions, or URLs would overwrite each other.
+
+### Keep index paths relative to the cache root
+
+`index.json` will store artifact and resolved paths relative to the runtime artifact cache root. Runtime code will resolve those paths under the cache root and reject any path that escapes that root.
+
+Rationale:
+- Relative paths keep metadata stable if the cache root is relocated by test setup or operating system behavior.
+- Containment checks preserve the existing safety property used for download and resource paths.
+
+### Record last use on every successful artifact request
+
+Every successful runtime artifact request will set `lastUsedAt` to the current UTC time before returning the resolved artifact path. New entries will also record `createdAt`.
+
+Timestamps should be serialized in RFC3339 format. A clock abstraction should be used in tests so last-use and cleanup behavior are deterministic.
+
+Rationale:
+- Cache cleanup depends on reliable last-use metadata.
+- Updating last use on cache hits keeps active artifacts from being removed by cleanup.
+
+### Reuse `internal/directorymutex` with exclusive cache locks
+
+The runtime artifact cache will use `internal/directorymutex` to coordinate cross-process access. The cache directory must be created before constructing the mutex because `directorymutex.New` requires an existing directory.
+
+Use an exclusive lock for all mutating cache operations:
+- runtime artifact materialization and cache-hit metadata updates
+- manual cleanup
+- configuration writes, if introduced by a cache command
+
+Use an exclusive lock for cache listing in the first version too, even though listing is conceptually read-only. The current shared-lock stress test in `internal/directorymutex` is skipped as flaky, so depending on shared mode is unnecessary risk for a cache whose operations are infrequent.
+
+Force unlocking deliberately clears the stale cache lock marker without acquiring the cache lock first, because it is the recovery path for cases where normal lock acquisition is blocked.
+
+Diagnostic cache inspection should not take the cache lock. It should report the observed lock status and read metadata best-effort. This avoids blocking diagnostics when the cache is locked, which is the case diagnostics often need to explain.
+
+The cache lock acquisition timeout should be longer than the deployment-directory default because another launcher process may be downloading and extracting a runtime artifact. A cache-specific helper should wrap the caller context with a practical timeout when none is present. Lock release should use a context that is not canceled by command cancellation, matching the deployment lock pattern.
+
+Rationale:
+- The existing directory mutex already provides marker-file based cross-process locking and force-clear support.
+- Exclusive-only cache access keeps the first version simple and avoids relying on flaky shared-lock behavior.
+- A longer timeout avoids failing concurrent launches while the first process is warming the cache.
+
+Alternative considered: use OS-specific file locks. Rejected because the repository already has a portable lock abstraction that fits this directory-oriented cache.
+
+### Add cache unlocking as a user-facing maintenance operation
+
+The cache management command set will include an unlock operation that force-clears the cache lock marker. The help text must warn that users should only unlock when they are certain no launcher process is using the cache.
+
+Rationale:
+- `directorymutex` markers can remain after process crashes.
+- A shared cache can block unrelated deployments if a stale lock is left behind.
+- Deployment directories already have a similar operational model through diagnostic unlocking.
+
+### Add read-only cache diagnostics
+
+`exasol diag cache` will report cache state without mutating the cache. It should include:
+- cache root path
+- configuration file path
+- parsed retention value or configuration error
+- index file path
+- index parse status
+- lock status from `directorymutex.Status()`
+- artifact entry count
+- approximate total artifact size
+- checksum status for cached downloaded artifacts
+- stale candidate count using the configured retention when available
+- missing files referenced by metadata
+- unexpected files or directories that are not referenced by metadata, where practical
+
+Checksum diagnostics should compute the checksum of the cached downloaded artifact and compare it with the expected checksum recorded in metadata. The check applies to the downloaded artifact, not the extracted resolved path, matching the runtime artifact verification model. Diagnostics should report mismatches as corrupted artifacts and include enough entry metadata for the user to identify what will be cleaned.
+
+The diagnostic command should succeed with a useful report when the cache is missing, locked, or partially invalid. It should fail only when the underlying environment prevents even basic inspection.
+
+Rationale:
+- Users and support engineers need a non-destructive way to understand cache problems before cleaning or unlocking.
+- Diagnostics should be useful exactly when regular cache operations are blocked.
+- Reporting checksum mismatches helps distinguish missing files, stale entries, and corrupted cached artifacts before a user chooses a cleanup action.
+
+### Add cache management commands
+
+The cache command group will expose:
+- `exasol cache list`: list cached artifacts and last-use timestamps.
+- `exasol cache clean`: remove artifacts older than the configured retention and report what was removed.
+- `exasol cache clean --invalid`: remove artifacts whose cached downloaded artifact no longer matches the expected checksum.
+- `exasol cache clean --all`: remove all cached runtime artifacts and reset cache artifact metadata.
+- `exasol cache clean --partial-downloads`: remove staged downloads that were not committed as usable cached artifacts.
+- `exasol cache clean --dry-run`: preview indexed artifacts selected by the cleanup mode without deleting artifacts or changing metadata.
+- `exasol cache unlock`: force-clear a stale cache lock.
+
+`cache list` should support the existing `--json` output pattern for automation. Text output should include logical artifact ID, platform, last-used timestamp, human-friendly size, and resolved path. Reported size should represent the full cached entry; for extracted artifacts this includes both the downloaded archive and extracted contents. Paths that are inside the runtime artifact cache should be displayed relative to the cache root, so reports remain readable while the cache root is still shown explicitly. `cache clean` should print a summary with removed entry count and human-friendly removed size; when invalid-artifact cleanup is requested, the summary should also report how many removed entries failed checksum verification. During dry runs, the summary should use "would remove" wording, report the indexed artifacts selected by cache metadata for metadata-based modes, and must not mutate files or metadata. Partial-download dry runs should report staged partial downloads selected for removal. JSON output may be added if it fits the existing command patterns during implementation.
+
+`--invalid`, `--all`, and `--partial-downloads` are cleanup selectors and should be mutually exclusive. With no selector, `cache clean` selects stale cleanup. `--dry-run` is not a selector; it can be combined with stale cleanup, invalid-artifact cleanup, full-cache cleanup, or partial-download cleanup.
+
+Cache commands do not operate on a deployment directory, so they should not register `--deployment-dir`, enforce deployment compatibility, or start deployment log sessions.
+
+Rationale:
+- User-facing maintenance belongs under `cache`.
+- Diagnostics belongs under `diag` and remains read-only.
+- Keeping these commands independent from deployment directories makes cache maintenance possible even when no deployment exists.
+
+### Keep cleanup conservative and bounded
+
+Manual cleanup removes entries whose `lastUsedAt` is older than the configured retention. When the user requests invalid-artifact cleanup, manual cleanup removes entries whose cached downloaded artifact fails checksum verification. When the user requests partial-download cleanup, manual cleanup removes staged downloads that were not committed as usable cached artifacts and leaves indexed artifacts unchanged. When the user requests full-cache cleanup, manual cleanup wipes the runtime artifact cache contents, including files not referenced by metadata and staged partial downloads, and resets artifact metadata while preserving cache configuration. Cleanup removes files that belong to removed entries and removes the corresponding index entries.
+
+Dry-run cleanup computes the same metadata-based cleanup plan as the selected cleanup mode and reports the indexed artifacts selected by that plan without deleting files, changing cache metadata, or updating cleanup timestamps. For full-cache cleanup, the applied cleanup also removes unindexed cache contents, but dry-run reporting remains limited to indexed cache entries.
+
+Automatic cleanup should run opportunistically after a successful runtime artifact request, not before returning a path. The index should record `lastCleanupAt`, and automatic cleanup should run only when the previous cleanup is older than a bounded interval, such as 24 hours. Automatic cleanup should remove stale artifacts only; invalid-artifact cleanup remains explicit because it requires checksum reads over cached artifacts and is a maintenance action. Automatic cleanup failures should be logged but should not fail the artifact request.
+
+Rationale:
+- Updating last use before cleanup prevents the just-used artifact from becoming a cleanup candidate.
+- Bounding automatic cleanup avoids making every launcher operation scan the whole cache.
+- Manual cleanup remains the strict path for users who explicitly asked to clean the cache.
+- Invalid-artifact cleanup is explicit so normal launcher operations do not pay the cost of checksumming every cached artifact.
+- Full-cache cleanup is explicit because it removes artifacts that may still be within the retention window.
+- Dry-run cleanup lets users inspect indexed artifacts selected for cleanup before applying it.
+
+Alternative considered: clean on every artifact request. Rejected because it adds unnecessary filesystem scanning to normal launcher operations.
+
+### Preserve runtime artifact validation behavior
+
+Cache hits are valid only when:
+- cache metadata matches the requested artifact identity
+- the downloaded artifact path exists
+- the resolved path exists when extraction is enabled
+
+Cache misses or invalid hits should refresh the artifact by downloading to the cache's download staging area, verifying the checksum, extracting when required, and atomically committing metadata after files are in place.
+
+Rationale:
+- This preserves the existing download, checksum, and extraction safety model.
+- It keeps stale or partial downloads from becoming visible as usable artifacts.
+
+## Risks / Trade-offs
+
+- [A stale cache lock can block runtime artifact resolution] -> Provide `exasol cache unlock`, document when it is safe, and expose lock state through `exasol diag cache`.
+- [Exclusive locking can serialize independent cache operations] -> Accept for the first version because runtime artifact operations are infrequent and shared locking has known test instability.
+- [Holding the cache lock during download can block other launchers] -> Use a longer cache lock timeout and keep the implementation simple; optimize with per-entry locks later if runtime artifacts grow significantly.
+- [Checksum diagnostics and invalid-artifact cleanup can be expensive for large caches] -> Run full checksum verification only for explicit diagnostics and invalid-artifact cleanup, not for normal listing or automatic cleanup.
+- [Full-cache cleanup can remove artifacts that are still useful] -> Require an explicit `--all` selector and support `--dry-run` so users can preview the impact.
+- [Invalid user configuration could affect deployment commands] -> Do not fail runtime artifact resolution solely because automatic cleanup configuration is invalid; report invalid config in cache commands and diagnostics.
+- [Manual unlock can be misused while another process is active] -> Make command help explicit and keep diagnostics available so users can inspect before unlocking.
+
+## Migration Plan
+
+1. Add the new cache path/config resolution helpers and runtime artifact cache data model.
+2. Refactor `internal/runtimeartifacts.Manager` so production construction resolves the per-user cache rather than requiring a deployment directory.
+3. Update `internal/tofu.ResolveBinaryPath` to use the default runtime artifact cache.
+4. Add cache management and diagnostic commands.
+5. Update docs that currently state runtime artifacts are stored in deployment directories.
+
+Rollback is straightforward because the change does not modify deployment state. Reverting the launcher returns runtime artifact resolution to deployment-local storage; any per-user cache files become unused local cache data.
+
+## Open Questions
+
+None.

--- a/openspec/changes/add-runtime-artifact-cache/proposal.md
+++ b/openspec/changes/add-runtime-artifact-cache/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Runtime artifacts are currently cached per deployment, so common artifacts are downloaded and stored repeatedly and cannot be managed centrally. A per-user runtime artifact cache reduces duplication, makes artifact reuse visible, and gives users a way to inspect and clean up cached data.
+
+## What Changes
+
+- Add a per-user cache for launcher runtime artifacts.
+- Track when each cached artifact was last used so stale artifacts can be identified.
+- Add user configuration for the retention period used when cleaning stale cached artifacts.
+- Resolve runtime artifacts through the shared cache while preserving artifact validation and refresh behavior when artifact metadata changes.
+- Add launcher cache management commands for listing cached artifacts, cleaning stale, corrupted, or partial-download data, previewing cleanup, wiping the cache, and unlocking a stale cache lock.
+- Add cache diagnostics that report cache health, integrity, and state without mutating the cache.
+- Update documentation to explain cache behavior and management.
+
+## Capabilities
+
+### New Capabilities
+- `runtime-artifact-cache`: how the launcher caches, reuses, reports, and cleans per-user runtime artifacts.
+
+### Modified Capabilities
+<!-- None: no existing permanent spec covers runtime artifact caching. -->
+
+## Impact
+
+- `internal/runtimeartifacts`: change cache ownership from deployment-local storage to a per-user runtime artifact cache, including metadata, cleanup, and locking.
+- `internal/tofu`: resolve OpenTofu through the updated runtime artifact cache abstraction.
+- `internal/config` or a new internal cache/config package: resolve user cache/config locations and read cache configuration.
+- `cmd/exasol`: add cache management and diagnostic commands.
+- Documentation: update launcher architecture/development/user-facing docs where they describe runtime artifacts and cache management.
+- Tests: add unit tests for cache metadata, last-use tracking, cleanup, locking, configuration, and command output.
+- No new external runtime dependencies are expected.

--- a/openspec/changes/add-runtime-artifact-cache/specs/runtime-artifact-cache/spec.md
+++ b/openspec/changes/add-runtime-artifact-cache/specs/runtime-artifact-cache/spec.md
@@ -1,0 +1,177 @@
+# runtime-artifact-cache Specification
+
+## Purpose
+
+Define how the launcher caches, reuses, reports, and cleans per-user runtime artifacts.
+
+## ADDED Requirements
+
+### Requirement: Runtime artifacts SHALL be cached per user
+The launcher SHALL maintain a per-user cache for runtime artifacts that can be reused across launcher operations.
+
+#### Scenario: Runtime artifact is materialized on demand
+- **WHEN** a launcher operation requires a runtime artifact that is not present in the user's cache
+- **THEN** the launcher materializes the artifact before using it
+- **AND** the artifact is recorded in the user's cache metadata
+
+#### Scenario: Cached runtime artifact is reused
+- **WHEN** a launcher operation requires a runtime artifact that is already present and valid in the user's cache
+- **THEN** the launcher reuses the cached artifact
+- **AND** the artifact is not downloaded again
+
+### Requirement: Runtime artifact cache entries SHALL track last use
+The launcher SHALL record when each cached runtime artifact was last used.
+
+#### Scenario: New artifact records last use
+- **WHEN** a runtime artifact is added to the user's cache
+- **THEN** the cache metadata records a last-use timestamp for that artifact
+
+#### Scenario: Cache hit updates last use
+- **WHEN** a launcher operation reuses a cached runtime artifact
+- **THEN** the cache metadata updates that artifact's last-use timestamp
+
+### Requirement: Runtime artifact changes SHALL refresh cached artifacts
+The launcher SHALL treat a cached runtime artifact as invalid when the artifact requested by the launcher no longer matches the artifact recorded in the cache.
+
+#### Scenario: Changed artifact is refreshed
+- **WHEN** a launcher operation requires a runtime artifact
+- **AND** the user's cache contains an older or different artifact for the same runtime need
+- **THEN** the launcher materializes the requested artifact before using it
+- **AND** the previous cached artifact remains eligible for cleanup
+
+### Requirement: Runtime artifact downloads SHALL be verified before use
+The launcher SHALL verify downloaded runtime artifacts before making them available for use.
+
+#### Scenario: Verification succeeds
+- **WHEN** a runtime artifact is downloaded
+- **AND** the downloaded artifact matches the expected integrity metadata
+- **THEN** the launcher may record and use the artifact
+
+#### Scenario: Verification fails
+- **WHEN** a runtime artifact is downloaded
+- **AND** the downloaded artifact does not match the expected integrity metadata
+- **THEN** the launcher rejects the artifact
+- **AND** the rejected artifact is not recorded as usable in the cache
+
+### Requirement: Cache cleanup SHALL use configured retention
+The launcher SHALL use per-user cache configuration to determine when cached runtime artifacts are old enough to be cleaned.
+
+#### Scenario: Configured retention identifies stale artifacts
+- **WHEN** cache cleanup evaluates cached runtime artifacts
+- **THEN** artifacts whose last-use timestamp is older than the configured retention are treated as stale
+- **AND** artifacts whose last-use timestamp is within the configured retention are preserved
+
+#### Scenario: Missing retention configuration uses a default
+- **WHEN** cache cleanup runs without an existing user retention configuration
+- **THEN** the launcher uses a default retention value
+
+### Requirement: Cache cleanup SHALL remove stale artifacts
+The launcher SHALL remove stale runtime artifacts and their cache metadata during cleanup.
+
+#### Scenario: Manual cleanup removes stale artifacts
+- **WHEN** a user invokes cache cleanup
+- **THEN** the launcher removes cached runtime artifacts that are stale
+- **AND** the launcher reports the cleanup result
+
+#### Scenario: Automatic cleanup is attempted during cache use
+- **WHEN** the launcher successfully uses the runtime artifact cache
+- **AND** automatic cleanup is due
+- **THEN** the launcher attempts to remove stale cached runtime artifacts
+
+### Requirement: Cache cleanup SHALL support corrupted artifact removal
+The launcher SHALL provide a way to remove cached runtime artifacts that fail integrity verification.
+
+#### Scenario: User cleans corrupted artifacts
+- **WHEN** a user invokes cache cleanup for corrupted runtime artifacts
+- **THEN** the launcher removes cached runtime artifacts that fail integrity verification
+- **AND** the launcher reports the cleanup result
+
+### Requirement: Cache cleanup SHALL support full cache removal
+The launcher SHALL provide a way to remove all cached runtime artifacts.
+
+#### Scenario: User removes all cached artifacts
+- **WHEN** a user invokes cleanup for all cached runtime artifacts
+- **THEN** the launcher removes all cached runtime artifacts
+- **AND** the launcher reports the cleanup result
+
+#### Scenario: Full cleanup removes unindexed cache contents
+- **WHEN** a user invokes cleanup for all cached runtime artifacts
+- **AND** the runtime artifact cache contains files or directories not referenced by cache metadata
+- **THEN** the launcher removes those unreferenced cache contents
+- **AND** the launcher resets runtime artifact cache metadata
+
+### Requirement: Cache cleanup SHALL support partial download removal
+The launcher SHALL provide a way to remove partial runtime artifact downloads that were not committed as usable cached artifacts.
+
+#### Scenario: User cleans partial downloads
+- **WHEN** a user invokes cache cleanup for partial downloads
+- **THEN** the launcher removes partial runtime artifact downloads
+- **AND** indexed cached runtime artifacts remain available
+- **AND** the launcher reports the cleanup result
+
+### Requirement: Cache cleanup SHALL support previewing cleanup
+The launcher SHALL provide a way to preview selected cleanup work without changing cache contents or cache metadata.
+
+#### Scenario: User previews indexed cleanup
+- **WHEN** a user invokes cache cleanup in preview mode for cleanup that selects cached runtime artifacts
+- **THEN** the launcher reports which indexed cached runtime artifacts would be removed
+- **AND** cached runtime artifacts are not removed
+- **AND** cache metadata is not changed
+
+#### Scenario: User previews partial download cleanup
+- **WHEN** a user invokes cache cleanup for partial downloads in preview mode
+- **THEN** the launcher reports which partial runtime artifact downloads would be removed
+- **AND** partial runtime artifact downloads are not removed
+- **AND** cache metadata is not changed
+
+### Requirement: Cache listing SHALL report cached artifacts
+The launcher SHALL provide a way to list cached runtime artifacts.
+
+#### Scenario: User lists cached artifacts
+- **WHEN** a user requests the runtime artifact cache contents
+- **THEN** the launcher reports each cached runtime artifact
+- **AND** the report includes each artifact's last-use timestamp
+
+#### Scenario: Empty cache is listed
+- **WHEN** a user requests the runtime artifact cache contents
+- **AND** no runtime artifacts are cached
+- **THEN** the launcher reports that the cache is empty
+
+### Requirement: Cache unlocking SHALL support stale-lock recovery
+The launcher SHALL provide a way to clear a stale runtime artifact cache lock.
+
+#### Scenario: User clears stale cache lock
+- **WHEN** a user requests cache unlocking
+- **THEN** the launcher clears the cache lock if one exists
+- **AND** the launcher reports the unlock result
+
+### Requirement: Cache diagnostics SHALL report cache state without mutation
+The launcher SHALL provide runtime artifact cache diagnostics that inspect cache state without changing cache contents or cache locks.
+
+#### Scenario: User inspects cache diagnostics
+- **WHEN** a user requests runtime artifact cache diagnostics
+- **THEN** the launcher reports cache state information
+- **AND** cached runtime artifacts are not removed
+- **AND** cache locks are not cleared
+
+#### Scenario: Diagnostics report corrupted artifacts
+- **WHEN** a user requests runtime artifact cache diagnostics
+- **AND** one or more cached runtime artifacts fail integrity verification
+- **THEN** cache diagnostics report those artifacts as corrupted
+- **AND** cached runtime artifacts are not removed
+
+#### Scenario: Diagnostics report cache problems
+- **WHEN** runtime artifact cache metadata, configuration, integrity, or lock state cannot be interpreted normally
+- **THEN** cache diagnostics report the observed problem
+- **AND** diagnostics continue reporting any remaining cache state that can be inspected
+
+### Requirement: Runtime artifact cache operations SHALL coordinate concurrent access
+The launcher SHALL coordinate operations that read or mutate runtime artifact cache state so concurrent launcher processes do not corrupt cached artifacts or cache metadata.
+
+#### Scenario: Concurrent cache mutation is serialized
+- **WHEN** multiple launcher processes attempt to mutate runtime artifact cache state concurrently
+- **THEN** only one mutation proceeds at a time
+
+#### Scenario: Cache operation reports lock contention
+- **WHEN** a cache operation cannot proceed because another process holds the cache
+- **THEN** the launcher reports that the cache is currently locked

--- a/openspec/changes/add-runtime-artifact-cache/tasks.md
+++ b/openspec/changes/add-runtime-artifact-cache/tasks.md
@@ -1,0 +1,84 @@
+## 1. Cache paths and configuration
+
+- [x] 1.1 Add helpers that resolve the per-user runtime artifact cache root under the operating system user cache directory with a `.exasol/personal/runtime-artifacts` namespace
+- [x] 1.2 Add helpers that resolve the launcher configuration directory from the launcher root directory
+- [x] 1.3 Implement cache retention configuration loading with a default `retention_days` value when configuration is missing
+- [x] 1.4 Implement default configuration file creation when an explicit cache command initializes cache configuration
+- [x] 1.5 Add validation and clear errors for invalid retention configuration
+
+## 2. Cache index and metadata
+
+- [x] 2.1 Add a runtime artifact cache index model with schema version, last cleanup timestamp, and artifact entries
+- [x] 2.2 Add cache entry fields for logical artifact ID, platform, source metadata, relative artifact path, relative resolved path, created timestamp, last-use timestamp, and size
+- [x] 2.3 Implement artifact identity derivation from logical artifact ID, platform, source URL, checksum, extraction setting, download path, and resource path
+- [x] 2.4 Implement cache index read/write with missing-file defaults, JSON validation, relative path containment checks, and atomic writes
+- [x] 2.5 Add a test clock abstraction so timestamp and cleanup behavior can be tested deterministically
+
+## 3. Cache locking
+
+- [x] 3.1 Add a runtime artifact cache lock helper that creates the cache directory before constructing `internal/directorymutex`
+- [x] 3.2 Use exclusive locks for cache materialization, metadata updates, listing, cleanup, and unlock operations
+- [x] 3.3 Use a cache-specific lock acquisition timeout suitable for download/extraction waits and release locks with a cancellation-independent context
+- [x] 3.4 Map cache lock acquisition failures to clear user-facing errors
+- [x] 3.5 Implement cache lock status inspection for diagnostics without acquiring or mutating the lock
+- [x] 3.6 Implement force-clearing of stale cache locks for the cache unlock command
+
+## 4. Runtime artifact manager
+
+- [x] 4.1 Refactor `internal/runtimeartifacts.Manager` so production construction uses the per-user cache instead of a deployment directory
+- [x] 4.2 Keep test constructors that allow explicit cache roots, platform values, and clock injection
+- [x] 4.3 Update the request flow to compute artifact identity, acquire the cache lock, read the index, and validate cache hits
+- [x] 4.4 Update cache hits to refresh `lastUsedAt`, persist metadata, and return the resolved path
+- [x] 4.5 Update cache misses and invalid hits to download to a temporary location, verify checksum, extract when required, and commit files plus metadata atomically
+- [x] 4.6 Preserve existing path containment, checksum mismatch, platform resolution, download path, and archive extraction behavior
+- [x] 4.7 Implement opportunistic automatic cleanup after successful artifact use when cleanup is due
+- [x] 4.8 Update `internal/tofu.ResolveBinaryPath` to use the new default runtime artifact manager
+- [x] 4.9 Stage runtime artifact downloads under the cache's download staging area
+
+## 5. Cache operations
+
+- [x] 5.1 Implement a cache listing operation that returns cached artifact entries with last-use timestamps and size information
+- [x] 5.2 Implement a manual cleanup operation that removes stale artifacts and metadata according to the configured retention
+- [x] 5.3 Implement corrupted artifact detection by checksumming cached downloaded artifacts against their expected checksums
+- [x] 5.4 Implement a manual cleanup mode that removes corrupted artifacts and metadata on explicit request
+- [x] 5.5 Implement a manual cleanup mode that removes all cached runtime artifacts and resets artifact metadata
+- [x] 5.6 Implement dry-run cleanup planning for stale, invalid-artifact, and full-cache cleanup without mutating files or metadata
+- [x] 5.7 Implement cleanup summaries with removed entry count, removed byte count, corrupted entry count when applicable, and dry-run wording when applicable
+- [x] 5.8 Implement diagnostic cache inspection that reports cache root, config status, index status, lock status, entry count, size, checksum status, stale candidates, missing referenced files, and unexpected unreferenced files where practical
+- [x] 5.9 Ensure diagnostic inspection does not remove artifacts, rewrite metadata, or clear locks
+- [x] 5.10 Implement partial-download cleanup and include staged downloads in full-cache cleanup
+
+## 6. CLI wiring
+
+- [x] 6.1 Add a top-level `cache` command group that does not register deployment-directory flags or deployment compatibility checks
+- [x] 6.2 Add `cache list` with text output and JSON output support
+- [x] 6.3 Add `cache clean` with text summary output for stale cleanup
+- [x] 6.4 Add an explicit `--invalid` cleanup option to `cache clean`
+- [x] 6.5 Add an explicit `--all` cleanup option to `cache clean`
+- [x] 6.6 Add a `--dry-run` option to `cache clean` that previews the selected cleanup mode
+- [x] 6.7 Make `--invalid` and `--all` mutually exclusive while allowing `--dry-run` with any cleanup mode
+- [x] 6.8 Add `cache unlock` with help text warning users to unlock only when no launcher process is using the cache
+- [x] 6.9 Add `diag cache` as a read-only diagnostic command
+- [x] 6.10 Verify cache and diagnostic cache commands do not start deployment log sessions or emit default deployment directory messages
+- [x] 6.11 Add `cache clean --partial-downloads` and keep cleanup selectors mutually exclusive
+
+## 7. Tests
+
+- [x] 7.1 Add unit tests for cache path/config resolution, default retention, invalid retention, and default config creation
+- [x] 7.2 Add unit tests for cache index read/write, artifact identity, relative path containment, and atomic metadata updates
+- [x] 7.3 Add runtime artifact manager tests for first materialization, cache hit reuse, last-use updates, artifact identity changes, missing file refresh, checksum mismatch, and archive extraction
+- [x] 7.4 Add cleanup tests for stale vs retained artifacts, corrupted artifacts, full-cache removal, dry-run behavior, automatic cleanup gating, metadata removal, file removal, and cleanup summaries
+- [x] 7.5 Add diagnostic tests for checksum match and checksum mismatch reporting
+- [x] 7.6 Add locking tests for exclusive serialization, lock contention errors, diagnostic lock status, and force unlock behavior
+- [x] 7.7 Add CLI tests for `cache list`, `cache list --json`, `cache clean`, `cache clean --invalid`, `cache clean --all`, `cache clean --dry-run`, invalid cleanup-mode combinations, `cache unlock`, and `diag cache`
+- [x] 7.8 Add tests that cache commands do not require or resolve a deployment directory
+- [x] 7.9 Add tests for download staging location, partial-download cleanup, full-cache cleanup of staged downloads, and CLI partial-download cleanup output
+
+## 8. Documentation and verification
+
+- [x] 8.1 Update architecture and development documentation to describe per-user runtime artifact caching instead of deployment-local runtime artifact storage
+- [x] 8.2 Update user-facing command documentation/help examples for cache listing, cleaning, unlocking, and diagnostics
+- [x] 8.3 Run formatting for touched Go files
+- [x] 8.4 Run focused Go unit tests for runtime artifacts, cache commands, diagnostics, and Tofu resource resolution
+- [x] 8.5 Run the repository's standard unit-test and lint checks; document any pre-existing unrelated failures
+- [x] 8.6 Update cache management documentation for partial-download cleanup

--- a/tools/lockfileupdate/README.md
+++ b/tools/lockfileupdate/README.md
@@ -21,7 +21,7 @@ For each infrastructure preset directory under `assets/infrastructure/*`:
    - it must contain at least one `.tf` file.
    Presets that don’t use OpenTofu are skipped.
 2. Copy the preset directory into a temporary working directory.
-3. Resolve the OpenTofu binary through the runtime resource manager.
+3. Resolve the OpenTofu binary through the runtime artifact cache.
 4. Run `tofu providers lock` for multiple `-platform=...` values.
 5. Copy the generated `.terraform.lock.hcl` back into the original preset directory in `assets/`.
 6. Remove the temporary directory.
@@ -58,6 +58,6 @@ Example (update only one preset):
 
 ## Notes / assumptions
 
-- The tool resolves OpenTofu through the same runtime resource mechanism used by the launcher.
+- The tool resolves OpenTofu through the same runtime artifact cache used by the launcher.
 - The tool intentionally avoids writing state files; it only regenerates lockfiles.
 - Platform list defaults are conservative; adjust them if the project’s supported platforms change.

--- a/tools/lockfileupdate/main.go
+++ b/tools/lockfileupdate/main.go
@@ -145,7 +145,7 @@ func updateLockfileForPreset(ctx context.Context, presetDir string, platforms []
 		return fmt.Errorf("copy preset dir to temp: %w", err)
 	}
 
-	tofuPath, err := tofu.ResolveBinaryPath(context.Background(), tmpRoot)
+	tofuPath, err := tofu.ResolveBinaryPath(ctx)
 	if err != nil {
 		return fmt.Errorf("resolve tofu binary path: %w", err)
 	}

--- a/tools/tofu/main.go
+++ b/tools/tofu/main.go
@@ -9,16 +9,14 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path/filepath"
 
 	"github.com/exasol/exasol-personal/internal/tofu"
 )
 
 func main() {
-	cacheDir := flag.String("cache-dir", filepath.Join(os.TempDir(), "exasol-personal-runtime"), "Directory used to cache runtime resources")
 	flag.Parse()
 
-	binaryPath, err := tofu.ResolveBinaryPath(context.Background(), *cacheDir)
+	binaryPath, err := tofu.ResolveBinaryPath(context.Background())
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
## Description

Currently, resources are downloaded and cached per deployment directory. This PR adds a per-user artifact cache in the directory returned by `os.UserCacheDir()`.

The layout of the cache is:

```
.exasol
└── personal
    └── runtime-artifacts
        ├── downloads
        │   └── tmp.<hash>-<random>
        ├── artifacts
        │   └── <Resource ID>
        │       └── <OS>_<Arch>
        │           └── <hash>
        │               └── <Artifact>
        └── index.json
```

Where `downloads` contains files while they are being downloaded,  `index.json` contains information about the contents of the cache, and the `<hash>` is derived from:
- Logical runtime artifact ID.
- Platform.
- Source URL.
- Expected checksum.
- Extraction flag.
- Download path override.
- Resource path within an archive.

This PR also adds the following commands to manage the cache:

- `exasol cache list`: Lists the contents of the cache.
- `exasol cache clean --partial-downloads`: Removes artifacts which haven't finished downloading.
- `exasol cache clean --invalid`: Removes artifacts which have incorrect checksums.
- `exasol cache clean --all`: Wipes the cache.
- `exasol cache unlock`: Forcefully unlocks the cache (dangerous!).
- `exasol diag cache`: Outputs some information about the state of the cache.

All the `exasol cache clean` variants accept a `--dry-run` flag.

## Related Issue

[SPOT-31029](https://exasol.atlassian.net/browse/SPOT-31029)

## Type of Change

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [x] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Added per-user resource cache.
- Removed per-deployment resource cache.
- Added `exasol cache <list,clean,unlock>` commands.
- Added `exasol diag cache` command.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

[SPOT-30669]: https://exasol.atlassian.net/browse/SPOT-30669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SPOT-31029]: https://exasol.atlassian.net/browse/SPOT-31029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ