### PR TITLE
fix: exasol help now shows correct cli args for presets

### DIFF
--- a/cmd/exasol/infra_variables.go
+++ b/cmd/exasol/infra_variables.go
@@ -210,6 +210,12 @@ func collectInfrastructureVariableOverrides(cmd *cobra.Command) map[string]strin
 }
 
 func scanInfrastructurePresetSelection(args []string) (*deploy.PresetRef, error) {
+	// Handle "exasol help init local" form: strip the leading "help" token so the
+	// preset scanner finds the actual command. Cobra registers its help subcommand
+	// lazily inside ExecuteC, so rootCmd.Find won't resolve it at this point.
+	if len(args) > 0 && args[0] == helpCommandName {
+		args = args[1:]
+	}
 	cmd, remainingArgs := preregisteredCommand(args)
 	if cmd != initCmd && cmd != installCmd {
 		return nil, errors.New("no command with infrastructure preset argument found")

--- a/cmd/exasol/install_variables.go
+++ b/cmd/exasol/install_variables.go
@@ -192,6 +192,9 @@ func collectInstallationVariableOverrides(cmd *cobra.Command) map[string]string 
 }
 
 func scanInstallationPresetSelection(args []string) (*deploy.PresetRef, error) {
+	if len(args) > 0 && args[0] == helpCommandName {
+		args = args[1:]
+	}
 	cmd, remainingArgs := preregisteredCommand(args)
 	if cmd != initCmd && cmd != installCmd {
 		return nil, errors.New("no command with installation preset argument found")

--- a/cmd/exasol/preregister_args.go
+++ b/cmd/exasol/preregister_args.go
@@ -15,6 +15,8 @@ import (
 	"github.com/spf13/pflag"
 )
 
+const helpCommandName = "help"
+
 func preregisteredCommand(args []string) (*cobra.Command, []string) {
 	cmd, remainingArgs, err := rootCmd.Find(args)
 	if err != nil {
@@ -35,7 +37,7 @@ func preregisteredPositionals(args []string) ([]string, error) {
 	flagset.SetOutput(io.Discard)
 	flagset.SetInterspersed(true)
 	flagset.ParseErrorsAllowlist.UnknownFlags = true
-	flagset.BoolP("help", "h", false, "")
+	flagset.BoolP(helpCommandName, "h", false, "")
 
 	if err := flagset.Parse(args); err != nil && !errors.Is(err, pflag.ErrHelp) {
 		return nil, fmt.Errorf("cannot parse pre-registration args: %w", err)


### PR DESCRIPTION
Previously, `exasol help <preset>` would not show the preset's arguments from `infrastructure.yaml` (`--help` did work correctly)

Now, the output includes the preset's args.