### PR TITLE
chore: fixing goreleaser pre-hook

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,7 +32,10 @@ builds:
     binary: exasol
     hooks:
       pre:
-        - cmd: GOOS="{{ .Os }}" GOARCH="{{ .Arch }}" task local-runner-stage
+        - cmd: task local-runner-stage
+          env:
+            - GOOS={{ .Os }}
+            - GOARCH={{ .Arch }}
           output: true
       post:
         - cmd: ./.github/scripts/sign-windows-binary.sh "{{ .Path }}"


### PR DESCRIPTION
## Description

Fixes the GoReleaser build pre-hook by passing GOOS and GOARCH through the hook environment instead of prefixing them in cmd.

This prevents GoReleaser v2.16 from trying to execute GOOS=linux as the command name during release builds. 

## Related Issue

n/a
## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [x] `chore`: Maintenance tasks


## Testing

Validated with goreleaser check and a local local-runner-stage run.


## Checklist

<!-- Mark completed items with an "x" -->

- [ ] Code follows the project's [coding guidelines](doc/best_practices.md)
- [ ] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [ ] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

<!-- Any additional information, screenshots, or context -->
