### PR TITLE
feat: CI testing for exasol local

### DIFF
--- a/.github/actions/tests-deployment/action.yml
+++ b/.github/actions/tests-deployment/action.yml
@@ -9,11 +9,39 @@ inputs:
     description: Taskfile target to execute for deployment tests.
     required: false
     default: tests-deployment
+  system-python:
+    description: >
+      Skip managed Python install and use system Python instead.
+      Use on self-hosted runners that lack write access to the tool cache
+      (e.g. the macOS ARM64 virtualization runner).
+    required: false
+    default: 'false'
 runs:
   using: "composite"
   steps:
     - name: Setup Python and Task
+      if: ${{ inputs.system-python != 'true' }}
       uses: ./.github/actions/setup-python
+    - name: Setup Task (system Python path)
+      if: ${{ inputs.system-python == 'true' }}
+      uses: ./.github/actions/setup-task
+    - name: Install uv (system Python path)
+      if: ${{ inputs.system-python == 'true' }}
+      shell: bash
+      run: |
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+    - name: Install Python 3.13 and Poetry via uv (system Python path)
+      if: ${{ inputs.system-python == 'true' }}
+      shell: bash
+      run: |
+        uv python install 3.13
+        uv tool install poetry
+        echo "$(dirname "$(uv python find 3.13)")" >> "$GITHUB_PATH"
+    - name: Install test dependencies (system Python path)
+      if: ${{ inputs.system-python == 'true' }}
+      shell: bash
+      run: task tests-setup
     - name: Run Deployment Tests
       shell: bash
       env:

--- a/.github/scripts/run-deployment-tests.sh
+++ b/.github/scripts/run-deployment-tests.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+OS="${1:-all}"
+SUITE="${2:-all}"
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [[ "$BRANCH" == "HEAD" ]]; then
+    echo "ERROR: Cannot trigger workflow from a detached HEAD — check out a branch first"
+    exit 1
+fi
+
+LOCAL_SHA=$(git rev-parse HEAD)
+REMOTE_SHA=$(git rev-parse "origin/${BRANCH}" 2>/dev/null) || {
+    echo "ERROR: Branch '${BRANCH}' has not been pushed to origin"
+    exit 1
+}
+
+if [[ "$LOCAL_SHA" != "$REMOTE_SHA" ]]; then
+    echo "ERROR: Local commit ${LOCAL_SHA:0:7} has not been pushed (origin/${BRANCH} is at ${REMOTE_SHA:0:7})"
+    exit 1
+fi
+
+echo "Triggering deployment tests on ${BRANCH} (${LOCAL_SHA:0:7}), suite=${SUITE}, os=${OS}"
+gh workflow run tests-deployment.yml --ref "${BRANCH}" --field "suite=${SUITE}" --field "os=${OS}"

--- a/.github/workflows/tests-deployment.yml
+++ b/.github/workflows/tests-deployment.yml
@@ -3,8 +3,17 @@ name: Deployment Tests
 on:
   workflow_dispatch:
     inputs:
+      suite:
+        description: Which test suite to run
+        required: false
+        default: all
+        type: choice
+        options:
+          - all
+          - cloud
+          - local
       os:
-        description: Operating system selector
+        description: Operating system selector (cloud suite only)
         required: false
         default: all
         type: choice
@@ -21,6 +30,7 @@ env:
 
 jobs:
   plan-tests-deployment:
+    if: ${{ inputs.suite != 'local' }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.plan.outputs.matrix }}
@@ -57,6 +67,7 @@ jobs:
           echo "matrix=${filtered_plan_json}" >> "${GITHUB_OUTPUT}"
 
   tests-deployment:
+    if: ${{ inputs.suite != 'local' }}
     needs: plan-tests-deployment
     environment:
       name: deployment-tests
@@ -145,6 +156,44 @@ jobs:
         if: always()
         with:
           context: tests-deployment-${{ matrix.infra }}-${{ matrix.os }}
+          status: ${{ job.status }}
+          description: ${{ env.STATUS_DESC }}
+          target-url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+  tests-deployment-local:
+    if: ${{ inputs.suite != 'cloud' }}
+    environment:
+      name: deployment-tests
+    runs-on:
+      - self-hosted
+      - macOS
+      - ARM64
+      - virtualization
+    permissions:
+      contents: read
+      statuses: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/status-set
+        with:
+          context: tests-deployment-local-self-hosted
+          status: pending
+          description: ${{ env.STATUS_DESC }}
+          target-url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      - uses: ./.github/actions/build
+      - uses: ./.github/actions/tests-deployment
+        with:
+          infra: local
+          task: tests-deployment-local
+          system-python: 'true'
+
+      - uses: ./.github/actions/status-set
+        if: always()
+        with:
+          context: tests-deployment-local-self-hosted
           status: ${{ job.status }}
           description: ${{ env.STATUS_DESC }}
           target-url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ coverage.out
 *.key
 # Added by goreleaser init:
 dist/
