### PR TITLE
feat: `exasol init local` now support port overrides

### DIFF
--- a/assets/infrastructure/local/infrastructure.yaml
+++ b/assets/infrastructure/local/infrastructure.yaml
@@ -4,6 +4,7 @@ backend: local
 
 local:
   cpuCount: 2
+  memoryMB: 2048
   dataSizeGB: 100
 
 compatibility:

--- a/assets/infrastructure/local/infrastructure.yaml
+++ b/assets/infrastructure/local/infrastructure.yaml
@@ -4,7 +4,6 @@ backend: local
 
 local:
   cpuCount: 2
-  memoryMB: 2048
   dataSizeGB: 100
 
 compatibility:

--- a/internal/deploy/local_backend.go
+++ b/internal/deploy/local_backend.go
@@ -45,6 +45,7 @@ const (
 	localCPUCountConfigName    = "cpu_count"
 	localMemoryMBConfigName    = "memory_mb"
 	localDataSizeGBConfigName  = "data_size_gb"
+	localPortsConfigName       = "ports"
 )
 
 var errUnsupportedLocalPlatform = errors.New(
@@ -119,17 +120,29 @@ func applyLocalConfigOverrides(
 		if name == "" {
 			continue
 		}
-		parsed, err := parseLocalPositiveIntConfig(name, strings.TrimSpace(rawValue))
-		if err != nil {
-			return err
-		}
+		rawValue = strings.TrimSpace(rawValue)
 
-		switch canonicalLocalConfigName(name) {
-		case canonicalLocalConfigName(localCPUCountConfigName):
+		canonical := canonicalLocalConfigName(name)
+		switch {
+		case canonical == canonicalLocalConfigName(localPortsConfigName):
+			local.Ports = rawValue
+		case canonical == canonicalLocalConfigName(localCPUCountConfigName):
+			parsed, err := parseLocalPositiveIntConfig(name, rawValue)
+			if err != nil {
+				return err
+			}
 			local.CPUCount = parsed
-		case canonicalLocalConfigName(localMemoryMBConfigName):
+		case canonical == canonicalLocalConfigName(localMemoryMBConfigName):
+			parsed, err := parseLocalPositiveIntConfig(name, rawValue)
+			if err != nil {
+				return err
+			}
 			local.MemoryMB = parsed
-		case canonicalLocalConfigName(localDataSizeGBConfigName):
+		case canonical == canonicalLocalConfigName(localDataSizeGBConfigName):
+			parsed, err := parseLocalPositiveIntConfig(name, rawValue)
+			if err != nil {
+				return err
+			}
 			local.DataSizeGB = parsed
 		default:
 			return fmt.Errorf("unknown local infrastructure configuration option %q", name)
@@ -280,6 +293,11 @@ func localConfigVariableDefinitions(
 			Type:           ConfigVariableTypeNumber,
 			DefaultDisplay: strconv.Itoa(runtimeConfig.dataSizeGB),
 		},
+		localPortsConfigName: {
+			Name:        localPortsConfigName,
+			Description: "Port overrides for the Exasol Local VM (format: <service>:<port>,...)",
+			Type:        ConfigVariableTypeString,
+		},
 	}
 }
 
@@ -382,6 +400,7 @@ type localRuntimeConfig struct {
 	cpuCount   int
 	memoryMB   int
 	dataSizeGB int
+	ports      string
 }
 
 func defaultLocalRuntimeConfig(detectedHostMemoryMB int) localRuntimeConfig {
@@ -426,6 +445,7 @@ func resolveLocalRuntimeConfig(
 		if manifest.Local.DataSizeGB != 0 {
 			runtimeConfig.dataSizeGB = manifest.Local.DataSizeGB
 		}
+		runtimeConfig.ports = manifest.Local.Ports
 	}
 
 	if err := validateLocalRuntimeConfig(runtimeConfig, detectedHostMemoryMB); err != nil {

--- a/internal/deploy/local_runtime.go
+++ b/internal/deploy/local_runtime.go
@@ -59,15 +59,15 @@ func startPreparedLocalRuntime(
 	}
 
 	localConfig := toLocalRuntimeConfig(runtimeConfig)
-	startArgs := []string{
-		"start",
-		strconv.Itoa(localConfig.CPUCount),
-		strconv.Itoa(localConfig.MemoryMB),
-		strconv.Itoa(localConfig.DataSizeGB),
-	}
+	startArgs := []string{"start"}
 	if localConfig.Ports != "" {
 		startArgs = append(startArgs, "--ports", localConfig.Ports)
 	}
+	startArgs = append(startArgs,
+		strconv.Itoa(localConfig.CPUCount),
+		strconv.Itoa(localConfig.MemoryMB),
+		strconv.Itoa(localConfig.DataSizeGB),
+	)
 	if err := localruntime.RunCommand(
 		ctx,
 		deployment,

--- a/internal/deploy/local_runtime.go
+++ b/internal/deploy/local_runtime.go
@@ -59,15 +59,19 @@ func startPreparedLocalRuntime(
 	}
 
 	localConfig := toLocalRuntimeConfig(runtimeConfig)
+	startArgs := []string{
+		"start",
+		strconv.Itoa(localConfig.CPUCount),
+		strconv.Itoa(localConfig.MemoryMB),
+		strconv.Itoa(localConfig.DataSizeGB),
+	}
+	if localConfig.Ports != "" {
+		startArgs = append(startArgs, "--ports", localConfig.Ports)
+	}
 	if err := localruntime.RunCommand(
 		ctx,
 		deployment,
-		[]string{
-			"start",
-			strconv.Itoa(localConfig.CPUCount),
-			strconv.Itoa(localConfig.MemoryMB),
-			strconv.Itoa(localConfig.DataSizeGB),
-		},
+		startArgs,
 		out,
 		outErr,
 	); err != nil {
@@ -121,6 +125,7 @@ func toLocalRuntimeConfig(runtimeConfig localRuntimeConfig) localruntime.Config 
 		CPUCount:   runtimeConfig.cpuCount,
 		MemoryMB:   runtimeConfig.memoryMB,
 		DataSizeGB: runtimeConfig.dataSizeGB,
+		Ports:      runtimeConfig.ports,
 	}
 }
 

--- a/internal/localruntime/runtime.go
+++ b/internal/localruntime/runtime.go
@@ -47,6 +47,7 @@ type Config struct {
 	CPUCount   int
 	MemoryMB   int
 	DataSizeGB int
+	Ports      string
 }
 
 type State struct {

--- a/internal/presets/infrastructure_manifest.go
+++ b/internal/presets/infrastructure_manifest.go
@@ -24,9 +24,10 @@ type InfrastructureTofu struct {
 //
 //nolint:tagliatelle // These YAML keys are part of the preset contract.
 type InfrastructureLocal struct {
-	CPUCount   int `yaml:"cpuCount,omitempty"`
-	MemoryMB   int `yaml:"memoryMB,omitempty"`
-	DataSizeGB int `yaml:"dataSizeGB,omitempty"`
+	CPUCount   int    `yaml:"cpuCount,omitempty"`
+	MemoryMB   int    `yaml:"memoryMB,omitempty"`
+	DataSizeGB int    `yaml:"dataSizeGB,omitempty"`
+	Ports      string `yaml:"ports,omitempty"`
 }
 
 // InfrastructureManifest represents the infrastructure metadata and optional tofu configuration.

--- a/tests/tests/deployment/test_local_deployment.py
+++ b/tests/tests/deployment/test_local_deployment.py
@@ -47,7 +47,10 @@ def local_ports_deployment(
 def test_ports_override_sets_db_port(
     local_ports_deployment: tuple[Deployment, int],
 ) -> None:
-    """--ports db:<port> passes the port through to the VM runner and the DB is reachable on it."""
+    """--ports db:<port> passes the port through to the VM runner.
+
+    The DB is reachable on the specified port.
+    """
     deployment, custom_db_port = local_ports_deployment
 
     deployment_json = Path(deployment.deployment_dir.name) / "deployment.json"

--- a/tests/tests/deployment/test_local_deployment.py
+++ b/tests/tests/deployment/test_local_deployment.py
@@ -1,0 +1,58 @@
+# Copyright 2026 Exasol AG
+# SPDX-License-Identifier: MIT
+
+"""Tests specific to local VM deployments."""
+
+import json
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Final
+
+import pytest
+
+from framework.deployment import Deployment
+from framework.launcher import DeploymentConfig, Launcher
+
+
+@pytest.fixture
+def local_ports_deployment(
+    exasol_path: str,
+    infra: str,
+) -> Iterator[tuple[Deployment, int]]:
+    if infra != "local":
+        pytest.skip("ports override is local-only")
+
+    custom_db_port: Final = 9564
+    config = DeploymentConfig(infra="local")
+
+    deployment = Deployment(
+        Launcher(exasol_path),
+        "--ports",
+        f"db:{custom_db_port}",
+        config=config,
+    )
+    try:
+        deployment.deploy()
+        yield deployment, custom_db_port
+    finally:
+        deployment.cleanup()
+
+
+@pytest.mark.skipif(
+    sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
+)
+@pytest.mark.installation_e2e
+@pytest.mark.local_e2e
+def test_ports_override_sets_db_port(
+    local_ports_deployment: tuple[Deployment, int],
+) -> None:
+    """--ports db:<port> passes the port through to the VM runner and the DB is reachable on it."""
+    deployment, custom_db_port = local_ports_deployment
+
+    deployment_json = Path(deployment.deployment_dir.name) / "deployment.json"
+    info = json.loads(deployment_json.read_text())
+    assert info["connection"]["dbPort"] == custom_db_port
+
+    proc = deployment.connect(input="SELECT * FROM Dual", capture_output=True)
+    assert "DUMMY" in proc.stdout

--- a/tests/tests/deployment/test_standard_deployment.py
+++ b/tests/tests/deployment/test_standard_deployment.py
@@ -436,12 +436,7 @@ def test_diag_cos_runs_confd_client(
 )
 @pytest.mark.installation_e2e
 @pytest.mark.local_e2e
-def test_license_session_limit(reusable_deployment: Deployment, infra: str) -> None:
-    if infra == "local":
-        pytest.skip(
-            "Session limit enforcement is not yet implemented for local deployments"
-        )
-
+def test_license_session_limit(reusable_deployment: Deployment) -> None:
     # license_session_limit is the limit defined in Exasol Personal
     # license. This value should match it.
     license_session_limit: Final = 20


### PR DESCRIPTION
passthrough for new `--ports` argument of the thin launcher.

See https://github.com/exasol/exasol-local-vm/pull/26