### PR TITLE
fix: preserve typed connect JSON output

### DIFF
--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -86,8 +86,8 @@ func effectiveMaxRows(requested, modeDefault int) int {
 }
 
 type jsonQueryResult struct {
-	Columns []string   `json:"columns"`
-	Rows    [][]string `json:"rows"`
+	Columns []string `json:"columns"`
+	Rows    [][]any  `json:"rows"`
 }
 
 type resultPrinter func(io.Writer, generaltypes.QueryResulter) error
@@ -289,13 +289,14 @@ func printResultJSON(
 	jsonFormat JSONFormat,
 ) error {
 	encoder := json.NewEncoder(output)
+	encoder.SetEscapeHTML(false)
 	if normalizeJSONFormat(jsonFormat) == JSONFormatPretty {
 		encoder.SetIndent("", "  ")
 	}
 
 	return encoder.Encode(jsonQueryResult{
 		Columns: queryResult.ColumnNames(),
-		Rows:    queryResult.Rows(),
+		Rows:    queryResult.Values(),
 	})
 }
 

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -51,6 +51,7 @@ var (
 type stubQueryResult struct {
 	columnNames []string
 	rows        [][]string
+	values      [][]any
 	truncated   bool
 }
 
@@ -60,6 +61,22 @@ func (s stubQueryResult) ColumnNames() []string {
 
 func (s stubQueryResult) Rows() [][]string {
 	return s.rows
+}
+
+func (s stubQueryResult) Values() [][]any {
+	if s.values != nil {
+		return s.values
+	}
+
+	values := make([][]any, len(s.rows))
+	for i, row := range s.rows {
+		values[i] = make([]any, len(row))
+		for j, value := range row {
+			values[i][j] = value
+		}
+	}
+
+	return values
 }
 
 func (s stubQueryResult) Truncated() bool {
@@ -116,6 +133,30 @@ func TestPrintResultJSON(t *testing.T) {
 			expected:   unknownPrettyJSON,
 			normalized: JSONFormatPretty,
 		},
+		{
+			name:   "renders typed values without html escaping",
+			format: JSONFormatCompact,
+			result: stubQueryResult{
+				columnNames: []string{"N", "OK", "MISSING", "TEXT", "CREATED_AT"},
+				rows: [][]string{{
+					"42",
+					"true",
+					"<nil>",
+					"<tag>&value",
+					"2026-06-23T12:00:00Z",
+				}},
+				values: [][]any{{
+					int64(42),
+					true,
+					nil,
+					"<tag>&value",
+					"2026-06-23T12:00:00Z",
+				}},
+			},
+			expected: "{\"columns\":[\"N\",\"OK\",\"MISSING\",\"TEXT\",\"CREATED_AT\"]," +
+				"\"rows\":[[42,true,null,\"<tag>&value\",\"2026-06-23T12:00:00Z\"]]}\n",
+			normalized: JSONFormatCompact,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -135,9 +176,21 @@ func TestPrintResultJSON(t *testing.T) {
 			var decoded jsonQueryResult
 			require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
 			require.Equal(t, test.result.columnNames, decoded.Columns)
-			require.Equal(t, test.result.rows, decoded.Rows)
+			require.Equal(t, jsonRoundTripValues(t, test.result.Values()), decoded.Rows)
 		})
 	}
+}
+
+func jsonRoundTripValues(t *testing.T, values [][]any) [][]any {
+	t.Helper()
+
+	data, err := json.Marshal(values)
+	require.NoError(t, err)
+
+	var decoded [][]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+
+	return decoded
 }
 
 func TestResolveNonInteractiveSQL(t *testing.T) {

--- a/internal/connect/exasol/database.go
+++ b/internal/connect/exasol/database.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"os"
 	"regexp"
+	"time"
 
 	"github.com/exasol/exasol-driver-go"
 	"github.com/exasol/exasol-personal/internal/connect/exasol/types"
@@ -146,7 +147,7 @@ func (db *Database) Exec(
 	// driver streams the local file; they never produce a result set.
 	if isImportQuery(query) {
 		_, err := db.conn.Exec(query, nil)
-		return &QueryResult{columnNames: []string{}, rows: [][]string{}}, err
+		return emptyQueryResult(), err
 	}
 
 	// QueryContext returns driver.Rows, which transparently fetches result-set
@@ -165,7 +166,7 @@ func (db *Database) Exec(
 // result is flagged truncated and no additional rows are fetched.
 func collectRows(rows driver.Rows, maxRows int) (*QueryResult, error) {
 	columns := rows.Columns()
-	result := &QueryResult{columnNames: columns, rows: [][]string{}}
+	result := &QueryResult{columnNames: columns, rows: [][]string{}, values: [][]any{}}
 
 	dest := make([]driver.Value, len(columns))
 
@@ -185,11 +186,31 @@ func collectRows(rows driver.Rows, maxRows int) (*QueryResult, error) {
 		}
 
 		row := make([]string, len(columns))
+		values := make([]any, len(columns))
 		for i, value := range dest {
 			row[i] = fmt.Sprint(value)
+			values[i] = jsonValue(value)
 		}
 
 		result.rows = append(result.rows, row)
+		result.values = append(result.values, values)
+	}
+}
+
+func emptyQueryResult() *QueryResult {
+	return &QueryResult{columnNames: []string{}, rows: [][]string{}, values: [][]any{}}
+}
+
+func jsonValue(value driver.Value) any {
+	switch typedValue := value.(type) {
+	case nil, string, bool, int64, float64:
+		return typedValue
+	case []byte:
+		return string(typedValue)
+	case time.Time:
+		return typedValue.Format(time.RFC3339Nano)
+	default:
+		return fmt.Sprint(typedValue)
 	}
 }
 

--- a/internal/connect/exasol/database_test.go
+++ b/internal/connect/exasol/database_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/exasol/exasol-personal/internal/connect/exasol/types"
 	"github.com/exasol/exasol-personal/internal/connect/exasol/types/typesfakes"
@@ -176,6 +177,7 @@ func TestExec(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, []string{"col1", "col2"}, result.ColumnNames())
 				require.Equal(t, [][]string{{"val1", "val2"}}, result.Rows())
+				require.Equal(t, [][]any{{"val1", "val2"}}, result.Values())
 				require.False(t, result.Truncated())
 			},
 		},
@@ -197,6 +199,7 @@ func TestExec(t *testing.T) {
 				require.NoError(t, err)
 				require.Empty(t, result.ColumnNames())
 				require.Empty(t, result.Rows())
+				require.Empty(t, result.Values())
 				require.False(t, result.Truncated())
 			},
 		},