+ci-downloads/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -202,6 +202,21 @@ tasks:
       - |
         poetry run pytest -vv --exasol-path={{.BUILD_DIR}}{{.SEP}}{{.BINARY_NAME}} --infra={{.INFRA}} {{if .STACKIT_PROJECT_ID}}--stackit-project-id={{.STACKIT_PROJECT_ID}}{{end}} -m "installation_e2e" {{.TESTS_DIR}}{{.SEP}}tests{{.SEP}}deployment
 
+  tests-deployment-local:
+    desc: Run local VM deployment tests (macOS Apple Silicon only)
+    deps: [tests-setup]
+    dir: '{{.TESTS_DIR}}'
+    cmds:
+      - poetry run pytest -vv --exasol-path={{.BUILD_DIR}}{{.SEP}}{{.BINARY_NAME}} --infra=local -m "local_e2e" {{.TESTS_DIR}}{{.SEP}}tests{{.SEP}}deployment
+
+  run-deployment-tests:
+    desc: Trigger the deployment tests workflow on the current pushed commit (`task run-deployment-tests SUITE=local`, `task run-deployment-tests OS=macos-latest`)
+    vars:
+      OS: '{{default "all" .OS}}'
+      SUITE: '{{default "all" .SUITE}}'
+    cmds:
+      - .github/scripts/run-deployment-tests.sh "{{.OS}}" "{{.SUITE}}"
+
   lint-ruff:
     desc: Run ruff check
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -17,6 +17,9 @@ vars:
   BUILD_DIR: '{{.ROOT_PATH}}{{.SEP}}{{.BUILD_DIR_NAME}}'
   TESTS_DIR: '{{.ROOT_PATH}}{{.SEP}}tests'
 
+includes:
+  github: ./tasks/github.Taskfile.yml
+
 tasks:
   default:
     silent: true
@@ -208,14 +211,6 @@ tasks:
     dir: '{{.TESTS_DIR}}'
     cmds:
       - poetry run pytest -vv --exasol-path={{.BUILD_DIR}}{{.SEP}}{{.BINARY_NAME}} --infra=local -m "local_e2e" {{.TESTS_DIR}}{{.SEP}}tests{{.SEP}}deployment
-
-  run-deployment-tests:
-    desc: Trigger the deployment tests workflow on the current pushed commit (`task run-deployment-tests SUITE=local`, `task run-deployment-tests OS=macos-latest`)
-    vars:
-      OS: '{{default "all" .OS}}'
-      SUITE: '{{default "all" .SUITE}}'
-    cmds:
-      - .github/scripts/run-deployment-tests.sh "{{.OS}}" "{{.SUITE}}"
 
   lint-ruff:
     desc: Run ruff check

--- a/tasks/github.Taskfile.yml
+++ b/tasks/github.Taskfile.yml
@@ -1,0 +1,11 @@
+# Github utilities
+version: '3'
+
+tasks:
+  trigger-deployment-tests:
+    desc: Trigger the deployment tests workflow on the current pushed commit (`task run-deployment-tests SUITE=local`, `task run-deployment-tests OS=macos-latest`)
+    vars:
+      OS: '{{default "all" .OS}}'
+      SUITE: '{{default "all" .SUITE}}'
+    cmds:
+      - .github/scripts/run-deployment-tests.sh "{{.OS}}" "{{.SUITE}}"

--- a/tests/framework/launcher.py
+++ b/tests/framework/launcher.py
@@ -81,18 +81,10 @@ class Launcher:
             },
         )
 
-    def init(
-        self,
-        deployment_dir: str,
-        *args: str,
-        config: DeploymentConfig | None = None,
-        **kwargs: Unpack[SubprocessRunKwargs],
-    ) -> CompletedProcess[str]:
-        if config is None:
-            config = DeploymentConfig()
-
-        init_args = [config.infra, "--cluster-size", str(config.cluster_size)]
-
+    def _build_init_args(self, config: DeploymentConfig) -> list[str]:
+        init_args = [config.infra]
+        if config.infra != "local":
+            init_args.extend(["--cluster-size", str(config.cluster_size)])
         if config.instance_type is not None:
             init_args.extend(["--instance-type", config.instance_type])
         if config.data_volume_size is not None:
@@ -109,11 +101,22 @@ class Launcher:
                 location = os.getenv("TF_VAR_LOCATION") or os.getenv("AZURE_LOCATION")
             if location is not None and location.strip() != "":
                 init_args.extend(["--location", location])
