### PR TITLE
docs: reflect new "Analytics Database for Agentic AI" positioning in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # Exasol Personal
 
-**The High-Performance Analytics Engine — Free for Personal Use**
+**The Analytics Database for Agentic AI — Free for Personal Use**
 
 *Deploy a full-scale Exasol database on your own infrastructure in minutes*
 
@@ -19,11 +19,12 @@
 
 ## 🔥 Key Features
 
+- 🤖 **Built for Agentic AI** — Connect AI agents and LLM tools directly through a scriptable CLI
+- 🧠 **Built-in AI Functions** — Leverage native AI/ML capabilities with GPU acceleration, right where your data lives
 - 🏎️ **In-Memory Performance** — Run complex analytics at in-memory speed with Exasol's industry-leading analytics engine
 - 🏢 **Full Enterprise Features** — Access all enterprise-scale capabilities of the Exasol database, completely free for personal use
 - ♾️ **Unlimited Data** — Store and analyze unlimited amounts of data with no artificial limits
 - 📈 **Scalable Architecture** — Scale up to any number of nodes using Exasol's MPP (Massively Parallel Processing) architecture
-- 🤖 **Built-in AI Functions** — Leverage native AI/ML capabilities with GPU acceleration
 - ⚙️ **Simple Deployment** — Spin up Exasol on AWS, Azure, Exoscale, STACKIT, or your local system with just a few commands
 - 🖥️ **Cross-Platform CLI** — Install and manage your cluster using the Exasol Launcher on Linux, macOS, or Windows
 
@@ -167,15 +168,6 @@ FILE 'product_reviews.parquet';
 
 Both tables are distributed by `PRODUCT_ID`, enabling efficient joins between them.
 
-
-## ⚙️ Choosing cluster size and compute instance types
-
-By default the launcher deploys a single-node cluster on a memory-optimized instance (e.g. `r6i.xlarge` on AWS, `Standard_E4s_v3` on Azure, `standard.extra-large` on Exoscale, `m2i.4` on STACKIT). To change the number of nodes or the instance type, use the `--cluster-size` and `--instance-type` options:
-```bash
-exasol install <preset> --cluster-size <number> --instance-type <string>
-```
-If the deployment process is interrupted, resources that were already created will not be removed automatically and cloud resources may continue to accrue cost. In that case, use `exasol destroy` to clean up the deployment, or remove the resources manually in the target environment.
-
 ## ⏯️ Start and stop Exasol Personal
 
 To save costs, you can temporarily stop Exasol Personal by using the following command:
@@ -217,6 +209,15 @@ If you have already deleted the deployment directory and the Exasol Launcher, yo
 
 For local deployments, `exasol destroy` deletes the local VM disk/data and launcher-managed share for that deployment.
 
+## ⚙️ Cloud: Choosing cluster size and compute instance types
+
+By default the launcher deploys a single-node cluster on a memory-optimized instance in the cloud (e.g. `r6i.xlarge` on AWS, `Standard_E4s_v3` on Azure, `standard.extra-large` on Exoscale, `m2i.4` on STACKIT). To change the number of nodes or the instance type, use the `--cluster-size` and `--instance-type` options:
+```bash
+exasol install <preset> --cluster-size <number> --instance-type <string>
+```
+If the deployment process is interrupted, resources that were already created will not be removed automatically and cloud resources may continue to accrue cost. In that case, use `exasol destroy` to clean up the deployment, or remove the resources manually in the target environment.
+
+
 ## 🔜 Next steps
 
 Once the deployment process is complete, use `exasol info` for information about how to connect to your Exasol database. The credentials for connecting to the database from a client are stored in the file `secrets.json` in the deployment directory.
@@ -251,6 +252,8 @@ Exasol Admin is an easy-to-use web interface that you can use to administer your
 - The credentials for connecting to Exasol Admin are stored in the file `secrets.json` in the deployment directory.
 
 Your browser may show a security warning when connecting to Exasol Admin because of the self-signed certificate. Accept this warning and continue.
+
+Currently, Exasol Admin is only available on cloud deployments.
 
 ## 🔒 Connect using SSH
 


### PR DESCRIPTION
## Description

Refreshes the README to reflect Exasol Personal's new positioning: **"The Analytics Database for Agentic AI."** The headline tagline and the Key Features list are updated to lead with the AI/agentic story, and a few unrelated rough edges in the doc are polished along the way.

This is a documentation-only change; no code, behavior, or dependencies are affected.

## Related Issue

N/A

## Type of Change

- [x] `docs`: Documentation update

## Changes Made

- Update the headline tagline to **"The Analytics Database for Agentic AI — Free for Personal Use."**
- Reorder the **Key Features** list to lead with AI capabilities, and add a **"Built for Agentic AI"** bullet highlighting agent/LLM access via a scriptable CLI.
- Reframe the **"Built-in AI Functions"** bullet to emphasize AI running where the data lives.
- Move the **"Choosing cluster size and compute instance types"** section to the cloud-deployment area and re-title it **"Cloud: …"**, since it does not apply to local deployments.
- Note that **Exasol Admin** is currently available only on cloud deployments.

## Testing

- [x] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality — N/A (documentation only)
- [x] Manually tested the changes (reviewed the rendered README)

### Test Details

Documentation-only change — no code paths are touched, so no tests were added. Verified by rendering the README and confirming headings, list order, and links are intact.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [ ] Ran `task fmt` and `task lint` — N/A (no code changed)
- [x] Updated documentation (if applicable)
- [ ] Added/updated tests — N/A (documentation only)
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

Pure positioning copy plus minor structural polish; safe to review against the rendered README.
