### PR TITLE
Update default cloud deployment versions

### DIFF
--- a/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/hostLauncherVersionCheck.sh
+++ b/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/hostLauncherVersionCheck.sh
@@ -34,7 +34,7 @@ if [[ -z "${version_check_url}" ]]; then
   version_check_url="${DEFAULT_VERSION_CHECK_URL}"
 fi
 if [[ -z "${exasol_version}" ]]; then
-  exasol_version="2025.2.0"
+  exasol_version="2026.1.0"
 fi
 
 # Missing launcher-governed values means init/deploy artifacts are incomplete.

--- a/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/prepareExasol.sh
+++ b/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/prepareExasol.sh
@@ -19,7 +19,7 @@ source "${SCRIPT_DIR}/logging.sh"
 # shellcheck source=./config.sh
 source "${SCRIPT_DIR}/config.sh"
 
-c4_version='4.29.0'
+c4_version='4.31.0'
 
 log_step_info "Preparing system..."
 

--- a/assets/installation/ubuntu/installation.yaml
+++ b/assets/installation/ubuntu/installation.yaml
@@ -11,7 +11,7 @@ variables:
     exasol_version:
       description: Exasol database version to install. Only change this if you are sure the release is compatible.
       type: string
-      default: "2025.2.0"
+      default: "2026.1.0"
     no_db_version_check:
       description: Disable the daily database version check (C4).
       type: bool


### PR DESCRIPTION
## Description

Update the pinned cloud deployment defaults used by the Ubuntu installation flow.

## Related Issue

SPOT-30370

## Type of Change

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Updated the internal C4 download version from `4.29.0` to `4.31.0`.
- Updated the Ubuntu installation preset default Exasol Database version from `2025.2.0` to `2026.1.0`.
- Updated the host-side version-check fallback from `2025.2.0` to `2026.1.0`.
- Kept C4 as an internal implementation detail; it is not exposed as a preset parameter.

## Testing

- [x] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [ ] Manually tested the changes

### Test Details

- `env HOME=/tmp/exasol-test-home USERPROFILE=/tmp/exasol-test-home XDG_CACHE_HOME=/tmp/exasol-test-cache GOCACHE=/tmp/go-build-cache go test ./internal/presets ./internal/deploy`

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [ ] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

Existing deployments and local deployments are intentionally unchanged.