### PR TITLE
Fix launcher version update checks

### DIFF
--- a/cmd/exasol/version.go
+++ b/cmd/exasol/version.go
@@ -4,9 +4,10 @@
 package main
 
 import (
+	_ "embed"
 	"encoding/json"
-	"fmt"
-	"os"
+	"strings"
+	"text/template"
 
 	// Legacy v3 variants of semver are found in this repo due indirect tflint dependencies.
 	// We should use the modern v4 within the our code though.
@@ -32,6 +33,13 @@ var versionCheckOpts = struct {
 	Latest bool
 }{}
 
+//go:embed version_latest_text.tmpl
+var latestVersionTextTemplateSource string
+
+var latestVersionTextTemplate = template.Must(
+	template.New("version-latest-text").Parse(latestVersionTextTemplateSource),
+)
+
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: versionCmdShortDesc,
@@ -42,8 +50,18 @@ var versionCmd = &cobra.Command{
 		ctx := cmd.Context()
 
 		if !versionCheckOpts.Latest {
-			_, err := fmt.Fprintln(os.Stdout, semver.MustParse(CurrentLauncherVersion))
-			return err
+			if commonFlags.OutputJson {
+				output, err := formatCurrentVersionJSON(CurrentLauncherVersion)
+				if err != nil {
+					return err
+				}
+				addTerminalOutput(output)
+
+				return nil
+			}
+			addTerminalOutput(formatCurrentVersionText(CurrentLauncherVersion))
+
+			return nil
 		}
 
 		response, err := deploy.FetchLatestVersion(
@@ -55,55 +73,76 @@ var versionCmd = &cobra.Command{
 			return err
 		}
 		if commonFlags.OutputJson {
-			encoder := json.NewEncoder(os.Stdout)
-			encoder.SetIndent("", "  ")
+			content, marshalErr := json.MarshalIndent(response, "", "  ")
+			if marshalErr != nil {
+				return marshalErr
+			}
+			addTerminalOutput(string(content))
 
-			return encoder.Encode(response)
+			return nil
 		}
 
-		return printLatestVersionText(CurrentLauncherVersion, response)
+		text, err := formatLatestVersionText(CurrentLauncherVersion, response)
+		if err != nil {
+			return err
+		}
+		addTerminalOutput(text)
+
+		return nil
 	},
 }
 
-//nolint:revive // Suppress warning about not handing Fprintf errors
-func printLatestVersionText(
-	currentVersion string,
-	response *deploy.VersionCheckResponse,
-) error {
-	if response.LatestVersion.Version == currentVersion {
-		fmt.Fprintf(
-			os.Stdout,
-			"You are using the latest version of Exasol Personal (%s).\n",
-			currentVersion,
-		)
+type currentVersionOutput struct {
+	Version string `json:"version"`
+}
 
-		return nil
+func formatCurrentVersionText(currentVersion string) string {
+	return semver.MustParse(currentVersion).String()
+}
+
+func formatCurrentVersionJSON(currentVersion string) (string, error) {
+	version, err := semver.Parse(currentVersion)
+	if err != nil {
+		return "", err
+	}
+	content, err := json.MarshalIndent(currentVersionOutput{Version: version.String()}, "", "  ")
+	if err != nil {
+		return "", err
 	}
 
-	fmt.Fprintf(
-		os.Stdout,
-		"The latest official version of Exasol Personal available is: %s "+
-			"(you are using %s)\n",
-		response.LatestVersion.Version,
-		currentVersion,
-	)
-	fmt.Fprintf(os.Stdout, "  Version: %s\n", response.LatestVersion.Version)
-	fmt.Fprintf(
-		os.Stdout,
-		"  Operating System: %s\n",
-		response.LatestVersion.OperatingSystem,
-	)
-	fmt.Fprintf(
-		os.Stdout,
-		"  Architecture: %s\n",
-		response.LatestVersion.Architecture,
-	)
-	fmt.Fprintf(os.Stdout, "  Filename: %s\n", response.LatestVersion.Filename)
-	fmt.Fprintf(os.Stdout, "  Size: %d bytes\n", response.LatestVersion.Size)
-	fmt.Fprintf(os.Stdout, "  Download URL: %s\n", response.LatestVersion.URL)
-	fmt.Fprintf(os.Stdout, "  SHA256: %s\n\n", response.LatestVersion.SHA256)
+	return string(content), nil
+}
 
-	return nil
+func formatLatestVersionText(
+	currentVersion string,
+	response *deploy.VersionCheckResponse,
+) (string, error) {
+	latestVersion := response.LatestVersion.Version
+	updateAvailable, err := deploy.IsVersionUpdateAvailable(currentVersion, latestVersion)
+	if err != nil {
+		return "", err
+	}
+	state := "newer"
+	if !updateAvailable && latestVersion == currentVersion {
+		state = "equal"
+	} else if !updateAvailable {
+		state = "older"
+	}
+	var builder strings.Builder
+	err = latestVersionTextTemplate.Execute(&builder, struct {
+		CurrentVersion string
+		LatestVersion  deploy.LatestVersionInfo
+		State          string
+	}{
+		CurrentVersion: currentVersion,
+		LatestVersion:  response.LatestVersion,
+		State:          state,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return builder.String(), nil
 }
 
 func registerVersionCheckFlags() {

--- a/cmd/exasol/version_latest_text.tmpl
+++ b/cmd/exasol/version_latest_text.tmpl
@@ -1,0 +1,14 @@
+{{- if eq .State "equal" -}}
+You are using the latest version of Exasol Personal ({{ .CurrentVersion }}).
+{{- else if eq .State "older" -}}
+The latest official version of Exasol Personal available is: {{ .LatestVersion.Version }} (you are using {{ .CurrentVersion }}). No newer official version is available.
+{{- else -}}
+The latest official version of Exasol Personal available is: {{ .LatestVersion.Version }} (you are using {{ .CurrentVersion }})
+  Version: {{ .LatestVersion.Version }}
+  Operating System: {{ .LatestVersion.OperatingSystem }}
+  Architecture: {{ .LatestVersion.Architecture }}
+  Filename: {{ .LatestVersion.Filename }}
+  Size: {{ .LatestVersion.Size }} bytes
+  Download URL: {{ .LatestVersion.URL }}
+  SHA256: {{ .LatestVersion.SHA256 }}
+{{- end -}}

--- a/cmd/exasol/version_test.go
+++ b/cmd/exasol/version_test.go
@@ -1,0 +1,170 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/deploy"
+)
+
+func TestFormatCurrentVersionText_ReportsText(t *testing.T) {
+	t.Parallel()
+
+	// Given: a current launcher version.
+	// When: text output is formatted.
+	actual := formatCurrentVersionText("2.0.0-rc1")
+
+	// Then: the version remains plain text.
+	if actual != "2.0.0-rc1" {
+		t.Fatalf("expected text output %q, got %q", "2.0.0-rc1", actual)
+	}
+}
+
+func TestFormatCurrentVersionJSON_ReportsStructuredJSON(t *testing.T) {
+	t.Parallel()
+
+	// Given: a current launcher version.
+	// When: JSON output is formatted.
+	actual, err := formatCurrentVersionJSON("2.0.0-rc1")
+	// Then: the version is returned as structured JSON.
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var parsed struct {
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal([]byte(actual), &parsed); err != nil {
+		t.Fatalf("expected valid JSON, got %q: %v", actual, err)
+	}
+	if parsed.Version != "2.0.0-rc1" {
+		t.Fatalf("expected JSON version %q, got %q", "2.0.0-rc1", parsed.Version)
+	}
+}
+
+func TestFormatLatestVersionText_ReportsNewerEqualAndOlderVersions(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name           string
+		currentVersion string
+		latestVersion  string
+		expected       []string
+		unexpected     []string
+	}{
+		{
+			name:           "reported version is newer",
+			currentVersion: "1.4.0",
+			latestVersion:  "1.4.1",
+			expected: []string{
+				"The latest official version of Exasol Personal available is: 1.4.1",
+				"(you are using 1.4.0)",
+				"  Version: 1.4.1",
+				"  Download URL: https://example.com/exasol",
+			},
+			unexpected: []string{"No newer official version is available"},
+		},
+		{
+			name:           "reported version is equal",
+			currentVersion: "1.4.1",
+			latestVersion:  "1.4.1",
+			expected: []string{
+				"You are using the latest version of Exasol Personal (1.4.1).",
+			},
+			unexpected: []string{"Download URL", "No newer official version is available"},
+		},
+		{
+			name:           "reported version is older",
+			currentVersion: "2.0.0-rc1",
+			latestVersion:  "1.4.1",
+			expected: []string{
+				"The latest official version of Exasol Personal available is: 1.4.1",
+				"(you are using 2.0.0-rc1)",
+				"No newer official version is available.",
+			},
+			unexpected: []string{"Download URL"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Given: a latest-version response.
+			response := latestVersionResponse(test.latestVersion)
+			// When: the response is rendered as user-facing text.
+			actual, err := formatLatestVersionText(test.currentVersion, response)
+			// Then: the output describes whether the reported version is newer.
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			for _, expected := range test.expected {
+				if !strings.Contains(actual, expected) {
+					t.Fatalf("expected output to contain %q, got %q", expected, actual)
+				}
+			}
+			for _, unexpected := range test.unexpected {
+				if strings.Contains(actual, unexpected) {
+					t.Fatalf("expected output to not contain %q, got %q", unexpected, actual)
+				}
+			}
+		})
+	}
+}
+
+func TestFormatLatestVersionText_RejectsInvalidVersionData(t *testing.T) {
+	t.Parallel()
+
+	// Given: an invalid latest-version response.
+	response := latestVersionResponse("")
+
+	// When: the response is rendered as user-facing text.
+	_, err := formatLatestVersionText("1.4.1", response)
+
+	// Then: the invalid response is surfaced as an error.
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "failed to parse latest launcher version") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestVersionCmdQueuesPrimaryOutputForTerminalFlush(t *testing.T) {
+	t.Parallel()
+
+	resetTerminalMessages()
+	defer resetTerminalMessages()
+
+	// Given: the version command emits primary output through the terminal queue.
+	addTerminalOutput("1.4.1")
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	// When: queued terminal messages are flushed.
+	writeTerminalMessages(&stdout, &stderr)
+
+	// Then: primary command output goes to stdout and notices do not pollute it.
+	if stdout.String() != "1.4.1\n" {
+		t.Fatalf("unexpected stdout: %q", stdout.String())
+	}
+	if stderr.String() != "" {
+		t.Fatalf("unexpected stderr: %q", stderr.String())
+	}
+}
+
+func latestVersionResponse(version string) *deploy.VersionCheckResponse {
+	return &deploy.VersionCheckResponse{
+		LatestVersion: deploy.LatestVersionInfo{
+			Version:         version,
+			Filename:        "exasol",
+			URL:             "https://example.com/exasol",
+			Size:            42,
+			SHA256:          "abc123",
+			OperatingSystem: "Linux",
+			Architecture:    "x86_64",
+		},
+	}
+}

--- a/doc/version_checking.md
+++ b/doc/version_checking.md
@@ -54,6 +54,20 @@ The launcher sends the following query parameters:
 
 The response contains a `latestVersion` object with metadata for the newest available release on that platform (version, download URL, checksums, and platform).
 
+### Version ordering policy
+
+The launcher interprets version strings as semantic versions when deciding whether a reported release is an update. An update is available only when the reported `latestVersion.version` has greater semantic version precedence than the current launcher version.
+
+Prerelease identifiers are part of the comparison. For example, `2.0.0` is newer than `2.0.0-rc1`, and `2.0.0-rc1` is newer than `1.4.1`. An older official release such as `1.4.1` is not reported as an update for a newer release candidate such as `2.0.0-rc1`.
+
+If either the current launcher version or the reported version cannot be parsed as a semantic version, the automatic update hint treats the check as a best-effort failure and does not show an update message.
+
+### Output stream policy
+
+Explicit `exasol version` output is primary command output and is written to stdout through the shared terminal-output flush path, including `exasol version --json`, `exasol version --latest`, and `exasol version --latest --json`. JSON output is structured and is never mixed with human-readable update text.
+
+Implicit update hints that can appear while running other commands are metadata, not primary command output. They are emitted as terminal notices on stderr after the command finishes so stdout remains reserved for data that automation might parse.
+
 ## Database version check (daily DB update awareness)
 
 Some Exasol database releases include an internal, non-disruptive **daily version check** (performed by the database/cluster services).

--- a/internal/deploy/version_check.go
+++ b/internal/deploy/version_check.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/exasol/exasol-personal/internal/config"
 )
 
@@ -117,6 +118,28 @@ type SilentVersionCheckResult struct {
 	Checked         bool
 	UpdateAvailable bool
 	LatestVersion   string
+}
+
+// IsVersionUpdateAvailable reports whether latestVersion is newer than currentVersion.
+func IsVersionUpdateAvailable(currentVersion, latestVersion string) (bool, error) {
+	current, err := semver.Parse(currentVersion)
+	if err != nil {
+		return false, fmt.Errorf(
+			"failed to parse current launcher version %q: %w",
+			currentVersion,
+			err,
+		)
+	}
+	latest, err := semver.Parse(latestVersion)
+	if err != nil {
+		return false, fmt.Errorf(
+			"failed to parse latest launcher version %q: %w",
+			latestVersion,
+			err,
+		)
+	}
+
+	return latest.GT(current), nil
 }
 
 func parseVersionCheckResponse(body io.Reader) (*VersionCheckResponse, error) {
@@ -229,11 +252,12 @@ func CheckLatestVersionUpdate(
 		return false, "", err
 	}
 	latest := response.LatestVersion.Version
-	if latest == "" || latest == currentVersion {
-		return false, latest, nil
+	available, err := IsVersionUpdateAvailable(currentVersion, latest)
+	if err != nil {
+		return false, latest, err
 	}
 
-	return true, latest, nil
+	return available, latest, nil
 }
 
 // PerformSilentVersionCheck runs a guarded version check and updates state.

--- a/internal/deploy/version_check_test.go
+++ b/internal/deploy/version_check_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsVersionUpdateAvailable_UsesSemanticVersionOrdering(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name           string
+		currentVersion string
+		latestVersion  string
+		expected       bool
+	}{
+		{
+			name:           "older official release is not newer than newer release candidate",
+			currentVersion: "2.0.0-rc1",
+			latestVersion:  "1.4.1",
+			expected:       false,
+		},
+		{
+			name:           "equal versions are not updates",
+			currentVersion: "1.4.1",
+			latestVersion:  "1.4.1",
+			expected:       false,
+		},
+		{
+			name:           "newer patch version is an update",
+			currentVersion: "1.4.0",
+			latestVersion:  "1.4.1",
+			expected:       true,
+		},
+		{
+			name:           "final release is newer than its release candidate",
+			currentVersion: "2.0.0-rc1",
+			latestVersion:  "2.0.0",
+			expected:       true,
+		},
+		{
+			name:           "release candidate is newer than older final release",
+			currentVersion: "1.4.1",
+			latestVersion:  "2.0.0-rc1",
+			expected:       true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Given: current and latest launcher versions.
+			// When: update availability is evaluated.
+			actual, err := IsVersionUpdateAvailable(test.currentVersion, test.latestVersion)
+			// Then: semantic version precedence decides whether an update is available.
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if actual != test.expected {
+				t.Fatalf("expected update availability %t, got %t", test.expected, actual)
+			}
+		})
+	}
+}
+
+func TestIsVersionUpdateAvailable_RejectsInvalidVersionData(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name           string
+		currentVersion string
+		latestVersion  string
+		expectedError  string
+	}{
+		{
+			name:           "invalid current version",
+			currentVersion: "not-a-version",
+			latestVersion:  "1.4.1",
+			expectedError:  "failed to parse current launcher version",
+		},
+		{
+			name:           "missing latest version",
+			currentVersion: "1.4.1",
+			latestVersion:  "",
+			expectedError:  "failed to parse latest launcher version",
+		},
+		{
+			name:           "invalid latest version",
+			currentVersion: "1.4.1",
+			latestVersion:  "latest",
+			expectedError:  "failed to parse latest launcher version",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Given: invalid version input.
+			// When: update availability is evaluated.
+			updateAvailable, err := IsVersionUpdateAvailable(
+				test.currentVersion,
+				test.latestVersion,
+			)
+
+			// Then: no update is reported and the parse problem is surfaced.
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if updateAvailable {
+				t.Fatal("expected invalid version data to not report an update")
+			}
+			if !strings.Contains(err.Error(), test.expectedError) {
+				t.Fatalf("expected error to contain %q, got %q", test.expectedError, err)
+			}
+		})
+	}
+}

--- a/openspec/changes/archive/2026-06-24-fix-version-update-checks/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-24-fix-version-update-checks/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-23

--- a/openspec/changes/archive/2026-06-24-fix-version-update-checks/design.md
+++ b/openspec/changes/archive/2026-06-24-fix-version-update-checks/design.md
@@ -1,0 +1,53 @@
+## Context
+
+Launcher update checks currently compare the reported latest version to the current launcher version by string equality. Any different non-empty version is treated as an update, so a prerelease launcher such as `2.0.0-rc1` can be told that an older official release such as `1.4.1` is available.
+
+The repository already uses `github.com/blang/semver/v4`, so the fix can use the existing semantic-version parser without introducing a new dependency.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Use semantic version precedence for launcher update availability.
+- Preserve the best-effort, non-blocking behavior of automatic update hints.
+- Make `exasol version --latest` accurate when the reported latest version is newer, equal, or older than the current launcher version.
+- Document the prerelease comparison policy.
+
+**Non-Goals:**
+- Change the version-check service API.
+- Change release publishing.
+- Automatically install launcher updates.
+- Change deployment directory compatibility checks.
+
+## Decisions
+
+- Treat an update as available only when `latestVersion.version` has greater semantic precedence than the current launcher version.
+  - Rationale: this directly models "newer" and prevents false positives from older official releases.
+  - Alternative considered: compare only major/minor/patch and ignore prerelease metadata. That would make `2.0.0` and `2.0.0-rc1` appear equal, hiding a real final-release update from prerelease users.
+
+- Use SemVer prerelease precedence as implemented by the existing semver library.
+  - Rationale: release candidates are valid SemVer prereleases and should sort before their final release but after older release lines.
+  - Alternative considered: special-case `rc` strings. That is narrower and less reliable than the established SemVer rules.
+
+- Keep invalid or missing version data as a check failure rather than an available update.
+  - Rationale: silent checks must not show misleading update hints. Explicit `version --latest` calls can surface the error to the user.
+
+- Route version-check output according to whether it is primary command output or metadata.
+  - Rationale: stdout must remain parseable for commands that produce data, especially JSON. Implicit update hints are metadata and belong on stderr, while explicit `exasol version` output is the requested command output and belongs on stdout.
+  - Alternative considered: send all human-readable update information to stderr. That would make `exasol version --latest` surprising because its directly requested report would not be emitted on the primary output stream.
+
+- Use the terminal-message queue for explicit version command output instead of direct stdout writes.
+  - Rationale: this keeps output routing centralized and consistent with the existing terminal notice/output infrastructure.
+  - Alternative considered: write explicit version output directly to stdout. That works functionally, but bypasses the project's established command-output flush path.
+
+- Render human-readable latest-version output with an embedded text template.
+  - Rationale: the multi-line report is easier to read and maintain as a template than as manual string concatenation.
+  - Alternative considered: build the report with a string builder. That avoids direct stream writes, but makes the output structure harder to review.
+
+## Risks / Trade-offs
+
+- Invalid service responses may suppress automatic hints until the next scheduled check.
+  - Mitigation: the check remains best-effort, logs debug details, and explicit `exasol version --latest` can report the parsing problem.
+- Users running prerelease launchers may see that the latest official release is older than their current version.
+  - Mitigation: the explicit command should say the reported latest official version is not newer instead of calling it an update.
+- Mixed stdout/stderr behavior can be surprising if the policy is not documented.
+  - Mitigation: document that explicit version commands write primary output to stdout, while implicit hints use stderr.

--- a/openspec/changes/archive/2026-06-24-fix-version-update-checks/proposal.md
+++ b/openspec/changes/archive/2026-06-24-fix-version-update-checks/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The launcher can currently report an older official release as an available update when the current launcher is a newer release candidate. This creates false update guidance for prerelease users and undermines the update-check message.
+
+## What Changes
+
+- Compare launcher versions using semantic version precedence instead of string equality.
+- Treat prerelease versions intentionally when deciding whether a reported official release is an update.
+- Keep the update check best-effort and non-blocking.
+- Document the launcher version-check policy so release candidates, final releases, and older versions are handled consistently.
+- Add tests for older official releases versus release candidates, equal versions, newer versions, and prerelease-versus-final cases.
+
+## Capabilities
+
+### New Capabilities
+- `launcher-version-check`: Covers launcher update-check behavior, including semantic version ordering, prerelease handling, and user-facing update messages.
+
+### Modified Capabilities
+
+## Impact
+
+- Affects launcher update-check code in the Go CLI and deploy support packages.
+- Affects user-facing `exasol version --latest` output and automatic update hints.
+- Adds unit tests for version comparison behavior.
+- Updates version-check documentation.

--- a/openspec/changes/archive/2026-06-24-fix-version-update-checks/specs/launcher-version-check/spec.md
+++ b/openspec/changes/archive/2026-06-24-fix-version-update-checks/specs/launcher-version-check/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: Automatic Launcher Update Hint Uses Semantic Ordering
+The launcher SHALL show an automatic update hint only when the version-check service reports a launcher version with greater semantic version precedence than the current launcher version.
+
+#### Scenario: Older official release is not an update for newer release candidate
+- **WHEN** the current launcher version is `2.0.0-rc1`
+- **AND** the version-check service reports `1.4.1`
+- **THEN** the launcher does not show an automatic update hint
+
+#### Scenario: Newer patch release is an update
+- **WHEN** the current launcher version is `1.4.0`
+- **AND** the version-check service reports `1.4.1`
+- **THEN** the launcher shows an automatic update hint for `1.4.1`
+
+#### Scenario: Equal versions are not an update
+- **WHEN** the current launcher version is `1.4.1`
+- **AND** the version-check service reports `1.4.1`
+- **THEN** the launcher does not show an automatic update hint
+
+### Requirement: Prerelease Versions Follow SemVer Precedence
+The launcher SHALL compare prerelease versions according to semantic version precedence.
+
+#### Scenario: Final release is newer than its release candidate
+- **WHEN** the current launcher version is `2.0.0-rc1`
+- **AND** the version-check service reports `2.0.0`
+- **THEN** the launcher treats `2.0.0` as an available update
+
+#### Scenario: Release candidate is newer than older final release
+- **WHEN** the current launcher version is `1.4.1`
+- **AND** the version-check service reports `2.0.0-rc1`
+- **THEN** the launcher treats `2.0.0-rc1` as an available update
+
+### Requirement: Explicit Latest Version Output Is Accurate
+The `exasol version --latest` command SHALL distinguish newer, equal, and older reported versions in its user-facing text.
+
+#### Scenario: Reported version is newer
+- **WHEN** the current launcher version is `1.4.0`
+- **AND** the version-check service reports `1.4.1`
+- **THEN** the command says a newer version is available
+
+#### Scenario: Reported version is equal
+- **WHEN** the current launcher version is `1.4.1`
+- **AND** the version-check service reports `1.4.1`
+- **THEN** the command says the user is using the latest version
+
+#### Scenario: Reported version is older
+- **WHEN** the current launcher version is `2.0.0-rc1`
+- **AND** the version-check service reports `1.4.1`
+- **THEN** the command says the reported latest official version is not newer than the current launcher version
+
+### Requirement: Invalid Version Data Does Not Produce Update Hints
+The launcher SHALL NOT produce an automatic update hint when either the current launcher version or the reported latest version cannot be parsed as a semantic version.
+
+#### Scenario: Reported version is invalid
+- **WHEN** the version-check service reports an invalid version string
+- **THEN** the launcher does not show an automatic update hint
+- **AND** the check is handled as a best-effort failure
+
+### Requirement: Version Check Output Streams Preserve Primary Command Output
+The launcher SHALL write explicit version command output to stdout and implicit update metadata to stderr.
+
+#### Scenario: Explicit current-version JSON report is primary output
+- **WHEN** the user runs `exasol version --json`
+- **THEN** the current launcher version is written as JSON to stdout
+- **AND** the response is routed through the terminal output queue
+
+#### Scenario: Explicit text latest-version report is primary output
+- **WHEN** the user runs `exasol version --latest`
+- **THEN** the human-readable latest-version report is written to stdout
+- **AND** the report is routed through the terminal output queue
+
+#### Scenario: Explicit JSON latest-version report is primary output
+- **WHEN** the user runs `exasol version --latest --json`
+- **THEN** the JSON latest-version response is written to stdout
+- **AND** the response is routed through the terminal output queue
+- **AND** the JSON response is not mixed with human-readable update text
+
+#### Scenario: Implicit update hint is metadata
+- **WHEN** a command other than `exasol version` discovers an available launcher update through the automatic update check
+- **THEN** the update hint is written as a terminal notice on stderr
+- **AND** the command's stdout remains reserved for primary command output

--- a/openspec/changes/archive/2026-06-24-fix-version-update-checks/tasks.md
+++ b/openspec/changes/archive/2026-06-24-fix-version-update-checks/tasks.md
@@ -1,0 +1,30 @@
+## 1. Version Comparison
+
+- [x] 1.1 Add a semantic version comparison helper for launcher update checks.
+- [x] 1.2 Make automatic update checks report updates only when the reported latest version is semantically newer.
+- [x] 1.3 Ensure invalid or missing version data does not produce automatic update hints.
+
+## 2. User-Facing Output
+
+- [x] 2.1 Update `exasol version --latest` text output for newer, equal, and older reported versions.
+- [x] 2.2 Preserve existing JSON output shape for `exasol version --latest --json`.
+
+## 3. Documentation
+
+- [x] 3.1 Document the launcher version-check semantic ordering policy.
+- [x] 3.2 Document prerelease handling for release candidates and final releases.
+
+## 4. Tests and Validation
+
+- [x] 4.1 Add Go unit tests for `2.0.0-rc1` versus `1.4.1`, equal versions, newer patch versions, and prerelease-versus-final cases.
+- [x] 4.2 Add Go unit tests for user-facing latest-version text.
+- [x] 4.3 Run focused unit tests for the changed packages.
+- [x] 4.4 Run repository-required formatting and validation commands.
+
+## 5. Output Stream Policy
+
+- [x] 5.1 Document that explicit version command output goes to stdout.
+- [x] 5.2 Document that implicit update hints are metadata and go to stderr.
+- [x] 5.3 Route explicit version command output through the terminal output queue.
+- [x] 5.4 Render human-readable latest-version output with an embedded template.
+- [x] 5.5 Make `exasol version --json` emit structured JSON.

--- a/openspec/specs/launcher-version-check/spec.md
+++ b/openspec/specs/launcher-version-check/spec.md
@@ -1,0 +1,86 @@
+# launcher-version-check Specification
+
+## Purpose
+Defines launcher update-check behavior, including semantic version ordering, prerelease handling, explicit version command output, and implicit update hint stream routing.
+
+## Requirements
+### Requirement: Automatic Launcher Update Hint Uses Semantic Ordering
+The launcher SHALL show an automatic update hint only when the version-check service reports a launcher version with greater semantic version precedence than the current launcher version.
+
+#### Scenario: Older official release is not an update for newer release candidate
+- **WHEN** the current launcher version is `2.0.0-rc1`
+- **AND** the version-check service reports `1.4.1`
+- **THEN** the launcher does not show an automatic update hint
+
+#### Scenario: Newer patch release is an update
+- **WHEN** the current launcher version is `1.4.0`
+- **AND** the version-check service reports `1.4.1`
+- **THEN** the launcher shows an automatic update hint for `1.4.1`
+
+#### Scenario: Equal versions are not an update
+- **WHEN** the current launcher version is `1.4.1`
+- **AND** the version-check service reports `1.4.1`
+- **THEN** the launcher does not show an automatic update hint
+
+### Requirement: Prerelease Versions Follow SemVer Precedence
+The launcher SHALL compare prerelease versions according to semantic version precedence.
+
+#### Scenario: Final release is newer than its release candidate
+- **WHEN** the current launcher version is `2.0.0-rc1`
+- **AND** the version-check service reports `2.0.0`
+- **THEN** the launcher treats `2.0.0` as an available update
+
+#### Scenario: Release candidate is newer than older final release
+- **WHEN** the current launcher version is `1.4.1`
+- **AND** the version-check service reports `2.0.0-rc1`
+- **THEN** the launcher treats `2.0.0-rc1` as an available update
+
+### Requirement: Explicit Latest Version Output Is Accurate
+The `exasol version --latest` command SHALL distinguish newer, equal, and older reported versions in its user-facing text.
+
+#### Scenario: Reported version is newer
+- **WHEN** the current launcher version is `1.4.0`
+- **AND** the version-check service reports `1.4.1`
+- **THEN** the command says a newer version is available
+
+#### Scenario: Reported version is equal
+- **WHEN** the current launcher version is `1.4.1`
+- **AND** the version-check service reports `1.4.1`
+- **THEN** the command says the user is using the latest version
+
+#### Scenario: Reported version is older
+- **WHEN** the current launcher version is `2.0.0-rc1`
+- **AND** the version-check service reports `1.4.1`
+- **THEN** the command says the reported latest official version is not newer than the current launcher version
+
+### Requirement: Invalid Version Data Does Not Produce Update Hints
+The launcher SHALL NOT produce an automatic update hint when either the current launcher version or the reported latest version cannot be parsed as a semantic version.
+
+#### Scenario: Reported version is invalid
+- **WHEN** the version-check service reports an invalid version string
+- **THEN** the launcher does not show an automatic update hint
+- **AND** the check is handled as a best-effort failure
+
+### Requirement: Version Check Output Streams Preserve Primary Command Output
+The launcher SHALL write explicit version command output to stdout and implicit update metadata to stderr.
+
+#### Scenario: Explicit current-version JSON report is primary output
+- **WHEN** the user runs `exasol version --json`
+- **THEN** the current launcher version is written as JSON to stdout
+- **AND** the response is routed through the terminal output queue
+
+#### Scenario: Explicit text latest-version report is primary output
+- **WHEN** the user runs `exasol version --latest`
+- **THEN** the human-readable latest-version report is written to stdout
+- **AND** the report is routed through the terminal output queue
+
+#### Scenario: Explicit JSON latest-version report is primary output
+- **WHEN** the user runs `exasol version --latest --json`
+- **THEN** the JSON latest-version response is written to stdout
+- **AND** the response is routed through the terminal output queue
+- **AND** the JSON response is not mixed with human-readable update text
+
+#### Scenario: Implicit update hint is metadata
+- **WHEN** a command other than `exasol version` discovers an available launcher update through the automatic update check
+- **THEN** the update hint is written as a terminal notice on stderr
+- **AND** the command's stdout remains reserved for primary command output

--- a/tests/tests/integration/test_cli.py
+++ b/tests/tests/integration/test_cli.py
@@ -46,6 +46,23 @@ def test_version(exasol_path: str) -> None:
     assert version_command_output == tag_expected_str
 
 
+def test_version_json(exasol_path: str) -> None:
+    # Given the current version of the program based on the the latest git version tag
+    git_describe_command_result = run_command(
+        ["git", "describe", "--tags", "--abbrev=0"],
+    )
+    git_tag_version_str = git_describe_command_result.stdout.strip()
+
+    # When I run the version command with JSON output
+    version_command_result = run_command(
+        [exasol_path, "version", "--json"],
+    )
+    version_command_output = json.loads(version_command_result.stdout)
+
+    # Then the version is returned as structured JSON
+    assert version_command_output == {"version": git_tag_version_str[1:]}
+
+
 def test_info_command_exists(exasol_path: str) -> None:
     """Verify info command is available."""
     result = run_command([exasol_path, "info", "--help"])


### PR DESCRIPTION
## Description

Fix launcher version update checks to compare versions by semantic precedence. This prevents a prerelease launcher such as `2.0.0-rc1` from being told that an older stable release such as `1.4.1` is a newer available version.

The command layer now owns terminal and JSON output formatting for `exasol version`, while the internal version-check package returns version-check data and comparison results only.

## Related Issue

Fixes https://exasol.atlassian.net/browse/SPOT-31136

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [x] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Added SemVer-based launcher update comparison, including prerelease handling.
- Routed explicit `exasol version` output through the shared terminal-output path and added JSON output for `exasol version --json`.
- Added focused Go and integration tests, documented the version-check stream policy, and archived the OpenSpec change.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

- `task all`

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

OpenSpec change `fix-version-update-checks` was archived and the permanent launcher version-check spec was synced.
