### PR TITLE
feat: standardize exasol connect --json into one invocation document

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ exasol connect -f script.sql             # run statements from a file
 ```bash
 exasol connect --csv -c "SELECT * FROM PRODUCTS" > products.csv
 ```
+With `--json`, non-interactive execution writes exactly one JSON document to stdout for the full invocation, including multi-statement runs and SQL errors. Interactive `exasol connect --json` continues to emit one JSON document per executed statement.
 
 In an interactive session, query output is capped at 100 rows by default so a large `SELECT` doesn't flood the terminal; a note is printed when output is truncated. Piped or `--command`/`--file` (non-interactive) execution returns the full result set. Use `--max-rows N` to set the cap explicitly, or `--max-rows 0` for unlimited:
 ```bash

--- a/cmd/exasol/connect.go
+++ b/cmd/exasol/connect.go
@@ -16,6 +16,11 @@ const connectCmdShortDesc = "Open an SQL connection to a running database"
 const connectCmdLongDesc = connectCmdShortDesc + `
 
 Establish an SQL connection to the database instance in an active deployment.
+When run non-interactively with --json, stdout contains one JSON document for
+the full invocation. Statement records include statementType and rowsAffected;
+result-set statements report rowsAffected as 0 when the driver does not expose
+affected-row metadata. Interactive --json sessions continue to print one JSON
+document per executed statement instead of an invocation envelope.
 `
 
 const connectCmdExample = `  exasol connect
