### PR TITLE
Fixes docs and help text for to include local deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **The High-Performance Analytics Engine — Free for Personal Use**
 
-*Deploy a full-scale Exasol cluster on your own cloud infrastructure in minutes*
+*Deploy a full-scale Exasol database on your own infrastructure in minutes*
 
 [![Documentation](https://img.shields.io/badge/docs-exasol.com-blue)](https://docs.exasol.com/db/latest/home.htm)
 [![Community](https://img.shields.io/badge/community-exasol-green)](https://community.exasol.com)
@@ -24,19 +24,19 @@
 - ♾️ **Unlimited Data** — Store and analyze unlimited amounts of data with no artificial limits
 - 📈 **Scalable Architecture** — Scale up to any number of nodes using Exasol's MPP (Massively Parallel Processing) architecture
 - 🤖 **Built-in AI Functions** — Leverage native AI/ML capabilities with GPU acceleration
-- ⚙️ **Simple Deployment** — Spin up a distributed cluster on AWS, Azure, Exoscale, or STACKIT with just a few commands
+- ⚙️ **Simple Deployment** — Spin up Exasol on AWS, Azure, Exoscale, STACKIT, or your local system with just a few commands
 - 🖥️ **Cross-Platform CLI** — Install and manage your cluster using the Exasol Launcher on Linux, macOS, or Windows
 
 
 ## ✅ Prerequisites
 
-A cloud account on one of the supported platforms with permission to provision compute instances, or an Apple Silicon Mac for local deployment:
+A cloud account on one of the supported platforms with permission to provision compute instances, or a macOS Apple Silicon system for local deployment:
 
 - **AWS** — [Set up an AWS account for Exasol Personal](./HOWTO_SETUP_AWS_ACCOUNT.md)
 - **Azure** — [Set up an Azure account for Exasol Personal](./HOWTO_SETUP_AZURE_ACCOUNT.md)
 - **Exoscale** — [Set up an Exoscale account for Exasol Personal](./HOWTO_SETUP_EXOSCALE_ACCOUNT.md)
 - **STACKIT** — [Set up a STACKIT account for Exasol Personal](./HOWTO_SETUP_STACKIT_ACCOUNT.md)
-- **Local** — macOS on Apple Silicon for an Exasol Local deployment
+- **Local** — local deployment on macOS Apple Silicon only
 
 
 ## 🏎️ Quick Start (macOS / Linux)
@@ -47,7 +47,7 @@ A cloud account on one of the supported platforms with permission to provision c
 curl https://downloads.exasol.com/exasol-personal/installer.sh | sh
 ```
 
-2. Install on your cloud of choice
+2. Install on a cloud provider or your local system
 
 ```bash
 exasol install aws        # Amazon Web Services
@@ -66,7 +66,7 @@ exasol install stackit    # STACKIT
 ````
 
 ```bash
-exasol install local      # Exasol Local on Apple Silicon macOS
+exasol install local      # local system, macOS Apple Silicon only
 ```
 
 Read on for Windows instructions and full details.
@@ -85,20 +85,20 @@ Read on for Windows instructions and full details.
 
    On Windows: download the Exasol Launcher from the [Exasol Download Portal](https://downloads.exasol.com/exasol-personal) and copy the `exasol` binary to a directory in your `PATH`.
 
-2. Configure authentication for your cloud provider. See the relevant account setup guide in [Prerequisites](#-prerequisites) for the environment variables and credentials required.
+2. For cloud presets, configure authentication for your provider. See the relevant account setup guide in [Prerequisites](#-prerequisites) for the environment variables and credentials required.
 
-3. To install Exasol Personal, run the following command with the preset for your cloud provider:
+3. To install Exasol Personal, run the following command with the preset for your cloud provider or local system:
    ```bash
    exasol install aws        # Amazon Web Services
    exasol install azure      # Microsoft Azure
    exasol install exoscale   # Exoscale
    exasol install stackit    # STACKIT
-   exasol install local      # Exasol Local on Apple Silicon macOS
+   exasol install local      # local system, macOS Apple Silicon only
    ```
    The `exasol install` command does the following:
-   - Generates OpenTofu files in the deployment directory
-   - Provisions the necessary cloud infrastructure
-   - Starts up the infrastructure
+   - Generates backend files in the deployment directory
+   - Provisions the necessary deployment resources
+   - Starts the deployment
    - Downloads and installs Exasol Personal on that infrastructure
 
    The whole process normally takes about 10 to 20 minutes to complete.
@@ -107,9 +107,9 @@ Read on for Windows instructions and full details.
 
 By default, Exasol Personal stores deployment state in `~/.exasol/personal/deployments/default`. If you run a command from an existing deployment directory, Exasol Personal uses that directory instead. Pass `--deployment-dir <path>` to choose a different deployment directory explicitly.
 
-Keep the deployment directory until cloud resources have been destroyed. Deleting the directory does not remove cloud resources and can make cleanup harder.
+Keep the deployment directory until deployment resources have been destroyed. Deleting the directory does not remove those resources and can make cleanup harder.
 
-An initialized deployment directory is tied to the selected infrastructure and installation presets. Rerun `exasol install <preset>` with the same presets to retry a failed deployment safely, or use `exasol config get`, `exasol config set`, and `exasol config reset` to inspect or change parameters for the existing presets without deleting local state. To switch presets in the same deployment directory, run `exasol destroy --remove` before initializing again, or run `exasol remove` if the cloud resources are already gone.
+An initialized deployment directory is tied to the selected infrastructure and installation presets. Rerun `exasol install <preset>` with the same presets to retry a failed deployment safely, or use `exasol config get`, `exasol config set`, and `exasol config reset` to inspect or change parameters for the existing presets without deleting local state. To switch presets in the same deployment directory, run `exasol destroy --remove` before initializing again, or run `exasol remove` if the deployment resources are already gone.
 
 Runtime tools such as OpenTofu are downloaded on demand and reused from a per-user runtime artifact cache. Use `exasol cache list` to inspect cached artifacts, `exasol cache clean` to remove stale artifacts, `exasol cache clean --invalid` to remove artifacts that fail integrity checks, `exasol cache clean --partial-downloads` to remove staged partial downloads, `exasol cache clean --all` to wipe cached artifacts, and `exasol diag cache` to inspect cache health without changing it. Add `--dry-run` to a cleanup command to preview what would be removed.
 
@@ -174,7 +174,7 @@ By default the launcher deploys a single-node cluster on a memory-optimized inst
 ```bash
 exasol install <preset> --cluster-size <number> --instance-type <string>
 ```
-If the deployment process is interrupted, cloud resources that were already created will not be removed automatically and may continue to accrue cost. In that case, use `exasol destroy` to clean up the deployment, or remove the resources manually in your cloud provider's console.
+If the deployment process is interrupted, resources that were already created will not be removed automatically and cloud resources may continue to accrue cost. In that case, use `exasol destroy` to clean up the deployment, or remove the resources manually in the target environment.
 
 ## ⏯️ Start and stop Exasol Personal
 
@@ -192,28 +192,28 @@ exasol start
 ```
 The IP addresses of the nodes will change when you restart Exasol Personal. Check the output of the `start` command to know how to connect to the deployment after a restart.
 
-For local deployments, the launcher manages the Exasol Local VM runtime and an internal deployment share inside the deployment directory. The initial local database credentials are `sys` / `exasol`. `exasol shell host` opens the local VM shell, and `exasol shell container` opens a shell inside the Exasol Local database container.
+For local deployments, which currently require macOS Apple Silicon, the launcher manages a local VM runtime and an internal deployment share inside the deployment directory. The initial local database credentials are `sys` / `exasol`. `exasol shell host` opens the local VM shell, and `exasol shell container` opens a shell inside the local database container.
 
 ## 🗑️ Remove Exasol Personal
 
-To completely remove an Exasol Personal deployment, use `exasol destroy`. This command will terminate and delete the compute instances and all associated resources on your cloud platform.
+To completely remove an Exasol Personal deployment, use `exasol destroy`. This command deletes the deployment resources and all associated data.
 
 To learn more about this command, use `exasol destroy --help`.
 
-By default, `exasol destroy` keeps the local deployment files so you can inspect the deployment or recreate the same preset. To also remove the local deployment directory after cloud resources have been destroyed, run:
+By default, `exasol destroy` keeps the local deployment files so you can inspect the deployment or recreate the same preset. To also remove the local deployment directory after deployment resources have been destroyed, run:
 ```bash
 exasol destroy --remove
 ```
 
-If cloud resources were already deleted manually or you no longer have access to destroy them through the launcher, use the local recovery command:
+If deployment resources were already deleted manually or you no longer have access to destroy them through the launcher, use the local recovery command:
 ```bash
 exasol remove
 ```
-This removes the local deployment directory. It does not destroy cloud resources.
+This removes the local deployment directory. It does not destroy deployment resources.
 
-Deleting the deployment directory and the Exasol Launcher will not remove the resources that were created in your cloud environment. To completely remove a deployment, you must use the `exasol destroy` command before deleting the deployment directory.
+Deleting the deployment directory and the Exasol Launcher will not remove the resources that were created in the target environment. To completely remove a deployment, you must use the `exasol destroy` command before deleting the deployment directory.
 
-If you have already deleted the deployment directory and the Exasol Launcher, you must remove the resources manually in your cloud provider’s console.
+If you have already deleted the deployment directory and the Exasol Launcher, you must remove the resources manually in the target environment.
 
 For local deployments, `exasol destroy` deletes the local VM disk/data and launcher-managed share for that deployment.
 
@@ -270,7 +270,7 @@ exasol shell container
 
 Exasol Personal uses **presets** — self-contained directories of templates and config files — to provision infrastructure and install Exasol. Each deployment combines two presets:
 
-- **Infrastructure preset** — provisions cloud resources (compute, network, storage). Built-in: `aws`, `azure`, `exoscale`, `stackit`.
+- **Infrastructure preset** — provisions deployment resources for a cloud provider or local system. Built-in: `aws`, `azure`, `exoscale`, `stackit`, `local`.
 - **Installation preset** — installs and configures Exasol on the provisioned nodes. Built-in: `ubuntu` (used by default).
 
 ```bash
@@ -289,7 +289,7 @@ exasol presets
 
 ### Local presets
 
-You can store your own preset directories anywhere on your filesystem and pass the path directly to `exasol install`. This lets you target additional cloud platforms or customize provisioning without modifying the launcher.
+You can store your own preset directories anywhere on your filesystem and pass the path directly to `exasol install`. This lets you target additional infrastructure platforms or customize provisioning without modifying the launcher.
 
 ### Building your own preset
 

--- a/cmd/exasol/destroy.go
+++ b/cmd/exasol/destroy.go
@@ -10,12 +10,13 @@ import (
 
 const destroyCmdShortDesc = `Destroy a deployment`
 
+// nolint: revive
 const destroyCmdLongDesc = destroyCmdShortDesc + `
 
 Destroying a deployment deletes all resources - including all data.
 If you want to retain any data, make sure you've created and moved backups to another safe location.
 By default, local deployment files are kept so the same deployment can be inspected or recreated.
-Pass --remove to remove the local deployment directory after cloud resources have been destroyed.
+Pass --remove to remove the local deployment directory after deployment resources have been destroyed.
 `
 
 var destroyOpts = struct {
@@ -29,10 +30,11 @@ func registerDestroyFlags(cmd *cobra.Command) {
 		"auto-approve",
 		false,
 		"Force destroy without confirmation prompt")
+	// nolint: revive
 	cmd.Flags().BoolVar(&destroyOpts.Remove,
 		"remove",
 		false,
-		"Remove the local deployment directory after cloud resources are successfully destroyed")
+		"Remove the local deployment directory after deployment resources are successfully destroyed")
 }
 
 var destroyCmd = &cobra.Command{
@@ -76,7 +78,7 @@ var destroyCmd = &cobra.Command{
 func destroyConfirmationPrompt(localRemovalTarget string) string {
 	prompt := "WARNING: Destroying a deployment " +
 		"is an irreversible operation, " +
-		"and removes all cloud resources " +
+		"and removes all deployment resources " +
 		"- including all data."
 	if localRemovalTarget != "" {
 		prompt += "\n\nLocal deployment directory to remove after destroy:\n" + localRemovalTarget

--- a/cmd/exasol/init.go
+++ b/cmd/exasol/init.go
@@ -42,7 +42,7 @@ var initCmdLongDesc = initCmdShortDesc + `
 	For an already initialized deployment with the same presets, supplied configuration
 	flags update only the selected parameters. Omitted parameters keep their values.
 	To switch presets, run exasol destroy --remove first, or exasol remove if the
-	cloud resources are already gone.` +
+	deployment resources are already gone.` +
 	deploymentDirectoryResolutionHelp + presetSelectionHelp
 
 var initCmd = &cobra.Command{

--- a/cmd/exasol/install.go
+++ b/cmd/exasol/install.go
@@ -21,7 +21,7 @@ var installCmdLongDesc = installCmdShortDesc + `
 	and installs Exasol.
 	Rerunning install with the same presets is safe for retrying failed deployments.
 	To switch presets, run exasol destroy --remove first, or exasol remove if the
-	cloud resources are already gone.` +
+	deployment resources are already gone.` +
 	deploymentDirectoryResolutionHelp + presetSelectionHelp
 
 var installCmd = &cobra.Command{

--- a/cmd/exasol/remove.go
+++ b/cmd/exasol/remove.go
@@ -8,15 +8,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const removeCmdShortDesc = `Remove a local deployment directory without destroying cloud resources`
+const removeCmdShortDesc = `Remove a local deployment directory without destroying resources`
 
 const removeCmdLongDesc = removeCmdShortDesc + `
 
-This is a recovery command for cases where cloud resources were already deleted manually,
+This is a recovery command for cases where deployment resources were already deleted manually,
 or where you no longer have access to destroy them through the launcher.
 
 WARNING: This command removes the local deployment directory. It does not destroy
-cloud resources and can make launcher-based cleanup impossible if resources still exist.
+deployment resources and can make launcher-based cleanup impossible if resources still exist.
 `
 
 var removeOpts = struct {
@@ -56,7 +56,7 @@ var removeCmd = &cobra.Command{
 
 func removeConfirmationPrompt(deploymentDir string) string {
 	return "WARNING: This removes the local deployment directory. " +
-		"It does not destroy cloud resources. Continue only if the " +
+		"It does not destroy deployment resources. Continue only if the " +
 		"resources were already deleted manually or you accept that " +
 		"launcher-based cleanup may no longer be possible.\n\n" +
 		"Local deployment directory to remove:\n" +

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -4,13 +4,13 @@ This document describes the high-level architecture, design philosophy, and tech
 
 ## Overview
 
-The Exasol Personal tool (`exasol`) is a command-line application that automates the deployment and management of Exasol Database on cloud infrastructure. It handles infrastructure provisioning, software installation, and provides database connectivity.
+The Exasol Personal tool (`exasol`) is a command-line application that automates the deployment and management of Exasol Database on supported cloud and local infrastructure. It handles infrastructure provisioning, software installation, and provides database connectivity.
 
 **What you'll find here:**
 - Design philosophy and requirements
 - Technical choices and rationale
 - High-level application workflow
-- Cloud infrastructure approach
+- Infrastructure approach
 - Interfaces and integration points
 
 **What's documented elsewhere:**
@@ -54,7 +54,7 @@ The Exasol Personal tool (`exasol`) is a command-line application that automates
 - No silent failures or data loss
 
 **Expandability**
-- Pluggable infrastructure presets per cloud provider
+- Pluggable infrastructure presets per deployment target
 - Pluggable installation presets per operating system / approach
 - Extensible configuration system
 - Template-based customization
@@ -71,11 +71,11 @@ The Exasol Personal tool (`exasol`) is a command-line application that automates
 
 ### Platform Support
 - **Deployment platforms:** Users can run the tool on Linux, macOS, or Windows
-- **Cloud targets:** Currently AWS (others can be added)
+- **Deployment targets:** Cloud presets and local deployment backends
 - **Distribution:** Single statically-compiled binary per platform
 
 ### Prerequisites
-- **Cloud credentials:** Must be configured via environment variables (e.g., `AWS_PROFILE`)
+- **Infrastructure credentials:** Cloud presets require provider credentials via environment variables (e.g., `AWS_PROFILE`)
 - **Network access:** Required for cloud API calls and software downloads
 - **Disk space:** Sufficient for deployment directory (~500MB)
 
@@ -102,8 +102,8 @@ The `init` command prepares a deployment directory:
 
 The `deploy` command provisions infrastructure and installs the database:
 
-1. **Validate inputs** - Check deployment directory (state + manifests) and cloud credentials
-2. **Execute Infrastructure-as-Code** - Run OpenTofu to provision cloud resources
+1. **Validate inputs** - Check deployment directory (state + manifests) and infrastructure prerequisites
+2. **Provision resources** - Run the selected backend to create deployment resources
 3. **Wait for infrastructure ready** - Poll until instances are accessible
 4. **Execute and monitor installation** - Run the selected installation preset and report progress
 5. **Store connection information** - Save connection details locally
@@ -126,7 +126,7 @@ The `connect` command provides database access:
 The `destroy` command tears down all resources:
 
 1. Read deployment state
-2. Execute OpenTofu destroy to remove cloud resources
+2. Execute the selected backend destroy operation to remove deployment resources
 3. Clean up state files (optional)
 
 ## Cloud Infrastructure Architecture

--- a/doc/glossary.md
+++ b/doc/glossary.md
@@ -28,7 +28,7 @@ The infrastructure template selected for deployment. It defines the infrastructu
 The installation template that defines how software is installed on provisioned infrastructure. It should ideally be independent of the infrastructure preset and work with any.
 
 ### Active Deployment
-A successfully provisioned and running Exasol deployment, including cloud infrastructure, database process, and valid state.
+A successfully provisioned and running Exasol deployment, including deployment resources, database process, and valid state.
 
 ### Running Database
 An initialized and operational Exasol database ready to accept SQL connections and queries.

--- a/internal/deploy/configure.go
+++ b/internal/deploy/configure.go
@@ -17,12 +17,12 @@ import (
 var ErrConfigureNotAllowed = errors.New("deployment cannot be configured in its current state")
 
 // configureNotAllowedHint guides the user out of any non-initialized state in
-// which the deployment may already have cloud resources. It is used both when
+// which the deployment may already have resources. It is used both when
 // the deployment is live (running, stopped) and when a previous deploy or
-// destroy was interrupted or failed: in those cases the cloud may still hold
+// destroy was interrupted or failed: in those cases the target infrastructure may still hold
 // resources whose configuration the user must not silently change.
-const configureNotAllowedHint = "the deployment may already have cloud resources;\n" +
-	"run `exasol destroy` (or `exasol remove` if you have confirmed the cloud resources are " +
+const configureNotAllowedHint = "the deployment may already have resources;\n" +
+	"run `exasol destroy` (or `exasol remove` if you have confirmed the resources are " +
 	"gone) before changing configuration, then run `exasol config set` and `exasol deploy`"
 
 type DeploymentID string
@@ -43,7 +43,7 @@ type DeploymentLayout struct {
 }
 
 // WorkflowStatePermitsConfigure rejects configuration changes whenever the
-// deployment may already have cloud resources. Only freshly-initialized
+// deployment may already have resources. Only freshly-initialized
 // deployments may be configured; any later state (running, stopped, deployment
 // failed, interrupted during deploy or destroy, or an operation in progress)
 // requires the user to run `exasol destroy` (or `exasol remove`) first so that

--- a/internal/deploy/preset_identity.go
+++ b/internal/deploy/preset_identity.go
@@ -74,7 +74,7 @@ func EnsureDeploymentPresetIdentityMatches(
 		"%w: existing infrastructure %q, installation %q; "+
 			"requested infrastructure %q, installation %q.\n"+
 			"Run `exasol destroy --remove` before initializing different presets, "+
-			"or run `exasol remove` if the cloud resources are already gone",
+			"or run `exasol remove` if the deployment resources are already gone",
 		ErrDeploymentPresetMismatch,
 		presetIdentityDisplay(existing.infrastructure),
 		presetIdentityDisplay(existing.installation),

--- a/internal/deploy/status.go
+++ b/internal/deploy/status.go
@@ -255,7 +255,7 @@ func staleOperationInProgressMessage(operation string) string {
 	switch operation {
 	case config.DestroyOperation:
 		return "A previous destroy operation did not finish cleanly. " +
-			"If cloud resources may still exist, run `destroy` again. " +
+			"If deployment resources may still exist, run `destroy` again. " +
 			"If resources were already deleted or cannot be destroyed through the launcher, " +
 			"run `remove` to delete only the local deployment directory."
 	case config.DeployOperation:

--- a/tests/tests/integration/test_reconfiguration.py
+++ b/tests/tests/integration/test_reconfiguration.py
@@ -433,7 +433,7 @@ def test_config_set_refuses_running_deployment(
 
     # Then it tells the user to destroy before changing configuration
     stderr = exc.value.stderr.lower()
-    assert "deployment may already have cloud resources" in stderr
+    assert "deployment may already have resources" in stderr
     assert "exasol destroy" in stderr
 
 
@@ -454,13 +454,13 @@ def test_config_set_refuses_running_deployment(
         ),
     ],
 )
-def test_config_set_refuses_state_with_possible_cloud_resources(
+def test_config_set_refuses_state_with_possible_resources(
     exasol_path: str,
     tmp_path: Path,
     workflow_state: dict[str, object],
 ) -> None:
     # Given an initialized deployment whose previous operation failed or was
-    # interrupted, so cloud resources may already exist
+    # interrupted, so deployment resources may already exist
     deployment_dir = tmp_path / "deployment"
     infra_id = first_infrastructure_preset_id_or_skip(exasol_path)
     run_command(
@@ -493,7 +493,7 @@ def test_config_set_refuses_state_with_possible_cloud_resources(
 
     # Then it refuses the configuration change with destroy guidance
     stderr = exc.value.stderr.lower()
-    assert "deployment may already have cloud resources" in stderr
+    assert "deployment may already have resources" in stderr
     assert "exasol destroy" in stderr
 
 
@@ -596,7 +596,7 @@ def test_install_refuses_same_preset_configuration_change_for_running_deployment
 
     # Then it refuses the configuration change without destroying or mutating state
     stderr = exc.value.stderr.lower()
-    assert "deployment may already have cloud resources" in stderr
+    assert "deployment may already have resources" in stderr
     assert "exasol destroy" in stderr
     assert _get_active_configuration(
         exasol_path,
@@ -774,7 +774,8 @@ def test_remove_removes_local_deployment_directory_without_destroy(
         ]
     )
 
-    # Then the local deployment directory is removed without destroying cloud resources
+    # Then the local deployment directory is removed
+    # without destroying deployment resources
     assert result.returncode == 0
     assert not deployment_dir.exists()
 


### PR DESCRIPTION
## Description

Updates documentation and terminal-facing help text so deployment wording no longer assumes every preset provisions cloud resources. The wording now covers both cloud providers and the local system, and clearly states that the `local` preset currently supports macOS Apple Silicon only.

## Related Issue

n/a

## Type of Change

  - [ ] `feat`: New feature
  - [ ] `fix`: Bug fix
  - [x] `docs`: Documentation update
  - [ ] `test`: Test additions or changes
  - [ ] `refactor`: Code refactoring
  - [ ] `chore`: Maintenance tasks

## Changes Made

  - Replaced generic cloud-only wording with backend-neutral “deployment resources” wording in CLI help and prompts.
  - Updated README copy to describe cloud providers and the local system without referring to “Exasol Local” as a target.
  - Documented that local deployment currently requires macOS Apple Silicon.

## Testing

  - [x] All existing tests pass (`task all`)
  - [ ] Added new tests for new functionality
  - [x] Manually tested the changes

### Test Details

  - Reviewed rendered README/help wording for cloud and local deployment terminology.
  - Ran `git diff --check` to verify formatting/whitespace.

## Checklist

  - [x] Code follows the project's [coding guidelines](doc/best_practices.md)
  - [x] Ran `task fmt` and `task lint`
  - [x] Updated documentation (if applicable)
  - [ ] Added/updated tests
  - [ ] All tests pass locally
  - [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

This PR is intentionally limited to user-facing wording and documentation. It does not change command behavior.
