### PR TITLE
SPOT-31123/SPOT-31132: Improve info guidance and JSON output

### DIFF
--- a/cmd/exasol/hidden.go
+++ b/cmd/exasol/hidden.go
@@ -4,14 +4,24 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
-	"github.com/exasol/exasol-personal/internal/deploy"
+	"github.com/exasol/exasol-personal/internal/config"
 	"github.com/spf13/cobra"
 )
 
 // These commands are only for internal purposes / debugging and are not visible to users directly
+
+func addConnectionInstructionsTerminalOutput(deployment config.DeploymentDir) error {
+	content, err := os.ReadFile(deployment.ConnectionInstructionsPath())
+	if err != nil {
+		return err
+	}
+
+	addTerminalOutput(string(content))
+
+	return nil
+}
 
 var printConnectionInstructions = &cobra.Command{
 	Use:    "print-connection-instructions",
@@ -21,17 +31,8 @@ var printConnectionInstructions = &cobra.Command{
 	Hidden: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cmd.SilenceUsage = true
-		content, err := deploy.GetConnectionInstructionsText(
-			cmd.Context(),
-			commonFlags.Deployment(),
-		)
-		if err != nil {
-			return err
-		}
 
-		_, err = fmt.Fprintln(os.Stdout, content)
-
-		return err
+		return addConnectionInstructionsTerminalOutput(commonFlags.Deployment())
 	},
 }
 

--- a/cmd/exasol/info.go
+++ b/cmd/exasol/info.go
@@ -5,23 +5,20 @@ package main
 
 import (
 	"context"
-	"fmt"
+	_ "embed"
+	"encoding/json"
 	"io"
 	"os"
+	"text/template"
 
 	"github.com/exasol/exasol-personal/internal/config"
 	"github.com/exasol/exasol-personal/internal/deploy"
 	"github.com/spf13/cobra"
 )
 
-const deploymentInfoCmdShortDesc = "Prints a summary of your Exasol deployment."
+const deploymentInfoCmdShortDesc = "Prints information about your Exasol deployment."
 
 const deploymentInfoCmdLongDesc = deploymentInfoCmdShortDesc + `
-
-Shows key deployment attributes in plain text, including:
-
-- Deployment name, Deployment State, Cluster size and Cluster State
-- Connection details appropriate for the active deployment backend
 
 You can use the '--json' option to print the output in JSON format.
 
@@ -30,12 +27,24 @@ Example usage:
     exasol info --json
 `
 