@@ -23,7 +28,7 @@ const connectCmdExample = `  exasol connect
   exasol connect --csv -c "SELECT * FROM products" > products.csv
   exasol connect -c "SELECT 1; SELECT 2"
   exasol connect -f script.sql
-	printf 'SELECT 1;\n' | exasol connect --json=compact`
+  printf 'SELECT 1;\n' | exasol connect --json=compact`
 
 var connectOpts = connect.Opts{
 	ExecuteOnSemicolon: true,

--- a/cmd/exasol/connect_test.go
+++ b/cmd/exasol/connect_test.go
@@ -141,6 +141,21 @@ func TestConnectCmdExamplesMentionCommandAndFile(t *testing.T) {
 	}
 }
 
+func TestConnectLongDescriptionMentionsInvocationJSONContract(t *testing.T) {
+	t.Parallel()
+
+	for _, expected := range []string{
+		"one JSON document for",
+		"Statement records include statementType and rowsAffected",
+		"rowsAffected as 0 when the driver does not expose",
+		"Interactive --json sessions continue to print one JSON",
+	} {
+		if !strings.Contains(connectCmdLongDesc, expected) {
+			t.Fatalf("expected long description to contain %q", expected)
+		}
+	}
+}
+
 func TestConnectRegistersCommandAndFileFlags(t *testing.T) {
 	t.Parallel()
 
@@ -162,11 +177,8 @@ func TestConnectRegistersCSVFlag(t *testing.T) {
 	t.Parallel()
 
 	flag := connectCmd.Flags().Lookup("csv")
-	if flag == nil {
-		t.Fatal("expected --csv flag to be registered")
-	}
-	if flag.DefValue != "false" {
-		t.Fatalf("expected --csv default false, got %q", flag.DefValue)
+	if flag == nil || flag.DefValue != "false" {
+		t.Fatal("expected --csv flag to be registered with default false")
 	}
 }
 

--- a/cmd/exasol/main.go
+++ b/cmd/exasol/main.go
@@ -4,19 +4,28 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/exasol/exasol-personal/internal/util"
 )
 
+type cliSilentError interface {
+	SuppressCLIError() bool
+}
+
 func main() {
 	util.StartSignalHandler(func(_ os.Signal) {
 		os.Exit(1)
 	})
 
-	err := Execute()
-	if err != nil {
+	if err := Execute(); err != nil {
+		var silentErr cliSilentError
+		if errors.As(err, &silentErr) && silentErr.SuppressCLIError() {
+			os.Exit(1)
+		}
+
 		_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -6,7 +6,6 @@ package connect
 import (
 	"context"
 	"encoding/csv"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -194,9 +193,9 @@ func Connect(
 	}
 
 	// The interactive preview cap applies only when an interactive shell is
-	// actually started. --command/--file and piped input return everything by
-	// default, so they behave as non-interactive (unlimited) unless --max-rows
-	// is set explicitly.
+	// actually started. --command/--file and non-interactive JSON execution
+	// return everything by default, so they behave as non-interactive
+	// (unlimited) unless --max-rows is set explicitly.
 	interactiveShell := !nonInteractive && util.IsInteractiveStdin()
 
 	modeDefault := 0
@@ -204,6 +203,17 @@ func Connect(
 		modeDefault = interactivePreviewMaxRows
 	}
 	maxRows := effectiveMaxRows(opts.MaxRows, modeDefault)
+
+	if nonInteractive && opts.OutputFormat == OutputFormatJSON {
+		return runJSONStatements(
+			ctx,
+			nonInteractiveSQL,
+			database,
+			output,
+			opts.JSONFormat,
+			maxRows,
+		)
+	}
 
 	processInput := func(input string) error {
 		// The input string is expected to be trimmed of whitespace
@@ -237,15 +247,25 @@ func Connect(
 		}
 	}
 
-	return RunShellWithOpts(processInput, ShellOpts{ExecuteOnSemicolon: opts.ExecuteOnSemicolon})
+	return RunShellWithOpts(processInput, ShellOpts{
+		ExecuteOnSemicolon: opts.ExecuteOnSemicolon,
+	})
 }
 
 // resolveNonInteractiveSQL returns the SQL to run non-interactively, derived
-// from --file or --command. The boolean reports whether a non-interactive
-// source was supplied; when false, the caller falls back to the interactive
-// shell. A --file that cannot be read yields an error before any database
-// connection is attempted.
+// from --file, --command, or piped stdin in JSON mode. The boolean reports
+// whether a non-interactive source was supplied; when false, the caller falls
+// back to the shell path. A --file that cannot be read yields an error before
+// any database connection is attempted.
 func resolveNonInteractiveSQL(opts *Opts) (string, bool, error) {
+	return resolveNonInteractiveSQLFrom(opts, os.Stdin, util.IsInteractiveStdin())
+}
+
+func resolveNonInteractiveSQLFrom(
+	opts *Opts,
+	stdin io.Reader,
+	interactiveStdin bool,
+) (string, bool, error) {
 	switch {
 	case opts.File != "":
 		contents, err := os.ReadFile(opts.File)
@@ -256,6 +276,13 @@ func resolveNonInteractiveSQL(opts *Opts) (string, bool, error) {
 		return string(contents), true, nil
 	case opts.Command != "":
 		return opts.Command, true, nil
+	case !interactiveStdin && opts.OutputFormat == OutputFormatJSON:
+		contents, err := io.ReadAll(stdin)
+		if err != nil {
+			return "", false, fmt.Errorf("reading piped SQL from stdin: %w", err)
+		}
+
+		return string(contents), true, nil
 	default:
 		return "", false, nil
 	}
@@ -304,16 +331,10 @@ func printResultJSON(
 	queryResult generaltypes.QueryResulter,
 	jsonFormat JSONFormat,
 ) error {
-	encoder := json.NewEncoder(output)
-	encoder.SetEscapeHTML(false)
-	if normalizeJSONFormat(jsonFormat) == JSONFormatPretty {
-		encoder.SetIndent("", "  ")
-	}
-
-	return encoder.Encode(jsonQueryResult{
+	return encodeJSONDocument(output, jsonQueryResult{
 		Columns: queryResult.ColumnNames(),
 		Rows:    queryResult.Values(),
-	})
+	}, jsonFormat)
 }
 
 func printResultCSV(output io.Writer, queryResult generaltypes.QueryResulter) error {

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -5,11 +5,14 @@ package connect
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
+	generaltypes "github.com/exasol/exasol-personal/internal/connect/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,10 +52,12 @@ var (
 )
 
 type stubQueryResult struct {
-	columnNames []string
-	rows        [][]string
-	values      [][]any
-	truncated   bool
+	columnNames   []string
+	rows          [][]string
+	values        [][]any
+	statementType generaltypes.StatementType
+	rowsAffected  int64
+	truncated     bool
 }
 
 func (s stubQueryResult) ColumnNames() []string {
@@ -77,6 +82,18 @@ func (s stubQueryResult) Values() [][]any {
 	}
 
 	return values
+}
+
+func (s stubQueryResult) StatementType() generaltypes.StatementType {
+	if s.statementType == "" {
+		return generaltypes.StatementTypeUnknown
+	}
+
+	return s.statementType
+}
+
+func (s stubQueryResult) RowsAffected() int64 {
+	return s.rowsAffected
 }
 
 func (s stubQueryResult) Truncated() bool {
@@ -260,7 +277,11 @@ func TestResolveNonInteractiveSQL(t *testing.T) {
 	t.Run("command supplies SQL", func(t *testing.T) {
 		t.Parallel()
 
-		sql, nonInteractive, err := resolveNonInteractiveSQL(&Opts{Command: "SELECT 1"})
+		sql, nonInteractive, err := resolveNonInteractiveSQLFrom(
+			&Opts{Command: "SELECT 1"},
+			bytes.NewBuffer(nil),
+			true,
+		)
 
 		require.NoError(t, err)
 		require.True(t, nonInteractive)
@@ -273,7 +294,11 @@ func TestResolveNonInteractiveSQL(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "script.sql")
 		require.NoError(t, os.WriteFile(path, []byte("SELECT 1; SELECT 2;"), 0o600))
 
-		sql, nonInteractive, err := resolveNonInteractiveSQL(&Opts{File: path})
+		sql, nonInteractive, err := resolveNonInteractiveSQLFrom(
+			&Opts{File: path},
+			bytes.NewBuffer(nil),
+			true,
+		)
 
 		require.NoError(t, err)
 		require.True(t, nonInteractive)
@@ -285,7 +310,11 @@ func TestResolveNonInteractiveSQL(t *testing.T) {
 
 		path := filepath.Join(t.TempDir(), "does-not-exist.sql")
 
-		sql, nonInteractive, err := resolveNonInteractiveSQL(&Opts{File: path})
+		sql, nonInteractive, err := resolveNonInteractiveSQLFrom(
+			&Opts{File: path},
+			bytes.NewBuffer(nil),
+			true,
+		)
 
 		require.Error(t, err)
 		require.ErrorContains(t, err, "reading SQL file")
@@ -296,7 +325,39 @@ func TestResolveNonInteractiveSQL(t *testing.T) {
 	t.Run("no flag falls back to interactive", func(t *testing.T) {
 		t.Parallel()
 
-		sql, nonInteractive, err := resolveNonInteractiveSQL(&Opts{})
+		sql, nonInteractive, err := resolveNonInteractiveSQLFrom(
+			&Opts{},
+			bytes.NewBuffer(nil),
+			true,
+		)
+
+		require.NoError(t, err)
+		require.False(t, nonInteractive)
+		require.Empty(t, sql)
+	})
+
+	t.Run("piped stdin supplies SQL non-interactively for json output", func(t *testing.T) {
+		t.Parallel()
+
+		sql, nonInteractive, err := resolveNonInteractiveSQLFrom(
+			&Opts{OutputFormat: OutputFormatJSON},
+			bytes.NewBufferString("SELECT 1; SELECT 2;"),
+			false,
+		)
+
+		require.NoError(t, err)
+		require.True(t, nonInteractive)
+		require.Equal(t, "SELECT 1; SELECT 2;", sql)
+	})
+
+	t.Run("piped stdin keeps shell path for non json output", func(t *testing.T) {
+		t.Parallel()
+
+		sql, nonInteractive, err := resolveNonInteractiveSQLFrom(
+			&Opts{OutputFormat: OutputFormatTable},
+			bytes.NewBufferString("SELECT 1; SELECT 2;"),
+			false,
+		)
 
 		require.NoError(t, err)
 		require.False(t, nonInteractive)
@@ -304,37 +365,193 @@ func TestResolveNonInteractiveSQL(t *testing.T) {
 	})
 }
 
-func TestRunStatementsRendersEachResult(t *testing.T) {
-	t.Parallel()
-
-	// The non-interactive runner uses the same printer the interactive shell
-	// does, so each statement's result is rendered identically.
-	var buf bytes.Buffer
-
-	result := stubQueryResult{columnNames: []string{"N"}, rows: [][]string{{"1"}}}
-	printer := newJSONResultPrinter(JSONFormatCompact)
-
-	process := func(input string) error {
-		if input == "" {
-			return nil
-		}
-
-		return printer(&buf, result)
-	}
-
-	err := runStatements("SELECT 1; SELECT 1;", process)
-
-	require.NoError(t, err)
-	require.Equal(t, compactJSONResult2x(result), buf.String())
+type stubDatabase struct {
+	results []stubExecResult
+	queries []string
+	maxRows []int
 }
 
-func compactJSONResult2x(result stubQueryResult) string {
-	var buf bytes.Buffer
-	printer := newJSONResultPrinter(JSONFormatCompact)
-	_ = printer(&buf, result)
-	single := buf.String()
+type stubExecResult struct {
+	result stubQueryResult
+	err    error
+}
 
-	return single + single
+func (*stubDatabase) Connect(context.Context) error { return nil }
+func (*stubDatabase) Close() error                  { return nil }
+
+func (db *stubDatabase) Exec(
+	_ context.Context,
+	query string,
+	maxRows int,
+) (generaltypes.QueryResulter, error) {
+	db.queries = append(db.queries, query)
+	db.maxRows = append(db.maxRows, maxRows)
+
+	if len(db.results) == 0 {
+		return nil, errors.New("unexpected Exec call")
+	}
+
+	next := db.results[0]
+	db.results = db.results[1:]
+
+	if next.err != nil {
+		return nil, next.err
+	}
+
+	return next.result, nil
+}
+
+func TestRunJSONStatements(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single statement renders one invocation envelope", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		database := &stubDatabase{
+			results: []stubExecResult{{
+				result: stubQueryResult{
+					columnNames:   []string{"N"},
+					values:        [][]any{{int64(1)}},
+					statementType: generaltypes.StatementTypeSelect,
+				},
+			}},
+		}
+
+		err := runJSONStatements(t.Context(), "SELECT 1", database, &buf, JSONFormatCompact, 0)
+
+		require.NoError(t, err)
+		require.JSONEq(t, `{
+			"statements": [
+				{
+					"statement": "SELECT 1",
+					"statementType": "SELECT",
+					"rowsAffected": 0,
+					"columns": ["N"],
+					"rows": [[1]],
+					"truncated": false
+				}
+			]
+		}`, buf.String())
+	})
+
+	t.Run("multi statement output includes ddl metadata", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		database := &stubDatabase{
+			results: []stubExecResult{
+				{
+					result: stubQueryResult{
+						columnNames:   []string{},
+						values:        [][]any{},
+						statementType: generaltypes.StatementTypeOpenSchema,
+						rowsAffected:  0,
+					},
+				},
+				{
+					result: stubQueryResult{
+						columnNames:   []string{"N"},
+						values:        [][]any{},
+						statementType: generaltypes.StatementTypeSelect,
+						rowsAffected:  0,
+					},
+				},
+			},
+		}
+
+		err := runJSONStatements(
+			t.Context(),
+			"OPEN SCHEMA foo; SELECT 1 WHERE FALSE",
+			database,
+			&buf,
+			JSONFormatCompact,
+			0,
+		)
+
+		require.NoError(t, err)
+		require.JSONEq(t, `{
+			"statements": [
+				{
+					"statement": "OPEN SCHEMA foo",
+					"statementType": "OPEN_SCHEMA",
+					"rowsAffected": 0,
+					"columns": [],
+					"rows": [],
+					"truncated": false
+				},
+				{
+					"statement": "SELECT 1 WHERE FALSE",
+					"statementType": "SELECT",
+					"rowsAffected": 0,
+					"columns": ["N"],
+					"rows": [],
+					"truncated": false
+				}
+			]
+		}`, buf.String())
+	})
+
+	t.Run("failing statement is rendered as structured json error", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		database := &stubDatabase{
+			results: []stubExecResult{
+				{
+					result: stubQueryResult{
+						columnNames:   []string{"N"},
+						values:        [][]any{{int64(1)}},
+						statementType: generaltypes.StatementTypeSelect,
+					},
+				},
+				{
+					err: errors.New(
+						"E-EGOD-11: execution failed with SQL error code '42636' and message " +
+							"'ETL-6009: syntax error near SELECT at line 3, " +
+							"column 7 session 12345'",
+					),
+				},
+			},
+		}
+
+		err := runJSONStatements(
+			t.Context(),
+			"SELECT 1; INVALID SQL",
+			database,
+			&buf,
+			JSONFormatCompact,
+			0,
+		)
+
+		require.Error(t, err)
+		var silentErr interface{ SuppressCLIError() bool }
+		require.ErrorAs(t, err, &silentErr)
+		require.True(t, silentErr.SuppressCLIError())
+		var decoded jsonExecutionResult
+		require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
+		require.Len(t, decoded.Statements, 2)
+		require.Equal(t, "SELECT 1", decoded.Statements[0].Statement)
+		require.Equal(t, generaltypes.StatementTypeSelect, decoded.Statements[0].StatementType)
+		require.Equal(t, [][]any{{float64(1)}}, decoded.Statements[0].Rows)
+
+		require.Equal(t, "INVALID SQL", decoded.Statements[1].Statement)
+		require.Equal(t, generaltypes.StatementTypeUnknown, decoded.Statements[1].StatementType)
+		require.NotNil(t, decoded.Statements[1].Error)
+		require.Equal(t, "ETL-6009", decoded.Statements[1].Error.ErrorCode)
+		require.Equal(t, "42636", decoded.Statements[1].Error.SQLState)
+		require.Equal(
+			t,
+			"ETL-6009: syntax error near SELECT at line 3, column 7 session 12345",
+			decoded.Statements[1].Error.Message,
+		)
+		require.NotNil(t, decoded.Statements[1].Error.SessionID)
+		require.Equal(t, "12345", *decoded.Statements[1].Error.SessionID)
+		require.NotNil(t, decoded.Statements[1].Error.Position)
+		require.Equal(t, 3, *decoded.Statements[1].Error.Position.Line)
+		require.Equal(t, 7, *decoded.Statements[1].Error.Position.Column)
+		require.Equal(t, []string{"SELECT 1", "INVALID SQL"}, database.queries)
+	})
 }
 
 func TestEffectiveMaxRows(t *testing.T) {

--- a/internal/connect/exasol/database.go
+++ b/internal/connect/exasol/database.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"regexp"
 	"time"
 
 	"github.com/exasol/exasol-driver-go"
@@ -20,7 +19,10 @@ import (
 	"github.com/exasol/exasol-personal/internal/util"
 )
 
-var ErrNoVersion = errors.New("the database didn't return version when queried")
+var (
+	ErrNoVersion   = errors.New("the database didn't return version when queried")
+	ErrNoSessionID = errors.New("the database didn't return session id when queried")
+)
 
 const closePanicMsg = "tried to call Close before Connect on an instance of Exasol database"
 
@@ -28,7 +30,9 @@ type Database struct {
 	connectionString string
 	connect          types.ConnectFunc
 
-	conn types.ExasolConnector
+	conn              types.ExasolConnector
+	sessionID         *string
+	sessionIDResolved bool
 }
 
 type opts struct {
@@ -74,19 +78,6 @@ func New(
 		connectionString: dsnConfigBuilder.String(),
 		connect:          opts.connect,
 	}, nil
-}
-
-const WHITESPACE = `\s+`
-
-var localImportRegex = regexp.MustCompile(
-	`(?ims)^\s*IMPORT[\s(]+.+FROM` + WHITESPACE + `LOCAL` + WHITESPACE + `CSV.*$`,
-)
-
-// IsImportQuery returns true if the passed query is a file import query.
-//
-// Copied from https://github.com/exasol/exasol-driver-go/blob/main/internal/utils/helper.go
-func isImportQuery(query string) bool {
-	return localImportRegex.MatchString(query)
 }
 
 func defaultConnectFunc(input string) (types.ExasolConnector, error) {
@@ -142,31 +133,50 @@ func (db *Database) Exec(
 	maxRows int,
 ) (generaltypes.QueryResulter, error) {
 	slog.Debug("executing query", "query", query, "max_rows", maxRows)
+	statementType := generaltypes.ClassifyStatement(query)
 
-	// File import queries are executed through the driver's Exec because the
-	// driver streams the local file; they never produce a result set.
-	if isImportQuery(query) {
-		_, err := db.conn.Exec(query, nil)
-		return emptyQueryResult(), err
+	// Non-result statements use the driver's Exec path. IMPORT statements also
+	// belong here; LOCAL IMPORT streams a client-side file and never returns a
+	// result set.
+	if statementType.UsesExecPath() {
+		result, err := db.conn.Exec(query, nil)
+		return statementOnlyQueryResult(
+			statementType,
+			rowsAffected(result),
+		), db.wrapExecutionError(ctx, err)
 	}
 
 	// QueryContext returns driver.Rows, which transparently fetches result-set
 	// chunks (large results) and closes the server-side handle on Close.
 	rows, err := db.conn.QueryContext(ctx, query, nil)
 	if err != nil {
-		return nil, err
+		return nil, db.wrapExecutionError(ctx, err)
 	}
 	defer rows.Close()
 
-	return collectRows(rows, maxRows)
+	result, err := collectRows(rows, maxRows, statementType)
+	if err != nil {
+		return nil, db.wrapExecutionError(ctx, err)
+	}
+
+	return result, nil
 }
 
 // collectRows materializes up to maxRows rows from rows (maxRows == 0 means
 // unlimited). When maxRows is reached and at least one further row exists, the
 // result is flagged truncated and no additional rows are fetched.
-func collectRows(rows driver.Rows, maxRows int) (*QueryResult, error) {
+func collectRows(
+	rows driver.Rows,
+	maxRows int,
+	statementType generaltypes.StatementType,
+) (*QueryResult, error) {
 	columns := rows.Columns()
-	result := &QueryResult{columnNames: columns, rows: [][]string{}, values: [][]any{}}
+	result := &QueryResult{
+		columnNames:   columns,
+		rows:          [][]string{},
+		values:        [][]any{},
+		statementType: statementType,
+	}
 
 	dest := make([]driver.Value, len(columns))
 
@@ -197,8 +207,65 @@ func collectRows(rows driver.Rows, maxRows int) (*QueryResult, error) {
 	}
 }
 
-func emptyQueryResult() *QueryResult {
-	return &QueryResult{columnNames: []string{}, rows: [][]string{}, values: [][]any{}}
+func statementOnlyQueryResult(
+	statementType generaltypes.StatementType,
+	rowsAffected int64,
+) *QueryResult {
+	return &QueryResult{
+		columnNames:   []string{},
+		rows:          [][]string{},
+		values:        [][]any{},
+		statementType: statementType,
+		rowsAffected:  rowsAffected,
+	}
+}
+
+func rowsAffected(result driver.Result) int64 {
+	if result == nil {
+		return 0
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return 0
+	}
+
+	return rowsAffected
+}
+
+func (db *Database) wrapExecutionError(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	structured := generaltypes.StructuredSQLErrorFromError(err)
+	if sessionID := db.ensureSessionID(ctx); sessionID != nil {
+		// Prefer the live session identifier from the connection when available.
+		// Message-derived values are only a fallback for errors that already carry one.
+		structured.SessionID = sessionID
+	}
+
+	return executionError{cause: err, structured: structured}
+}
+
+func (db *Database) ensureSessionID(ctx context.Context) *string {
+	if db.sessionID != nil || db.sessionIDResolved {
+		return db.sessionID
+	}
+
+	// Only attempt the lazy lookup once per connection. On failure we keep the
+	// execution error intact instead of issuing extra metadata queries.
+	db.sessionIDResolved = true
+
+	sessionID, err := db.currentSessionID(ctx)
+	if err != nil {
+		slog.Debug("Couldn't get the database session id", "err", err.Error())
+		return nil
+	}
+
+	db.sessionID = sessionID
+
+	return db.sessionID
 }
 
 func jsonValue(value driver.Value) any {
@@ -218,21 +285,59 @@ func jsonValue(value driver.Value) any {
 func (db *Database) version(ctx context.Context) (string, error) {
 	slog.Debug("getting the database version")
 
-	queryResult, err := db.Exec(ctx,
+	version, found, err := db.queryScalar(ctx,
 		"SELECT param_value FROM exa_metadata WHERE param_name = 'databaseProductVersion'",
-		0,
 	)
 	if err != nil {
 		return "", err
 	}
-
-	rows := queryResult.Rows()
-
-	if len(rows) == 0 || len(rows[0]) == 0 {
+	if !found {
 		return "", ErrNoVersion
 	}
 
-	return rows[0][0], nil
+	return version, nil
+}
+
+func (db *Database) currentSessionID(ctx context.Context) (*string, error) {
+	slog.Debug("getting the database session id")
+
+	sessionID, found, err := db.queryScalar(ctx, "SELECT CURRENT_SESSION")
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, ErrNoSessionID
+	}
+
+	return &sessionID, nil
+}
+
+// queryScalar runs query and returns the first cell of the first row as a
+// string. The boolean reports whether a row and non-nil value were present.
+func (db *Database) queryScalar(ctx context.Context, query string) (string, bool, error) {
+	rows, err := db.conn.QueryContext(ctx, query, nil)
+	if err != nil {
+		return "", false, err
+	}
+	if rows == nil {
+		return "", false, nil
+	}
+	defer rows.Close()
+
+	dest := make([]driver.Value, len(rows.Columns()))
+	if err := rows.Next(dest); err != nil {
+		if errors.Is(err, io.EOF) {
+			return "", false, nil
+		}
+
+		return "", false, err
+	}
+
+	if len(dest) == 0 || dest[0] == nil {
+		return "", false, nil
+	}
+
+	return fmt.Sprint(dest[0]), true, nil
 }
 
 func printVersion(output io.Writer, version string) error {

--- a/internal/connect/exasol/database_test.go
+++ b/internal/connect/exasol/database_test.go
@@ -29,6 +29,11 @@ type fakeRows struct {
 	closeCount int
 }
 
+type fakeResult struct {
+	rowsAffected int64
+	rowsErr      error
+}
+
 func (f *fakeRows) Columns() []string { return f.columns }
 
 func (f *fakeRows) Close() error {
@@ -46,6 +51,18 @@ func (f *fakeRows) Next(dest []driver.Value) error {
 	f.pos++
 
 	return nil
+}
+
+func (fakeResult) LastInsertId() (int64, error) {
+	return 0, errors.New("not implemented")
+}
+
+func (f fakeResult) RowsAffected() (int64, error) {
+	if f.rowsErr != nil {
+		return 0, f.rowsErr
+	}
+
+	return f.rowsAffected, nil
 }
 
 func testDatabaseFactory(t *testing.T, connect types.ConnectFunc) generaltypes.Databaser {
@@ -78,10 +95,18 @@ func TestConnect(t *testing.T) {
 		{
 			name: "database successfully connects",
 			given: func(mocks *mocks) {
-				mocks.fakeConnector.QueryContextReturns(&fakeRows{
-					columns: []string{"v"},
-					data:    [][]driver.Value{{"2025.1.0"}},
-				}, nil)
+				mocks.fakeConnector.QueryContextStub = func(
+					_ context.Context, query string, _ []driver.NamedValue,
+				) (driver.Rows, error) {
+					if strings.Contains(query, "exa_metadata") {
+						return &fakeRows{
+							columns: []string{"v"},
+							data:    [][]driver.Value{{"2025.1.0"}},
+						}, nil
+					}
+
+					return nil, errTest
+				}
 			},
 			then: func(t *testing.T, mocks *mocks, err error) {
 				t.Helper()
@@ -92,7 +117,11 @@ func TestConnect(t *testing.T) {
 		{
 			name: "version query fails",
 			given: func(mocks *mocks) {
-				mocks.fakeConnector.QueryContextReturns(nil, errTest)
+				mocks.fakeConnector.QueryContextStub = func(
+					_ context.Context, _ string, _ []driver.NamedValue,
+				) (driver.Rows, error) {
+					return nil, errTest
+				}
 			},
 			then: func(t *testing.T, mocks *mocks, err error) {
 				t.Helper()
@@ -104,7 +133,11 @@ func TestConnect(t *testing.T) {
 		{
 			name: "version query returns empty result",
 			given: func(mocks *mocks) {
-				mocks.fakeConnector.QueryContextReturns(&fakeRows{columns: []string{}}, nil)
+				mocks.fakeConnector.QueryContextStub = func(
+					_ context.Context, _ string, _ []driver.NamedValue,
+				) (driver.Rows, error) {
+					return &fakeRows{columns: []string{}}, nil
+				}
 			},
 			then: func(t *testing.T, mocks *mocks, err error) {
 				t.Helper()
@@ -157,13 +190,14 @@ func TestExec(t *testing.T) {
 	}
 
 	for _, test := range []struct {
-		name      string
-		query     string
-		maxRows   int
-		queryRows driver.Rows
-		queryErr  error
-		execErr   error
-		then      func(*testing.T, *mocks, generaltypes.QueryResulter, error)
+		name       string
+		query      string
+		maxRows    int
+		queryRows  driver.Rows
+		queryErr   error
+		execResult driver.Result
+		execErr    error
+		then       func(*testing.T, *mocks, generaltypes.QueryResulter, error)
 	}{
 		{
 			name:  "select query",
@@ -178,6 +212,8 @@ func TestExec(t *testing.T) {
 				require.Equal(t, []string{"col1", "col2"}, result.ColumnNames())
 				require.Equal(t, [][]string{{"val1", "val2"}}, result.Rows())
 				require.Equal(t, [][]any{{"val1", "val2"}}, result.Values())
+				require.Equal(t, generaltypes.StatementTypeSelect, result.StatementType())
+				require.Equal(t, int64(0), result.RowsAffected())
 				require.False(t, result.Truncated())
 			},
 		},
@@ -191,21 +227,40 @@ func TestExec(t *testing.T) {
 			},
 		},
 		{
-			name:      "non-resultset statement",
-			query:     "OPEN SCHEMA dummy",
-			queryRows: &fakeRows{columns: []string{}},
-			then: func(t *testing.T, _ *mocks, result generaltypes.QueryResulter, err error) {
+			name:       "non-resultset statement",
+			query:      "OPEN SCHEMA dummy",
+			execResult: fakeResult{rowsAffected: 0},
+			then: func(t *testing.T, mocks *mocks, result generaltypes.QueryResulter, err error) {
 				t.Helper()
 				require.NoError(t, err)
+				require.Equal(t, 1, mocks.fakeConnector.ExecCallCount())
 				require.Empty(t, result.ColumnNames())
 				require.Empty(t, result.Rows())
 				require.Empty(t, result.Values())
+				require.Equal(t, generaltypes.StatementTypeOpenSchema, result.StatementType())
+				require.Equal(t, int64(0), result.RowsAffected())
 				require.False(t, result.Truncated())
 			},
 		},
 		{
-			name:  "file import query",
-			query: "IMPORT INTO dummy FROM LOCAL CSV FILE './dummy.csv'",
+			name:       "dml statement reports rows affected",
+			query:      "UPDATE dummy SET x = 1",
+			execResult: fakeResult{rowsAffected: 3},
+			then: func(t *testing.T, mocks *mocks, result generaltypes.QueryResulter, err error) {
+				t.Helper()
+				require.NoError(t, err)
+				require.Equal(t, 1, mocks.fakeConnector.ExecCallCount())
+				require.Empty(t, result.ColumnNames())
+				require.Empty(t, result.Rows())
+				require.Empty(t, result.Values())
+				require.Equal(t, generaltypes.StatementTypeUpdate, result.StatementType())
+				require.Equal(t, int64(3), result.RowsAffected())
+			},
+		},
+		{
+			name:       "file import query",
+			query:      "IMPORT INTO dummy FROM LOCAL CSV FILE './dummy.csv'",
+			execResult: fakeResult{rowsAffected: 4},
 			then: func(t *testing.T, mocks *mocks, result generaltypes.QueryResulter, err error) {
 				t.Helper()
 				require.NoError(t, err)
@@ -213,6 +268,8 @@ func TestExec(t *testing.T) {
 				require.Equal(t, []string{}, result.ColumnNames())
 				require.Equal(t, [][]string{}, result.Rows())
 				require.Equal(t, [][]any{}, result.Values())
+				require.Equal(t, generaltypes.StatementTypeImport, result.StatementType())
+				require.Equal(t, int64(4), result.RowsAffected())
 			},
 		},
 		{
@@ -226,6 +283,7 @@ func TestExec(t *testing.T) {
 				require.Equal(t, []string{}, result.ColumnNames())
 				require.Equal(t, [][]string{}, result.Rows())
 				require.Equal(t, [][]any{}, result.Values())
+				require.Equal(t, generaltypes.StatementTypeImport, result.StatementType())
 			},
 		},
 	} {
@@ -234,9 +292,8 @@ func TestExec(t *testing.T) {
 
 			mocks := &mocks{&typesfakes.FakeExasolConnector{}}
 
-			// version() (called by Connect) also goes through QueryContext, so
-			// answer the version query separately and reserve the per-case rows
-			// for the query under test.
+			// version() (called by Connect) goes through QueryContext, so answer
+			// it separately and reserve the per-case rows for the query under test.
 			mocks.fakeConnector.QueryContextStub = func(
 				_ context.Context, query string, _ []driver.NamedValue,
 			) (driver.Rows, error) {
@@ -249,7 +306,7 @@ func TestExec(t *testing.T) {
 
 				return test.queryRows, test.queryErr
 			}
-			mocks.fakeConnector.ExecReturns(nil, test.execErr)
+			mocks.fakeConnector.ExecReturns(test.execResult, test.execErr)
 
 			connect := func(string) (types.ExasolConnector, error) {
 				return mocks.fakeConnector, nil
@@ -299,6 +356,112 @@ func TestExecClosesResultRows(t *testing.T) {
 	require.Equal(t, 1, queryRows.closeCount)
 }
 
+func TestExecWrapsSQLErrorWithLiveSessionID(t *testing.T) {
+	t.Parallel()
+
+	fakeConnector := &typesfakes.FakeExasolConnector{}
+	fakeConnector.QueryContextStub = func(
+		_ context.Context, query string, _ []driver.NamedValue,
+	) (driver.Rows, error) {
+		switch {
+		case strings.Contains(query, "exa_metadata"):
+			return &fakeRows{columns: []string{"v"}, data: [][]driver.Value{{"2025.1.0"}}}, nil
+		case strings.Contains(query, "CURRENT_SESSION"):
+			return &fakeRows{
+				columns: []string{"session_id"},
+				data:    [][]driver.Value{{int64(12345)}},
+			}, nil
+		default:
+			return nil, errors.New(
+				"E-EGOD-11: execution failed with SQL error code '42000' and message " +
+					"'syntax error near SELECT'",
+			)
+		}
+	}
+
+	database := testDatabaseFactory(t, func(string) (types.ExasolConnector, error) {
+		return fakeConnector, nil
+	})
+	require.NoError(t, database.Connect(t.Context()))
+
+	_, err := database.Exec(t.Context(), "SELECT * FROM Dual", 0)
+	require.Error(t, err)
+
+	structured := generaltypes.StructuredSQLErrorFromError(err)
+	require.Equal(t, "42000", structured.ErrorCode)
+	require.Equal(t, "42000", structured.SQLState)
+	require.Equal(t, "syntax error near SELECT", structured.Message)
+	require.NotNil(t, structured.SessionID)
+	require.Equal(t, "12345", *structured.SessionID)
+	require.Equal(t, 3, fakeConnector.QueryContextCallCount())
+}
+
+func TestExecPrefersLiveSessionIDOverMessageSessionID(t *testing.T) {
+	t.Parallel()
+
+	fakeConnector := &typesfakes.FakeExasolConnector{}
+	fakeConnector.QueryContextStub = func(
+		_ context.Context, query string, _ []driver.NamedValue,
+	) (driver.Rows, error) {
+		switch {
+		case strings.Contains(query, "exa_metadata"):
+			return &fakeRows{columns: []string{"v"}, data: [][]driver.Value{{"2025.1.0"}}}, nil
+		case strings.Contains(query, "CURRENT_SESSION"):
+			return &fakeRows{
+				columns: []string{"session_id"},
+				data:    [][]driver.Value{{int64(12345)}},
+			}, nil
+		default:
+			return nil, errors.New(
+				"E-EGOD-11: execution failed with SQL error code '42000' and message " +
+					"'syntax error near SELECT in session 99999'",
+			)
+		}
+	}
+
+	database := testDatabaseFactory(t, func(string) (types.ExasolConnector, error) {
+		return fakeConnector, nil
+	})
+	require.NoError(t, database.Connect(t.Context()))
+
+	_, err := database.Exec(t.Context(), "SELECT * FROM Dual", 0)
+	require.Error(t, err)
+
+	structured := generaltypes.StructuredSQLErrorFromError(err)
+	require.NotNil(t, structured.SessionID)
+	require.Equal(t, "12345", *structured.SessionID)
+	require.Equal(t, 3, fakeConnector.QueryContextCallCount())
+}
+
+func TestExecDoesNotFetchSessionIDOnSuccessfulQueries(t *testing.T) {
+	t.Parallel()
+
+	queryRows := &fakeRows{
+		columns: []string{"n"},
+		data:    [][]driver.Value{{int64(1)}},
+	}
+
+	fakeConnector := &typesfakes.FakeExasolConnector{}
+	fakeConnector.QueryContextStub = func(
+		_ context.Context, query string, _ []driver.NamedValue,
+	) (driver.Rows, error) {
+		if strings.Contains(query, "exa_metadata") {
+			return &fakeRows{columns: []string{"v"}, data: [][]driver.Value{{"2025.1.0"}}}, nil
+		}
+
+		return queryRows, nil
+	}
+
+	database := testDatabaseFactory(t, func(string) (types.ExasolConnector, error) {
+		return fakeConnector, nil
+	})
+	require.NoError(t, database.Connect(t.Context()))
+
+	_, err := database.Exec(t.Context(), "SELECT * FROM Dual", 0)
+	require.NoError(t, err)
+	require.Equal(t, 2, fakeConnector.QueryContextCallCount())
+}
+
 func TestCollectRows(t *testing.T) {
 	t.Parallel()
 
@@ -315,7 +478,7 @@ func TestCollectRows(t *testing.T) {
 		t.Parallel()
 
 		rows := makeRows(5)
-		result, err := collectRows(rows, 0)
+		result, err := collectRows(rows, 0, generaltypes.StatementTypeSelect)
 
 		require.NoError(t, err)
 		require.Len(t, result.Rows(), 5)
@@ -327,7 +490,7 @@ func TestCollectRows(t *testing.T) {
 		t.Parallel()
 
 		rows := makeRows(5)
-		result, err := collectRows(rows, 2)
+		result, err := collectRows(rows, 2, generaltypes.StatementTypeSelect)
 
 		require.NoError(t, err)
 		require.Len(t, result.Rows(), 2)
@@ -339,7 +502,7 @@ func TestCollectRows(t *testing.T) {
 		t.Parallel()
 
 		rows := makeRows(2)
-		result, err := collectRows(rows, 2)
+		result, err := collectRows(rows, 2, generaltypes.StatementTypeSelect)
 
 		require.NoError(t, err)
 		require.Len(t, result.Rows(), 2)
@@ -350,7 +513,7 @@ func TestCollectRows(t *testing.T) {
 		t.Parallel()
 
 		rows := &fakeRows{columns: []string{"n"}, data: [][]driver.Value{{int64(1000000)}}}
-		result, err := collectRows(rows, 0)
+		result, err := collectRows(rows, 0, generaltypes.StatementTypeSelect)
 
 		require.NoError(t, err)
 		require.Equal(t, [][]string{{"1000000"}}, result.Rows())
@@ -374,7 +537,7 @@ func TestCollectRows(t *testing.T) {
 			}},
 		}
 
-		result, err := collectRows(rows, 0)
+		result, err := collectRows(rows, 0, generaltypes.StatementTypeSelect)
 
 		require.NoError(t, err)
 		require.Equal(t, [][]string{{
@@ -400,7 +563,7 @@ func TestCollectRows(t *testing.T) {
 	t.Run("propagates a non-EOF Next error", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := collectRows(&errRows{err: errTest}, 0)
+		_, err := collectRows(&errRows{err: errTest}, 0, generaltypes.StatementTypeSelect)
 		require.ErrorIs(t, err, errTest)
 	})
 }

--- a/internal/connect/exasol/execution_error.go
+++ b/internal/connect/exasol/execution_error.go
@@ -1,0 +1,23 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package exasol
+
+import generaltypes "github.com/exasol/exasol-personal/internal/connect/types"
+
+type executionError struct {
+	cause      error
+	structured generaltypes.StructuredSQLError
+}
+
+func (e executionError) Error() string {
+	return e.cause.Error()
+}
+
+func (e executionError) Unwrap() error {
+	return e.cause
+}
+
+func (e executionError) StructuredSQLError() generaltypes.StructuredSQLError {
+	return e.structured
+}

--- a/internal/connect/exasol/query_result.go
+++ b/internal/connect/exasol/query_result.go
@@ -3,12 +3,16 @@
 
 package exasol
 
+import generaltypes "github.com/exasol/exasol-personal/internal/connect/types"
+
 // QueryResult holds the materialized result of a query.
 type QueryResult struct {
-	columnNames []string
-	rows        [][]string
-	values      [][]any
-	truncated   bool
+	columnNames   []string
+	rows          [][]string
+	values        [][]any
+	statementType generaltypes.StatementType
+	rowsAffected  int64
+	truncated     bool
 }
 
 func (qr *QueryResult) ColumnNames() []string {
@@ -21,6 +25,14 @@ func (qr *QueryResult) Rows() [][]string {
 
 func (qr *QueryResult) Values() [][]any {
 	return qr.values
+}
+
+func (qr *QueryResult) StatementType() generaltypes.StatementType {
+	return qr.statementType
+}
+
+func (qr *QueryResult) RowsAffected() int64 {
+	return qr.rowsAffected
 }
 
 func (qr *QueryResult) Truncated() bool {

--- a/internal/connect/json_execution.go
+++ b/internal/connect/json_execution.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package connect
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+
+	generaltypes "github.com/exasol/exasol-personal/internal/connect/types"
+)
+
+type jsonStatementResult struct {
+	Statement     string                           `json:"statement"`
+	StatementType generaltypes.StatementType       `json:"statementType"`
+	RowsAffected  int64                            `json:"rowsAffected"`
+	Columns       []string                         `json:"columns"`
+	Rows          [][]any                          `json:"rows"`
+	Truncated     bool                             `json:"truncated"`
+	Error         *generaltypes.StructuredSQLError `json:"error,omitempty"`
+}
+
+type jsonExecutionResult struct {
+	Statements []jsonStatementResult `json:"statements"`
+}
+
+type renderedJSONSQLError struct {
+	cause error
+}
+
+func (e renderedJSONSQLError) Error() string {
+	return e.cause.Error()
+}
+
+func (e renderedJSONSQLError) Unwrap() error {
+	return e.cause
+}
+
+func (renderedJSONSQLError) SuppressCLIError() bool {
+	return true
+}
+
+func runJSONStatements(
+	ctx context.Context,
+	sql string,
+	database generaltypes.Databaser,
+	output io.Writer,
+	jsonFormat JSONFormat,
+	maxRows int,
+) error {
+	statements := nonInteractiveStatements(sql)
+	document := jsonExecutionResult{
+		Statements: make([]jsonStatementResult, 0, len(statements)),
+	}
+
+	var executionErr error
+	for _, statement := range statements {
+		queryResult, err := database.Exec(ctx, statement, maxRows)
+		if err != nil {
+			structuredErr := generaltypes.StructuredSQLErrorFromError(err)
+			document.Statements = append(document.Statements, jsonStatementResult{
+				Statement: statement,
+				// Reclassify from the SQL text here because failed statements do not
+				// return a QueryResult carrying database-populated metadata.
+				StatementType: generaltypes.ClassifyStatement(statement),
+				RowsAffected:  0,
+				Columns:       []string{},
+				Rows:          [][]any{},
+				Truncated:     false,
+				Error:         &structuredErr,
+			})
+
+			executionErr = err
+
+			break
+		}
+
+		document.Statements = append(document.Statements, jsonStatementResult{
+			Statement:     statement,
+			StatementType: queryResult.StatementType(),
+			RowsAffected:  queryResult.RowsAffected(),
+			Columns:       queryResult.ColumnNames(),
+			Rows:          queryResult.Values(),
+			Truncated:     queryResult.Truncated(),
+		})
+
+		if queryResult.Truncated() {
+			if err := printTruncationFooter(os.Stderr, len(queryResult.Rows())); err != nil {
+				return err
+			}
+		}
+	}
+
+	if err := encodeJSONDocument(output, document, jsonFormat); err != nil {
+		return err
+	}
+
+	if executionErr != nil {
+		return renderedJSONSQLError{cause: executionErr}
+	}
+
+	return nil
+}
+
+func encodeJSONDocument(output io.Writer, payload any, jsonFormat JSONFormat) error {
+	encoder := json.NewEncoder(output)
+	encoder.SetEscapeHTML(false)
+	if normalizeJSONFormat(jsonFormat) == JSONFormatPretty {
+		encoder.SetIndent("", "  ")
+	}
+
+	return encoder.Encode(payload)
+}

--- a/internal/connect/shell.go
+++ b/internal/connect/shell.go
@@ -219,18 +219,22 @@ func runShellImpl(
 // trailing remainder after the final terminator is executed as a final
 // statement, mirroring the shell's end-of-input handling.
 func runStatements(sql string, processInput ProcessInputFunc) error {
-	statements, remainder := splitSemicolonTerminatedStatements(sql)
-	if trailing := strings.TrimSpace(remainder); trailing != "" {
-		statements = append(statements, trailing)
-	}
-
-	for _, statement := range statements {
+	for _, statement := range nonInteractiveStatements(sql) {
 		if err := processInput(strings.TrimSpace(statement)); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func nonInteractiveStatements(sql string) []string {
+	statements, remainder := splitSemicolonTerminatedStatements(sql)
+	if trailing := strings.TrimSpace(remainder); trailing != "" {
+		statements = append(statements, trailing)
+	}
+
+	return statements
 }
 
 // RunShell runs the shell, processing incoming input

--- a/internal/connect/types/sql_error.go
+++ b/internal/connect/types/sql_error.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package types
+
+import (
+	"errors"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type SQLErrorPosition struct {
+	Line   *int `json:"line,omitempty"`
+	Column *int `json:"column,omitempty"`
+}
+
+type StructuredSQLError struct {
+	ErrorCode string            `json:"errorCode"`
+	SQLState  string            `json:"sqlState"`
+	Message   string            `json:"message"`
+	SessionID *string           `json:"sessionId"`
+	Position  *SQLErrorPosition `json:"position"`
+}
+
+type structuredSQLErrorCarrier interface {
+	StructuredSQLError() StructuredSQLError
+}
+
+const (
+	driverErrorMatchCount = 4
+	submatchValueCount    = 2
+)
+
+var (
+	sqlDriverErrorPattern = regexp.MustCompile(
+		`(?s)([A-Z]-[A-Z0-9-]+): ` +
+			`execution failed with SQL error code '([^']*)' and message '(.*)'$`,
+	)
+	errorCodePattern = regexp.MustCompile(`^([A-Z]+-\d+):`)
+	sessionIDPattern = regexp.MustCompile(`(?i)\bsession(?:\s+id)?\s*[:=]?\s*(\d+)\b`)
+	linePattern      = regexp.MustCompile(`(?i)\bline\s+(\d+)\b`)
+	columnPattern    = regexp.MustCompile(`(?i)\bcolumn\s+(\d+)\b`)
+)
+
+func StructuredSQLErrorFromError(err error) StructuredSQLError {
+	if err == nil {
+		return StructuredSQLError{}
+	}
+
+	var carrier structuredSQLErrorCarrier
+	if errors.As(err, &carrier) {
+		return carrier.StructuredSQLError()
+	}
+
+	structured := StructuredSQLError{Message: err.Error()}
+
+	matches := findDriverErrorMatch(err)
+	if len(matches) == driverErrorMatchCount {
+		structured.SQLState = matches[2]
+		structured.Message = matches[3]
+	}
+
+	messageCode := errorCodePattern.FindStringSubmatch(structured.Message)
+	if len(messageCode) == submatchValueCount {
+		structured.ErrorCode = messageCode[1]
+	}
+
+	sessionID := sessionIDPattern.FindStringSubmatch(structured.Message)
+	if len(sessionID) == submatchValueCount {
+		value := sessionID[1]
+		structured.SessionID = &value
+	}
+
+	line := parseFirstMatch(linePattern, structured.Message)
+	column := parseFirstMatch(columnPattern, structured.Message)
+	if line != nil || column != nil {
+		structured.Position = &SQLErrorPosition{Line: line, Column: column}
+	}
+
+	if structured.ErrorCode == "" {
+		if structured.SQLState != "" {
+			structured.ErrorCode = structured.SQLState
+		} else {
+			structured.ErrorCode = "UNKNOWN"
+		}
+	}
+
+	return structured
+}
+
+func findDriverErrorMatch(err error) []string {
+	if err == nil {
+		return nil
+	}
+
+	queue := []error{err}
+
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+
+		if current == nil {
+			continue
+		}
+
+		matches := sqlDriverErrorPattern.FindStringSubmatch(current.Error())
+		if len(matches) == driverErrorMatchCount {
+			return matches
+		}
+
+		if typedErr, ok := any(current).(interface{ Unwrap() []error }); ok {
+			queue = append(queue, typedErr.Unwrap()...)
+			continue
+		}
+
+		if typedErr, ok := any(current).(interface{ Unwrap() error }); ok {
+			queue = append(queue, typedErr.Unwrap())
+		}
+	}
+
+	return nil
+}
+
+func parsePositiveInt(value string) *int {
+	if value == "" {
+		return nil
+	}
+
+	result, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || result <= 0 {
+		return nil
+	}
+
+	return &result
+}
+
+func parseFirstMatch(pattern *regexp.Regexp, message string) *int {
+	match := pattern.FindStringSubmatch(message)
+	if len(match) != submatchValueCount {
+		return nil
+	}
+
+	return parsePositiveInt(match[1])
+}