@@ -209,6 +212,7 @@ func TestExec(t *testing.T) {
 				require.Equal(t, 1, mocks.fakeConnector.ExecCallCount())
 				require.Equal(t, []string{}, result.ColumnNames())
 				require.Equal(t, [][]string{}, result.Rows())
+				require.Equal(t, [][]any{}, result.Values())
 			},
 		},
 		{
@@ -221,6 +225,7 @@ func TestExec(t *testing.T) {
 				require.Equal(t, 1, mocks.fakeConnector.ExecCallCount())
 				require.Equal(t, []string{}, result.ColumnNames())
 				require.Equal(t, [][]string{}, result.Rows())
+				require.Equal(t, [][]any{}, result.Values())
 			},
 		},
 	} {
@@ -349,6 +354,47 @@ func TestCollectRows(t *testing.T) {
 
 		require.NoError(t, err)
 		require.Equal(t, [][]string{{"1000000"}}, result.Rows())
+		require.Equal(t, [][]any{{int64(1000000)}}, result.Values())
+	})
+
+	t.Run("preserves json-compatible values beside display strings", func(t *testing.T) {
+		t.Parallel()
+
+		timestamp := time.Date(2026, 6, 23, 12, 30, 45, 123000000, time.UTC)
+		rows := &fakeRows{
+			columns: []string{"n", "fraction", "ok", "missing", "text", "payload", "created_at"},
+			data: [][]driver.Value{{
+				int64(42),
+				float64(1.5),
+				true,
+				nil,
+				"<tag>&value",
+				[]byte("bytes"),
+				timestamp,
+			}},
+		}
+
+		result, err := collectRows(rows, 0)
+
+		require.NoError(t, err)
+		require.Equal(t, [][]string{{
+			"42",
+			"1.5",
+			"true",
+			"<nil>",
+			"<tag>&value",
+			"[98 121 116 101 115]",
+			"2026-06-23 12:30:45.123 +0000 UTC",
+		}}, result.Rows())
+		require.Equal(t, [][]any{{
+			int64(42),
+			float64(1.5),
+			true,
+			nil,
+			"<tag>&value",
+			"bytes",
+			"2026-06-23T12:30:45.123Z",
+		}}, result.Values())
 	})
 
 	t.Run("propagates a non-EOF Next error", func(t *testing.T) {

--- a/internal/connect/exasol/query_result.go
+++ b/internal/connect/exasol/query_result.go
@@ -7,6 +7,7 @@ package exasol
 type QueryResult struct {
 	columnNames []string
 	rows        [][]string
+	values      [][]any
 	truncated   bool
 }
 
@@ -16,6 +17,10 @@ func (qr *QueryResult) ColumnNames() []string {
 
 func (qr *QueryResult) Rows() [][]string {
 	return qr.rows
+}
+
+func (qr *QueryResult) Values() [][]any {
+	return qr.values
 }
 
 func (qr *QueryResult) Truncated() bool {

--- a/internal/connect/types/types.go
+++ b/internal/connect/types/types.go
@@ -11,6 +11,7 @@ import "context"
 type QueryResulter interface {
 	ColumnNames() []string
 	Rows() [][]string
+	Values() [][]any
 	// Truncated reports whether more rows were available than are returned by
 	// Rows, because retrieval was capped by a row limit.
 	Truncated() bool

--- a/openspec/changes/archive/2026-06-23-fix-connect-json-output/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-23-fix-connect-json-output/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-23

--- a/openspec/changes/archive/2026-06-23-fix-connect-json-output/design.md
+++ b/openspec/changes/archive/2026-06-23-fix-connect-json-output/design.md
@@ -1,0 +1,41 @@
+## Context
+
+`exasol connect` currently materializes query results in `internal/connect/exasol.Database.Exec` as `[][]string`. Each `driver.Value` returned by the database driver is converted immediately with `fmt.Sprint`, so type information is lost before the JSON renderer sees the data. That makes JSON output serialize numbers and booleans as strings and turns SQL `NULL` into the string `"<nil>"`.
+
+The table renderer depends on string rows, so the fix must preserve the existing display-oriented path while adding a typed path for JSON output. The existing stdout/stderr split already keeps truncation notices on stderr; the JSON encoder still needs to avoid HTML escaping.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Preserve JSON-compatible SQL value types for `exasol connect --json`.
+- Emit SQL `NULL` values as JSON `null`.
+- Keep non-JSON table output compatible with the current rendered strings.
+- Keep `--json` stdout parseable and free of non-JSON status text in non-interactive execution.
+- Cover typed JSON output behavior with focused unit tests.
+
+**Non-Goals:**
+
+- No new CLI flags or output mode names.
+- No public REST API or broader SQL type-system definition.
+- No change to statement splitting, query execution order, truncation policy, or default pretty table output.
+- No deployment-level end-to-end test requirement for this change; those tests require live infrastructure and are reserved for release validation.
+
+## Decisions
+
+**Add typed rows beside string rows.** Extend `QueryResulter` with a typed row accessor such as `Values() [][]any`, and update `QueryResult` to store both typed values and display strings. `Rows() [][]string` remains available for table output and existing tests. Alternative: change `Rows()` to `[][]any` and convert table rows at the printer boundary. Rejected because it would make the existing display contract noisier and broaden the change surface.
+
+**Normalize driver values while collecting rows.** When `collectRows` receives a `driver.Value`, keep JSON-native values (`nil`, strings, booleans, integer and floating numeric types) as typed values and derive string rows separately with `fmt.Sprint`. For byte slices, timestamps, and other driver-supported values, keep JSON output stable by converting to strings. Alternative: defer all conversion to JSON rendering. Rejected because the database package owns the driver boundary and can keep the general query result contract consistent.
+
+**Keep precision conservative.** JSON numbers are emitted for numeric Go driver values already returned as numeric types. Values that arrive as strings stay strings. This avoids inventing SQL precision rules in the launcher and matches the Jira criterion that numbers are emitted as JSON numbers where the selected JSON contract can represent them safely.
+
+**Disable HTML escaping on the JSON encoder.** Use `encoder.SetEscapeHTML(false)` for connect JSON output so ordinary strings containing characters such as `<`, `>`, and `&` are not unnecessarily escaped. Alternative: post-process encoded JSON. Rejected because the standard encoder exposes the needed setting directly.
+
+**Continue writing diagnostics away from stdout.** Version/exit hints are already TTY-only and written to stderr. Truncation footer also remains stderr-only. This preserves parseable stdout for non-interactive `--json` use.
+
+## Risks / Trade-offs
+
+- **Interface expansion affects fakes and test doubles** -> Regenerate or manually update the counterfeiter fake and local stubs.
+- **Exact SQL DECIMAL precision semantics remain driver-dependent** -> Only emit numeric JSON values for numeric driver values; do not parse string values into numbers.
+- **Date and timestamp formatting depends on driver value shape** -> Convert non-JSON-native time values to strings, and test the selected behavior at the row collector boundary.
+- **Deployment-level JSON behavior is not tested in CI** -> Unit tests cover the contract without requiring cloud resources; deployment tests can be used manually when a live deployment is available.

--- a/openspec/changes/archive/2026-06-23-fix-connect-json-output/proposal.md
+++ b/openspec/changes/archive/2026-06-23-fix-connect-json-output/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+`exasol connect --json` currently serializes every SQL value as a string and renders SQL `NULL` as `"<nil>"`, which makes the output unsafe for scripts, `jq` pipelines, APIs, monitoring, and agent workflows. The JSON mode needs a stable machine-readable contract that preserves JSON-compatible SQL values.
+
+## What Changes
+
+- Preserve typed query result values through the connect execution path so JSON output can emit native JSON numbers, booleans, strings, and nulls.
+- Keep existing table output compatible by rendering the same display strings it uses today.
+- Emit SQL `NULL` as JSON `null` in `--json` output.
+- Emit JSON-compatible numeric and boolean values as JSON numbers and booleans where the driver value can be represented safely.
+- Encode JSON output without unnecessary HTML escaping of ordinary result strings.
+- Keep `--json` stdout clean in non-interactive execution; diagnostic and truncation messages stay off stdout.
+- Add focused tests for numeric, boolean, string, date or timestamp, null, and HTML-sensitive string behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- `connect-json-output`: JSON result formatting contract for `exasol connect --json`, including typed values, null handling, string escaping, and stdout cleanliness.
+
+### Modified Capabilities
+
+<!-- None. Existing connect input requirements remain unchanged. -->
+
+## Impact
+
+- `internal/connect/types`: extend the query result contract so JSON rendering can access typed row values while table rendering can continue using display strings.
+- `internal/connect/exasol`: preserve driver values when collecting rows and expose both typed values and string-rendered rows.
+- `internal/connect/connect.go`: render JSON from typed rows, disable HTML escaping, and preserve stdout/stderr separation.
+- Tests in `internal/connect/...` cover the JSON contract and table compatibility.
+- No new dependencies, no CLI flag changes, and no change to default non-JSON output mode.

--- a/openspec/changes/archive/2026-06-23-fix-connect-json-output/specs/connect-json-output/spec.md
+++ b/openspec/changes/archive/2026-06-23-fix-connect-json-output/specs/connect-json-output/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Typed JSON Query Result Values
+
+`exasol connect --json` SHALL emit query result rows using JSON-compatible value types instead of converting every cell to a string.
+
+#### Scenario: Numeric values are JSON numbers
+
+- **WHEN** a query result contains numeric SQL values returned by the database driver as safely representable numeric values
+- **THEN** `exasol connect --json` emits those cells as JSON numbers
+
+#### Scenario: Boolean values are JSON booleans
+
+- **WHEN** a query result contains boolean SQL values
+- **THEN** `exasol connect --json` emits those cells as JSON booleans
+
+#### Scenario: Null values are JSON null
+
+- **WHEN** a query result contains SQL `NULL` values
+- **THEN** `exasol connect --json` emits those cells as JSON `null`
+
+#### Scenario: Text values remain JSON strings
+
+- **WHEN** a query result contains text, date, timestamp, or other non-JSON-native values represented as strings
+- **THEN** `exasol connect --json` emits those cells as JSON strings
+
+### Requirement: JSON Strings Are Not HTML-Escaped Unnecessarily
+
+`exasol connect --json` SHALL encode result strings without unnecessary HTML escaping of ordinary characters.
+
+#### Scenario: HTML-sensitive characters stay readable
+
+- **WHEN** a query result string contains ordinary characters such as `<`, `>`, or `&`
+- **THEN** `exasol connect --json` emits those characters in the JSON string without replacing them with Unicode escape sequences solely for HTML safety
+
+### Requirement: JSON Stdout Is Machine-Readable
+
+When `--json` is used in non-interactive execution, `exasol connect` SHALL write only JSON result documents to stdout.
+
+#### Scenario: Non-interactive JSON output contains no prompts or status text
+
+- **WHEN** the user runs `exasol connect --json` non-interactively with SQL from `--command`, `--file`, or piped stdin
+- **THEN** stdout contains only the JSON result output for executed statements
+- **AND** prompts, banners, version messages, exit hints, and truncation notices are not written to stdout
+
+### Requirement: Non-JSON Output Compatibility
+
+Existing non-JSON query output SHALL continue to render display strings for result cells.
+
+#### Scenario: Pretty table output remains string-rendered
+
+- **WHEN** the user runs `exasol connect` without `--json`
+- **THEN** query result cells are rendered through the existing table output path using display strings

--- a/openspec/changes/archive/2026-06-23-fix-connect-json-output/tasks.md
+++ b/openspec/changes/archive/2026-06-23-fix-connect-json-output/tasks.md
@@ -1,0 +1,33 @@
+## 1. Query Result Contract
+
+- [x] 1.1 Extend `internal/connect/types.QueryResulter` with a typed row accessor for JSON-compatible values
+- [x] 1.2 Update `internal/connect/exasol.QueryResult` to store both typed values and display string rows
+- [x] 1.3 Keep non-resultset and import-query results returning empty typed and display rows
+
+## 2. Driver Value Collection
+
+- [x] 2.1 Update `collectRows` to preserve driver values for JSON output while still building `Rows() [][]string`
+- [x] 2.2 Convert SQL `NULL` driver values to typed `nil` and display strings compatible with existing table output
+- [x] 2.3 Preserve numeric and boolean driver values as JSON-native typed values
+- [x] 2.4 Convert date, timestamp, byte slice, and other non-JSON-native driver values to stable strings for JSON output
+
+## 3. JSON Rendering
+
+- [x] 3.1 Change `jsonQueryResult.Rows` to use typed row values instead of string rows
+- [x] 3.2 Configure the JSON encoder to avoid unnecessary HTML escaping
+- [x] 3.3 Confirm truncation notices, version messages, prompts, and exit hints stay off stdout for non-interactive JSON output
+- [x] 3.4 Keep table rendering on `Rows() [][]string` so existing non-JSON output remains compatible
+
+## 4. Tests
+
+- [x] 4.1 Add unit coverage for JSON numbers, booleans, strings, dates or timestamps, nulls, and HTML-sensitive strings
+- [x] 4.2 Add unit coverage for `collectRows` preserving typed values and display strings
+- [x] 4.3 Update existing test doubles and expectations for the expanded `QueryResulter` contract
+- [x] 4.4 Run focused Go tests for `internal/connect/...`
+
+## 5. Validation
+
+- [x] 5.1 Run `task fmt`
+- [x] 5.2 Run `task tests-unit`
+- [x] 5.3 Run `task lint`
+- [x] 5.4 Run `task all` if the focused validation passes and time permits

--- a/openspec/specs/connect-json-output/spec.md
+++ b/openspec/specs/connect-json-output/spec.md
@@ -1,0 +1,57 @@
+# connect-json-output Specification
+
+## Purpose
+Define the machine-readable JSON result contract for `exasol connect --json`.
+
+## Requirements
+### Requirement: Typed JSON Query Result Values
+
+`exasol connect --json` SHALL emit query result rows using JSON-compatible value types instead of converting every cell to a string.
+
+#### Scenario: Numeric values are JSON numbers
+
+- **WHEN** a query result contains numeric SQL values returned by the database driver as safely representable numeric values
+- **THEN** `exasol connect --json` emits those cells as JSON numbers
+
+#### Scenario: Boolean values are JSON booleans
+
+- **WHEN** a query result contains boolean SQL values
+- **THEN** `exasol connect --json` emits those cells as JSON booleans
+
+#### Scenario: Null values are JSON null
+
+- **WHEN** a query result contains SQL `NULL` values
+- **THEN** `exasol connect --json` emits those cells as JSON `null`
+
+#### Scenario: Text values remain JSON strings
+
+- **WHEN** a query result contains text, date, timestamp, or other non-JSON-native values represented as strings
+- **THEN** `exasol connect --json` emits those cells as JSON strings
+
+### Requirement: JSON Strings Are Not HTML-Escaped Unnecessarily
+
+`exasol connect --json` SHALL encode result strings without unnecessary HTML escaping of ordinary characters.
+
+#### Scenario: HTML-sensitive characters stay readable
+
+- **WHEN** a query result string contains ordinary characters such as `<`, `>`, or `&`
+- **THEN** `exasol connect --json` emits those characters in the JSON string without replacing them with Unicode escape sequences solely for HTML safety
+
+### Requirement: JSON Stdout Is Machine-Readable
+
+When `--json` is used in non-interactive execution, `exasol connect` SHALL write only JSON result documents to stdout.
+
+#### Scenario: Non-interactive JSON output contains no prompts or status text
+
+- **WHEN** the user runs `exasol connect --json` non-interactively with SQL from `--command`, `--file`, or piped stdin
+- **THEN** stdout contains only the JSON result output for executed statements
+- **AND** prompts, banners, version messages, exit hints, and truncation notices are not written to stdout
+
+### Requirement: Non-JSON Output Compatibility
+
+Existing non-JSON query output SHALL continue to render display strings for result cells.
+
+#### Scenario: Pretty table output remains string-rendered
+
+- **WHEN** the user runs `exasol connect` without `--json`
+- **THEN** query result cells are rendered through the existing table output path using display strings


### PR DESCRIPTION
## Description

`exasol connect --json` now preserves JSON-compatible SQL result values instead of converting every cell to a string. This makes JSON output safer for scripts, `jq` pipelines, APIs, monitoring, and agent workflows.

## Related Issue

https://exasol.atlassian.net/browse/SPOT-31131

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Added typed query result values alongside the existing display-string rows.
- Changed connect JSON rendering to emit typed rows and disable unnecessary HTML escaping.
- Kept non-JSON table output on the existing string-rendering path.
- Archived the OpenSpec change and added the permanent `connect-json-output` capability spec.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

### Test Details

- `go test ./internal/connect/...`
- `task fmt`
- `task tests-unit`
- `task lint`
- `task all` (includes 54 integration tests)

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation/specs (OpenSpec archived into permanent specs)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

The stdout-clean guarantee is scoped to JSON stdout. Logs, version notices, warnings, and truncation messages may still appear on stderr.