+//go:embed info_text.tmpl
+var deploymentInfoTextTemplateSource string
+
+var deploymentInfoTextTemplate = template.Must(
+	template.New("deployment-info-text").Parse(deploymentInfoTextTemplateSource),
+)
+
 func fetchDeploymentInfoJSON(
 	ctx context.Context,
 	deployment config.DeploymentDir,
 	writer io.Writer,
 ) error {
-	return deploy.PrintConnectionInsInJson(ctx, deployment, writer)
+	report, err := deploy.GetDeploymentInfoReport(ctx, deployment)
+	if err != nil {
+		return err
+	}
+
+	return renderDeploymentInfoJSON(writer, report)
 }
 
 func fetchDeploymentInfoText(
@@ -43,25 +52,29 @@ func fetchDeploymentInfoText(
 	deployment config.DeploymentDir,
 	writer io.Writer,
 ) error {
-	content, err := deploy.GetConnectionInstructionsText(ctx, deployment)
+	report, err := deploy.GetDeploymentInfoReport(ctx, deployment)
 	if err != nil {
 		return err
 	}
 
-	_, err = fmt.Fprintln(writer, content)
-
-	return err
+	return renderDeploymentInfoText(writer, report)
 }
 
-func addConnectionInstructionsTerminalOutput(deployment config.DeploymentDir) error {
-	content, err := os.ReadFile(deployment.ConnectionInstructionsPath())
-	if err != nil {
-		return err
-	}
+func renderDeploymentInfoJSON(
+	writer io.Writer,
+	report *deploy.DeploymentInfoReport,
+) error {
+	encoder := json.NewEncoder(writer)
+	encoder.SetIndent("", "  ")
 
-	addTerminalOutput(string(content))
+	return encoder.Encode(report)
+}
 
-	return nil
+func renderDeploymentInfoText(
+	writer io.Writer,
+	report *deploy.DeploymentInfoReport,
+) error {
+	return deploymentInfoTextTemplate.Execute(writer, report)
 }
 
 var deploymentInfoCmd = &cobra.Command{
@@ -84,7 +97,6 @@ var deploymentInfoCmd = &cobra.Command{
 // nolint: gochecknoinits
 func init() {
 	requireMinorVersionCompatibility(deploymentInfoCmd, CurrentLauncherVersion)
-	requireInitializedDeploymentDir(deploymentInfoCmd)
 	registerDeploymentDirFlag(deploymentInfoCmd, commonFlags)
 	registerOutputFlags(deploymentInfoCmd, commonFlags)
 	rootCmd.AddCommand(deploymentInfoCmd)

--- a/cmd/exasol/info_test.go
+++ b/cmd/exasol/info_test.go
@@ -1,0 +1,220 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/deploy"
+)
+
+func TestRenderDeploymentInfoJSONSerializesReportDirectly(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	report := &deploy.DeploymentInfoReport{
+		DeploymentDir:   "/deployment",
+		DeploymentID:    "test-deployment",
+		DeploymentState: deploy.StatusRunning,
+		Presets: &deploy.DeploymentPresetSummary{
+			Infrastructure: deploy.PresetIdentityInfo{
+				Selector:    "name:aws",
+				Kind:        "name",
+				Name:        "aws",
+				DisplayName: "AWS",
+			},
+			Installation: deploy.PresetIdentityInfo{
+				Selector:    "name:ubuntu",
+				Kind:        "name",
+				Name:        "ubuntu",
+				DisplayName: "Ubuntu",
+			},
+		},
+		Deployment: &config.DeploymentInfo{
+			ClusterSize:  3,
+			ClusterState: deploy.StatusRunning,
+		},
+		Connection: &deploy.ConnectionDetails{
+			Hostname:        "db.example.local",
+			DisplayHost:     "db.example.local",
+			DBPort:          8563,
+			Username:        "sys",
+			CertFingerprint: "fingerprint",
+			AdminUI: &config.DeploymentAdminUI{
+				URL:      "https://admin.example.local:8443",
+				Username: "admin",
+			},
+			ShellSupported: true,
+			SSHCommand:     "ssh exasol@example.local",
+		},
+	}
+	var output bytes.Buffer
+
+	// When
+	err := renderDeploymentInfoJSON(&output, report)
+	// Then
+	if err != nil {
+		t.Fatalf("expected deployment info JSON to render: %v", err)
+	}
+	var details deploy.DeploymentInfoReport
+	if err := json.Unmarshal(output.Bytes(), &details); err != nil {
+		t.Fatalf("expected valid JSON, got %q: %v", output.String(), err)
+	}
+	if details.DeploymentID != "test-deployment" {
+		t.Fatalf("expected deployment id to be preserved, got %q", details.DeploymentID)
+	}
+	if details.Presets.Infrastructure.Name != "aws" {
+		t.Fatalf("expected infrastructure preset in JSON, got %#v", details.Presets)
+	}
+	if details.Deployment.ClusterSize != 3 {
+		t.Fatalf("expected cluster size in JSON, got %#v", details.Deployment)
+	}
+	if details.Connection.DBPort != 8563 {
+		t.Fatalf("expected connection details in JSON, got %#v", details.Connection)
+	}
+}
+
+func TestRenderDeploymentInfoJSONOmitsTerminalOnlyGuidance(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	report := &deploy.DeploymentInfoReport{
+		DeploymentDir:   "/deployment",
+		DeploymentState: deploy.StatusNotInitialized,
+	}
+	var output bytes.Buffer
+
+	// When
+	err := renderDeploymentInfoJSON(&output, report)
+	// Then
+	if err != nil {
+		t.Fatalf("expected deployment info JSON to render: %v", err)
+	}
+	var details map[string]any
+	if err := json.Unmarshal(output.Bytes(), &details); err != nil {
+		t.Fatalf("expected valid JSON, got %q: %v", output.String(), err)
+	}
+	if details["deploymentState"] != deploy.StatusNotInitialized {
+		t.Fatalf(
+			"expected state %q, got %#v",
+			deploy.StatusNotInitialized,
+			details["deploymentState"],
+		)
+	}
+	for _, terminalOnlyField := range []string{"message", "error", "actions", "documentation"} {
+		if _, exists := details[terminalOnlyField]; exists {
+			t.Fatalf("expected JSON to omit %q, got %s", terminalOnlyField, output.String())
+		}
+	}
+}
+
+func TestRenderDeploymentInfoTextAppendsStateGuidance(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	report := &deploy.DeploymentInfoReport{
+		DeploymentDir:   "/deployment",
+		DeploymentState: deploy.StatusNotInitialized,
+	}
+	var output bytes.Buffer
+
+	// When
+	err := renderDeploymentInfoText(&output, report)
+	// Then
+	if err != nil {
+		t.Fatalf("expected deployment info text to render: %v", err)
+	}
+	content := output.String()
+	if !strings.Contains(
+		content,
+		"Exasol Product Documentation:\n"+
+			"  https://docs.exasol.com/\n\n"+
+			"No Exasol Personal deployment exists",
+	) {
+		t.Fatalf("expected documentation and guidance to be separated, got:\n%s", content)
+	}
+	for _, expected := range []string{
+		"Deployment State: not_initialized",
+		"No Exasol Personal deployment exists",
+		"exasol install <infra preset>",
+		"exasol presets list",
+	} {
+		if !strings.Contains(content, expected) {
+			t.Fatalf("expected text output to contain %q, got:\n%s", expected, content)
+		}
+	}
+}
+
+func TestRenderDeploymentInfoTextIncludesInitializedOverview(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	report := &deploy.DeploymentInfoReport{
+		DeploymentDir:   "/deployment",
+		DeploymentID:    "test-deployment",
+		DeploymentState: deploy.StatusInitialized,
+		Presets: &deploy.DeploymentPresetSummary{
+			Infrastructure: deploy.PresetIdentityInfo{DisplayName: "AWS"},
+			Installation:   deploy.PresetIdentityInfo{DisplayName: "Ubuntu"},
+		},
+	}
+	var output bytes.Buffer
+
+	// When
+	err := renderDeploymentInfoText(&output, report)
+	// Then
+	if err != nil {
+		t.Fatalf("expected deployment info text to render: %v", err)
+	}
+	content := output.String()
+	for _, expected := range []string{
+		"Deployment directory: /deployment",
+		"Deployment ID: test-deployment",
+		"Deployment State: initialized",
+		"Infrastructure preset: AWS",
+		"Installation preset: Ubuntu",
+		"Ready for deployment",
+		"exasol deploy",
+	} {
+		if !strings.Contains(content, expected) {
+			t.Fatalf("expected text output to contain %q, got:\n%s", expected, content)
+		}
+	}
+}
+
+func TestRenderDeploymentInfoTextExplainsActiveOperation(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	report := &deploy.DeploymentInfoReport{
+		DeploymentDir:   "/deployment",
+		DeploymentState: deploy.StatusOperationInProgress,
+	}
+	var output bytes.Buffer
+
+	// When
+	err := renderDeploymentInfoText(&output, report)
+	// Then
+	if err != nil {
+		t.Fatalf("expected deployment info text to render: %v", err)
+	}
+	content := output.String()
+	for _, expected := range []string{
+		"Deployment State: operation_in_progress",
+		"operation is in progress",
+		"Please wait",
+		"exasol status",
+	} {
+		if !strings.Contains(content, expected) {
+			t.Fatalf("expected text output to contain %q, got:\n%s", expected, content)
+		}
+	}
+	if strings.Contains(content, "SQL clients documentation") {
+		t.Fatalf("expected active operation output to omit SQL docs, got:\n%s", content)
+	}
+}

--- a/cmd/exasol/info_text.tmpl
+++ b/cmd/exasol/info_text.tmpl
@@ -1,0 +1,65 @@
+Exasol Personal Deployment Overview
+Deployment directory: {{ .DeploymentDir }}
+{{- if .DeploymentID }}
+Deployment ID: {{ .DeploymentID }}
+{{- end }}
+Deployment State: {{ .DeploymentState }}
+{{- with .Presets }}
+Infrastructure preset: {{ if .Infrastructure.DisplayName }}{{ .Infrastructure.DisplayName }}{{ else if .Infrastructure.Name }}{{ .Infrastructure.Name }}{{ else if .Infrastructure.Path }}{{ .Infrastructure.Path }}{{ else }}{{ .Infrastructure.Selector }}{{ end }}
+Installation preset: {{ if .Installation.DisplayName }}{{ .Installation.DisplayName }}{{ else if .Installation.Name }}{{ .Installation.Name }}{{ else if .Installation.Path }}{{ .Installation.Path }}{{ else }}{{ .Installation.Selector }}{{ end }}
+{{- end }}
+{{- with .Deployment }}
+{{- if .ClusterSize }}
+Cluster Size: {{ .ClusterSize }}
+{{- end }}
+{{- if .ClusterState }}
+Cluster State: {{ .ClusterState }}
+{{- end }}
+{{- end }}
+
+Exasol Product Documentation:
+  https://docs.exasol.com/
+
+{{ if eq .DeploymentState "not_initialized" -}}
+No Exasol Personal deployment exists in this deployment directory yet.
+
+Next steps:
+  exasol presets list             // list available presets
+  exasol install <infra preset>   // create and start a deployment  
+{{ else if eq .DeploymentState "initialized" -}}
+Ready for deployment.
+
+Next steps:
+  exasol deploy    // provision resources and start the database
+{{ else if eq .DeploymentState "operation_in_progress" -}}
+A deployment operation is in progress or did not finish cleanly.
+Please wait for any running launcher command to finish.
+
+Next steps:
+  exasol status    // check the deployment state
+{{ else if eq .DeploymentState "running" -}}
+
+SQL clients documentation:
+  https://docs.exasol.com/db/latest/connect_exasol/sql_clients.htm
+
+Next steps:
+  exasol connect   // open a SQL terminal connection
+  exasol stop      // stop the deployment without deleting resources
+{{ else if eq .DeploymentState "stopped" -}}
+Deployment stopped.
+
+Next steps:
+  exasol start     // restart the deployment
+  exasol destroy   // delete provisioned resources
+{{ else if eq .DeploymentState "deployment_failed" -}}
+Deployment failed.
+
+Next steps:
+  exasol deploy    // retry provisioning after fixing the problem
+  exasol destroy   // clean up resources
+{{ else if eq .DeploymentState "interrupted" -}}
+Deployment operation interrupted.
+
+Next steps:
+  exasol status    // inspect the interrupted deployment
+{{- end }}

--- a/internal/deploy/configuration.go
+++ b/internal/deploy/configuration.go
@@ -42,12 +42,12 @@ func (v DeploymentConfigValue) DisplayName() string {
 // (for example "name:aws" or "path:/abs/preset"); DisplayName and
 // Description come from the extracted manifest and are informational only.
 type PresetIdentityInfo struct {
-	Selector    string
-	Kind        string
-	Name        string
-	Path        string
-	DisplayName string
-	Description string
+	Selector    string `json:"selector,omitempty"`
+	Kind        string `json:"kind,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Path        string `json:"path,omitempty"`
+	DisplayName string `json:"displayName,omitempty"`
+	Description string `json:"description,omitempty"`
 }
 
 type DeploymentConfigurationSection struct {

--- a/internal/deploy/connection_instructions.go
+++ b/internal/deploy/connection_instructions.go
@@ -4,275 +4,56 @@
 package deploy
 
 import (
+	"bytes"
 	"context"
-	"encoding/json"
+	_ "embed"
 	"fmt"
-	"io"
 	"os"
-	"strconv"
-	"strings"
+	"text/template"
 
 	"github.com/exasol/exasol-personal/internal/config"
 )
 
-const (
-	SQLClientsDocURL = "https://docs.exasol.com/db/latest/connect_exasol/" +
-		"sql_clients.htm"
-	ProductDocURL                  = "https://docs.exasol.com/"
-	connectionInstructionsFileMode = 0o600
+const connectionInstructionsFileMode = 0o600
+
+//go:embed connection_instructions.tmpl
+var connectionInstructionsTemplateText string
+
+var connectionInstructionsTemplate = template.Must(
+	template.New("connection-instructions").Parse(connectionInstructionsTemplateText),
 )
-
-type ConnectionDetails struct {
-	DeploymentOverview
-
-	Backend         string
-	Hostname        string
-	DisplayHost     string
-	DBPort          string
-	AdminUI         *config.DeploymentAdminUI
-	Username        string
-	CertFingerprint string
-	InsecureSkipTLS bool
-	SecretsFilePath string
-	PublicIp        string
-	SSHCommand      string
-	SSHPort         string
-	ShellSupported  bool
-	AdminUISecured  bool
-}
-
-type DeploymentOverview struct {
-	DeploymentName  string
-	DeploymentState string
-	ClusterState    string
-	ClusterSize     int
-}
-
-type DocumentationLink struct {
-	Title string `json:"title"`
-	URL   string `json:"url"`
-}
-
-type Details struct {
-	DeploymentID    string              `json:"deploymentId,omitempty"`
-	DeploymentState string              `json:"deploymentState"`
-	ClusterSize     int                 `json:"clusterSize,omitempty"`
-	ClusterState    string              `json:"clusterstate,omitempty"`
-	Documentation   []DocumentationLink `json:"documentation"`
-}
-
-func readConnectionDetails(deployment config.DeploymentDir) (*ConnectionDetails, error) {
-	deploymentInfo, err := config.ReadDeploymentInfo(deployment)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read deployment info: %w", err)
-	}
-	connectionInfo, err := deploymentInfo.ConnectionInfo(deployment)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve deployment connection info: %w", err)
-	}
-	secrets, err := config.ReadSecrets(deployment)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read deployment secrets: %w", err)
-	}
-
-	return &ConnectionDetails{
-		DeploymentOverview: DeploymentOverview{
-			DeploymentName: connectionInfo.DeploymentName,
-			ClusterSize:    connectionInfo.ClusterSize,
-			ClusterState:   connectionInfo.ClusterState,
-		},
-		Backend:         deploymentInfo.Backend,
-		Hostname:        connectionInfo.Host,
-		DisplayHost:     connectionInfo.DisplayHost,
-		PublicIp:        connectionInfo.PublicIP,
-		DBPort:          strconv.Itoa(connectionInfo.DBPort),
-		AdminUI:         connectionInfo.AdminUI,
-		SSHCommand:      connectionInfo.SSHCommand,
-		SSHPort:         connectionInfo.SSHPort,
-		Username:        connectionInfo.Username,
-		CertFingerprint: connectionInfo.CertFingerprint,
-		InsecureSkipTLS: connectionInfo.InsecureSkipCertValidation,
-		SecretsFilePath: connectionInfo.SecretsFilePath,
-		ShellSupported:  connectionInfo.ShellSupported,
-		AdminUISecured:  secrets.AdminUiPassword != "",
-	}, nil
-}
-
-func GetSQLInstructions(connectionDetails *ConnectionDetails) string {
-	certificateLine := ""
-	if connectionDetails.CertFingerprint != "" {
-		certificateLine = "  - Certificate Fingerprint: " + connectionDetails.CertFingerprint + "\n"
-	} else if connectionDetails.InsecureSkipTLS {
-		certificateLine = "  - Certificate Validation: disable validation / " +
-			"use nocertcheck for the current deployment setup\n"
-	}
-
-	instructions := `
-=== How to Connect from a Graphical SQL Client ===
-To connect using a client of your choice:
-1. Create a new database connection.
-2. Choose 'Exasol' as the driver.
-3. Enter the following values below in 'Database':
-  - Server: ` + displayHostname(connectionDetails) + `
-  - Port: ` + connectionDetails.DBPort + `
-  - UserId: ` + connectionDetails.Username + `
-` + certificateLine + `  - Password: <stored in ` + connectionDetails.SecretsFilePath + `>
-
-=== CLI Connection Instructions ===
-To connect using the CLI:
-  exasol connect
-
-`
-
-	instructions += getAdminUIInstructions(connectionDetails)
-
-	if !connectionDetails.ShellSupported {
-		return instructions
-	}
-
-	if connectionDetails.Backend == localDeploymentBackend {
-		return instructions + `=== Local Shell Instructions ===
-  Local endpoint: ` + displayHostname(connectionDetails) + `
-  Exasol Local database container shell: exasol shell container
-  Host shell (VM OS): exasol shell host
-  Alternative: ` + connectionDetails.SSHCommand + `
-
-Note: exasol destroy deletes the local VM disk/data and launcher-managed share for this deployment.
-
-`
-	}
-
-	return instructions + `=== SSH Connection Instructions ===
-  Public IP: ` + connectionDetails.PublicIp + `
-  Primary admin shell (COS): exasol shell container
-  Host shell (OS): exasol shell host
-  Alternative: ` + connectionDetails.SSHCommand + `
-
-`
-}
-
-func getAdminUIInstructions(connectionDetails *ConnectionDetails) string {
-	if connectionDetails == nil || connectionDetails.AdminUI == nil ||
-		connectionDetails.AdminUI.URL == "" {
-		return ""
-	}
-
-	instructions := `
-=== How to open the Administration UI ===
-  URL: ` + connectionDetails.AdminUI.URL + `
-`
-	if connectionDetails.AdminUI.Username != "" {
-		instructions += "  Username: " + connectionDetails.AdminUI.Username + "\n"
-	}
-	if connectionDetails.AdminUISecured {
-		instructions += "  Password: <stored in " + connectionDetails.SecretsFilePath + ">\n"
-	}
-	if connectionDetails.AdminUI.CertFingerprint != "" {
-		instructions += "  Certificate Fingerprint: " +
-			connectionDetails.AdminUI.CertFingerprint + "\n"
-	} else if connectionDetails.AdminUI.InsecureSkipCertValidation {
-		instructions += "  Certificate Validation: accept the certificate if necessary\n"
-	}
-
-	return instructions + "\n"
-}
-
-func GetDocumentationLink() string {
-	return fmt.Sprintf(`
-=== SQL clients documentation ===
-  %s
-=== Exasol Product Documentation ===
-Or visit %s for general information about Exasol products.
-`, SQLClientsDocURL, ProductDocURL)
-}
-
-func renderDeploymentOverview(overview DeploymentOverview) string {
-	return `
-Exasol Personal Deployment Overview
-Deployment Name: ` + overview.DeploymentName + `
-Deployment State: ` + overview.DeploymentState + `
-Cluster Size: ` + strconv.Itoa(overview.ClusterSize) + `
-Cluster State: ` + overview.ClusterState + `
-`
-}
 
 func GetConnectionInstructionsText(
 	ctx context.Context,
 	deployment config.DeploymentDir,
 ) (string, error) {
-	var content string
-	err := withDeploymentSharedLock(ctx, deployment, func(deployment config.DeploymentDir) error {
-		var getErr error
-		content, getErr = getConnectionInstructionsTextUnsafe(ctx, deployment)
-
-		return getErr
-	})
+	report, err := GetDeploymentInfoReport(ctx, deployment)
 	if err != nil {
 		return "", err
 	}
 
-	return content, nil
+	return RenderConnectionInstructionsText(report)
 }
 
 func getConnectionInstructionsTextUnsafe(
 	ctx context.Context,
 	deployment config.DeploymentDir,
 ) (string, error) {
-	deploymentStatus, err := GetStatus(ctx, deployment, false)
+	report, err := getDeploymentInfoReportWithExistingLock(ctx, deployment)
 	if err != nil {
-		return "", fmt.Errorf("failed to get status: %w", err)
+		return "", err
 	}
 
-	wfState := deploymentStatus.Status
-
-	switch wfState {
-	case StatusRunning:
-		connectionDetails, err := readConnectionDetails(deployment)
-		if err != nil {
-			return "", err
-		}
-		overview := connectionDetails.DeploymentOverview
-		overview.DeploymentState = wfState
-		content := renderDeploymentOverview(
-			overview,
-		) + GetSQLInstructions(
-			connectionDetails,
-		) + GetDocumentationLink()
-
-		return content, nil
-	case StatusStopped:
-		overview, err := readDeploymentOverview(deployment, wfState)
-		if err != nil {
-			return "", err
-		}
-		content := renderDeploymentOverview(overview) + GetDocumentationLink()
-
-		return content, nil
-	default:
-		return deploymentStatus.Message, nil
-	}
+	return RenderConnectionInstructionsText(report)
 }
 
-func readDeploymentOverview(
-	deployment config.DeploymentDir,
-	wfState string,
-) (DeploymentOverview, error) {
-	deploymentInfo, err := config.ReadDeploymentInfo(deployment)
-	if err != nil {
-		return DeploymentOverview{}, fmt.Errorf("failed to read deployment info: %w", err)
+func RenderConnectionInstructionsText(report *DeploymentInfoReport) (string, error) {
+	var output bytes.Buffer
+	if err := connectionInstructionsTemplate.Execute(&output, report); err != nil {
+		return "", err
 	}
 
-	clusterState := strings.TrimSpace(deploymentInfo.ClusterState)
-	if clusterState == "" {
-		clusterState = wfState
-	}
-
-	return DeploymentOverview{
-		DeploymentName:  deploymentInfo.DeploymentId,
-		DeploymentState: wfState,
-		ClusterSize:     deploymentInfo.ClusterSize,
-		ClusterState:    clusterState,
-	}, nil
+	return output.String(), nil
 }
 
 func writeConnectionInstructionsFile(deployment config.DeploymentDir, content string) error {
@@ -286,71 +67,4 @@ func writeConnectionInstructionsFile(deployment config.DeploymentDir, content st
 	}
 
 	return nil
-}
-
-func PrintConnectionInsInJson(
-	ctx context.Context,
-	deployment config.DeploymentDir,
-	writer io.Writer,
-) error {
-	return withDeploymentSharedLock(ctx, deployment, func(deployment config.DeploymentDir) error {
-		return printConnectionInsInJSONUnsafe(ctx, deployment, writer)
-	})
-}
-
-func printConnectionInsInJSONUnsafe(
-	ctx context.Context,
-	deployment config.DeploymentDir,
-	writer io.Writer,
-) error {
-	deploymentStatus, err := GetStatus(ctx, deployment, false)
-	if err != nil {
-		return fmt.Errorf("failed to get status: %w", err)
-	}
-
-	wfState := deploymentStatus.Status
-
-	details := Details{}
-	details.DeploymentState = wfState
-	details.Documentation = []DocumentationLink{
-		{
-			Title: "SQL clients documentation",
-			URL:   SQLClientsDocURL,
-		},
-		{
-			Title: "Exasol Product Documentation",
-			URL:   ProductDocURL,
-		},
-	}
-
-	encoder := json.NewEncoder(writer)
-	encoder.SetIndent("", "  ")
-	if wfState == StatusRunning || wfState == StatusStopped {
-		info, err := config.ReadDeploymentInfo(deployment)
-		if err != nil {
-			return err
-		}
-		info.DeploymentState = wfState
-
-		return encoder.Encode(info)
-	}
-
-	return encoder.Encode(details)
-}
-
-func displayHostname(connectionDetails *ConnectionDetails) string {
-	if connectionDetails == nil {
-		return ""
-	}
-	if connectionDetails.DisplayHost != "" {
-		return connectionDetails.DisplayHost
-	}
-	if connectionDetails.Hostname != "" {
-		return connectionDetails.Hostname
-	}
-	if connectionDetails.PublicIp != "" {
-		return connectionDetails.PublicIp
-	}
-
-	return connectionDetails.Hostname
 }

--- a/internal/deploy/connection_instructions.tmpl
+++ b/internal/deploy/connection_instructions.tmpl
@@ -1,0 +1,73 @@
+Exasol Personal Deployment Overview
+Deployment directory: {{ .DeploymentDir }}
+{{- if .DeploymentID }}
+Deployment ID: {{ .DeploymentID }}
+{{- end }}
+Deployment State: {{ .DeploymentState }}
+{{- with .Deployment }}
+{{- if .ClusterSize }}
+Cluster Size: {{ .ClusterSize }}
+{{- end }}
+{{- if .ClusterState }}
+Cluster State: {{ .ClusterState }}
+{{- end }}
+{{- end }}
+{{- with .Connection }}
+
+=== How to Connect from a Graphical SQL Client ===
+To connect using a client of your choice:
+1. Create a new database connection.
+2. Choose 'Exasol' as the driver.
+3. Enter the following values below in 'Database':
+  - Server: {{ .DisplayHostname }}
+  - Port: {{ .DBPort }}
+  - UserId: {{ .Username }}
+{{- if .CertFingerprint }}
+  - Certificate Fingerprint: {{ .CertFingerprint }}
+{{- else if .InsecureSkipTLS }}
+  - Certificate Validation: disable validation / use nocertcheck for the current deployment setup
+{{- end }}
+  - Password: <stored in {{ .SecretsFilePath }}>
+
+=== CLI Connection Instructions ===
+To connect using the CLI:
+  exasol connect
+
+{{ if .HasAdminUI -}}
+=== How to open the Administration UI ===
+  URL: {{ .AdminUI.URL }}
+{{- if .AdminUI.Username }}
+  Username: {{ .AdminUI.Username }}
+{{- end }}
+{{- if .AdminUISecured }}
+  Password: <stored in {{ .SecretsFilePath }}>
+{{- end }}
+{{- if .AdminUI.CertFingerprint }}
+  Certificate Fingerprint: {{ .AdminUI.CertFingerprint }}
+{{- else if .AdminUI.InsecureSkipCertValidation }}
+  Certificate Validation: accept the certificate if necessary
+{{- end }}
+
+{{ end -}}
+{{ if .ShellSupported }}{{ if .IsLocalBackend }}
+=== Host Shell Instructions ===
+  Local endpoint: {{ .DisplayHostname }}
+  Host shell (VM OS): exasol shell host
+  Alternative: {{ .SSHCommand }}
+
+Note: exasol destroy deletes the local VM disk/data and launcher-managed share for this deployment.
+{{ else }}
+=== SSH Connection Instructions ===
+  Public IP: {{ .PublicIp }}
+  Host shell (OS): exasol shell host
+  Alternative: {{ .SSHCommand }}
+{{ end }}{{ end }}
+{{- end }}
+
+{{- with .Connection }}
+=== SQL clients documentation ===
+  https://docs.exasol.com/db/latest/connect_exasol/sql_clients.htm
+
+{{- end }}
+=== Exasol Product Documentation ===
+  https://docs.exasol.com/

--- a/internal/deploy/connection_instructions_test.go
+++ b/internal/deploy/connection_instructions_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/presets"
 )
 
 func TestGetConnectionInstructionsTextStoppedDoesNotRequireConnectionHost(t *testing.T) {
@@ -16,6 +17,7 @@ func TestGetConnectionInstructionsTextStoppedDoesNotRequireConnectionHost(t *tes
 
 	// Given
 	deployment := config.NewDeploymentDir(t.TempDir())
+	initDeploymentForInfoTest(t, deployment)
 	writeStoppedWorkflowState(t, deployment)
 	writeDeploymentInfoWithoutConnectionHost(t, deployment)
 
@@ -30,11 +32,64 @@ func TestGetConnectionInstructionsTextStoppedDoesNotRequireConnectionHost(t *tes
 	assertContains(t, content, "Cluster State: stopped")
 }
 
+func TestGetConnectionInstructionsTextNotInitializedRendersTechnicalState(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	deployment := config.NewDeploymentDir(t.TempDir())
+
+	// When
+	content, err := GetConnectionInstructionsText(context.Background(), deployment)
+	// Then
+	if err != nil {
+		t.Fatalf("expected missing deployment info to render without error, got: %v", err)
+	}
+	assertContains(t, content, "Deployment directory: "+deployment.Root())
+	assertContains(t, content, "Deployment State: not_initialized")
+}
+
+func TestGetConnectionInstructionsTextNotInitializedHandlesMissingDirectory(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	deployment := config.NewDeploymentDir(t.TempDir() + "/missing")
+
+	// When
+	content, err := GetConnectionInstructionsText(context.Background(), deployment)
+	// Then
+	if err != nil {
+		t.Fatalf("expected missing deployment directory to render without error, got: %v", err)
+	}
+	assertContains(t, content, "Deployment directory: "+deployment.Root())
+	assertContains(t, content, "Deployment State: not_initialized")
+}
+
+func initDeploymentForInfoTest(t *testing.T, deployment config.DeploymentDir) {
+	t.Helper()
+
+	err := InitDeployment(
+		context.Background(),
+		PresetRef{Name: presets.DefaultInfrastructure},
+		PresetRef{Name: presets.DefaultInstallation},
+		map[string]string{},
+		map[string]string{},
+		deployment,
+		false,
+		"0.0.0",
+	)
+	if err != nil {
+		t.Fatalf("failed to initialize deployment: %v", err)
+	}
+}
+
 func writeStoppedWorkflowState(t *testing.T, deployment config.DeploymentDir) {
 	t.Helper()
 
-	state := &config.ExasolPersonalState{}
-	err := state.SetWorkflowStateAndWrite(&config.WorkflowStateStopped{}, deployment)
+	state, err := config.ReadExasolPersonalState(deployment)
+	if err != nil {
+		t.Fatalf("failed to read workflow state: %v", err)
+	}
+	err = state.SetWorkflowStateAndWrite(&config.WorkflowStateStopped{}, deployment)
 	if err != nil {
 		t.Fatalf("failed to write stopped workflow state: %v", err)
 	}
@@ -64,66 +119,98 @@ func assertContains(t *testing.T, content string, expected string) {
 	}
 }
 
-func TestGetSQLInstructions_OmitsAdminUIWhenMetadataMissing(t *testing.T) {
+func TestRenderConnectionInstructionsText_OmitsAdminUIWhenMetadataMissing(t *testing.T) {
 	t.Parallel()
 
 	// Given
-	connectionDetails := &ConnectionDetails{
-		Backend:         localDeploymentBackend,
-		DisplayHost:     "127.0.0.1",
-		DBPort:          "28563",
-		Username:        "sys",
-		SecretsFilePath: "/deployment/secrets.json",
-		SSHCommand:      "ssh -i key exasol@127.0.0.1 -p 20022",
-		ShellSupported:  true,
+	report := &DeploymentInfoReport{
+		DeploymentDir:   "/deployment",
+		DeploymentID:    "test-deployment",
+		DeploymentState: StatusRunning,
+		Deployment: &config.DeploymentInfo{
+			ClusterSize:  1,
+			ClusterState: StatusRunning,
+		},
+		Connection: &ConnectionDetails{
+			Backend:         localDeploymentBackend,
+			DisplayHost:     "127.0.0.1",
+			DBPort:          28563,
+			Username:        "sys",
+			SecretsFilePath: "/deployment/secrets.json",
+			SSHCommand:      "ssh -i key exasol@127.0.0.1 -p 20022",
+			ShellSupported:  true,
+		},
 	}
 
 	// When
-	instructions := GetSQLInstructions(connectionDetails)
-
+	content, err := RenderConnectionInstructionsText(report)
 	// Then
-	if !strings.Contains(instructions, "exasol connect") {
-		t.Fatalf("expected CLI instructions, got %q", instructions)
+	if err != nil {
+		t.Fatalf("expected deployment info to render: %v", err)
 	}
-	if !strings.Contains(instructions, "Local Shell Instructions") {
-		t.Fatalf("expected shell instructions to be preserved, got %q", instructions)
+	if !strings.Contains(content, "exasol connect") {
+		t.Fatalf("expected CLI instructions, got %q", content)
 	}
-	if strings.Contains(instructions, "Administration UI") {
-		t.Fatalf("expected Admin UI instructions to be omitted, got %q", instructions)
+	if !strings.Contains(
+		content,
+		"  - UserId: sys\n  - Password: <stored in /deployment/secrets.json>",
+	) {
+		t.Fatalf("expected password line to remain separate, got %q", content)
+	}
+	if !strings.Contains(content, "Host Shell Instructions") {
+		t.Fatalf("expected shell instructions to be preserved, got %q", content)
+	}
+	if strings.Contains(content, "container shell") {
+		t.Fatalf("expected container shell instructions to be omitted, got %q", content)
+	}
+	if strings.Contains(content, "Administration UI") {
+		t.Fatalf("expected Admin UI instructions to be omitted, got %q", content)
 	}
 }
 
-func TestGetSQLInstructions_IncludesAdminUIWhenMetadataPresent(t *testing.T) {
+func TestRenderConnectionInstructionsText_IncludesAdminUIWhenMetadataPresent(t *testing.T) {
 	t.Parallel()
 
 	// Given
-	connectionDetails := &ConnectionDetails{
-		DisplayHost:     "db.example.local",
-		DBPort:          "8563",
-		Username:        "sys",
-		SecretsFilePath: "/deployment/secrets.json",
-		AdminUI: &config.DeploymentAdminUI{
-			URL:                        "https://admin.example.local:8443",
-			Username:                   "admin",
-			InsecureSkipCertValidation: true,
+	report := &DeploymentInfoReport{
+		DeploymentDir:   "/deployment",
+		DeploymentID:    "test-deployment",
+		DeploymentState: StatusRunning,
+		Deployment: &config.DeploymentInfo{
+			ClusterSize:  1,
+			ClusterState: StatusRunning,
 		},
-		AdminUISecured: true,
+		Connection: &ConnectionDetails{
+			DisplayHost:     "db.example.local",
+			DBPort:          8563,
+			Username:        "sys",
+			SecretsFilePath: "/deployment/secrets.json",
+			AdminUI: &config.DeploymentAdminUI{
+				URL:                        "https://admin.example.local:8443",
+				Username:                   "admin",
+				InsecureSkipCertValidation: true,
+			},
+			AdminUISecured: true,
+		},
 	}
 
 	// When
-	instructions := GetSQLInstructions(connectionDetails)
-
+	content, err := RenderConnectionInstructionsText(report)
 	// Then
+	if err != nil {
+		t.Fatalf("expected deployment info to render: %v", err)
+	}
 	for _, expected := range []string{
 		"Administration UI",
 		"https://admin.example.local:8443",
+		"URL: https://admin.example.local:8443\n  Username: admin",
 		"Username: admin",
 		"Password: <stored in /deployment/secrets.json>",
 		"Certificate Validation: accept the certificate if necessary",
 		"exasol connect",
 	} {
-		if !strings.Contains(instructions, expected) {
-			t.Fatalf("expected instructions to contain %q, got %q", expected, instructions)
+		if !strings.Contains(content, expected) {
+			t.Fatalf("expected instructions to contain %q, got %q", expected, content)
 		}
 	}
 }

--- a/internal/deploy/info.go
+++ b/internal/deploy/info.go
@@ -1,0 +1,232 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/exasol/exasol-personal/internal/config"
+)
+
+type ConnectionDetails struct {
+	Backend         string                    `json:"backend,omitempty"`
+	Hostname        string                    `json:"host,omitempty"`
+	DisplayHost     string                    `json:"displayHost,omitempty"`
+	DBPort          int                       `json:"dbPort,omitempty"`
+	AdminUI         *config.DeploymentAdminUI `json:"adminUi,omitempty"`
+	Username        string                    `json:"username,omitempty"`
+	CertFingerprint string                    `json:"certFingerprint,omitempty"`
+	InsecureSkipTLS bool                      `json:"insecureSkipCertValidation,omitempty"`
+	SecretsFilePath string                    `json:"-"`
+	PublicIp        string                    `json:"publicIp,omitempty"`
+	SSHCommand      string                    `json:"sshCommand,omitempty"`
+	SSHPort         string                    `json:"sshPort,omitempty"`
+	ShellSupported  bool                      `json:"shellSupported,omitempty"`
+	AdminUISecured  bool                      `json:"-"`
+}
+
+type DeploymentInfoReport struct {
+	DeploymentDir   string                   `json:"deploymentDir"`
+	DeploymentID    string                   `json:"deploymentId,omitempty"`
+	DeploymentState string                   `json:"deploymentState"`
+	Presets         *DeploymentPresetSummary `json:"presets,omitempty"`
+	Deployment      *config.DeploymentInfo   `json:"deployment,omitempty"`
+	Connection      *ConnectionDetails       `json:"connection,omitempty"`
+}
+
+type DeploymentPresetSummary struct {
+	Infrastructure PresetIdentityInfo `json:"infrastructure"`
+	Installation   PresetIdentityInfo `json:"installation"`
+}
+
+type DeploymentAttributes struct {
+	ClusterSize  int    `json:"clusterSize,omitempty"`
+	ClusterState string `json:"clusterState,omitempty"`
+}
+
+func (details *ConnectionDetails) DisplayHostname() string {
+	return displayHostname(details)
+}
+
+func (details *ConnectionDetails) IsLocalBackend() bool {
+	if details == nil {
+		return false
+	}
+
+	return details.Backend == localDeploymentBackend
+}
+
+func (details *ConnectionDetails) HasAdminUI() bool {
+	return details != nil && details.AdminUI != nil && details.AdminUI.URL != ""
+}
+
+func readConnectionDetails(deployment config.DeploymentDir) (*ConnectionDetails, error) {
+	deploymentInfo, err := config.ReadDeploymentInfo(deployment)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read deployment info: %w", err)
+	}
+	connectionInfo, err := deploymentInfo.ConnectionInfo(deployment)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve deployment connection info: %w", err)
+	}
+	secrets, err := config.ReadSecrets(deployment)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read deployment secrets: %w", err)
+	}
+
+	return &ConnectionDetails{
+		Backend:         deploymentInfo.Backend,
+		Hostname:        connectionInfo.Host,
+		DisplayHost:     connectionInfo.DisplayHost,
+		PublicIp:        connectionInfo.PublicIP,
+		DBPort:          connectionInfo.DBPort,
+		AdminUI:         connectionInfo.AdminUI,
+		SSHCommand:      connectionInfo.SSHCommand,
+		SSHPort:         connectionInfo.SSHPort,
+		Username:        connectionInfo.Username,
+		CertFingerprint: connectionInfo.CertFingerprint,
+		InsecureSkipTLS: connectionInfo.InsecureSkipCertValidation,
+		SecretsFilePath: connectionInfo.SecretsFilePath,
+		ShellSupported:  connectionInfo.ShellSupported,
+		AdminUISecured:  secrets.AdminUiPassword != "",
+	}, nil
+}
+
+func GetDeploymentInfoReport(
+	ctx context.Context,
+	deployment config.DeploymentDir,
+) (*DeploymentInfoReport, error) {
+	// A successful shared lock gives us a consistent deployment directory snapshot.
+	// If another launcher command holds the exclusive lock, we deliberately return
+	// only the high-level status instead of reading partially written artifacts.
+	var report *DeploymentInfoReport
+	err := withDeploymentSharedLock(ctx, deployment, func(deployment config.DeploymentDir) error {
+		var getErr error
+		report, getErr = getDeploymentInfoReportWithExistingLock(ctx, deployment)
+
+		return getErr
+	})
+	if err != nil {
+		status, statusErr := statusFromLockError(err)
+		if statusErr != nil {
+			return nil, statusErr
+		}
+
+		return minimalDeploymentInfoReport(deployment, status.Status), nil
+	}
+
+	return report, nil
+}
+
+func getDeploymentInfoReportWithExistingLock(
+	ctx context.Context,
+	deployment config.DeploymentDir,
+) (*DeploymentInfoReport, error) {
+	// Callers must already hold either the shared or exclusive deployment directory
+	// lock. This avoids lock re-entry when deploy/start generates connection
+	// instructions while holding the exclusive lock, and keeps normal user-facing
+	// reads protected by GetDeploymentInfoReport's shared lock.
+	deploymentStatus, err := GetStatus(ctx, deployment, false)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get status: %w", err)
+	}
+
+	return deploymentInfoReportFromState(deployment, deploymentStatus.Status)
+}
+
+func deploymentInfoReportFromState(
+	deployment config.DeploymentDir,
+	deploymentState string,
+) (*DeploymentInfoReport, error) {
+	report := minimalDeploymentInfoReport(deployment, deploymentState)
+	if deploymentState == StatusNotInitialized {
+		return report, nil
+	}
+
+	if err := addDeploymentIdentity(deployment, report); err != nil {
+		if deploymentState == StatusOperationInProgress {
+			return report, nil
+		}
+
+		return nil, err
+	}
+	if deploymentState == StatusOperationInProgress {
+		return report, nil
+	}
+	addDeploymentAttributes(deployment, report)
+
+	switch deploymentState {
+	case StatusRunning:
+		connectionDetails, err := readConnectionDetails(deployment)
+		if err != nil {
+			return nil, err
+		}
+		report.Connection = connectionDetails
+
+		return report, nil
+	default:
+		return report, nil
+	}
+}
+
+func minimalDeploymentInfoReport(
+	deployment config.DeploymentDir,
+	deploymentState string,
+) *DeploymentInfoReport {
+	return &DeploymentInfoReport{
+		DeploymentDir:   deployment.Root(),
+		DeploymentState: deploymentState,
+	}
+}
+
+func addDeploymentIdentity(
+	deployment config.DeploymentDir,
+	report *DeploymentInfoReport,
+) error {
+	exasolState, err := config.ReadExasolPersonalState(deployment)
+	if err != nil {
+		return err
+	}
+	report.DeploymentID = exasolState.DeploymentId
+	configuration, err := readDeploymentConfiguration(deployment)
+	if err != nil {
+		return err
+	}
+	report.Presets = &DeploymentPresetSummary{
+		Infrastructure: configuration.Infrastructure.Identity,
+		Installation:   configuration.Installation.Identity,
+	}
+
+	return nil
+}
+
+func addDeploymentAttributes(
+	deployment config.DeploymentDir,
+	report *DeploymentInfoReport,
+) {
+	if deploymentInfo, err := config.ReadDeploymentInfo(deployment); err == nil {
+		if report.DeploymentID == "" {
+			report.DeploymentID = deploymentInfo.DeploymentId
+		}
+		report.Deployment = deploymentInfo
+	}
+}
+
+func displayHostname(connectionDetails *ConnectionDetails) string {
+	if connectionDetails == nil {
+		return ""
+	}
+	if connectionDetails.DisplayHost != "" {
+		return connectionDetails.DisplayHost
+	}
+	if connectionDetails.Hostname != "" {
+		return connectionDetails.Hostname
+	}
+	if connectionDetails.PublicIp != "" {
+		return connectionDetails.PublicIp
+	}
+
+	return connectionDetails.Hostname
+}

--- a/internal/deploy/info_test.go
+++ b/internal/deploy/info_test.go
@@ -1,0 +1,165 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+)
+
+func TestGetDeploymentInfoReportInitializedIncludesOverviewAndPresets(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	deployment := config.NewDeploymentDir(t.TempDir())
+	initDeploymentForInfoTest(t, deployment)
+
+	// When
+	report, err := GetDeploymentInfoReport(context.Background(), deployment)
+	// Then
+	if err != nil {
+		t.Fatalf("expected initialized deployment info report, got error: %v", err)
+	}
+	if report.DeploymentDir != deployment.Root() {
+		t.Fatalf("expected deployment dir %q, got %q", deployment.Root(), report.DeploymentDir)
+	}
+	if report.DeploymentID == "" {
+		t.Fatal("expected deployment ID")
+	}
+	if report.DeploymentState != StatusInitialized {
+		t.Fatalf("expected state %q, got %q", StatusInitialized, report.DeploymentState)
+	}
+	if report.Presets == nil {
+		t.Fatal("expected preset summary")
+	}
+}
+
+func TestDeploymentInfoReportOperationInProgressOmitsPartialDeploymentDetails(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	deployment := config.NewDeploymentDir(t.TempDir())
+	initDeploymentForInfoTest(t, deployment)
+	if err := config.WriteDeploymentInfo(deployment.Root(), &config.DeploymentInfo{
+		DeploymentId:    "test-deployment",
+		ClusterSize:     1,
+		ClusterState:    StatusRunning,
+		DeploymentState: StatusRunning,
+	}); err != nil {
+		t.Fatalf("failed to write deployment info: %v", err)
+	}
+
+	// When
+	report, err := deploymentInfoReportFromState(
+		deployment,
+		StatusOperationInProgress,
+	)
+	// Then
+	if err != nil {
+		t.Fatalf("expected operation in progress report, got error: %v", err)
+	}
+	if report.DeploymentState != StatusOperationInProgress {
+		t.Fatalf("expected state %q, got %q", StatusOperationInProgress, report.DeploymentState)
+	}
+	if report.Presets == nil {
+		t.Fatal("expected stable preset summary")
+	}
+	if report.Deployment != nil {
+		t.Fatalf("expected partial deployment attributes to be omitted, got %#v", report.Deployment)
+	}
+	if report.Connection != nil {
+		t.Fatalf("expected connection details to be omitted, got %#v", report.Connection)
+	}
+}
+
+func TestDeploymentInfoReportOperationInProgressToleratesMissingIdentity(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	deployment := config.NewDeploymentDir(t.TempDir() + "/missing")
+
+	// When
+	report, err := deploymentInfoReportFromState(
+		deployment,
+		StatusOperationInProgress,
+	)
+	// Then
+	if err != nil {
+		t.Fatalf("expected operation in progress report without identity files, got error: %v", err)
+	}
+	if report.DeploymentDir != deployment.Root() {
+		t.Fatalf("expected deployment dir %q, got %q", deployment.Root(), report.DeploymentDir)
+	}
+	if report.DeploymentState != StatusOperationInProgress {
+		t.Fatalf("expected state %q, got %q", StatusOperationInProgress, report.DeploymentState)
+	}
+	if report.Presets != nil {
+		t.Fatalf("expected presets to remain optional, got %#v", report.Presets)
+	}
+	if report.Deployment != nil {
+		t.Fatalf("expected deployment attributes to remain optional, got %#v", report.Deployment)
+	}
+	if report.Connection != nil {
+		t.Fatalf("expected connection details to remain optional, got %#v", report.Connection)
+	}
+}
+
+func TestGetDeploymentInfoReportNotInitializedIncludesStructuredState(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	deployment := config.NewDeploymentDir(t.TempDir())
+
+	// When
+	report, err := GetDeploymentInfoReport(context.Background(), deployment)
+	// Then
+	if err != nil {
+		t.Fatalf("expected missing deployment info to resolve without error, got: %v", err)
+	}
+	if report.DeploymentState != StatusNotInitialized {
+		t.Fatalf("expected state %q, got %q", StatusNotInitialized, report.DeploymentState)
+	}
+	if report.DeploymentDir != deployment.Root() {
+		t.Fatalf(
+			"expected deployment dir %q, got %q",
+			deployment.Root(),
+			report.DeploymentDir,
+		)
+	}
+	if report.Presets != nil {
+		t.Fatalf("expected no presets for not-initialized deployment, got %#v", report.Presets)
+	}
+	if report.Deployment != nil {
+		t.Fatalf("expected no deployment attributes, got %#v", report.Deployment)
+	}
+	if report.Connection != nil {
+		t.Fatalf("expected no connection details, got %#v", report.Connection)
+	}
+}
+
+func TestGetDeploymentInfoReportNotInitializedHandlesMissingDirectory(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	deployment := config.NewDeploymentDir(t.TempDir() + "/missing")
+
+	// When
+	report, err := GetDeploymentInfoReport(context.Background(), deployment)
+	// Then
+	if err != nil {
+		t.Fatalf("expected missing deployment directory to resolve without error, got: %v", err)
+	}
+	if report.DeploymentState != StatusNotInitialized {
+		t.Fatalf("expected state %q, got %q", StatusNotInitialized, report.DeploymentState)
+	}
+	if report.DeploymentDir != deployment.Root() {
+		t.Fatalf(
+			"expected deployment dir %q, got %q",
+			deployment.Root(),
+			report.DeploymentDir,
+		)
+	}
+}

--- a/internal/deploy/status.go
+++ b/internal/deploy/status.go
@@ -26,6 +26,11 @@ const (
 	StatusDatabaseReady            = "database_ready"
 )
 
+const notInitializedMessage = "No Exasol Personal deployment exists in this " +
+	"deployment directory yet. " +
+	"Run `exasol install <infra preset>` to create and start one, or pass " +
+	"`--deployment-dir <path>` to inspect an existing deployment."
+
 type StatusOutput struct {
 	DeploymentDir string `json:"deploymentDir"`
 	Status        string `json:"status"`
@@ -273,9 +278,8 @@ func staleOperationInProgressMessage(operation string) string {
 
 func notInitializedStatus() *StatusOutput {
 	return &StatusOutput{
-		Status: StatusNotInitialized,
-		Message: "No workflow state file was found. " +
-			"Run `init` or `install` to start a new deployment in this directory.",
+		Status:  StatusNotInitialized,
+		Message: notInitializedMessage,
 	}
 }
 

--- a/openspec/changes/improve-deployment-info-guidance/.openspec.yaml
+++ b/openspec/changes/improve-deployment-info-guidance/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-18

--- a/openspec/changes/improve-deployment-info-guidance/design.md
+++ b/openspec/changes/improve-deployment-info-guidance/design.md
@@ -1,0 +1,37 @@
+## Context
+
+`exasol info` is used by humans and automation to understand a deployment directory. The final experience needs to cover both first-run discovery, where no deployment exists yet, and initialized deployment discovery, where scripts need structured deployment and connection information.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Provide a helpful human-readable `exasol info` experience across deployment states.
+- Provide valid JSON from `exasol info --json` for automation without terminal-only text on stdout.
+- Make not-yet-initialized deployment directories a reportable state instead of an error case.
+- Keep state-specific next steps focused on what the user can do next.
+- Keep the JSON contract stable enough for scripts and agents to branch on deployment state and read connection-relevant fields.
+
+**Non-Goals:**
+- No changes to deployment creation, provisioning, start, stop, destroy, or remove behavior.
+- No changes to the meaning of existing deployment states.
+- No replacement of diagnostic commands that expose lower-level troubleshooting information.
+- No terminal guidance prose in JSON output.
+
+## Decisions
+
+**Separate human guidance from machine-readable state.**
+Text output should include next-step guidance because it is read by users in a terminal. JSON output should stay concise and structured so scripts can parse it without filtering explanatory text.
+
+**Treat missing deployment state as an explicit state.**
+When the resolved deployment directory is not initialized, `info` should report `not_initialized` and the resolved directory instead of failing solely because setup has not happened yet.
+
+**Show next steps according to the current state.**
+Text output should guide the user toward `presets list` and `install` before initialization, `deploy` after initialization, `connect` or `stop` when running, and `start` or `destroy` when stopped.
+
+**Expose connection details only when they are meaningful.**
+JSON output should include connection-relevant details for running deployments and omit them when the deployment state does not have stable connection information.
+
+## Risks / Trade-offs
+
+- Scripts that expected `exasol info` to fail before initialization may need to branch on `deploymentState` instead; this is intentional because `not_initialized` is now a valid reported state.
+- Text output wording may evolve, so automation should consume `--json` rather than parse human-readable guidance.

--- a/openspec/changes/improve-deployment-info-guidance/proposal.md
+++ b/openspec/changes/improve-deployment-info-guidance/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Users and automation need `exasol info` to be the obvious place to discover deployment state and connection-relevant details. The command previously failed too early for missing deployments and the machine-readable output was not a clear public contract for deployment discovery.
+
+## What Changes
+
+- Make `exasol info` useful before deployment initialization by reporting the resolved deployment directory, the `not_initialized` state, and clear next steps.
+- Make `exasol info --json` a stable machine-readable deployment overview for both uninitialized and initialized deployment directories.
+- Keep human-readable `exasol info` as the default experience, with state-specific next steps that help users choose the next command.
+- Ensure machine-readable output stays valid JSON on stdout and does not include terminal-only prose or prompts.
+- Preserve existing lifecycle semantics: this change reports deployment state and guidance but does not create, modify, start, stop, or destroy deployments.
+
+## Capabilities
+
+### New Capabilities
+
+- `deployment-info-reporting`: how users and automation discover deployment state, next steps, and connection-relevant information through `exasol info`.
+
+### Modified Capabilities
+
+<!-- None: no existing permanent spec covers deployment information reporting. -->
+
+## Impact
+
+- User-facing CLI behavior for `exasol info` and `exasol info --json`.
+- Automation that reads `exasol info --json` can rely on structured deployment state and connection-relevant fields.
+- Existing deployment lifecycle commands and connection semantics are unchanged.

--- a/openspec/changes/improve-deployment-info-guidance/specs/deployment-info-reporting/spec.md
+++ b/openspec/changes/improve-deployment-info-guidance/specs/deployment-info-reporting/spec.md
@@ -1,0 +1,94 @@
+# deployment-info-reporting Specification
+
+## Purpose
+
+Define how `exasol info` reports deployment state, next steps, and machine-readable deployment information.
+
+## ADDED Requirements
+
+### Requirement: Info SHALL report uninitialized deployment directories
+
+`exasol info` SHALL succeed when the resolved deployment directory has no initialized deployment yet, and SHALL report that state to the user.
+
+#### Scenario: Text output before initialization
+
+- **WHEN** a user runs `exasol info` for a resolved deployment directory with no initialized deployment
+- **THEN** the command succeeds
+- **AND** the output identifies the resolved deployment directory
+- **AND** the output reports the deployment state as `not_initialized`
+- **AND** the output tells the user how to discover presets and create a deployment
+
+#### Scenario: JSON output before initialization
+
+- **WHEN** a user runs `exasol info --json` for a resolved deployment directory with no initialized deployment
+- **THEN** the command succeeds
+- **AND** stdout contains valid JSON
+- **AND** the JSON contains the resolved deployment directory
+- **AND** the JSON reports `deploymentState` as `not_initialized`
+
+### Requirement: Info text output SHALL guide users by deployment state
+
+Human-readable `exasol info` output SHALL include concise next-step guidance appropriate to the current deployment state.
+
+#### Scenario: Initialized deployment
+
+- **WHEN** a user runs `exasol info` for an initialized deployment that has not been deployed yet
+- **THEN** the output reports the initialized state
+- **AND** the output points the user toward deploying the database
+
+#### Scenario: Running deployment
+
+- **WHEN** a user runs `exasol info` for a running deployment
+- **THEN** the output reports the running state
+- **AND** the output points the user toward connecting to or stopping the deployment
+
+#### Scenario: Stopped deployment
+
+- **WHEN** a user runs `exasol info` for a stopped deployment
+- **THEN** the output reports the stopped state
+- **AND** the output points the user toward starting or destroying the deployment
+
+#### Scenario: Deployment operation is not complete
+
+- **WHEN** a user runs `exasol info` while a deployment operation is in progress, interrupted, or failed
+- **THEN** the output reports the current state
+- **AND** the output gives a state-appropriate next step
+
+### Requirement: Info JSON output SHALL be machine-readable deployment information
+
+`exasol info --json` SHALL write only valid JSON to stdout and SHALL provide a structured deployment overview suitable for scripts and agents.
+
+#### Scenario: JSON stdout is parseable
+
+- **WHEN** a user runs `exasol info --json`
+- **THEN** stdout contains valid JSON
+- **AND** stdout does not contain banners, prompts, or explanatory terminal prose outside JSON
+
+#### Scenario: Initialized deployment metadata is available
+
+- **WHEN** a user runs `exasol info --json` for an initialized deployment
+- **THEN** the JSON includes the deployment state
+- **AND** the JSON includes the resolved deployment directory
+- **AND** the JSON includes the deployment identifier when one is available
+- **AND** the JSON includes selected preset information when preset identity is available
+
+#### Scenario: Running deployment connection details are available
+
+- **WHEN** a user runs `exasol info --json` for a running deployment with connection details
+- **THEN** the JSON includes connection-relevant fields such as backend, host, database port, username, TLS guidance, Admin UI details when available, and shell access details when available
+
+#### Scenario: Connection details are not stable for the current state
+
+- **WHEN** a user runs `exasol info --json` for a deployment state where connection details are absent or not stable
+- **THEN** the JSON still reports the deployment state and resolved deployment directory
+- **AND** connection details are omitted
+
+### Requirement: Info SHALL preserve deployment lifecycle behavior
+
+`exasol info` SHALL report deployment information without creating, modifying, starting, stopping, destroying, or removing deployment resources.
+
+#### Scenario: Information command does not mutate deployment lifecycle
+
+- **WHEN** a user runs `exasol info` or `exasol info --json`
+- **THEN** the command reports the current deployment information
+- **AND** the command does not change the deployment lifecycle state

--- a/openspec/changes/improve-deployment-info-guidance/tasks.md
+++ b/openspec/changes/improve-deployment-info-guidance/tasks.md
@@ -1,0 +1,21 @@
+## 1. User-facing info behavior
+
+- [x] 1.1 Make `exasol info` succeed for resolved deployment directories that are not initialized.
+- [x] 1.2 Show the resolved deployment directory and `not_initialized` state before initialization.
+- [x] 1.3 Add text next-step guidance for uninitialized, initialized, running, stopped, failed, interrupted, and in-progress states.
+- [x] 1.4 Preserve lifecycle semantics: `info` reports state and guidance without mutating deployment state.
+
+## 2. JSON deployment overview
+
+- [x] 2.1 Make `exasol info --json` return valid JSON for uninitialized deployment directories.
+- [x] 2.2 Include deployment state and resolved deployment directory in JSON output.
+- [x] 2.3 Include initialized deployment metadata and connection-relevant fields when available.
+- [x] 2.4 Keep terminal-only guidance prose out of JSON output.
+
+## 3. Verification
+
+- [x] 3.1 Add coverage for not-initialized text output.
+- [x] 3.2 Add coverage for not-initialized JSON output.
+- [x] 3.3 Add coverage for initialized/running JSON output with connection details.
+- [x] 3.4 Add coverage for deployment states where connection details are absent or not stable.
+- [x] 3.5 Run the repository validation used for the pull request.

--- a/tests/tests/integration/test_cli.py
+++ b/tests/tests/integration/test_cli.py
@@ -1,6 +1,7 @@
 # Copyright 2026 Exasol AG
 # SPDX-License-Identifier: MIT
 
+import json
 from pathlib import Path
 
 from .helpers import first_infrastructure_preset_id_or_skip, run_command
@@ -49,7 +50,44 @@ def test_info_command_exists(exasol_path: str) -> None:
     """Verify info command is available."""
     result = run_command([exasol_path, "info", "--help"])
     assert result.returncode == 0
-    assert "Prints a summary" in result.stdout
+    assert "Prints information about your Exasol deployment." in result.stdout
+
+
+def test_info_reports_missing_deployment_without_error(
+    exasol_path: str, tmp_path: Path
+) -> None:
+    # Given an empty deployment directory
+    deployment_dir = tmp_path / "deployment"
+    deployment_dir.mkdir()
+
+    # When info is invoked before a deployment exists
+    result = run_command([exasol_path, "info", "--deployment-dir", str(deployment_dir)])
+
+    # Then it exits successfully and guides the user toward creating a deployment
+    assert "No Exasol Personal deployment exists" in result.stdout
+    assert str(deployment_dir) in result.stdout
+    assert "exasol install <infra preset>" in result.stdout
+    assert "exasol presets list" in result.stdout
+
+
+def test_info_json_reports_missing_deployment_without_error(
+    exasol_path: str, tmp_path: Path
+) -> None:
+    # Given an empty deployment directory
+    deployment_dir = tmp_path / "deployment"
+    deployment_dir.mkdir()
+
+    # When info is invoked as JSON before a deployment exists
+    result = run_command(
+        [exasol_path, "info", "--json", "--deployment-dir", str(deployment_dir)]
+    )
+
+    # Then automation can branch on structured state instead of parsing an error
+    data = json.loads(result.stdout)
+    assert data["deploymentState"] == "not_initialized"
+    assert data["deploymentDir"] == str(deployment_dir)
+    assert "message" not in data
+    assert "actions" not in data
 
 
 def test_info_command_init_deployment(exasol_path: str, tmp_path: Path) -> None:

--- a/tests/tests/integration/test_deployment_directory_resolution.py
+++ b/tests/tests/integration/test_deployment_directory_resolution.py
@@ -165,7 +165,7 @@ def test_init_creates_default_deployment_dir(exasol_path: str, tmp_path: Path) -
     _assert_deployment_dir_logged(result.stderr, default_dir, "default")
 
 
-def test_initialized_state_error_mentions_resolved_default_dir(
+def test_info_reports_uninitialized_resolved_default_dir(
     exasol_path: str, tmp_path: Path
 ) -> None:
     # Given no initialized deployment is available in the current or default directory
@@ -176,17 +176,17 @@ def test_initialized_state_error_mentions_resolved_default_dir(
     default_dir = home / ".exasol" / "personal" / "deployments" / "default"
     launcher = str(Path(exasol_path).resolve())
 
-    # When a command requiring initialized state is invoked
+    # When info is invoked without an explicit deployment directory
     result = subprocess.run(
         [launcher, "info"],
         cwd=cwd,
         env=_env_with_home(home),
         capture_output=True,
         text=True,
-        check=False,
+        check=True,
     )
 
-    # Then the error explains the resolved deployment directory
-    assert result.returncode != 0
-    assert "deployment directory is not initialized" in result.stderr.lower()
-    assert f"in {json.dumps(str(default_dir))}" in result.stderr
+    # Then info reports the resolved default directory and guides the user
+    assert "No Exasol Personal deployment exists" in result.stdout
+    assert str(default_dir) in result.stdout
+    assert "exasol install <infra preset>" in result.stdout

--- a/tests/tests/integration/test_install.py
+++ b/tests/tests/integration/test_install.py
@@ -208,7 +208,8 @@ esac
         env=env,
     )
     info_data = json.loads(info_result.stdout)
-    assert info_data["backend"] == "local"
+    assert info_data["deploymentState"] == "running"
+    assert info_data["connection"]["backend"] == "local"
     assert info_data["connection"]["dbPort"] == LOCAL_TEST_DB_PORT
     assert "adminUi" not in info_data["connection"]
     assert "uiPort" not in info_data["connection"]


### PR DESCRIPTION
## Description

Updates `exasol info` so it is useful across the deployment lifecycle instead of only after enough deployment artifacts exist.

This PR covers two related user-facing stories:

- [SPOT-31123](https://exasol.atlassian.net/browse/SPOT-31123): `exasol info` guides users before deployment initialization.
- [SPOT-31132](https://exasol.atlassian.net/browse/SPOT-31132): `exasol info --json` exposes machine-readable deployment information from the discoverable `info` command.

The main external change is that `info` now reports a deployment overview and next steps for the current state. For automation, `info --json` returns a stable structured report with deployment state, the resolved deployment directory, preset identity where available, deployment attributes where available, and connection details when the deployment is running.

## Related Issue

SPOT-31123
SPOT-31132

## CLI Output Examples

### Not initialized: text output

Before:

```text
$ exasol info
Error: deployment directory is not initialized in "<deployment-dir>"
```

After:

```text
$ exasol info
Exasol Personal Deployment Overview
Deployment directory: <deployment-dir>
Deployment State: not_initialized

Exasol Product Documentation:
  https://docs.exasol.com/

No Exasol Personal deployment exists in this deployment directory yet.

Next steps:
  exasol presets list             // list available presets
  exasol install <infra preset>   // create and start a deployment
```

### Not initialized: JSON output

```json
{
  "deploymentDir": "<deployment-dir>",
  "deploymentState": "not_initialized"
}
```

The JSON output intentionally omits terminal-only guidance text so scripts and agents can branch on state without parsing prose.

### Running deployment: JSON output shape

```json
{
  "deploymentDir": "<deployment-dir>",
  "deploymentId": "<deployment-id>",
  "deploymentState": "running",
  "presets": {
    "infrastructure": {
      "selector": "name:aws",
      "kind": "name",
      "name": "aws",
      "displayName": "AWS"
    },
    "installation": {
      "selector": "name:default",
      "kind": "name",
      "name": "default"
    }
  },
  "deployment": {
    "clusterSize": 1
  },
  "connection": {
    "backend": "local",
    "host": "127.0.0.1",
    "displayHost": "127.0.0.1",
    "dbPort": 8563,
    "username": "sys",
    "insecureSkipCertValidation": true,
    "shellSupported": true
  }
}
```

### State-specific text guidance

`exasol info` now keeps text output focused on the next useful action:

- `not_initialized`: list presets or install a deployment.
- `initialized`: run `exasol deploy`.
- `running`: run `exasol connect` or `exasol stop`.
- `stopped`: run `exasol start` or `exasol destroy`.
- `operation_in_progress`, `deployment_failed`, and `interrupted`: inspect or retry from the reported state.

## Type of Change

- [x] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [x] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Allows `exasol info` and `exasol info --json` to run before deployment initialization.
- Reports `not_initialized` as structured deployment state instead of surfacing an initialized-deployment requirement error.
- Adds state-specific text guidance for common lifecycle states.
- Makes `exasol info --json` return a structured deployment overview for initialized deployments, including nested connection details when available.
- Keeps JSON stdout free of human-only guidance text.
- Adds a retroactive OpenSpec change for the final high-level UX contract.
- Adds Go unit coverage and Python integration coverage for text and JSON behavior.

## Refactoring Notes

The implementation now builds one deployment information report and renders the user-facing outputs from that shared report. This reduces drift between `info`, generated connection instructions, and JSON output, and it makes partial states safer because the command can report high-level state without forcing reads of connection details that do not exist yet or are not stable.

Connection instructions also moved from string concatenation to template rendering. That makes the rendered output easier to review, test, and evolve while preserving the externally visible connection guidance.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

`task all` passed locally.

CI on the PR was running after the latest push when this description was refreshed; completed checks visible at that time were passing.

## Risk Notes

Low to moderate risk. The behavior change is intentionally user-facing for `info`: scripts that expected `exasol info` to fail before initialization should now use `deploymentState == "not_initialized"` from `--json`. Lifecycle commands and deployment state semantics are unchanged.

## Checklist

- [x] Code follows the project's coding guidelines
- [x] Ran `task lint` via `task all`
- [x] Updated documentation/specs where applicable
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow Conventional Commits

## Additional Notes

Jira and OpenSpec describe only the final user-facing behavior. The refactoring details above are included here to explain why the PR is larger than the narrow initial `not_initialized` UX fix.


[SPOT-31123]: https://exasol.atlassian.net/browse/SPOT-31123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SPOT-31132]: https://exasol.atlassian.net/browse/SPOT-31132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