--- a/internal/connect/types/sql_error_test.go
+++ b/internal/connect/types/sql_error_test.go
@@ -1,0 +1,162 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package types
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fakeStructuredSQLError struct {
+	structured StructuredSQLError
+}
+
+func (fakeStructuredSQLError) Error() string {
+	return "wrapped structured sql error"
+}
+
+func (f fakeStructuredSQLError) StructuredSQLError() StructuredSQLError {
+	return f.structured
+}
+
+func TestStructuredSQLErrorFromError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("parses real driver format and falls back errorCode to sql state", func(t *testing.T) {
+		t.Parallel()
+
+		structured := StructuredSQLErrorFromError(errors.New(
+			"E-EGOD-11: execution failed with SQL error code '42000' and message " +
+				"'syntax error near SELECT'",
+		))
+
+		require.Equal(t, "42000", structured.ErrorCode)
+		require.Equal(t, "42000", structured.SQLState)
+		require.Equal(t, "syntax error near SELECT", structured.Message)
+		require.Nil(t, structured.SessionID)
+		require.Nil(t, structured.Position)
+	})
+
+	t.Run("prefers vendor error code from message when present", func(t *testing.T) {
+		t.Parallel()
+
+		structured := StructuredSQLErrorFromError(errors.New(
+			"E-EGOD-11: execution failed with SQL error code '42636' and message " +
+				"'ETL-6009: syntax error near SELECT at line 3, column 7'",
+		))
+
+		require.Equal(t, "ETL-6009", structured.ErrorCode)
+		require.Equal(t, "42636", structured.SQLState)
+		require.Equal(
+			t,
+			"ETL-6009: syntax error near SELECT at line 3, column 7",
+			structured.Message,
+		)
+		require.NotNil(t, structured.Position)
+		require.Equal(t, 3, *structured.Position.Line)
+		require.Equal(t, 7, *structured.Position.Column)
+	})
+
+	t.Run("captures whichever position fields are available", func(t *testing.T) {
+		t.Parallel()
+
+		structured := StructuredSQLErrorFromError(errors.New(
+			"E-EGOD-11: execution failed with SQL error code '42636' and message " +
+				"'syntax error near SELECT at column 7'",
+		))
+
+		require.Equal(t, "42636", structured.ErrorCode)
+		require.Equal(t, "42636", structured.SQLState)
+		require.NotNil(t, structured.Position)
+		require.Nil(t, structured.Position.Line)
+		require.Equal(t, 7, *structured.Position.Column)
+	})
+
+	t.Run("ignores non-positive position values", func(t *testing.T) {
+		t.Parallel()
+
+		structured := StructuredSQLErrorFromError(errors.New(
+			"E-EGOD-11: execution failed with SQL error code '42636' and message " +
+				"'syntax error near SELECT at line 0, column 7'",
+		))
+
+		require.Equal(t, "42636", structured.ErrorCode)
+		require.Equal(t, "42636", structured.SQLState)
+		require.NotNil(t, structured.Position)
+		require.Nil(t, structured.Position.Line)
+		require.Equal(t, 7, *structured.Position.Column)
+	})
+
+	t.Run("falls back to unknown for non driver errors", func(t *testing.T) {
+		t.Parallel()
+
+		structured := StructuredSQLErrorFromError(errors.New("plain network failure"))
+
+		require.Equal(t, "UNKNOWN", structured.ErrorCode)
+		require.Empty(t, structured.SQLState)
+		require.Equal(t, "plain network failure", structured.Message)
+		require.Nil(t, structured.SessionID)
+		require.Nil(t, structured.Position)
+	})
+
+	t.Run("parses wrapped driver errors", func(t *testing.T) {
+		t.Parallel()
+
+		structured := StructuredSQLErrorFromError(
+			fmt.Errorf(
+				"retrying execution: %w",
+				errors.New(
+					"E-EGOD-11: execution failed with SQL error code '22003' and message "+
+						"'numeric value out of range'",
+				),
+			),
+		)
+
+		require.Equal(t, "22003", structured.ErrorCode)
+		require.Equal(t, "22003", structured.SQLState)
+		require.Equal(t, "numeric value out of range", structured.Message)
+	})
+
+	t.Run("parses prefixed multiline driver errors", func(t *testing.T) {
+		t.Parallel()
+
+		structured := StructuredSQLErrorFromError(errors.New(
+			"failed to login: E-EGOD-11: execution failed with SQL error code '42636' and " +
+				"message 'ETL-6009: syntax error near SELECT\nat line 3, column 7'",
+		))
+
+		require.Equal(t, "ETL-6009", structured.ErrorCode)
+		require.Equal(t, "42636", structured.SQLState)
+		require.Equal(
+			t,
+			"ETL-6009: syntax error near SELECT\nat line 3, column 7",
+			structured.Message,
+		)
+		require.NotNil(t, structured.Position)
+		require.Equal(t, 3, *structured.Position.Line)
+		require.Equal(t, 7, *structured.Position.Column)
+	})
+
+	t.Run("prefers a pre-structured carrier", func(t *testing.T) {
+		t.Parallel()
+
+		expected := StructuredSQLError{
+			ErrorCode: "ETL-6009",
+			SQLState:  "42636",
+			Message:   "structured already",
+			SessionID: ptrToString("12345"),
+		}
+
+		structured := StructuredSQLErrorFromError(fakeStructuredSQLError{structured: expected})
+
+		require.Equal(t, expected, structured)
+	})
+}
+
+func ptrToString(value string) *string {
+	return &value
+}

