### PR TITLE
feat: CSV output support

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,10 @@ To run SQL without entering the interactive shell, pass it directly. Both flags 
 exasol connect -c "SELECT 1; SELECT 2"   # run inline statement(s)
 exasol connect -f script.sql             # run statements from a file
 ```
-`--command` and `--file` are mutually exclusive. In this non-interactive mode, execution stops at the first failing statement and `connect` exits with a non-zero status so scripts can detect errors. Combine with `--json` for machine-readable output.
+`--command` and `--file` are mutually exclusive. In this non-interactive mode, execution stops at the first failing statement and `connect` exits with a non-zero status so scripts can detect errors. Combine with `--json` for machine-readable output, or use `--csv` for CSV output:
+```bash
+exasol connect --csv -c "SELECT * FROM PRODUCTS" > products.csv
+```
 
 In an interactive session, query output is capped at 100 rows by default so a large `SELECT` doesn't flood the terminal; a note is printed when output is truncated. Piped or `--command`/`--file` (non-interactive) execution returns the full result set. Use `--max-rows N` to set the cap explicitly, or `--max-rows 0` for unlimited:
 ```bash

--- a/cmd/exasol/connect.go
+++ b/cmd/exasol/connect.go
@@ -27,6 +27,7 @@ const connectCmdExample = `  exasol connect
 
 var connectOpts = connect.Opts{
 	ExecuteOnSemicolon: true,
+	OutputFormat:       connect.OutputFormatTable,
 	JSONFormat:         connect.JSONFormatPretty,
 	MaxRows:            connect.MaxRowsUnset,
 }
@@ -43,10 +44,21 @@ var connectCmd = &cobra.Command{
 			return errors.New("--command and --file are mutually exclusive")
 		}
 
-		connectOpts.OutputJSON = cmd.Flags().Changed("json")
+		connectOpts.OutputFormat = selectedConnectOutputFormat(cmd)
 
 		return deploy.Connect(cmd.Context(), &connectOpts, commonFlags.Deployment())
 	},
+}
+
+func selectedConnectOutputFormat(cmd *cobra.Command) connect.OutputFormat {
+	if cmd.Flags().Changed("csv") {
+		return connect.OutputFormatCSV
+	}
+	if cmd.Flags().Changed("json") {
+		return connect.OutputFormatJSON
+	}
+
+	return connect.OutputFormatTable
 }
 
 func registerConnectFlags() {
@@ -84,8 +96,7 @@ func registerConnectFlags() {
 		"Output in JSON format: pretty, compact",
 	)
 
-	connectCmd.Flags().BoolVar(
-		&connectOpts.OutputCSV,
+	connectCmd.Flags().Bool(
 		"csv", false,
 		"Output in CSV format",
 	)

--- a/cmd/exasol/connect.go
+++ b/cmd/exasol/connect.go
@@ -20,6 +20,7 @@ Establish an SQL connection to the database instance in an active deployment.
 
 const connectCmdExample = `  exasol connect
   exasol connect --json
