### PR TITLE
feat: reject local deployment early in init phase on unspported platf…

### DIFF
--- a/internal/deploy/backend.go
+++ b/internal/deploy/backend.go
@@ -34,7 +34,9 @@ type DeployOptions struct {
 //
 // All methods operate against the deployment and manifest that were supplied
 // when the backend was constructed (see newDeploymentBackend).
+// nolint: interfacebloat
 type deploymentBackend interface {
+	ValidateEnvironment() error
 	SetupWorkspace(ctx context.Context) error
 	Configure(
 		ctx context.Context,

--- a/internal/deploy/init.go
+++ b/internal/deploy/init.go
@@ -89,6 +89,21 @@ func InitDeployment(
 	if err := ValidatePresetSelection(infrastructurePreset, installationPreset); err != nil {
 		return err
 	}
+	infrastructureManifest, err := readInfrastructureManifestFromPreset(infrastructurePreset)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to load infrastructure preset %q: %w",
+			presetLabel(infrastructurePreset),
+			err,
+		)
+	}
+	backend, err := newDeploymentBackend(deployment, infrastructureManifest)
+	if err != nil {
+		return err
+	}
+	if err := backend.ValidateEnvironment(); err != nil {
+		return err
+	}
 
 	// Init only creates fresh deployment state. Existing deployment orchestration
 	// belongs to the command layer.

--- a/internal/deploy/preset_validation_test.go
+++ b/internal/deploy/preset_validation_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -72,6 +73,47 @@ install: []
 	}
 	if !strings.Contains(err.Error(), "missing capabilities [remote-exec]") {
 		t.Fatalf("expected compatibility error, got %v", err)
+	}
+
+	entries, readErr := os.ReadDir(deploymentDir)
+	if readErr != nil {
+		t.Fatalf("expected to read deployment dir, got %v", readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf(
+			"expected deployment directory to remain untouched, found %d entries",
+			len(entries),
+		)
+	}
+}
+
+func TestInitDeployment_RejectsUnsupportedLocalPlatformBeforeMutation(t *testing.T) {
+	if runtime.GOOS == localSupportedOS && runtime.GOARCH == localSupportedArch {
+		t.Skip("current platform supports local deployments")
+	}
+	t.Setenv(localAllowUnsupportedEnv, "")
+
+	// Given
+	deploymentDir := t.TempDir()
+
+	// When
+	err := InitDeployment(
+		context.Background(),
+		PresetRef{Name: "local"},
+		PresetRef{Name: "local"},
+		map[string]string{},
+		map[string]string{},
+		config.NewDeploymentDir(deploymentDir),
+		false,
+		"0.0.0",
+	)
+
+	// Then
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), errUnsupportedLocalPlatform.Error()) {
+		t.Fatalf("expected unsupported local platform error, got %v", err)
 	}
 
 	entries, readErr := os.ReadDir(deploymentDir)

--- a/internal/deploy/tofu_backend.go
+++ b/internal/deploy/tofu_backend.go
@@ -67,6 +67,10 @@ func newTofuBackend(
 	return b
 }
 
+func (*tofuBackend) ValidateEnvironment() error {
+	return nil
+}
+
 func (b *tofuBackend) SetupWorkspace(_ context.Context) error {
 	if !b.hasTofu() {
 		slog.Info("tofu: no configuration defined; skipping workspace setup")

--- a/tests/tests/integration/test_install.py
+++ b/tests/tests/integration/test_install.py
@@ -3,6 +3,7 @@
 
 import json
 import os
+import platform
 import sys
 from pathlib import Path
 from subprocess import CalledProcessError
@@ -73,6 +74,36 @@ def test_install_executes_init_step(exasol_path: str, tmp_path: Path) -> None:
     stderr = (excinfo.value.stderr or "").lower()
     assert "initialization failed" in stderr
     assert "deployment directory is not empty" in stderr
+
+
+@pytest.mark.skipif(
+    sys.platform == "darwin" and platform.machine().lower() in {"arm64", "aarch64"},
+    reason="local deployments are supported on macOS Apple Silicon",
+)
+def test_init_local_rejects_unsupported_platform_before_writing_files(
+    exasol_path: str, tmp_path: Path
+) -> None:
+    # Given an empty deployment directory on an unsupported local platform
+    deployment_dir = tmp_path / "deployment"
+    deployment_dir.mkdir()
+
+    # When init is invoked for the local preset
+    with pytest.raises(CalledProcessError) as exc:
+        run_command(
+            [
+                exasol_path,
+                "init",
+                "local",
+                "--deployment-dir",
+                str(deployment_dir),
+                "--no-launcher-version-check",
+            ]
+        )
+
+    # Then it fails before writing deployment state
+    stderr = exc.value.stderr.lower()
+    assert "local deployments are only supported on macos apple silicon" in stderr
+    assert list(deployment_dir.iterdir()) == []
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION

## Description

Rejects `exasol init local` early on unsupported platforms. Local deployments currently require macOS Apple Silicon, so initialization now fails on Windows and Linux before writing deployment state,
instead of allowing users to discover the unsupported platform later during `deploy`.

## Related Issue

n/a

## Type of Change

  - [x] `feat`: New feature
  - [ ] `fix`: Bug fix
  - [ ] `docs`: Documentation update
  - [ ] `test`: Test additions or changes
  - [ ] `refactor`: Code refactoring
  - [ ] `chore`: Maintenance tasks

## Changes Made

  - Added backend environment validation to the init flow.
  - Kept the OpenTofu backend validation as a no-op and reused the existing local backend platform validation.
  - Added regression coverage that verifies `init local` fails on unsupported platforms before mutating the deployment directory.

## Testing

  - [x] All existing tests pass (`task all`)
  - [x] Added new tests for new functionality
  - [x] Manually tested the changes

### Test Details

  - Ran focused Go tests for deployment initialization and command behavior.
  - Ran the integration test for unsupported `init local` behavior.
  - Manually verified that `exasol init local --deployment-dir <empty-dir>` fails on Linux with the macOS Apple Silicon support message and leaves the directory empty.

## Checklist

  - [x] Code follows the project's [coding guidelines](doc/best_practices.md)
  - [ ] Ran `task fmt` and `task lint`
  - [ ] Updated documentation (if applicable)
  - [x] Added/updated tests
  - [ ] All tests pass locally
  - [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

I saw the vars EXASOL_LOCAL_ALLOW_UNSUPPORTED_PLATFORM and EXASOL_LOCAL_SKIP_DB_WAIT. Do we need them still or are those pure development artifacts that are not longer that helpful? Feels weird to leave that in. @wizenink 