### PR TITLE
fix: save node connection key in openssh format

### DIFF
--- a/internal/localruntime/runtime.go
+++ b/internal/localruntime/runtime.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
-	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -25,6 +24,7 @@ import (
 	"github.com/exasol/exasol-personal/assets/localruntimebin"
 	"github.com/exasol/exasol-personal/internal/config"
 	"github.com/exasol/exasol-personal/internal/util"
+	"golang.org/x/crypto/ssh"
 )
 
 const (
@@ -35,6 +35,7 @@ const (
 	vmStateFileName    = "vm-state.json"
 	vmPIDFileName      = "vm.pid"
 	PrivateKeyFileName = "node_access.pem"
+	openSSHKeyPEMType  = "OPENSSH PRIVATE KEY"
 	stopPollInterval   = 500 * time.Millisecond
 	stopTimeout        = 90 * time.Second
 	dirMode            = 0o750
@@ -359,8 +360,14 @@ func processRunning(pid int) bool {
 }
 
 func (runtime *localRuntime) ensureSSHKey() error {
-	if _, err := os.Stat(runtime.paths.PrivateKeyPath); err == nil {
-		return nil
+	if keyData, err := os.ReadFile(runtime.paths.PrivateKeyPath); err == nil {
+		if isOpenSSHPrivateKey(keyData) {
+			return nil
+		}
+
+		if err := os.Remove(runtime.paths.PrivateKeyPath); err != nil {
+			return fmt.Errorf("failed to replace invalid local SSH key: %w", err)
+		}
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("failed to inspect local SSH key: %w", err)
 	}
@@ -369,14 +376,11 @@ func (runtime *localRuntime) ensureSSHKey() error {
 	if err != nil {
 		return fmt.Errorf("failed to generate local SSH key: %w", err)
 	}
-	privateKeyPKCS8, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	privateKeyBlock, err := ssh.MarshalPrivateKey(privateKey, "")
 	if err != nil {
 		return fmt.Errorf("failed to marshal local SSH private key: %w", err)
 	}
-	privateKeyPEM := pem.EncodeToMemory(&pem.Block{
-		Type:  "PRIVATE KEY",
-		Bytes: privateKeyPKCS8,
-	})
+	privateKeyPEM := pem.EncodeToMemory(privateKeyBlock)
 	if err := os.MkdirAll(filepath.Dir(runtime.paths.PrivateKeyPath), dirMode); err != nil {
 		return fmt.Errorf("failed to create local SSH key directory: %w", err)
 	}
@@ -389,6 +393,18 @@ func (runtime *localRuntime) ensureSSHKey() error {
 	}
 
 	return nil
+}
+
+func isOpenSSHPrivateKey(keyData []byte) bool {
+	block, _ := pem.Decode(keyData)
+	if block == nil || block.Type != openSSHKeyPEMType {
+		return false
+	}
+	if _, err := ssh.ParsePrivateKey(keyData); err != nil {
+		return false
+	}
+
+	return true
 }
 
 func readRunnerState(statePath string) (*runnerState, error) {

--- a/internal/localruntime/runtime_test.go
+++ b/internal/localruntime/runtime_test.go
@@ -5,7 +5,11 @@ package localruntime
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"os"
 	"path/filepath"
@@ -207,7 +211,7 @@ func TestEnsureSSHKey_PreservesExistingPrivateKey(t *testing.T) {
 	// Given
 	deployment := config.NewDeploymentDir(t.TempDir())
 	localRuntime := newRuntime(deployment, Config{})
-	existingKey := []byte("existing private key")
+	existingKey := generateOpenSSHPrivateKey(t)
 	if err := os.MkdirAll(filepath.Dir(localRuntime.paths.PrivateKeyPath), 0o750); err != nil {
 		t.Fatalf("failed to create local key directory: %v", err)
 	}
@@ -257,12 +261,82 @@ func TestEnsureSSHKey_GeneratesEd25519Key(t *testing.T) {
 	if signer.PublicKey().Type() != ssh.KeyAlgoED25519 {
 		t.Fatalf("expected ED25519 SSH key, got %q", signer.PublicKey().Type())
 	}
+	block, _ := pem.Decode(privateKey)
+	if block == nil || block.Type != openSSHKeyPEMType {
+		t.Fatalf("expected OpenSSH private key PEM, got %#v", block)
+	}
 
 	if _, err := os.Stat(filepath.Join(localRuntime.paths.WorkDir, "vm-shared")); err == nil {
 		t.Fatal("expected SSH key setup not to create managed share")
 	} else if !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("failed to inspect managed share: %v", err)
 	}
+}
+
+func TestEnsureSSHKey_ReplacesLegacyPKCS8PrivateKey(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	deployment := config.NewDeploymentDir(t.TempDir())
+	localRuntime := newRuntime(deployment, Config{})
+	legacyKey := generatePKCS8PrivateKey(t)
+	if err := os.MkdirAll(filepath.Dir(localRuntime.paths.PrivateKeyPath), 0o750); err != nil {
+		t.Fatalf("failed to create local key directory: %v", err)
+	}
+	if err := os.WriteFile(localRuntime.paths.PrivateKeyPath, legacyKey, 0o600); err != nil {
+		t.Fatalf("failed to write legacy private key: %v", err)
+	}
+
+	// When
+	if err := localRuntime.ensureSSHKey(); err != nil {
+		t.Fatalf("expected SSH key setup to succeed, got %v", err)
+	}
+
+	// Then
+	privateKey, err := os.ReadFile(localRuntime.paths.PrivateKeyPath)
+	if err != nil {
+		t.Fatalf("expected generated SSH private key to be readable, got %v", err)
+	}
+	if string(privateKey) == string(legacyKey) {
+		t.Fatal("expected legacy private key to be replaced")
+	}
+	block, _ := pem.Decode(privateKey)
+	if block == nil || block.Type != openSSHKeyPEMType {
+		t.Fatalf("expected replacement key in OpenSSH format, got %#v", block)
+	}
+	if _, err := ssh.ParsePrivateKey(privateKey); err != nil {
+		t.Fatalf("expected replacement key to parse, got %v", err)
+	}
+}
+
+func generateOpenSSHPrivateKey(t *testing.T) []byte {
+	t.Helper()
+
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate test SSH key: %v", err)
+	}
+	block, err := ssh.MarshalPrivateKey(privateKey, "")
+	if err != nil {
+		t.Fatalf("failed to marshal test SSH key: %v", err)
+	}
+
+	return pem.EncodeToMemory(block)
+}
+
+func generatePKCS8PrivateKey(t *testing.T) []byte {
+	t.Helper()
+
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate test SSH key: %v", err)
+	}
+	data, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	if err != nil {
+		t.Fatalf("failed to marshal test PKCS8 key: %v", err)
+	}
+
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: data})
 }
 
 func TestStop_InvokesOriginalRunnerStop(t *testing.T) {


### PR DESCRIPTION
## Description

MacOS OpenSSH implementation does not accept `ed25519` keys packed in `PKCS#8`, making the ssh connection line to fail on MacOS local deployments.

This PR fixes this by saving the key on the standard openssh key format.

## Related Issue

<!-- Link to the related issue(s). Use "Fixes #123" or "Closes #123" to auto-close issues when PR is merged -->

Fixes #

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

<!-- List the key changes in this PR -->

- Save ssh key on openssh format instead of PKCS#8
-
-

## Testing

<!-- Describe how you tested your changes -->

- [x] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

<!-- Describe your testing approach -->

## Checklist

<!-- Mark completed items with an "x" -->

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

<!-- Any additional information, screenshots, or context -->
