### PR TITLE
chore: update to mac-runner-aarch64 v1.0.0-rc4

### DIFF
--- a/assets/resources/resources.yaml
+++ b/assets/resources/resources.yaml
@@ -25,6 +25,6 @@ exasol-local-runner:
   extract: true
   artifact:
     darwin/arm64:
-      url: https://github.com/exasol/exasol-local-vm/releases/download/v1.0.0-rc3/mac-runner-aarch64.zip
-      sha256: ac18f3762fe662c4f42ada6810c173c6cfb9cac2e4907c8634c670a19e03a2de
+      url: https://github.com/exasol/exasol-local-vm/releases/download/v1.0.0-rc4/mac-runner-aarch64.zip
+      sha256: 07fda8c0dd5fb4aac8a8a10d44573b29625dc7954c442229a21f011e441095a6
       resource_path: launcher


### PR DESCRIPTION
Just updating to user the latest local vm runner release candidate (rc4)