### PR TITLE
chore(release): fix issue with cross-compiling releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,10 +32,7 @@ builds:
     binary: exasol
     hooks:
       pre:
-        - cmd: task local-runner-stage
-          env:
-            - GOOS={{ .Os }}
-            - GOARCH={{ .Arch }}
+        - cmd: task local-runner-stage TARGET_GOOS="{{ .Os }}" TARGET_GOARCH="{{ .Arch }}"
           output: true
       post:
         - cmd: ./.github/scripts/sign-windows-binary.sh "{{ .Path }}"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -37,9 +37,13 @@ tasks:
       LOCAL_RUNNER_REPO: '{{default "exasol/exasol-local-vm" .LOCAL_RUNNER_REPO}}'
       LOCAL_RUNNER_VERSION: '{{default "v1.0.0-rc1" .LOCAL_RUNNER_VERSION}}'
       LOCAL_RUNNER_ASSET: '{{default "mac-runner-aarch64.zip" .LOCAL_RUNNER_ASSET}}'
+      TARGET_GOOS: '{{default "" .TARGET_GOOS}}'
+      TARGET_GOARCH: '{{default "" .TARGET_GOARCH}}'
     cmds:
       - >-
         go run ./tools/localrunner stage
+        {{if .TARGET_GOOS}}-goos {{.TARGET_GOOS}}{{end}}
+        {{if .TARGET_GOARCH}}-goarch {{.TARGET_GOARCH}}{{end}}
         -repo {{.LOCAL_RUNNER_REPO}}
         -version {{.LOCAL_RUNNER_VERSION}}
         -asset {{.LOCAL_RUNNER_ASSET}}


### PR DESCRIPTION
## Description

Fixes GoReleaser local runner staging during cross-platform releases.

The release hook now passes the build target as Task variables instead of GOOS/GOARCH, so the staging helper still compiles for the CI host while deciding whether to stage based on the target platform. Non-macOS and non-arm64 macOS targets skip staging; only darwin/arm64 downloads or stages the mac runner.

