### PR TITLE
fix(azure): unblock bootstrap blob upload; un-skip Windows+Azure infra tests

### DIFF
--- a/assets/infrastructure/azure/main.tf
+++ b/assets/infrastructure/azure/main.tf
@@ -130,7 +130,9 @@ resource "azurerm_storage_account" "remote_archive" {
   shared_access_key_enabled = true
 
   # Keep the standard blob endpoint reachable and rely on network_rules below
-  # to restrict access to the deployment subnet.
+  # to restrict access to the deployment subnet. This account holds backup data
+  # and receives no client-side uploads, so (unlike bootstrap_assets) the strict
+  # subnet firewall is kept.
   public_network_access_enabled = true
 
   network_rules {
@@ -164,11 +166,23 @@ resource "azurerm_storage_account" "bootstrap_assets" {
   public_network_access_enabled   = true
   shared_access_key_enabled       = true
 
-  network_rules {
-    default_action             = "Deny"
-    bypass                     = ["AzureServices"]
-    virtual_network_subnet_ids = [azurerm_subnet.subnet.id]
-  }
+  # NOTE: no `network_rules`/`default_action` firewall here — intentionally, and
+  # unlike the `remote_archive` account above.
+  #
+  # The bootstrap blobs below are uploaded by the deploying client (the launcher
+  # running `tofu apply`), which runs OUTSIDE the deployment VNet — a CI runner or
+  # an end user's machine. A subnet-scoped `default_action = "Deny"` firewall
+  # blocks that data-plane upload with HTTP 403 and breaks `deploy` entirely
+  # (SPOT-31457). Terraform cannot know the deploying client's public IP to allow
+  # it without an external IP-lookup service or a launcher change, both of which
+  # we deliberately avoid.
+  #
+  # Confidentiality does not depend on this firewall: the container is private,
+  # `allow_nested_items_to_be_public = false` forbids anonymous access, transport
+  # is HTTPS/TLS1.2, and the VMs read blobs with a read-only, object-scoped SAS
+  # (see `azurerm_storage_account_sas.bootstrap_assets`). The blobs themselves are
+  # non-secret bootstrap scripts. The sensitive `remote_archive` account keeps its
+  # strict `network_rules` because nothing uploads to it from outside the VNet.
 
   tags = local.common_tags
 }

--- a/cmd/exasol/terminal_notice_test.go
+++ b/cmd/exasol/terminal_notice_test.go
@@ -8,9 +8,14 @@ import (
 	"testing"
 )
 
+// TestTerminalMessagesPrintNoticesInQueueOrderAndOutputToStdout must not run in
+// parallel: it mutates the package-level terminal message queues
+// (resetTerminalMessages/addTerminal*/writeTerminalMessages), which are shared
+// global state. Running alongside other tests that touch them (e.g.
+// TestVersionCmdQueuesPrimaryOutputForTerminalFlush) trips the race detector.
+//
+//nolint:paralleltest // mutates shared package globals; must run serially
 func TestTerminalMessagesPrintNoticesInQueueOrderAndOutputToStdout(t *testing.T) {
-	t.Parallel()
-
 	resetTerminalMessages()
 	defer resetTerminalMessages()
 

--- a/cmd/exasol/version_test.go
+++ b/cmd/exasol/version_test.go
@@ -132,9 +132,13 @@ func TestFormatLatestVersionText_RejectsInvalidVersionData(t *testing.T) {
 	}
 }
 
+// TestVersionCmdQueuesPrimaryOutputForTerminalFlush must not run in parallel: it
+// mutates the shared package-level terminal message queues (resetTerminalMessages),
+// which races with other tests that touch the same globals (see
+// TestTerminalMessagesPrintNoticesInQueueOrderAndOutputToStdout).
+//
+//nolint:paralleltest // mutates shared package globals; must run serially
 func TestVersionCmdQueuesPrimaryOutputForTerminalFlush(t *testing.T) {
-	t.Parallel()
-
 	resetTerminalMessages()
 	defer resetTerminalMessages()
 

--- a/tests/tests/deployment/test_standard_deployment.py
+++ b/tests/tests/deployment/test_standard_deployment.py
@@ -476,9 +476,6 @@ def test_license_session_limit(reusable_deployment: Deployment) -> None:
     assert alive == license_session_limit
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
-)
 @pytest.mark.infrastructure_e2e
 def test_stop_and_start(reusable_deployment: Deployment) -> None:
     # Using resuable_deployment fixture
@@ -518,12 +515,14 @@ def test_stop_and_start(reusable_deployment: Deployment) -> None:
     # Immediately verify DB is connectable after start completes
     assert reusable_deployment.db_connectable()
 
+    # The interactive `connect()` spawns a shell that reads from stdin. On Windows
+    # that path depends on the piped-stdin fix tracked separately (SPOT-31454), so
+    # here we only assert the non-interactive stop/start/info lifecycle. Exercise
+    # the interactive check on POSIX, where it is supported today.
     if not sys.platform.startswith("win"):
         connect_result = reusable_deployment.connect()
         assert hasattr(connect_result, "returncode")
         assert connect_result.returncode == 0
-    else:
-        pytest.skip("Skipping DB connection for Windows OS")
 
 
 @pytest.mark.skipif(
@@ -585,9 +584,6 @@ def test_start_interrupt_sets_interrupted_state(
     assert reusable_deployment.has_status(StatusDatabaseReady)
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
-)
 @pytest.mark.infrastructure_e2e
 @pytest.mark.provider_aws
 @pytest.mark.provider_azure


### PR DESCRIPTION
## Description

Restores real signal from the Windows + Azure deployment E2E job (`pytest -m infrastructure_e2e`), which had all deploy-dependent tests skipped on Windows and — as this work uncovered — a broken Azure deploy that was masked by the only running test expecting failure.

Two related changes:

1. **fix(azure): unblock bootstrap blob upload from the deploying client (SPOT-31457).** The `bootstrap_assets` storage account was created with a subnet-scoped network firewall (`default_action = "Deny"`). The bootstrap blobs are uploaded by the deploying client (the launcher running `tofu apply`) from *outside* the deployment VNet, so every `azurerm_storage_blob` upload failed with HTTP 403 and the whole Azure deploy aborted. Removing the firewall from that account (only) unblocks the upload while preserving confidentiality.
2. **test: un-skip the cross-platform Windows infrastructure_e2e tests (SPOT-31453).** With the deploy fixed, `test_remote_archive_registered` (pure HTTP) and `test_stop_and_start` (subprocess lifecycle + websocket) can run on Windows.

## Related Issue

SPOT-31457 (Azure deploy fix) and SPOT-31453 (test un-skip), under epic SPOT-31452. Linked via the branch/PR key.

## Type of Change

- [x] `fix`: Bug fix
- [x] `test`: Test additions or changes

## Changes Made

- Remove the `network_rules` firewall from the `bootstrap_assets` Azure storage account so the out-of-VNet deploying client can upload bootstrap blobs; keep the sensitive `remote_archive` account strict. Documented inline in `assets/infrastructure/azure/main.tf`.
- Remove the blanket Windows `skipif` from `test_remote_archive_registered` and `test_stop_and_start`.
- Drop the trailing `pytest.skip` in `test_stop_and_start` so the non-interactive lifecycle runs on Windows; the interactive `connect()` check stays POSIX-only pending the piped-stdin fix (SPOT-31454).

## Testing

- [x] `terraform fmt -check` clean; `terraform validate` passes on the Azure preset.
- [x] `ruff check` / `ruff format --check` clean; `pytest --co` collects all tests.
- [ ] `task all` — not run: the deployment suite needs real Azure and cannot run locally.

### Test Details

Real validation is the **Windows + Azure** `Deployment Tests` workflow (`workflow_dispatch`, `infrastructure_e2e`). Prior run failed at deploy with the 403 above; this PR should let the deploy complete and the two un-skipped tests execute and pass.

## Security note (Azure fix)

Confidentiality does not depend on the removed firewall: the container is private, `allow_nested_items_to_be_public = false` forbids anonymous access, transport is HTTPS/TLS1.2, and VMs read via a read-only, object-scoped SAS. The blobs are non-secret bootstrap scripts. The `remote_archive` account (holds backup data, no client uploads) keeps its strict subnet firewall.

## Checklist

- [x] Ran `task fmt` / `task lint` equivalents (ruff + terraform fmt)
- [x] Commit messages follow Conventional Commits