+        return init_args
+
+    def init(
+        self,
+        deployment_dir: str,
+        *args: str,
+        config: DeploymentConfig | None = None,
+        **kwargs: Unpack[SubprocessRunKwargs],
+    ) -> CompletedProcess[str]:
+        if config is None:
+            config = DeploymentConfig()
 
         return self.run_command(
             "init",
             deployment_dir,
-            *init_args,
+            *self._build_init_args(config),
             *args,
             **kwargs,
         )

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -31,6 +31,7 @@ markers = [
   "launcher_tests: Tests that validate launcher CLI and behavioral contracts without real cloud deployment.",
   "installation_e2e: End-to-end tests focused on installation-level behavior.",
   "infrastructure_e2e: End-to-end tests focused on cloud infrastructure behavior.",
+  "local_e2e: End-to-end tests for the local macOS VM deployment.",
   "provider_aws: Tests that assert AWS-specific behavior.",
   "provider_azure: Tests that assert Azure-specific behavior.",
   "provider_stackit: Tests that assert STACKIT-specific behavior.",

--- a/tests/tests/conftest.py
+++ b/tests/tests/conftest.py
@@ -19,7 +19,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
         required=False,
         action="store",
         default="aws",
-        choices=["aws", "azure", "exoscale", "stackit"],
+        choices=["aws", "azure", "exoscale", "stackit", "local"],
         help="Infrastructure preset to use for deployment tests",
     )
     parser.addoption(

--- a/tests/tests/deployment/test_standard_deployment.py
+++ b/tests/tests/deployment/test_standard_deployment.py
@@ -86,8 +86,19 @@ def reusable_deployment(
             time.sleep(5)
 
         logging.info("Waiting for deploy to complete")
+        deploy_timeout = 40 * 60
 
-        deploy_return_code = deployment_proc.wait(timeout=20 * 60)
+        try:
+            deploy_return_code = deployment_proc.wait(timeout=deploy_timeout)
+        except subprocess.TimeoutExpired:
+            deployment_proc.kill()
+            deployment_proc.wait()
+            msg = (
+                f"Deploy command timed out after {deploy_timeout}s\n"
+                f"deployment.log tail:\n{deployment.deployment_log_tail()}"
+            )
+            raise RuntimeError(msg) from None
+
         if deploy_return_code != 0:
             msg = (
                 f"Deploy command failed with code {deploy_return_code}\n"

--- a/tests/tests/deployment/test_standard_deployment.py
+++ b/tests/tests/deployment/test_standard_deployment.py
@@ -109,6 +109,8 @@ def reusable_deployment(
 
 @pytest.mark.installation_e2e
 def test_connectable(reusable_deployment: Deployment) -> None:
+    # Note: not marked local_e2e — db_connectable() reads deployment.json nodes
+    # which the local backend does not populate.
     assert reusable_deployment.db_connectable()
 
 
@@ -121,6 +123,7 @@ def test_connectable(reusable_deployment: Deployment) -> None:
     sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
 )
 @pytest.mark.installation_e2e
+@pytest.mark.local_e2e
 def test_single_query(reusable_deployment: Deployment) -> None:
     query: Final = "SELECT * FROM Dual"
 
@@ -143,6 +146,7 @@ def test_single_query(reusable_deployment: Deployment) -> None:
     sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
 )
 @pytest.mark.installation_e2e
+@pytest.mark.local_e2e
 def test_exit_command(reusable_deployment: Deployment) -> None:
     queries: Final = [
         "exit",
@@ -161,6 +165,7 @@ def test_exit_command(reusable_deployment: Deployment) -> None:
     sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
 )
 @pytest.mark.installation_e2e
+@pytest.mark.local_e2e
 def test_multiple_queries(reusable_deployment: Deployment) -> None:
     queries: Final = [
         "CREATE SCHEMA test_multiple_queries;",
@@ -200,6 +205,7 @@ def test_multiple_queries(reusable_deployment: Deployment) -> None:
     sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
 )
 @pytest.mark.installation_e2e
+@pytest.mark.local_e2e
 def test_file_import(reusable_deployment: Deployment) -> None:
     people_csv_path: Final = Path(__file__).parent / Path("assets/people.csv")
 
@@ -244,6 +250,7 @@ def test_file_import(reusable_deployment: Deployment) -> None:
     sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
 )
 @pytest.mark.installation_e2e
+@pytest.mark.local_e2e
 def test_connect_table_width(reusable_deployment: Deployment) -> None:
     queries: Final = [
         "CREATE SCHEMA test_connect_table_width;",
@@ -273,16 +280,21 @@ def test_connect_table_width(reusable_deployment: Deployment) -> None:
         stderr=slave_fd,
     )
 
-    # Read the stdout of the connect command, KiB at a time.
-    os.close(slave_fd)
+    # Set non-blocking before draining: on macOS, closing slave_fd first causes
+    # immediate EIO on master_fd even if data is buffered. Keep slave_fd open and
+    # use non-blocking reads so we don't hang waiting for more data.
+    fl = fcntl.fcntl(master_fd, fcntl.F_GETFL)
+    fcntl.fcntl(master_fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
+
     output_raw = b""
     try:
         while chunk := os.read(master_fd, 1024):
             output_raw += chunk
     except OSError:
         pass
-
-    os.close(master_fd)
+    finally:
+        os.close(slave_fd)
+        os.close(master_fd)
 
     output_lines = [line.rstrip("\r") for line in str(output_raw, "utf-8").split("\n")]
     output = "\n".join(output_lines).strip("\n")
@@ -303,6 +315,7 @@ def test_connect_table_width(reusable_deployment: Deployment) -> None:
     sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
 )
 @pytest.mark.installation_e2e
+@pytest.mark.local_e2e
 def test_connect_interactive_shows_version_and_exit_hint(
     reusable_deployment: Deployment,
 ) -> None:
@@ -323,7 +336,11 @@ def test_connect_interactive_shows_version_and_exit_hint(
     finally:
         if proc.poll() is None:
             proc.kill()
-        os.close(slave_fd)
+
+    # Drain master_fd before closing slave_fd: on macOS, closing slave_fd first
+    # causes immediate EIO on master_fd even if data is buffered.
+    fl = fcntl.fcntl(master_fd, fcntl.F_GETFL)
+    fcntl.fcntl(master_fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
 
     output_raw = b""
     try:
@@ -332,6 +349,7 @@ def test_connect_interactive_shows_version_and_exit_hint(
     except OSError:
         pass
     finally:
+        os.close(slave_fd)
         os.close(master_fd)
 
     output = output_raw.decode("utf-8", errors="replace")
@@ -345,7 +363,15 @@ def test_connect_interactive_shows_version_and_exit_hint(
     sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
 )
 @pytest.mark.installation_e2e
-def test_diag_cos_runs_confd_client(reusable_deployment: Deployment) -> None:
+@pytest.mark.local_e2e
+def test_diag_cos_runs_confd_client(
+    reusable_deployment: Deployment, infra: str
+) -> None:
+    if infra == "local":
+        pytest.skip(
+            "confd_client is a COS tool; local deployments use a VM shell"
+            " fallback where it is not available"
+        )
     # Given: A running deployment and a PTY for an interactive container shell session.
     launcher_path = reusable_deployment.launcher.launcher_path
     deployment_dir = reusable_deployment.deployment_dir.name
@@ -370,7 +396,10 @@ def test_diag_cos_runs_confd_client(reusable_deployment: Deployment) -> None:
         if proc.poll() is None:
             proc.kill()
 
-        os.close(slave_fd)
+    # Drain master_fd before closing slave_fd: on macOS, closing slave_fd first
+    # causes immediate EIO on master_fd even if data is buffered.
+    fl = fcntl.fcntl(master_fd, fcntl.F_GETFL)
+    fcntl.fcntl(master_fd, fcntl.F_SETFL, fl | os.O_NONBLOCK)
 
     # Read all output from the PTY.
     output_raw = b""
@@ -380,6 +409,7 @@ def test_diag_cos_runs_confd_client(reusable_deployment: Deployment) -> None:
     except OSError:
         pass
     finally:
+        os.close(slave_fd)
         os.close(master_fd)
 
     output = output_raw.decode("utf-8", errors="replace")
@@ -394,7 +424,13 @@ def test_diag_cos_runs_confd_client(reusable_deployment: Deployment) -> None:
     sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
 )
 @pytest.mark.installation_e2e
-def test_license_session_limit(reusable_deployment: Deployment) -> None:
+@pytest.mark.local_e2e
+def test_license_session_limit(reusable_deployment: Deployment, infra: str) -> None:
+    if infra == "local":
+        pytest.skip(
+            "Session limit enforcement is not yet implemented for local deployments"
+        )
+
     # license_session_limit is the limit defined in Exasol Personal
     # license. This value should match it.
     license_session_limit: Final = 20


### PR DESCRIPTION
This PR contains:
- enables some of the pre-existing e2e tests to run for exasol local.
- increases timeout and catches errors for creating reusable deployments in the deployment tests. This increases reliability and prevents some orphaned resources.

These tests are run on the self-host mac instance, which requires some additional work to install dependencies due to reduced permissions compared to github's own containers.