+  exasol connect --csv -c "SELECT * FROM products" > products.csv
   exasol connect -c "SELECT 1; SELECT 2"
   exasol connect -f script.sql
 	printf 'SELECT 1;\n' | exasol connect --json=compact`
@@ -83,6 +84,12 @@ func registerConnectFlags() {
 		"Output in JSON format: pretty, compact",
 	)
 
+	connectCmd.Flags().BoolVar(
+		&connectOpts.OutputCSV,
+		"csv", false,
+		"Output in CSV format",
+	)
+
 	connectCmd.Flags().StringVarP(
 		&connectOpts.Command,
 		"command", "c", "",
@@ -96,6 +103,7 @@ func registerConnectFlags() {
 	)
 
 	connectCmd.MarkFlagsMutuallyExclusive("command", "file")
+	connectCmd.MarkFlagsMutuallyExclusive("json", "csv")
 
 	connectCmd.Flags().IntVar(
 		&connectOpts.MaxRows,

--- a/cmd/exasol/connect_test.go
+++ b/cmd/exasol/connect_test.go
@@ -119,6 +119,15 @@ func TestConnectCmdExamplesMentionJSONOptions(t *testing.T) {
 	}
 }
 
+func TestConnectCmdExamplesMentionCSVOption(t *testing.T) {
+	t.Parallel()
+
+	expected := `exasol connect --csv -c "SELECT * FROM products" > products.csv`
+	if !strings.Contains(connectCmdExample, expected) {
+		t.Fatalf("expected examples to contain %q", expected)
+	}
+}
+
 func TestConnectCmdExamplesMentionCommandAndFile(t *testing.T) {
 	t.Parallel()
 
@@ -146,6 +155,18 @@ func TestConnectRegistersCommandAndFileFlags(t *testing.T) {
 		if flag == nil || flag.Name != test.name {
 			t.Fatalf("expected -%s to be registered as --%s", test.shorthand, test.name)
 		}
+	}
+}
+
+func TestConnectRegistersCSVFlag(t *testing.T) {
+	t.Parallel()
+
+	flag := connectCmd.Flags().Lookup("csv")
+	if flag == nil {
+		t.Fatal("expected --csv flag to be registered")
+	}
+	if flag.DefValue != "false" {
+		t.Fatalf("expected --csv default false, got %q", flag.DefValue)
 	}
 }
 
@@ -178,6 +199,41 @@ func TestConnectCommandAndFileAreMutuallyExclusive(t *testing.T) {
 	}
 }
 
+// nolint: paralleltest // Builds and executes an isolated command instance.
+func TestConnectJSONAndCSVAreMutuallyExclusive(t *testing.T) {
+	var jsonFormat connect.JSONFormat
+	var csvOutput bool
+
+	cmd := &cobra.Command{
+		Use:           "connect",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(*cobra.Command, []string) error {
+			return nil
+		},
+	}
+	JSONFormatVarP(
+		cmd.Flags(),
+		&jsonFormat,
+		"json",
+		"j",
+		connect.JSONFormatPretty,
+		"",
+	)
+	cmd.Flags().BoolVar(&csvOutput, "csv", false, "")
+	cmd.MarkFlagsMutuallyExclusive("json", "csv")
+
+	cmd.SetArgs([]string{"--json", "--csv"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected an error when both --json and --csv are supplied")
+	}
+	if !strings.Contains(err.Error(), "json") || !strings.Contains(err.Error(), "csv") {
+		t.Fatalf("expected mutual-exclusivity error mentioning both flags, got: %v", err)
+	}
+}
+
 // nolint: paralleltest // Mutates the shared command usage template for inspection.
 func TestConnectUsageShowsJSONFormatUnderFlags(t *testing.T) {
 	originalTemplate := connectCmd.UsageTemplate()
@@ -197,6 +253,12 @@ func TestConnectUsageShowsJSONFormatUnderFlags(t *testing.T) {
 	}
 	if !strings.Contains(usage, "Output in JSON format: pretty, compact") {
 		t.Fatalf("expected usage to describe --json, got:\n%s", usage)
+	}
+	if !strings.Contains(usage, "--csv") {
+		t.Fatalf("expected usage to list --csv under flags, got:\n%s", usage)
+	}
+	if !strings.Contains(usage, "Output in CSV format") {
+		t.Fatalf("expected usage to describe --csv, got:\n%s", usage)
 	}
 	if !strings.Contains(usage, "Examples:") {
 		t.Fatalf("expected usage to include examples, got:\n%s", usage)

--- a/cmd/exasol/connect_test.go
+++ b/cmd/exasol/connect_test.go
@@ -179,7 +179,11 @@ func TestSelectedConnectOutputFormat(t *testing.T) {
 		expected connect.OutputFormat
 	}{
 		{name: "defaults to table", expected: connect.OutputFormatTable},
-		{name: "json flag selects json", args: []string{"--json"}, expected: connect.OutputFormatJSON},
+		{
+			name:     "json flag selects json",
+			args:     []string{"--json"},
+			expected: connect.OutputFormatJSON,
+		},
 		{name: "csv flag selects csv", args: []string{"--csv"}, expected: connect.OutputFormatCSV},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/cmd/exasol/connect_test.go
+++ b/cmd/exasol/connect_test.go
@@ -170,6 +170,44 @@ func TestConnectRegistersCSVFlag(t *testing.T) {
 	}
 }
 
+func TestSelectedConnectOutputFormat(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name     string
+		args     []string
+		expected connect.OutputFormat
+	}{
+		{name: "defaults to table", expected: connect.OutputFormatTable},
+		{name: "json flag selects json", args: []string{"--json"}, expected: connect.OutputFormatJSON},
+		{name: "csv flag selects csv", args: []string{"--csv"}, expected: connect.OutputFormatCSV},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var jsonFormat connect.JSONFormat
+			cmd := &cobra.Command{Use: "connect"}
+			JSONFormatVarP(
+				cmd.Flags(),
+				&jsonFormat,
+				"json",
+				"j",
+				connect.JSONFormatPretty,
+				"",
+			)
+			cmd.Flags().Bool("csv", false, "")
+
+			if err := cmd.Flags().Parse(test.args); err != nil {
+				t.Fatalf("unexpected parse error: %v", err)
+			}
+
+			if format := selectedConnectOutputFormat(cmd); format != test.expected {
+				t.Fatalf("unexpected format: got %q expected %q", format, test.expected)
+			}
+		})
+	}
+}
+
 // nolint: paralleltest // Builds and executes an isolated command instance.
 func TestConnectCommandAndFileAreMutuallyExclusive(t *testing.T) {
 	// Mirror the registration in registerConnectFlags so we exercise the

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -5,6 +5,7 @@ package connect
 
 import (
 	"context"
+	"encoding/csv"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -55,6 +56,7 @@ type Opts struct {
 	InsecureSkipCertValidation bool
 	ExecuteOnSemicolon         bool
 	OutputJSON                 bool
+	OutputCSV                  bool
 	JSONFormat                 JSONFormat
 	// Command holds inline SQL passed via --command. When set, the statements
 	// are executed non-interactively and the shell is not started.
@@ -173,7 +175,9 @@ func Connect(
 
 	output := os.Stdout
 	printer := printResultTable
-	if opts.OutputJSON {
+	if opts.OutputCSV {
+		printer = printResultCSV
+	} else if opts.OutputJSON {
 		printer = newJSONResultPrinter(opts.JSONFormat)
 	}
 
@@ -298,6 +302,34 @@ func printResultJSON(
 		Columns: queryResult.ColumnNames(),
 		Rows:    queryResult.Values(),
 	})
+}
+
+func printResultCSV(output io.Writer, queryResult generaltypes.QueryResulter) error {
+	columns := queryResult.ColumnNames()
+	if len(columns) == 0 {
+		return nil
+	}
+
+	writer := csv.NewWriter(output)
+	if err := writer.Write(columns); err != nil {
+		return err
+	}
+
+	for _, row := range queryResult.Values() {
+		record := make([]string, len(row))
+		for i, value := range row {
+			if value != nil {
+				record[i] = fmt.Sprint(value)
+			}
+		}
+		if err := writer.Write(record); err != nil {
+			return err
+		}
+	}
+
+	writer.Flush()
+
+	return writer.Error()
 }
 
 func printResultTable(output io.Writer, queryResult generaltypes.QueryResulter) error {

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -183,10 +183,14 @@ func Connect(
 	output := os.Stdout
 	printer := printResultTable
 	switch opts.OutputFormat {
+	case OutputFormatTable:
+		printer = printResultTable
 	case OutputFormatCSV:
 		printer = printResultCSV
 	case OutputFormatJSON:
 		printer = newJSONResultPrinter(opts.JSONFormat)
+	default:
+		printer = printResultTable
 	}
 
 	// The interactive preview cap applies only when an interactive shell is

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -28,6 +28,14 @@ const (
 	JSONFormatCompact JSONFormat = "compact"
 )
 
+type OutputFormat string
+
+const (
+	OutputFormatTable OutputFormat = "table"
+	OutputFormatJSON  OutputFormat = "json"
+	OutputFormatCSV   OutputFormat = "csv"
+)
+
 func (format JSONFormat) String() string {
 	return string(format)
 }
@@ -55,8 +63,7 @@ type Opts struct {
 	Password                   string
 	InsecureSkipCertValidation bool
 	ExecuteOnSemicolon         bool
-	OutputJSON                 bool
-	OutputCSV                  bool
+	OutputFormat               OutputFormat
 	JSONFormat                 JSONFormat
 	// Command holds inline SQL passed via --command. When set, the statements
 	// are executed non-interactively and the shell is not started.
@@ -175,9 +182,10 @@ func Connect(
 
 	output := os.Stdout
 	printer := printResultTable
-	if opts.OutputCSV {
+	switch opts.OutputFormat {
+	case OutputFormatCSV:
 		printer = printResultCSV
-	} else if opts.OutputJSON {
+	case OutputFormatJSON:
 		printer = newJSONResultPrinter(opts.JSONFormat)
 	}
 

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -181,6 +181,67 @@ func TestPrintResultJSON(t *testing.T) {
 	}
 }
 
+func TestPrintResultCSV(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name     string
+		result   stubQueryResult
+		expected string
+	}{
+		{
+			name: "renders header and rows",
+			result: stubQueryResult{
+				columnNames: []string{"ID", "NAME"},
+				values:      [][]any{{int64(1), "Alice"}, {int64(2), "Bob"}},
+			},
+			expected: "ID,NAME\n1,Alice\n2,Bob\n",
+		},
+		{
+			name: "quotes csv special characters",
+			result: stubQueryResult{
+				columnNames: []string{"ID", "NOTE"},
+				values: [][]any{{
+					int64(1),
+					"Alice, \"A\"\nLine",
+				}},
+			},
+			expected: "ID,NOTE\n1,\"Alice, \"\"A\"\"\nLine\"\n",
+		},
+		{
+			name: "renders null as empty field",
+			result: stubQueryResult{
+				columnNames: []string{"ID", "MISSING", "NAME"},
+				rows:        [][]string{{"1", "<nil>", "Alice"}},
+				values:      [][]any{{int64(1), nil, "Alice"}},
+			},
+			expected: "ID,MISSING,NAME\n1,,Alice\n",
+		},
+		{
+			name: "skips zero-column results",
+			result: stubQueryResult{
+				columnNames: []string{},
+				values:      [][]any{},
+			},
+			expected: "",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+
+			// Given a query result that should be emitted as CSV.
+			// When the result is rendered in CSV mode.
+			err := printResultCSV(&buf, test.result)
+
+			// Then the output follows standard CSV encoding.
+			require.NoError(t, err)
+			require.Equal(t, test.expected, buf.String())
+		})
+	}
+}
+
 func jsonRoundTripValues(t *testing.T, values [][]any) [][]any {
 	t.Helper()
 


### PR DESCRIPTION
## Description

Added CSV output support to `exasol connect` for users who want spreadsheet-friendly or shell-pipeline-friendly query results without parsing table output or converting JSON.

## Related Issue

n/a

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Added `exasol connect --csv`.
- Made `--csv` mutually exclusive with `--json`.
- Reused the existing result execution path and added a minimal CSV renderer.
- CSV output writes column headers, standard CSV-quoted rows, SQL `NULL` as empty fields, and skips zero-column results.
- Documented CSV usage with shell redirection in the README.
- Added focused tests for CSV output, quoting, NULL handling, zero-column results, flag registration, and `--csv`/`--json` exclusivity.

## Testing

<!-- Describe how you tested your changes -->

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

### Test Details

- `task fmt` passed.
- `go test -race ./internal/connect/... ./cmd/exasol/...` passed.
- `git diff --check` passed.

## Checklist

<!-- Mark completed items with an "x" -->

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

<!-- Any additional information, screenshots, or context -->