--- a/internal/connect/types/statement.go
+++ b/internal/connect/types/statement.go
@@ -1,0 +1,182 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package types
+
+import (
+	"strings"
+	"unicode"
+)
+
+const leadingKeywordLimit = 2
+
+type StatementType string
+
+const (
+	StatementTypeUnknown     StatementType = "UNKNOWN"
+	StatementTypeSelect      StatementType = "SELECT"
+	StatementTypeWith        StatementType = "WITH"
+	StatementTypeExplain     StatementType = "EXPLAIN"
+	StatementTypeInsert      StatementType = "INSERT"
+	StatementTypeUpdate      StatementType = "UPDATE"
+	StatementTypeDelete      StatementType = "DELETE"
+	StatementTypeMerge       StatementType = "MERGE"
+	StatementTypeImport      StatementType = "IMPORT"
+	StatementTypeExport      StatementType = "EXPORT"
+	StatementTypeCreate      StatementType = "CREATE"
+	StatementTypeAlter       StatementType = "ALTER"
+	StatementTypeDrop        StatementType = "DROP"
+	StatementTypeTruncate    StatementType = "TRUNCATE"
+	StatementTypeOpenSchema  StatementType = "OPEN_SCHEMA"
+	StatementTypeCloseSchema StatementType = "CLOSE_SCHEMA"
+	StatementTypeSet         StatementType = "SET"
+	StatementTypeCommit      StatementType = "COMMIT"
+	StatementTypeRollback    StatementType = "ROLLBACK"
+	StatementTypeGrant       StatementType = "GRANT"
+	StatementTypeRevoke      StatementType = "REVOKE"
+)
+
+func ClassifyStatement(sql string) StatementType {
+	keywords := leadingKeywords(sql, leadingKeywordLimit)
+	if len(keywords) == 0 {
+		return StatementTypeUnknown
+	}
+
+	switch keywords[0] {
+	case "SELECT":
+		return StatementTypeSelect
+	case "WITH":
+		return StatementTypeWith
+	case "EXPLAIN":
+		return StatementTypeExplain
+	case "INSERT":
+		return StatementTypeInsert
+	case "UPDATE":
+		return StatementTypeUpdate
+	case "DELETE":
+		return StatementTypeDelete
+	case "MERGE":
+		return StatementTypeMerge
+	case "IMPORT":
+		return StatementTypeImport
+	case "EXPORT":
+		return StatementTypeExport
+	case "CREATE":
+		return StatementTypeCreate
+	case "ALTER":
+		return StatementTypeAlter
+	case "DROP":
+		return StatementTypeDrop
+	case "TRUNCATE":
+		return StatementTypeTruncate
+	case "SET":
+		return StatementTypeSet
+	case "COMMIT":
+		return StatementTypeCommit
+	case "ROLLBACK":
+		return StatementTypeRollback
+	case "GRANT":
+		return StatementTypeGrant
+	case "REVOKE":
+		return StatementTypeRevoke
+	case "OPEN":
+		if len(keywords) > 1 && keywords[1] == "SCHEMA" {
+			return StatementTypeOpenSchema
+		}
+	case "CLOSE":
+		if len(keywords) > 1 && keywords[1] == "SCHEMA" {
+			return StatementTypeCloseSchema
+		}
+	default:
+		return StatementTypeUnknown
+	}
+
+	return StatementTypeUnknown
+}
+
+func (statementType StatementType) UsesExecPath() bool {
+	switch statementType {
+	case StatementTypeUnknown,
+		StatementTypeSelect,
+		StatementTypeWith,
+		StatementTypeExplain:
+		return false
+	case StatementTypeInsert,
+		StatementTypeUpdate,
+		StatementTypeDelete,
+		StatementTypeMerge,
+		StatementTypeImport,
+		StatementTypeExport,
+		StatementTypeCreate,
+		StatementTypeAlter,
+		StatementTypeDrop,
+		StatementTypeTruncate,
+		StatementTypeOpenSchema,
+		StatementTypeCloseSchema,
+		StatementTypeSet,
+		StatementTypeCommit,
+		StatementTypeRollback,
+		StatementTypeGrant,
+		StatementTypeRevoke:
+		return true
+	default:
+		return false
+	}
+}
+
+func leadingKeywords(sql string, limit int) []string {
+	trimmed := stripLeadingSQLComments(strings.TrimSpace(sql))
+	if trimmed == "" || limit <= 0 {
+		return nil
+	}
+
+	keywords := make([]string, 0, limit)
+	var builder strings.Builder
+
+	flush := func() bool {
+		if builder.Len() == 0 {
+			return false
+		}
+
+		keywords = append(keywords, strings.ToUpper(builder.String()))
+		builder.Reset()
+
+		return len(keywords) >= limit
+	}
+
+	for _, char := range trimmed {
+		if unicode.IsLetter(char) || unicode.IsDigit(char) || char == '_' {
+			_, _ = builder.WriteRune(char)
+			continue
+		}
+		if flush() {
+			break
+		}
+	}
+
+	flush()
+
+	return keywords
+}
+
+func stripLeadingSQLComments(sql string) string {
+	for {
+		trimmed := strings.TrimSpace(sql)
+		switch {
+		case strings.HasPrefix(trimmed, "--"):
+			newline := strings.IndexByte(trimmed, '\n')
+			if newline < 0 {
+				return ""
+			}
+			sql = trimmed[newline+1:]
+		case strings.HasPrefix(trimmed, "/*"):
+			end := strings.Index(trimmed, "*/")
+			if end < 0 {
+				return ""
+			}
+			sql = trimmed[end+2:]
+		default:
+			return trimmed
+		}
+	}
+}

