### PR TITLE
Implement version check data for VM runner

### DIFF
--- a/cmd/exasol/connect_test.go
+++ b/cmd/exasol/connect_test.go
@@ -177,8 +177,12 @@ func TestConnectRegistersCSVFlag(t *testing.T) {
 	t.Parallel()
 
 	flag := connectCmd.Flags().Lookup("csv")
-	if flag == nil || flag.DefValue != "false" {
-		t.Fatal("expected --csv flag to be registered with default false")
+	if flag == nil {
+		t.Fatal("expected --csv flag to be registered")
+		return
+	}
+	if flag.DefValue != "false" {
+		t.Fatalf("expected --csv default false, got %q", flag.DefValue)
 	}
 }
 

--- a/internal/deploy/local_backend_test.go
+++ b/internal/deploy/local_backend_test.go
@@ -311,7 +311,7 @@ func TestLocalBackendReadConfiguration_ExposesSizingValues(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected local configuration values, got %v", err)
 	}
-	defaults := defaultLocalRuntimeConfig(0)
+	defaults := defaultLocalRuntimeConfig(detectLocalHostMemoryMB(context.Background()))
 	assertConfigValue(t, values, localCPUCountConfigName, 4, localDefaultCPUCount)
 	assertConfigValue(t, values, localMemoryMBConfigName, 8192, defaults.memoryMB)
 	assertConfigValue(t, values, localDataSizeGBConfigName, 250, localDefaultDataSizeGB)

--- a/internal/deploy/local_runtime.go
+++ b/internal/deploy/local_runtime.go
@@ -61,6 +61,11 @@ func startPreparedLocalRuntime(
 
 	localConfig := toLocalRuntimeConfig(runtimeConfig)
 	startArgs := []string{"start"}
+	versionCheckArgs, err := localRunnerVersionCheckArgs(deployment)
+	if err != nil {
+		return err
+	}
+	startArgs = append(startArgs, versionCheckArgs...)
 	if localConfig.Ports != "" {
 		startArgs = append(startArgs, "--ports", localConfig.Ports)
 	}
@@ -87,6 +92,28 @@ func startPreparedLocalRuntime(
 	return writeLocalRuntimeArtifactsAndWait(ctx, deployment, state)
 }
 
+func localRunnerVersionCheckArgs(deployment config.DeploymentDir) ([]string, error) {
+	launcherState, err := config.ReadExasolPersonalState(deployment)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read local version-check settings: %w", err)
+	}
+
+	if !launcherState.VersionCheckEnabled {
+		return []string{"--version-check-enabled=false"}, nil
+	}
+
+	clusterIdentity := strings.TrimSpace(launcherState.ClusterIdentity)
+	if clusterIdentity == "" {
+		return nil, errors.New("deployment state is missing cluster identity")
+	}
+
+	return []string{
+		"--version-check-enabled=true",
+		"--version-check-url", GetVersionCheckURL(),
+		"--version-check-identity", clusterIdentity,
+	}, nil
+}
+
 // reconcileLocalVMState corrects a stale WorkflowStateRunning caused by an unclean
 // VM shutdown (e.g. SIGKILL). If the mac-runner socket reports the daemon is not
 // running, the state is updated to WorkflowStateStopped so that subsequent permit
@@ -96,7 +123,7 @@ func startPreparedLocalRuntime(
 // running outside the launcher's knowledge is an externally-caused inconsistency
 // that should surface as an error rather than be silently accepted.
 //
-// Errors from the VM status check are logged and swallowed — reconciliation is
+// Errors from the VM status check are logged and swallowed; reconciliation is
 // best-effort and must not block the caller's primary operation.
 // The caller must already hold the exclusive deployment lock.
 func reconcileLocalVMState(

--- a/internal/deploy/local_runtime_test.go
+++ b/internal/deploy/local_runtime_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/exasol/exasol-personal/internal/config"
@@ -17,11 +18,54 @@ import (
 
 const (
 	localTestDeploymentID     = "exasol-local-test"
+	localTestClusterIdentity  = "exasol-personal;exasol-local-test;local;local"
 	privateTestFileMode       = 0o600
 	executableTestFileMode    = 0o700
 	localTestDatabasePort     = 28563
 	localTestSSHForwardedPort = 20022
 )
+
+func TestLocalRunnerVersionCheckArgs_PassesLauncherVersionCheckSettings(t *testing.T) {
+	// Given
+	deployment := newTestDeploymentWithVersionCheckState(t, true, localTestClusterIdentity)
+	const expectedURL = "https://example.test/v1/version-check"
+	t.Setenv(VersionCheckURLEnvVar, expectedURL)
+
+	// When
+	args, err := localRunnerVersionCheckArgs(deployment)
+	// Then
+	if err != nil {
+		t.Fatalf("expected version-check args, got %v", err)
+	}
+	expected := []string{
+		"--version-check-enabled=true",
+		"--version-check-url", expectedURL,
+		"--version-check-identity", localTestClusterIdentity,
+	}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("expected args %#v, got %#v", expected, args)
+	}
+}
+
+func TestLocalRunnerVersionCheckArgs_DisablesRunnerWhenLauncherVersionCheckDisabled(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	// Given
+	deployment := newTestDeploymentWithVersionCheckState(t, false, "")
+
+	// When
+	args, err := localRunnerVersionCheckArgs(deployment)
+	// Then
+	if err != nil {
+		t.Fatalf("expected disabled version-check args, got %v", err)
+	}
+	expected := []string{"--version-check-enabled=false"}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("expected args %#v, got %#v", expected, args)
+	}
+}
 
 func TestWriteLocalDeploymentArtifacts_WritesEndpointConnectionAndSecrets(t *testing.T) {
 	t.Parallel()
@@ -216,8 +260,23 @@ func TestStopLocalRuntime_UpdatesDeploymentInfoState(t *testing.T) {
 func newTestDeploymentWithState(t *testing.T) config.DeploymentDir {
 	t.Helper()
 
+	return newTestDeploymentWithVersionCheckState(t, false, "")
+}
+
+func newTestDeploymentWithVersionCheckState(
+	t *testing.T,
+	versionCheckEnabled bool,
+	clusterIdentity string,
+) config.DeploymentDir {
+	t.Helper()
+
 	deployment := config.NewDeploymentDir(t.TempDir())
-	state := &config.ExasolPersonalState{DeploymentId: localTestDeploymentID}
+	state := &config.ExasolPersonalState{
+		DeploymentId:        localTestDeploymentID,
+		ClusterIdentity:     clusterIdentity,
+		VersionCheckEnabled: versionCheckEnabled,
+		DeploymentVersion:   "0.0.0",
+	}
 	workflowState := &config.WorkflowStateInitialized{}
 	if err := state.SetWorkflowStateAndWrite(workflowState, deployment); err != nil {
 		t.Fatalf("failed to write launcher state: %v", err)

--- a/tests/tests/integration/test_install.py
+++ b/tests/tests/integration/test_install.py
@@ -211,7 +211,33 @@ case "$1" in
     mkdir -p vm vm-shared
     ;;
   start)
-    if [ "$2" != "2" ] || [ "$3" != "2048" ] || [ "$4" != "100" ]; then
+    shift
+    version_check_enabled=""
+    while [ "$#" -gt 3 ]; do
+      case "$1" in
+        --version-check-enabled=*)
+          version_check_enabled="${1#*=}"
+          shift
+          ;;
+        --version-check-enabled)
+          version_check_enabled="$2"
+          shift 2
+          ;;
+        --version-check-url|--version-check-identity|--version-check-interval-seconds|--ports)
+          shift 2
+          ;;
+        *)
+          echo "unexpected start flag: $1" >&2
+          exit 3
+          ;;
+      esac
+    done
+    if [ "${version_check_enabled}" != "false" ]; then
+      echo "expected disabled version check, got: ${version_check_enabled}" >&2
+      exit 3
+    fi
+    printf '%s' "${version_check_enabled}" > start-version-check-enabled
+    if [ "$1" != "2" ] || [ "$2" != "2048" ] || [ "$3" != "100" ]; then
       echo "unexpected sizing args: $*" >&2
       exit 3
     fi
@@ -248,6 +274,7 @@ esac
             "local",
             "--deployment-dir",
             str(deployment_dir),
+            "--no-launcher-version-check",
         ],
         env=env,
     )
