### PR TITLE
docs: add agent-skills link to CLI help text

### DIFF
--- a/cmd/exasol/root.go
+++ b/cmd/exasol/root.go
@@ -34,7 +34,9 @@ Getting Started:
 
 	Note: Cloud presets require provider credentials in your environment.
   Use "exasol init --help", "exasol install --help", or "exasol presets list" to see the preset
-  compatibility matrix.`
+  compatibility matrix.
+
+  AI agent skills: https://github.com/exasol-labs/exasol-agent-skills`
 
 	rootCmdExample = `  exasol install aws`
 


### PR DESCRIPTION
## Description

Adds a pointer to the **Exasol AI Agent skills** repository in the `exasol` CLI's top-level help. Users running `exasol help` / `exasol --help` now see a link to the agent-skills resources at the end of the "Getting Started" section, reinforcing the "Analytics Database for Agentic AI" positioning.

Documentation-only change to the root command's long description; no code paths, flags, or behavior are affected.

## Related Issue

N/A

## Type of Change

- [x] `docs`: Documentation update

## Changes Made

- Append an "AI agent skills" link to `rootCmdLongDesc` in `cmd/exasol/root.go`, pointing to https://github.com/exasol-labs/exasol-agent-skills.
- `rootCmdShortDesc` is left as the single-line repo link, keeping the Cobra-conventional one-line `Short` description.

## Testing

- [x] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality — N/A (documentation only)
- [x] Manually tested the changes (`exasol --help` shows the skills link)

### Test Details

Documentation-only change. Verified with `go build ./...`, the full `go test ./...` suite, and `golangci-lint` on the touched package (0 issues), plus rendering `exasol --help` to confirm the link appears correctly formatted.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [ ] Added/updated tests — N/A (documentation only)
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