--- a/internal/connect/types/statement_test.go
+++ b/internal/connect/types/statement_test.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClassifyStatement(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name     string
+		sql      string
+		expected StatementType
+	}{
+		{name: "select", sql: "SELECT 1", expected: StatementTypeSelect},
+		{
+			name:     "with",
+			sql:      "WITH x AS (SELECT 1) SELECT * FROM x",
+			expected: StatementTypeWith,
+		},
+		{
+			name:     "merge",
+			sql:      "MERGE INTO t USING s ON t.id = s.id",
+			expected: StatementTypeMerge,
+		},
+		{
+			name:     "open schema after line comment",
+			sql:      "-- hi\nOPEN SCHEMA foo",
+			expected: StatementTypeOpenSchema,
+		},
+		{
+			name:     "close schema after block comment",
+			sql:      "/* hi */ CLOSE SCHEMA foo",
+			expected: StatementTypeCloseSchema,
+		},
+		{name: "set", sql: "SET AUTOCOMMIT ON", expected: StatementTypeSet},
+		{name: "unknown", sql: "CALL something()", expected: StatementTypeUnknown},
+		{name: "empty", sql: "   ", expected: StatementTypeUnknown},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, test.expected, ClassifyStatement(test.sql))
+		})
+	}
+}
+
+func TestStatementTypeUsesExecPath(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, StatementTypeSelect.UsesExecPath())
+	require.False(t, StatementTypeWith.UsesExecPath())
+	require.True(t, StatementTypeUpdate.UsesExecPath())
+	require.True(t, StatementTypeOpenSchema.UsesExecPath())
+	require.True(t, StatementTypeCloseSchema.UsesExecPath())
+	require.True(t, StatementTypeMerge.UsesExecPath())
+	require.False(t, StatementTypeUnknown.UsesExecPath())
+}