@@ -288,6 +315,10 @@ esac
 
     # Then the deployment is initialized and local connection artifacts are written
     assert result.returncode == 0
+    version_check_marker = (
+        deployment_dir / "local" / "runtime" / "start-version-check-enabled"
+    )
+    assert version_check_marker.read_text() == "false"
     deployment_data = json.loads((deployment_dir / "deployment.json").read_text())
     assert deployment_data["backend"] == "local"
     assert "nodes" not in deployment_data


### PR DESCRIPTION
## Description

This PR introduces enhancements to the local deployment workflow, focusing on version check flag propagation and improved test coverage. The main changes ensure that the local runner receives explicit version check arguments based on launcher configuration, and that these behaviors are thoroughly tested in both unit and integration tests.

## Related Issue

<!-- Link to the related issue(s). Use "Fixes #123" or "Closes #123" to auto-close issues when PR is merged -->

Fixes #

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Added a new function `localRunnerVersionCheckArgs` in `local_runtime.go` to determine and append version check flags (`--version-check-enabled`, `--version-check-url`, `--version-check-identity`) to the local runner's start command based on launcher state.
- Modified the local runner start logic to use the new function, enabling or disabling version checks as configured.
- Adjusted a test in `connect_test.go` to add an early return after a failed flag lookup, improving test robustness.
- Updated a test in `local_backend_test.go` to use actual detected memory size for default configuration, aligning test expectations with runtime behavior.
- Added missing import for `reflect` in `local_runtime_test.go` to support deep equality checks in tests.

## Testing

<!-- Describe how you tested your changes -->

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

<!-- Describe your testing approach -->

## Checklist

<!-- Mark completed items with an "x" -->

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

<!-- Any additional information, screenshots, or context -->
