### PR TITLE
fix: make start and stop lifecycle commands idempotent

### DIFF
--- a/cmd/exasol/deploymentControl.go
+++ b/cmd/exasol/deploymentControl.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"io"
 	"os"
 	"time"
@@ -61,6 +62,10 @@ var startCmd = &cobra.Command{
 			commonFlags.DeployVerbose,
 			waitTimeoutSeconds,
 		); err != nil {
+			if errors.Is(err, deploy.ErrLifecycleActionSkipped) {
+				return nil
+			}
+
 			return err
 		}
 

--- a/internal/deploy/deploymentControl.go
+++ b/internal/deploy/deploymentControl.go
@@ -5,6 +5,7 @@ package deploy
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
@@ -13,39 +14,136 @@ import (
 	"github.com/exasol/exasol-personal/internal/util"
 )
 
-func WorkflowStatePermitsStart(
+type lifecycleActionDecision struct {
+	shouldRun                  bool
+	guidance                   string
+	showConnectionInstructions bool
+}
+
+func workflowStatePermitsStart(
+	ctx context.Context,
 	exasolState *config.ExasolPersonalState,
 	deployment config.DeploymentDir,
-) error {
+) (lifecycleActionDecision, error) {
 	workflowState, err := exasolState.GetWorkflowState()
 	if err != nil {
 		slog.Error("failed to read workflow state")
-		return err
+		return noLifecycleAction(), err
 	}
 
 	switch state := workflowState.(type) {
+	case *config.WorkflowStateInitialized:
+		return guidanceOnly(
+			"deployment is initialized but not deployed yet; run `exasol deploy` " +
+				"or the same `exasol install <infra preset>` command to create and start it",
+		), nil
+
 	case *config.WorkflowStateStopped:
-		return nil
+		return runLifecycleAction(), nil
+
+	case *config.WorkflowStateRunning:
+		status, err := getStatusForStart(ctx, deployment, true)
+		if err != nil {
+			return noLifecycleAction(), err
+		}
+		if status.Status == StatusDatabaseReady {
+			return skipLifecycleActionWithConnectionInstructions(
+				"database is already ready to accept connections",
+			), nil
+		}
+
+		return guidanceOnly(
+			"deployment state is running, but the database is not ready; run `exasol status` " +
+				"for details, then run `exasol stop` and `exasol start` to restart it or " +
+				"`exasol destroy` to clean up resources",
+		), nil
+
+	case *config.WorkflowStateDeploymentFailed:
+		return guidanceOnly(
+			"deployment is in a failed state; fix the reported problem and run `exasol deploy` " +
+				"or the same `exasol install <infra preset>` command again, or run " +
+				"`exasol destroy` to clean up resources",
+		), nil
 
 	case *config.WorkflowStateOperationInProgress:
 		switch state.Operation {
 		case config.StartOperation:
-			return nil
+			return runLifecycleAction(), nil
 		default:
-			return newBlockedStateError(deployment, ErrUnspportedOperation)
+			return skipLifecycleAction(
+				operationInProgressGuidance(state.Operation, "start"),
+			), nil
 		}
 
 	case *config.WorkflowStateInterrupted:
 		switch state.InterruptedDuringOperation {
 		case config.StartOperation,
 			config.StopOperation:
-			return nil
+			return runLifecycleAction(), nil
 		default:
-			return newBlockedStateError(deployment, ErrUnspportedOperation)
+			return skipLifecycleAction(
+				interruptedOperationGuidance(state.InterruptedDuringOperation, "start"),
+			), nil
 		}
 	}
 
-	return newBlockedStateError(deployment, ErrUnexpectedDeploymentStatus)
+	return guidanceOnly(
+		"deployment is in an unexpected state; run `exasol status` for details",
+	), nil
+}
+
+var getStatusForStart = GetStatus
+
+func noLifecycleAction() lifecycleActionDecision {
+	return lifecycleActionDecision{
+		shouldRun:                  false,
+		guidance:                   "",
+		showConnectionInstructions: false,
+	}
+}
+
+func runLifecycleAction() lifecycleActionDecision {
+	return lifecycleActionDecision{
+		shouldRun:                  true,
+		guidance:                   "",
+		showConnectionInstructions: false,
+	}
+}
+
+func guidanceOnly(message string) lifecycleActionDecision {
+	return skipLifecycleAction(message)
+}
+
+func skipLifecycleAction(message string) lifecycleActionDecision {
+	return lifecycleActionDecision{
+		shouldRun:                  false,
+		guidance:                   message,
+		showConnectionInstructions: false,
+	}
+}
+
+func skipLifecycleActionWithConnectionInstructions(message string) lifecycleActionDecision {
+	return lifecycleActionDecision{
+		shouldRun:                  false,
+		guidance:                   message,
+		showConnectionInstructions: true,
+	}
+}
+
+func operationInProgressGuidance(operation, requestedAction string) string {
+	return "operation `" + operation + "` is in progress or did not finish cleanly; " +
+		"run `exasol status` for recovery guidance before running `exasol " + requestedAction + "`"
+}
+
+func interruptedOperationGuidance(operation, requestedAction string) string {
+	return "a previous `" + operation + "` operation was interrupted; run `exasol status` " +
+		"for recovery guidance before running `exasol " + requestedAction + "`"
+}
+
+func logLifecycleGuidance(message string) {
+	if message != "" {
+		slog.Warn(message)
+	}
 }
 
 //
@@ -56,10 +154,8 @@ func Start(
 	verbose bool,
 	waitTimeoutSeconds int,
 ) error {
-	return withDeploymentExclusiveLock(ctx, deployment,
+	err := withDeploymentExclusiveLock(ctx, deployment,
 		func(deployment config.DeploymentDir) error {
-			slog.Info("starting deployment. this may take a few minutes")
-
 			exasolState, err := config.ReadExasolPersonalState(deployment)
 			if err != nil {
 				return err
@@ -69,9 +165,20 @@ func Start(
 				return err
 			}
 
-			if err := WorkflowStatePermitsStart(exasolState, deployment); err != nil {
-				return err
+			decision, err := workflowStatePermitsStart(ctx, exasolState, deployment)
+			if err != nil {
+				return util.LoggedError(err, "run `status` for more information")
 			}
+			if !decision.shouldRun {
+				logLifecycleGuidance(decision.guidance)
+				if decision.showConnectionInstructions {
+					return nil
+				}
+
+				return ErrLifecycleActionSkipped
+			}
+
+			slog.Info("starting deployment. this may take a few minutes")
 
 			// Set the workflowstate to start operation in-progress
 			err = exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateOperationInProgress{
@@ -141,28 +248,51 @@ func Start(
 
 			return writeConnectionInstructionsFile(deployment, connectionInstructions)
 		})
+	if errors.Is(err, ErrDeploymentDirectoryLocked) {
+		slog.Warn(err.Error())
+		return ErrLifecycleActionSkipped
+	}
+
+	return err
 }
 
-func WorkflowStatePermitsStop(
+func workflowStatePermitsStop(
 	exasolState *config.ExasolPersonalState,
-	deployment config.DeploymentDir,
-) error {
+) (lifecycleActionDecision, error) {
 	workflowState, err := exasolState.GetWorkflowState()
 	if err != nil {
 		slog.Error("failed to read workflow state")
-		return err
+		return noLifecycleAction(), err
 	}
 
 	switch state := workflowState.(type) {
+	case *config.WorkflowStateInitialized:
+		return guidanceOnly(
+			"deployment is initialized but not deployed yet; there is nothing to stop; " +
+				"run `exasol deploy` or the same `exasol install <infra preset>` command " +
+				"to create and start it",
+		), nil
+
 	case *config.WorkflowStateRunning:
-		return nil
+		return runLifecycleAction(), nil
+
+	case *config.WorkflowStateStopped:
+		return guidanceOnly("deployment is already stopped"), nil
+
+	case *config.WorkflowStateDeploymentFailed:
+		return guidanceOnly(
+			"deployment is in a failed state; run `exasol status` for details, then retry " +
+				"`exasol deploy` or run `exasol destroy` to clean up resources",
+		), nil
 
 	case *config.WorkflowStateOperationInProgress:
 		switch state.Operation {
 		case config.StopOperation:
-			return nil
+			return runLifecycleAction(), nil
 		default:
-			return newBlockedStateError(deployment, ErrUnspportedOperation)
+			return skipLifecycleAction(
+				operationInProgressGuidance(state.Operation, "stop"),
+			), nil
 		}
 
 	case *config.WorkflowStateInterrupted:
@@ -170,21 +300,23 @@ func WorkflowStatePermitsStop(
 		case config.StartOperation,
 			config.StopOperation,
 			config.DestroyOperation:
-			return nil
+			return runLifecycleAction(), nil
 		default:
-			return newBlockedStateError(deployment, ErrUnspportedOperation)
+			return skipLifecycleAction(
+				interruptedOperationGuidance(state.InterruptedDuringOperation, "stop"),
+			), nil
 		}
 	}
 
-	return newBlockedStateError(deployment, ErrUnexpectedDeploymentStatus)
+	return guidanceOnly(
+		"deployment is in an unexpected state; run `exasol status` for details",
+	), nil
 }
 
 //nolint:revive
 func Stop(ctx context.Context, deployment config.DeploymentDir, verbose bool) error {
-	return withDeploymentExclusiveLock(ctx, deployment,
+	err := withDeploymentExclusiveLock(ctx, deployment,
 		func(deployment config.DeploymentDir) error {
-			slog.Info("stopping deployment. this may take a few minutes")
-
 			exasolState, err := config.ReadExasolPersonalState(deployment)
 			if err != nil {
 				return err
@@ -194,9 +326,17 @@ func Stop(ctx context.Context, deployment config.DeploymentDir, verbose bool) er
 				return err
 			}
 
-			if err = WorkflowStatePermitsStop(exasolState, deployment); err != nil {
-				return err
+			decision, err := workflowStatePermitsStop(exasolState)
+			if err != nil {
+				return util.LoggedError(err, "run `status` for more information")
 			}
+			if !decision.shouldRun {
+				logLifecycleGuidance(decision.guidance)
+
+				return nil
+			}
+
+			slog.Info("stopping deployment. this may take a few minutes")
 
 			// Set the workflowstate to stop in-progress
 			err = exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateOperationInProgress{
@@ -253,4 +393,10 @@ func Stop(ctx context.Context, deployment config.DeploymentDir, verbose bool) er
 
 			return nil
 		})
+	if errors.Is(err, ErrDeploymentDirectoryLocked) {
+		slog.Warn(err.Error())
+		return nil
+	}
+
+	return err
 }

--- a/internal/deploy/deploymentControl_test.go
+++ b/internal/deploy/deploymentControl_test.go
@@ -1,0 +1,222 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+)
+
+func TestWorkflowStatePermitsStart_RequiresStartForStoppedDeployment(t *testing.T) {
+	t.Parallel()
+
+	// Given: a deployment that is stopped.
+	exasolState := &config.ExasolPersonalState{}
+	if err := exasolState.SetWorkflowState(&config.WorkflowStateStopped{}); err != nil {
+		t.Fatalf("set workflow state failed: %v", err)
+	}
+
+	// When: start permission is checked.
+	decision, err := workflowStatePermitsStart(
+		context.Background(),
+		exasolState,
+		config.NewDeploymentDir(t.TempDir()),
+	)
+	// Then: the caller should start the backend.
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if !decision.shouldRun {
+		t.Fatal("expected stopped deployment to require backend start")
+	}
+}
+
+//nolint:paralleltest // Mutates package-level getStatusForStart.
+func TestWorkflowStatePermitsStart_SkipsStartForReadyDeployment(t *testing.T) {
+	// Given: a running deployment whose database is already ready.
+	exasolState := &config.ExasolPersonalState{}
+	if err := exasolState.SetWorkflowState(&config.WorkflowStateRunning{}); err != nil {
+		t.Fatalf("set workflow state failed: %v", err)
+	}
+
+	originalGetStatusForStart := getStatusForStart
+	getStatusForStart = func(
+		_ context.Context,
+		_ config.DeploymentDir,
+		checkConnection bool,
+	) (*StatusOutput, error) {
+		if !checkConnection {
+			t.Fatal("expected start check to verify database readiness")
+		}
+
+		return &StatusOutput{Status: StatusDatabaseReady}, nil
+	}
+	t.Cleanup(func() {
+		getStatusForStart = originalGetStatusForStart
+	})
+
+	// When: start permission is checked.
+	decision, err := workflowStatePermitsStart(
+		context.Background(),
+		exasolState,
+		config.NewDeploymentDir(t.TempDir()),
+	)
+	// Then: the caller can return successfully without starting the backend again.
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if decision.shouldRun {
+		t.Fatal("expected ready deployment to skip backend start")
+	}
+	if !decision.showConnectionInstructions {
+		t.Fatal("expected ready deployment to show connection instructions")
+	}
+	if !strings.Contains(decision.guidance, "already ready") {
+		t.Fatalf("expected already-ready guidance, got %q", decision.guidance)
+	}
+}
+
+//nolint:paralleltest // Mutates package-level getStatusForStart.
+func TestWorkflowStatePermitsStart_GuidesForRunningDeploymentThatIsNotReady(t *testing.T) {
+	// Given: a running deployment whose database is not ready.
+	deployment := config.NewDeploymentDir(t.TempDir())
+	exasolState := &config.ExasolPersonalState{}
+	if err := exasolState.SetWorkflowStateAndWrite(
+		&config.WorkflowStateRunning{},
+		deployment,
+	); err != nil {
+		t.Fatalf("write workflow state failed: %v", err)
+	}
+
+	originalGetStatusForStart := getStatusForStart
+	getStatusForStart = func(
+		_ context.Context,
+		_ config.DeploymentDir,
+		_ bool,
+	) (*StatusOutput, error) {
+		return &StatusOutput{Status: StatusDatabaseConnectionFailed}, nil
+	}
+	t.Cleanup(func() {
+		getStatusForStart = originalGetStatusForStart
+	})
+
+	// When: start permission is checked.
+	decision, err := workflowStatePermitsStart(
+		context.Background(),
+		exasolState,
+		deployment,
+	)
+	// Then: the command gives next-step guidance without retrying the backend.
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if decision.shouldRun {
+		t.Fatal("expected non-ready running deployment to skip backend start")
+	}
+	for _, expected := range []string{"not ready", "exasol status", "exasol stop", "exasol start"} {
+		if !strings.Contains(decision.guidance, expected) {
+			t.Fatalf("expected guidance to contain %q, got %q", expected, decision.guidance)
+		}
+	}
+}
+
+func TestWorkflowStatePermitsStart_GuidesForInitializedDeployment(t *testing.T) {
+	t.Parallel()
+
+	// Given: a deployment that has not been deployed yet.
+	exasolState := &config.ExasolPersonalState{}
+	if err := exasolState.SetWorkflowState(&config.WorkflowStateInitialized{}); err != nil {
+		t.Fatalf("set workflow state failed: %v", err)
+	}
+
+	// When: start permission is checked.
+	decision, err := workflowStatePermitsStart(
+		context.Background(),
+		exasolState,
+		config.NewDeploymentDir(t.TempDir()),
+	)
+	// Then: the caller gets guidance instead of an unexpected-status error.
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if decision.shouldRun {
+		t.Fatal("expected initialized deployment to skip backend start")
+	}
+	for _, expected := range []string{"initialized", "exasol deploy"} {
+		if !strings.Contains(decision.guidance, expected) {
+			t.Fatalf("expected guidance to contain %q, got %q", expected, decision.guidance)
+		}
+	}
+}
+
+func TestWorkflowStatePermitsStop_RequiresStopForRunningDeployment(t *testing.T) {
+	t.Parallel()
+
+	// Given: a deployment that is running.
+	exasolState := &config.ExasolPersonalState{}
+	if err := exasolState.SetWorkflowState(&config.WorkflowStateRunning{}); err != nil {
+		t.Fatalf("set workflow state failed: %v", err)
+	}
+
+	// When: stop permission is checked.
+	decision, err := workflowStatePermitsStop(exasolState)
+	// Then: the caller should stop the backend.
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if !decision.shouldRun {
+		t.Fatal("expected running deployment to require backend stop")
+	}
+}
+
+func TestWorkflowStatePermitsStop_GuidesForAlreadyStoppedDeployment(t *testing.T) {
+	t.Parallel()
+
+	// Given: a deployment that is already stopped.
+	exasolState := &config.ExasolPersonalState{}
+	if err := exasolState.SetWorkflowState(&config.WorkflowStateStopped{}); err != nil {
+		t.Fatalf("set workflow state failed: %v", err)
+	}
+
+	// When: stop permission is checked.
+	decision, err := workflowStatePermitsStop(exasolState)
+	// Then: the caller gets an idempotent no-op decision.
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if decision.shouldRun {
+		t.Fatal("expected stopped deployment to skip backend stop")
+	}
+	if !strings.Contains(decision.guidance, "already stopped") {
+		t.Fatalf("expected already-stopped guidance, got %q", decision.guidance)
+	}
+}
+
+func TestWorkflowStatePermitsStop_GuidesForInitializedDeployment(t *testing.T) {
+	t.Parallel()
+
+	// Given: a deployment that has not been deployed yet.
+	exasolState := &config.ExasolPersonalState{}
+	if err := exasolState.SetWorkflowState(&config.WorkflowStateInitialized{}); err != nil {
+		t.Fatalf("set workflow state failed: %v", err)
+	}
+
+	// When: stop permission is checked.
+	decision, err := workflowStatePermitsStop(exasolState)
+	// Then: the caller gets guidance instead of an unexpected-status error.
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if decision.shouldRun {
+		t.Fatal("expected initialized deployment to skip backend stop")
+	}
+	for _, expected := range []string{"nothing to stop", "exasol deploy"} {
+		if !strings.Contains(decision.guidance, expected) {
+			t.Fatalf("expected guidance to contain %q, got %q", expected, decision.guidance)
+		}
+	}
+}

--- a/internal/deploy/reconfiguration_test.go
+++ b/internal/deploy/reconfiguration_test.go
@@ -272,6 +272,16 @@ func assertBlockedStateError(
 	}
 }
 
+func assertContainsAll(t *testing.T, message string, wantSubstrings ...string) {
+	t.Helper()
+
+	for _, substring := range wantSubstrings {
+		if !strings.Contains(message, substring) {
+			t.Fatalf("expected message to contain %q, got %q", substring, message)
+		}
+	}
+}
+
 func TestWorkflowStatePermitsDeploy_BlockedStatesSurfaceRecoveryGuidance(t *testing.T) {
 	t.Parallel()
 
@@ -404,28 +414,22 @@ func TestWorkflowStatePermitsConnect_PermitsRunning(t *testing.T) {
 	}
 }
 
-func TestWorkflowStatePermitsStart_BlockedStatesSurfaceRecoveryGuidance(t *testing.T) {
+func TestWorkflowStatePermitsStart_SkippedStatesSurfaceRecoveryGuidance(t *testing.T) {
 	t.Parallel()
 
 	for _, test := range []struct {
 		name         string
 		state        any
-		sentinel     error
-		wantStatus   string
 		wantGuidance []string
 	}{
 		{
 			name:         "initialized",
 			state:        &config.WorkflowStateInitialized{},
-			sentinel:     ErrUnexpectedDeploymentStatus,
-			wantStatus:   StatusInitialized,
 			wantGuidance: []string{"deploy"},
 		},
 		{
 			name:         "deployment_failed",
 			state:        &config.WorkflowStateDeploymentFailed{Error: "boom"},
-			sentinel:     ErrUnexpectedDeploymentStatus,
-			wantStatus:   StatusDeploymentFailed,
 			wantGuidance: []string{"deploy"},
 		},
 		{
@@ -433,8 +437,6 @@ func TestWorkflowStatePermitsStart_BlockedStatesSurfaceRecoveryGuidance(t *testi
 			state: &config.WorkflowStateInterrupted{
 				InterruptedDuringOperation: config.DeployOperation,
 			},
-			sentinel:     ErrUnspportedOperation,
-			wantStatus:   StatusInterrupted,
 			wantGuidance: []string{"deploy"},
 		},
 	} {
@@ -442,55 +444,59 @@ func TestWorkflowStatePermitsStart_BlockedStatesSurfaceRecoveryGuidance(t *testi
 			t.Parallel()
 
 			deployment, state := deploymentInState(t, test.state)
-			err := WorkflowStatePermitsStart(state, deployment)
-			assertBlockedStateError(
-				t, deployment, err, test.sentinel, test.wantStatus, test.wantGuidance...,
+			decision, err := workflowStatePermitsStart(context.Background(), state, deployment)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if decision.shouldRun {
+				t.Fatal("expected start to be skipped")
+			}
+			assertContainsAll(
+				t, decision.guidance, test.wantGuidance...,
 			)
 		})
 	}
 }
 
-func TestWorkflowStatePermitsStop_BlockedStatesSurfaceRecoveryGuidance(t *testing.T) {
+func TestWorkflowStatePermitsStop_SkippedStatesSurfaceRecoveryGuidance(t *testing.T) {
 	t.Parallel()
 
 	for _, test := range []struct {
 		name         string
 		state        any
-		sentinel     error
-		wantStatus   string
 		wantGuidance []string
 	}{
 		{
 			name:         "initialized",
 			state:        &config.WorkflowStateInitialized{},
-			sentinel:     ErrUnexpectedDeploymentStatus,
-			wantStatus:   StatusInitialized,
 			wantGuidance: []string{"deploy"},
 		},
 		{
 			name:         "stopped",
 			state:        &config.WorkflowStateStopped{},
-			sentinel:     ErrUnexpectedDeploymentStatus,
-			wantStatus:   StatusStopped,
-			wantGuidance: []string{"start"},
+			wantGuidance: []string{"already stopped"},
 		},
 		{
 			name: "interrupted_during_deploy",
 			state: &config.WorkflowStateInterrupted{
 				InterruptedDuringOperation: config.DeployOperation,
 			},
-			sentinel:     ErrUnspportedOperation,
-			wantStatus:   StatusInterrupted,
 			wantGuidance: []string{"deploy"},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			deployment, state := deploymentInState(t, test.state)
-			err := WorkflowStatePermitsStop(state, deployment)
-			assertBlockedStateError(
-				t, deployment, err, test.sentinel, test.wantStatus, test.wantGuidance...,
+			_, state := deploymentInState(t, test.state)
+			decision, err := workflowStatePermitsStop(state)
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if decision.shouldRun {
+				t.Fatal("expected stop to be skipped")
+			}
+			assertContainsAll(
+				t, decision.guidance, test.wantGuidance...,
 			)
 		})
 	}

--- a/internal/deploy/shared.go
+++ b/internal/deploy/shared.go
@@ -71,6 +71,7 @@ type BackoffCondition func(context.Context) (bool, error)
 var (
 	ErrUnknownDeploymentType      = errors.New("unknown deployment type")
 	ErrNotImplemented             = errors.New("not implemented")
+	ErrLifecycleActionSkipped     = errors.New("lifecycle action skipped")
 	ErrUnexpectedDeploymentStatus = errors.New("unexpected deployment status")
 	ErrUnspportedOperation        = errors.New("unsupported operation")
 )

--- a/tests/tests/integration/test_install.py
+++ b/tests/tests/integration/test_install.py
@@ -25,6 +25,109 @@ def assert_lifecycle_json_signal(
     }
 
 
+def _assert_running_start_guidance(
+    exasol_path: str,
+    deployment_dir: Path,
+    env: dict[str, str],
+) -> None:
+    start_result = run_command(
+        [
+            exasol_path,
+            "start",
+            "--deployment-dir",
+            str(deployment_dir),
+        ],
+        env=env,
+    )
+    assert start_result.returncode == 0
+    assert "deployment state is running, but the database is not ready" in (
+        start_result.stderr
+    )
+    assert "exasol status" in start_result.stderr
+    assert "exasol stop" in start_result.stderr
+    assert "exasol start" in start_result.stderr
+
+
+def _assert_already_stopped_guidance(
+    exasol_path: str,
+    deployment_dir: Path,
+    env: dict[str, str],
+) -> None:
+    second_stop_result = run_command(
+        [
+            exasol_path,
+            "stop",
+            "--deployment-dir",
+            str(deployment_dir),
+        ],
+        env=env,
+    )
+    assert second_stop_result.returncode == 0
+    assert "deployment is already stopped" in second_stop_result.stderr
+
+
+def _assert_local_deployment_artifacts(deployment_dir: Path) -> None:
+    version_check_marker = (
+        deployment_dir / "local" / "runtime" / "start-version-check-enabled"
+    )
+    assert version_check_marker.read_text() == "false"
+
+    deployment_data = json.loads((deployment_dir / "deployment.json").read_text())
+    assert deployment_data["backend"] == "local"
+    assert "nodes" not in deployment_data
+    assert deployment_data["connection"]["host"] == "127.0.0.1"
+    assert deployment_data["connection"]["dbPort"] == LOCAL_TEST_DB_PORT
+    assert "adminUi" not in deployment_data["connection"]
+    assert "uiPort" not in deployment_data["connection"]
+    assert deployment_data["connection"]["insecureSkipCertValidation"] is True
+
+    secrets_data = json.loads((deployment_dir / "secrets.json").read_text())
+    assert secrets_data["dbPassword"] == "exasol"
+    assert "adminUiPassword" not in secrets_data
+
+
+def _assert_local_info(
+    exasol_path: str,
+    deployment_dir: Path,
+    env: dict[str, str],
+) -> None:
+    info_result = run_command(
+        [
+            exasol_path,
+            "info",
+            "--json",
+            "--deployment-dir",
+            str(deployment_dir),
+        ],
+        env=env,
+    )
+    info_data = json.loads(info_result.stdout)
+    assert info_data["deploymentState"] == "running"
+    assert info_data["connection"]["backend"] == "local"
+    assert info_data["connection"]["dbPort"] == LOCAL_TEST_DB_PORT
+    assert "adminUi" not in info_data["connection"]
+    assert "uiPort" not in info_data["connection"]
+
+
+def _assert_database_connection_failed_status(
+    exasol_path: str,
+    deployment_dir: Path,
+    env: dict[str, str],
+) -> None:
+    status_result = run_command(
+        [
+            exasol_path,
+            "status",
+            "--json",
+            "--deployment-dir",
+            str(deployment_dir),
+        ],
+        env=env,
+    )
+    status_data = json.loads(status_result.stdout)
+    assert status_data["status"] == "database_connection_failed"
+
+
 def test_install_requires_infra_preset_arg(exasol_path: str) -> None:
     # Given the install command
 
@@ -324,54 +427,16 @@ esac
 
     # Then the deployment is initialized and local connection artifacts are written
     assert result.returncode == 0
-    version_check_marker = (
-        deployment_dir / "local" / "runtime" / "start-version-check-enabled"
-    )
-    assert version_check_marker.read_text() == "false"
-    deployment_data = json.loads((deployment_dir / "deployment.json").read_text())
-    assert deployment_data["backend"] == "local"
-    assert "nodes" not in deployment_data
-    assert deployment_data["connection"]["host"] == "127.0.0.1"
-    assert deployment_data["connection"]["dbPort"] == LOCAL_TEST_DB_PORT
-    assert "adminUi" not in deployment_data["connection"]
-    assert "uiPort" not in deployment_data["connection"]
-    assert deployment_data["connection"]["insecureSkipCertValidation"] is True
-
-    secrets_data = json.loads((deployment_dir / "secrets.json").read_text())
-    assert secrets_data["dbPassword"] == "exasol"
-    assert "adminUiPassword" not in secrets_data
+    _assert_local_deployment_artifacts(deployment_dir)
 
     # Then info can consume the local artifacts without cloud-specific assumptions
-    info_result = run_command(
-        [
-            exasol_path,
-            "info",
-            "--json",
-            "--deployment-dir",
-            str(deployment_dir),
-        ],
-        env=env,
-    )
-    info_data = json.loads(info_result.stdout)
-    assert info_data["deploymentState"] == "running"
-    assert info_data["connection"]["backend"] == "local"
-    assert info_data["connection"]["dbPort"] == LOCAL_TEST_DB_PORT
-    assert "adminUi" not in info_data["connection"]
-    assert "uiPort" not in info_data["connection"]
+    _assert_local_info(exasol_path, deployment_dir, env)
 
     # Then status also handles the local artifacts even though the fake DB is absent
-    status_result = run_command(
-        [
-            exasol_path,
-            "status",
-            "--json",
-            "--deployment-dir",
-            str(deployment_dir),
-        ],
-        env=env,
-    )
-    status_data = json.loads(status_result.stdout)
-    assert status_data["status"] == "database_connection_failed"
+    _assert_database_connection_failed_status(exasol_path, deployment_dir, env)
+
+    # Then start on a running deployment gives recovery guidance instead of failing
+    _assert_running_start_guidance(exasol_path, deployment_dir, env)
 
     # Then stop updates persisted state and emits a JSON ready signal
     stop_result = run_command(
@@ -389,6 +454,9 @@ esac
     deployment_data = json.loads((deployment_dir / "deployment.json").read_text())
     assert deployment_data["deploymentState"] == "stopped"
     assert deployment_data["clusterState"] == "stopped"
+
+    # Then stopping an already stopped deployment is an idempotent no-op
+    _assert_already_stopped_guidance(exasol_path, deployment_dir, env)
 
     # Then start emits only the JSON ready signal on stdout
     start_result = run_command(


### PR DESCRIPTION
## Description

Make the `start` and `stop` lifecycle commands idempotent for states where no backend action should run. The commands now classify the deployment state first, give next-step guidance for non-actionable states, and only invoke backend start/stop when the state requires it.

This fixes the bug where unexpected lifecycle states surfaced as command errors without explaining what happened or what the user should do next.

Example behavior:

`exasol start`
- Stopped deployment: starts the backend and waits until the database is ready.
- Already running and `database_ready`: exits successfully, reports that the database is already ready, and keeps showing existing connection instructions.
- Initialized but not deployed: exits successfully with guidance to run `exasol deploy` or the same install command.
- Running but database is not ready: exits successfully with guidance to run `exasol status`, then restart with `exasol stop` / `exasol start` or clean up with `exasol destroy`.

`exasol stop`
- Running deployment: stops the backend and records the deployment as stopped.
- Already stopped: exits successfully and reports that no stop action is needed.
- Initialized but not deployed: exits successfully with guidance that there is nothing to stop and to run `exasol deploy` or install first.
- Failed or in-progress states: exits successfully with state-specific recovery guidance.

Real backend start/stop failures still propagate as errors.

## Related Issue

SPOT-31456

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Added lifecycle state decisions for `start` and `stop`.
- Skipped backend calls for already-satisfied or non-actionable states and logged guidance instead.
- Updated `start` command handling so guidance-only outcomes do not print misleading connection instructions.
- Added unit tests for idempotent start/stop decisions and guidance paths.
- Added integration coverage for the fake local runner so repeated `start`/`stop` command behavior and user guidance stay covered at the CLI level.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

### Test Details

- `poetry run pytest -vv --exasol-path=../bin/exasol tests/integration/test_install.py -k test_deploy_local_with_prestaged_fake_runner`
- `task all` completed successfully.
- Integration tests: 55 passed.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

`task all` was run with Go, lint, Poetry, and launcher caches redirected to `/tmp` because the sandboxed home cache is read-only.