--- a/internal/connect/types/types.go
+++ b/internal/connect/types/types.go
@@ -12,6 +12,8 @@ type QueryResulter interface {
 	ColumnNames() []string
 	Rows() [][]string
 	Values() [][]any
+	StatementType() StatementType
+	RowsAffected() int64
 	// Truncated reports whether more rows were available than are returned by
 	// Rows, because retrieval was capped by a row limit.
 	Truncated() bool

--- a/openspec/changes/standardize-connect-json-output/.openspec.yaml
+++ b/openspec/changes/standardize-connect-json-output/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-26

--- a/openspec/changes/standardize-connect-json-output/design.md
+++ b/openspec/changes/standardize-connect-json-output/design.md
@@ -1,0 +1,43 @@
+## Context
+
+The existing `connect-json-output` work preserved typed cell values, but `connect.Connect` still executes non-interactive scripts one statement at a time and prints each JSON result immediately. That behavior produces invalid concatenated JSON for multi-statement scripts, returns plain CLI errors for SQL failures, and uses the same `{columns:[], rows:[]}` shape for zero-row queries and non-result statements.
+
+The fix crosses the shell runner, connect execution flow, database adapter, and JSON renderer. It must preserve interactive table behavior, keep stdout machine-readable in non-interactive JSON mode, and avoid changing the default non-JSON output contract.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Emit one parseable JSON document per non-interactive `exasol connect --json` invocation.
+- Include per-statement metadata so result-set, DDL, and session statements are distinguishable.
+- Convert SQL failures in JSON mode into structured error objects without losing available database details.
+- Keep existing non-JSON output behavior unchanged.
+- Cover the new contract with focused unit tests and JSON rendering tests.
+
+**Non-Goals:**
+
+- No change to the default table or CSV output contracts.
+- No new SQL parsing engine or deep semantic SQL classification beyond lightweight statement-kind detection.
+- No change to the Exasol SQL type system or typed-cell behavior already delivered.
+- No new NDJSON mode in this change; the selected contract is a single invocation envelope.
+
+## Decisions
+
+**Use an invocation envelope for non-interactive JSON output.** Instead of printing one top-level object per statement, `connect.Connect` will collect non-interactive statement outcomes and encode a single document such as `{"statements":[...]}` on success, or `{"statements":[..., {"error": ...}]}` when a statement fails after partial execution. The structured error is attached to the failing statement record so consumers can identify the failed statement without correlating a separate top-level field. Interactive `--json` output is intentionally left on the existing per-statement shape in this change so the shell workflow and prompt-driven execution model stay unchanged. Alternative: add NDJSON or delimiters. Rejected because the user story explicitly wants whole-output `JSON.parse` compatibility and no custom stream splitter.
+
+**Represent each statement explicitly.** Add a statement record with `statement`, `statementType`, `rowsAffected`, `columns`, `rows`, and `truncated`. Result-set statements keep typed row values; DDL/session statements use empty columns/rows plus metadata so they no longer look identical to zero-row `SELECT`s. Alternative: add metadata beside the old top-level shape only for non-empty results. Rejected because consumers need uniform per-statement records.
+
+**Keep JSON aggregation in the connect layer.** The database adapter continues to execute one statement at a time, but returns richer execution metadata through `QueryResulter`. The connect layer owns script splitting and invocation-level envelope assembly. Alternative: move multi-statement aggregation into the database package. Rejected because splitting and non-interactive control flow already live in `internal/connect`.
+
+**Classify statement types with lightweight SQL inspection.** The launcher will infer a coarse statement type from the trimmed SQL text by examining the first keyword pair when needed, covering categories such as `SELECT`, `WITH`, `INSERT`, `UPDATE`, `DELETE`, `MERGE`, `IMPORT`, `EXPORT`, `CREATE`, `ALTER`, `DROP`, `TRUNCATE`, `OPEN_SCHEMA`, `CLOSE_SCHEMA`, `SET`, `COMMIT`, `ROLLBACK`, `GRANT`, and `REVOKE`. Alternative: rely on database driver metadata. Rejected because the current interfaces do not expose statement class and the story only needs stable coarse metadata.
+
+**Capture rows affected from the execution path that knows it.** Non-result statements and import-style executions will use `driver.Result.RowsAffected()` when available. Result-set statements still include `rowsAffected`, but use `0` when the driver does not expose affected-row semantics for that statement kind. This keeps DDL/session statements distinguishable without inventing an affected-row count for every query kind, and it keeps the JSON shape uniform for consumers.
+
+**Normalize SQL errors into structured JSON details.** Introduce a small structured error type in the connect domain that records `errorCode`, `sqlState`, `message`, `sessionId`, and optional line/column coordinates. The database adapter will inspect driver errors, extract those fields when present, and wrap unknown errors with at least the message. The session id is fetched lazily on the first execution error that needs enrichment instead of during every successful connect, so non-JSON and success-only sessions do not pay an extra round-trip. Non-JSON execution still returns ordinary Go errors so the CLI’s text behavior remains unchanged.
+
+## Risks / Trade-offs
+
+- **Statement classification is heuristic** -> Limit the contract to coarse stable types and cover representative SQL forms in tests.
+- **Driver error shapes may vary** -> Implement best-effort extraction with graceful fallback to message-only structured errors.
+- **Rows affected may be unavailable for some statements** -> Treat it as metadata populated when the driver provides it and keep statement type as the primary discriminator.
+- **Invocation-level JSON changes the single-statement shape** -> Update command docs, tests, and the capability spec so consumers have one consistent contract.

--- a/openspec/changes/standardize-connect-json-output/proposal.md
+++ b/openspec/changes/standardize-connect-json-output/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`exasol connect --json` is still awkward for automation after the value-typing work because multi-statement execution emits back-to-back top-level objects, SQL failures fall back to unstructured text, and DDL or session statements are indistinguishable from zero-row queries. Agent and integration consumers need one stable invocation-level JSON contract they can parse without custom stream splitting or regex-based error handling.
+
+## What Changes
+
+- Wrap non-interactive `exasol connect --json` results in a single invocation document that remains parseable for single statements, multi-statement scripts, and failures.
+- Add per-statement metadata to JSON output, including statement type, rows affected, truncation, and result-set data when present.
+- Emit structured SQL errors in JSON mode, including database error code, SQL state, message, session identifier, and line or column position when available.
+- Keep non-JSON output unchanged and continue preserving typed JSON cell values introduced by the earlier `connect-json-output` work.
+- Add focused tests covering single-statement, multi-statement, DDL or session statements, and structured SQL error behavior.
+
+## Capabilities
+
+### New Capabilities
+<!-- None. -->
+
+### Modified Capabilities
+- `connect-json-output`: expand the JSON result contract from per-statement result objects to a structured invocation envelope with statement metadata and structured SQL errors
+
+## Impact
+
+- `internal/connect`: aggregate non-interactive JSON execution into one document and render statement-level metadata.
+- `internal/connect/exasol`: classify executed statements, capture rows affected for non-result statements, and normalize SQL driver errors into structured JSON data.
+- `cmd/exasol`: refresh command help and examples if the emitted JSON shape changes materially.
+- Tests in `internal/connect/...` and command coverage need updates for the new JSON contract.

--- a/openspec/changes/standardize-connect-json-output/specs/connect-json-output/spec.md
+++ b/openspec/changes/standardize-connect-json-output/specs/connect-json-output/spec.md
@@ -1,0 +1,116 @@
+## ADDED Requirements
+
+### Requirement: JSON Statement Metadata Distinguishes Statement Outcomes
+
+`exasol connect --json` SHALL emit one statement record per executed SQL statement, and each record SHALL include metadata that distinguishes result-set statements from DDL, DML, and session statements.
+
+#### Scenario: DDL and session statements carry statement metadata
+
+- **WHEN** a non-result statement such as `OPEN SCHEMA`, `CREATE TABLE`, or `COMMIT` succeeds under `exasol connect --json`
+- **THEN** its statement record includes a stable `statementType`
+- **AND** the record includes `rowsAffected`
+- **AND** the record includes `columns` and `rows` as empty arrays when no result set was returned
+
+#### Scenario: Zero-row selects remain distinguishable from non-result statements
+
+- **WHEN** a `SELECT` statement succeeds with zero result rows under `exasol connect --json`
+- **THEN** its statement record includes `statementType` identifying it as a query statement
+- **AND** its `columns` reflect the query result columns even when `rows` is empty
+- **AND** consumers can distinguish it from a DDL or session statement without inferring from empty arrays alone
+
+#### Scenario: Result-set statements keep stable rowsAffected semantics
+
+- **WHEN** a result-set statement succeeds under `exasol connect --json`
+- **THEN** its statement record still includes `rowsAffected`
+- **AND** `rowsAffected` is `0` when the database driver does not expose affected-row metadata for that statement kind
+- **AND** consumers can rely on `statementType`, `columns`, and `rows` to interpret query results
+
+### Requirement: JSON SQL Errors Are Structured
+
+When `--json` is used in non-interactive execution, SQL failures SHALL be emitted as structured JSON rather than plain text.
+
+#### Scenario: Statement failure returns structured error details
+
+- **WHEN** a statement fails during `exasol connect --json` execution
+- **THEN** stdout remains a single valid JSON document
+- **AND** the document includes a structured error object with `errorCode`, `sqlState`, `message`, `sessionId`, and `position` line or column data when available
+- **AND** the error identifies the failing statement record or its position within the invocation
+
+#### Scenario: Earlier successful statements remain represented when a later statement fails
+
+- **WHEN** a multi-statement script succeeds for one or more statements before a later statement fails under `exasol connect --json`
+- **THEN** the JSON document includes statement records for the successful statements executed before the failure
+- **AND** the JSON document includes the structured error for the failing statement
+- **AND** no additional plain-text SQL error is written to stdout
+
+## MODIFIED Requirements
+
+### Requirement: Typed JSON Query Result Values
+
+`exasol connect --json` SHALL emit query result rows within statement records using JSON-compatible value types instead of converting every cell to a string.
+
+#### Scenario: Numeric values are JSON numbers
+
+- **WHEN** a query statement result contains numeric SQL values returned by the database driver as safely representable numeric values
+- **THEN** `exasol connect --json` emits those cells as JSON numbers in the statement record row data
+
+#### Scenario: Boolean values are JSON booleans
+
+- **WHEN** a query statement result contains boolean SQL values
+- **THEN** `exasol connect --json` emits those cells as JSON booleans in the statement record row data
+
+#### Scenario: Null values are JSON null
+
+- **WHEN** a query statement result contains SQL `NULL` values
+- **THEN** `exasol connect --json` emits those cells as JSON `null` in the statement record row data
+
+#### Scenario: Text values remain JSON strings
+
+- **WHEN** a query statement result contains text, date, timestamp, or other non-JSON-native values represented as strings
+- **THEN** `exasol connect --json` emits those cells as JSON strings in the statement record row data
+
+### Requirement: JSON Strings Are Not HTML-Escaped Unnecessarily
+
+`exasol connect --json` SHALL encode result strings without unnecessary HTML escaping of ordinary characters.
+
+#### Scenario: HTML-sensitive characters stay readable
+
+- **WHEN** a query result string contains ordinary characters such as `<`, `>`, or `&`
+- **THEN** `exasol connect --json` emits those characters in the JSON string without replacing them with Unicode escape sequences solely for HTML safety
+
+### Requirement: JSON Stdout Is Machine-Readable
+
+When `--json` is used in non-interactive execution, `exasol connect` SHALL write exactly one JSON document to stdout for the full invocation.
+
+#### Scenario: Single-statement JSON output uses the invocation envelope
+
+- **WHEN** the user runs `exasol connect --json` non-interactively with one SQL statement from `--command`, `--file`, or piped stdin
+- **THEN** stdout contains one valid JSON document for the invocation
+- **AND** the document contains exactly one statement record inside the invocation envelope
+
+#### Scenario: Multi-statement JSON output remains parseable
+
+- **WHEN** the user runs `exasol connect --json` non-interactively with multiple SQL statements
+- **THEN** stdout contains one valid JSON document for the invocation rather than adjacent top-level JSON objects
+- **AND** the document contains one statement record per executed statement in execution order
+
+#### Scenario: Non-interactive JSON output contains no prompts or status text
+
+- **WHEN** the user runs `exasol connect --json` non-interactively with SQL from `--command`, `--file`, or piped stdin
+- **THEN** stdout contains only the JSON invocation document
+- **AND** prompts, banners, version messages, exit hints, truncation notices, and unstructured SQL errors are not written to stdout
+
+#### Scenario: Interactive JSON output remains statement-oriented
+
+- **WHEN** the user runs `exasol connect --json` interactively in the shell
+- **THEN** each executed statement is emitted as its own JSON document
+- **AND** the interactive shell does not aggregate multiple statements into one invocation envelope
+
+### Requirement: Non-JSON Output Compatibility
+
+Existing non-JSON query output SHALL continue to render display strings for result cells.
+
+#### Scenario: Pretty table output remains string-rendered
+
+- **WHEN** the user runs `exasol connect` without `--json`
+- **THEN** query result cells are rendered through the existing table output path using display strings

--- a/openspec/changes/standardize-connect-json-output/tasks.md
+++ b/openspec/changes/standardize-connect-json-output/tasks.md
@@ -1,0 +1,17 @@
+## 1. JSON contract and execution metadata
+
+- [x] 1.1 Extend the connect query-result contract with statement metadata needed for JSON output, including statement type and rows affected
+- [x] 1.2 Add lightweight SQL statement classification and populate metadata for result-set, DDL, DML, import, and session statements
+- [x] 1.3 Add structured SQL error normalization in the connect or database layer so JSON mode can emit machine-readable error details
+
+## 2. Invocation-level JSON rendering
+
+- [x] 2.1 Refactor non-interactive JSON execution to aggregate executed statements into a single invocation document instead of printing one top-level object per statement
+- [x] 2.2 Ensure single-statement, multi-statement, and partial-success-plus-error flows all emit one valid JSON document on stdout
+- [x] 2.3 Keep table and CSV output behavior unchanged, including stderr-only truncation notices
+
+## 3. Tests and documentation
+
+- [x] 3.1 Update `internal/connect` JSON rendering tests for the new invocation envelope and statement metadata
+- [x] 3.2 Add or update database-layer tests covering statement metadata, rows affected, and structured SQL error extraction
+- [x] 3.3 Update command/help or spec-facing documentation that describes `exasol connect --json`, then run focused formatting and unit validation


### PR DESCRIPTION
## Description

Make `exasol connect --json` emit a single parseable JSON document per invocation, including multi-statement scripts and SQL errors. So integrations can use a standard `JSON.parse` instead of a stream splitter and regex error parsing.

## Related Issue

[SPOT-31227](https://exasol.atlassian.net/browse/SPOT-31227)

Fixes #

## Type of Change

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

-  Wrap non-interactive `--json` output in a single `{"statements":[...]}` envelope (single and multi-statement).
- Add per-statement `statementType` and `rowsAffected` so DDL/session statements are distinguishable from zero-row queries.
- Emit SQL errors under `--json` as a structured object (`errorCode`, `sqlState`, `message`, `sessionId`, `position`) on the failing statement; accept piped stdin as a JSON source.
- Keep table/CSV and interactive output unchanged.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

- Unit tests cover single-statement, multi-statement, DDL/session, and structured-error cases across the `connect`, `exasol`, and `types` packages.
- Manually verified against a live Exasol 2026.1.0 DB: the envelope parses as one JSON document, structured errors include `sessionId`/`position`, failures exit `1` with clean stdout, and non-JSON (table/CSV/piped) output is unchanged. Before/after logs included below.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

- **Behavior change:** non-interactive `--json` output changed from one `{columns,rows}` object per statement to a single `{"statements":[...]}` document.
- The `Exasol <version>` banner prints to stderr only on a TTY (stdout stays pure JSON); suppressing it under `--json` could be a follow-up.

**Dev Testing Logs:** [SPOT-31227-Dev-Testing-Logs.txt](https://github.com/user-attachments/files/29465956/SPOT-31227-Dev-Testing-Logs.txt)



[SPOT-31227]: https://exasol.atlassian.net/browse/SPOT-31227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