### PR TITLE
docs: document system requirements and limitations in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,30 @@ You can store your own preset directories anywhere on your filesystem and pass t
 
 See [doc/presets.md](doc/presets.md) for the full preset contract: manifest schema, required output artifacts, variable channels, and the reference implementations in `assets/infrastructure`.
 
+## 🖥️ System Requirements
+
+The Exasol Launcher runs on:
+
+- **macOS** — 12 (Monterey) or later, on Apple Silicon or Intel.
+- **Linux** — amd64 or arm64.
+- **Windows** — 10 or later, amd64.
+
+Where the database runs depends on the deployment type:
+
+- **Cloud deployments** — the database runs on your provider's infrastructure, so any supported launcher platform above works. The launcher provisions **Ubuntu 22.04 LTS (x86-64)** compute instances on all cloud providers.
+- **Local deployments** — the database runs in a VM on your machine, which requires macOS 15 (Sequoia) or later on Apple Silicon, with at least 8 GB RAM.
+
+## 🚧 Limitations
+
+Local deployments are intended for development and exploration and do not yet support every feature of a cloud deployment:
+
+- **UDFs** — user-defined functions are not available yet (coming soon).
+- **Virtual schemas** — virtual schemas are not available yet (coming soon).
+- **Admin UI** — the Administration UI is not available yet (coming soon).
+- **Multi-node clusters** — a local deployment is a single VM on your machine by design and always runs as a single node.
+
+Cloud deployments support all of the above.
+
 ## ⚖️ Licensing
 
 The Exasol Launcher source code in this repository is open-source software licensed under the [MIT License](./LICENSE). You are free to use, modify, and distribute it. Contributions are made under the same terms.


### PR DESCRIPTION
## Description

Adds two new README sections: **System Requirements** and **Limitations**. Documentation-only; no code, behavior, or dependencies change.

The requirements were not documented anywhere and had to be deduced from the code (Go toolchain floor, cloud preset images, and the embedded local VM runner's minimum-OS).

## Related Issue

N/A

## Type of Change

- [x] `docs`: Documentation update

## Changes Made

**System Requirements**
- Launcher platforms: macOS 12 (Monterey)+ (Apple Silicon or Intel), Linux (amd64/arm64), Windows 10+ (amd64).
- Cloud deployments provision **Ubuntu 22.04 LTS (x86-64)** instances (uniform across AWS, Azure, Exoscale, STACKIT).
- Local deployments run a VM requiring **macOS 15 (Sequoia)+ on Apple Silicon, ≥8 GB RAM** (from the embedded VM runner's `minos 15.0`).

**Limitations** (local deployments)
- UDFs, virtual schemas, and the Admin UI are not available yet (coming soon).
- Multi-node clusters are not supported by design — a local deployment is a single VM and always runs as a single node.
- Cloud deployments support all of the above.

## Testing

- [x] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality — N/A (documentation only)
- [x] Manually tested the changes (rendered the README; verified sections, layout, and links)

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [ ] Ran `task fmt` and `task lint` — N/A (no code changed)
- [x] Updated documentation (if applicable)
- [ ] Added/updated tests — N/A (documentation only)
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

The OS-version floors (macOS 12 / Windows 10 / Linux) derive from the Go 1.25 toolchain and are not enforced by an explicit check in the launcher; the local macOS 15 floor comes from the VM runner binary. Accurate as of the current toolchain/runner versions.
