### PR TITLE
fix(connect): suppress non-interactive version banner

### DIFF
--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -107,6 +107,7 @@ func NewExasolConnection(
 	username string,
 	password string,
 	insecureSkipCertValidation bool,
+	optFns ...exasol.OptFn,
 ) (generaltypes.Databaser, error) {
 	if password == "" {
 		secrets, err := config.ReadSecrets(deployment)
@@ -119,9 +120,9 @@ func NewExasolConnection(
 		return nil, errors.New("reading deployment connection info: missing connection info")
 	}
 
-	optsFns := []exasol.OptFn{}
+	databaseOptFns := append([]exasol.OptFn{}, optFns...)
 	if insecureSkipCertValidation || connectionInfo.InsecureSkipCertValidation {
-		optsFns = append(optsFns, exasol.WithoutValidateServerCertificate)
+		databaseOptFns = append(databaseOptFns, exasol.WithoutValidateServerCertificate)
 	}
 
 	database, err := exasol.New(
@@ -130,7 +131,7 @@ func NewExasolConnection(
 		connectionInfo.Host,
 		connectionInfo.CertFingerprint,
 		connectionInfo.DBPort,
-		optsFns...,
+		databaseOptFns...,
 	)
 	if err != nil {
 		return nil, err
@@ -162,12 +163,21 @@ func Connect(
 		return err
 	}
 
+	// The database version banner is a shell affordance. Non-interactive
+	// executions keep stdout reserved for result data and do not need it.
+	interactiveShell := !nonInteractive && util.IsInteractiveStdin()
+	databaseOptFns := []exasol.OptFn{}
+	if interactiveShell {
+		databaseOptFns = append(databaseOptFns, exasol.WithVersionOutput(os.Stderr))
+	}
+
 	database, err := NewExasolConnection(
 		deployment,
 		connectionInfo,
 		opts.Username,
 		opts.Password,
 		opts.InsecureSkipCertValidation,
+		databaseOptFns...,
 	)
 	if err != nil {
 		return err
@@ -196,8 +206,6 @@ func Connect(
 	// actually started. --command/--file and non-interactive JSON execution
 	// return everything by default, so they behave as non-interactive
 	// (unlimited) unless --max-rows is set explicitly.
-	interactiveShell := !nonInteractive && util.IsInteractiveStdin()
-
 	modeDefault := 0
 	if interactiveShell {
 		modeDefault = interactivePreviewMaxRows

--- a/internal/connect/exasol/database.go
+++ b/internal/connect/exasol/database.go
@@ -10,13 +10,11 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"os"
 	"time"
 
 	"github.com/exasol/exasol-driver-go"
 	"github.com/exasol/exasol-personal/internal/connect/exasol/types"
 	generaltypes "github.com/exasol/exasol-personal/internal/connect/types"
-	"github.com/exasol/exasol-personal/internal/util"
 )
 
 var (
@@ -33,11 +31,13 @@ type Database struct {
 	conn              types.ExasolConnector
 	sessionID         *string
 	sessionIDResolved bool
+	versionOutput     io.Writer
 }
 
 type opts struct {
 	validateServerCertificate bool
 	connect                   types.ConnectFunc
+	versionOutput             io.Writer
 }
 
 type OptFn func(*opts)
@@ -51,6 +51,12 @@ func WithoutValidateServerCertificate(opts *opts) {
 func WithConnectFunc(connect types.ConnectFunc) func(*opts) {
 	return func(opts *opts) {
 		opts.connect = connect
+	}
+}
+
+func WithVersionOutput(output io.Writer) func(*opts) {
+	return func(opts *opts) {
+		opts.versionOutput = output
 	}
 }
 
@@ -77,6 +83,7 @@ func New(
 	return &Database{
 		connectionString: dsnConfigBuilder.String(),
 		connect:          opts.connect,
+		versionOutput:    opts.versionOutput,
 	}, nil
 }
 
@@ -108,8 +115,8 @@ func (db *Database) Connect(ctx context.Context) error {
 		return nil
 	}
 
-	if util.IsInteractiveStdin() {
-		return printVersion(os.Stderr, version)
+	if db.versionOutput != nil {
+		return printVersion(db.versionOutput, version)
 	}
 
 	return nil

--- a/internal/connect/exasol/database_test.go
+++ b/internal/connect/exasol/database_test.go
@@ -4,6 +4,7 @@
 package exasol
 
 import (
+	"bytes"
 	"context"
 	"database/sql/driver"
 	"errors"
@@ -65,16 +66,21 @@ func (f fakeResult) RowsAffected() (int64, error) {
 	return f.rowsAffected, nil
 }
 
-func testDatabaseFactory(t *testing.T, connect types.ConnectFunc) generaltypes.Databaser {
+func testDatabaseFactory(
+	t *testing.T,
+	connect types.ConnectFunc,
+	optFns ...OptFn,
+) generaltypes.Databaser {
 	t.Helper()
 
+	allOptFns := append([]OptFn{WithConnectFunc(connect)}, optFns...)
 	database, err := New(
 		"foo",
 		"bar",
 		"192.168.0.1",
 		"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
 		8563,
-		WithConnectFunc(connect))
+		allOptFns...)
 	require.NoError(t, err)
 
 	return database
@@ -165,6 +171,35 @@ func TestConnect(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+func TestConnectPrintsVersionToConfiguredOutput(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	fakeConnector := &typesfakes.FakeExasolConnector{}
+	fakeConnector.QueryContextStub = func(
+		_ context.Context, query string, _ []driver.NamedValue,
+	) (driver.Rows, error) {
+		if strings.Contains(query, "exa_metadata") {
+			return &fakeRows{
+				columns: []string{"v"},
+				data:    [][]driver.Value{{"2026.1.0"}},
+			}, nil
+		}
+
+		return nil, errTest
+	}
+	connect := func(string) (types.ExasolConnector, error) {
+		return fakeConnector, nil
+	}
+	database := testDatabaseFactory(t, connect, WithVersionOutput(&output))
+
+	err := database.Connect(t.Context())
+
+	require.NoError(t, err)
+	require.Equal(t, "Exasol 2026.1.0\n", output.String())
+	require.NoError(t, database.Close())
 }
 
 func TestClose(t *testing.T) {


### PR DESCRIPTION
## Description

Suppress the database version banner for non-interactive `exasol connect` executions. The banner remains available for the interactive shell path, where it is written through the configured terminal output instead of being decided inside the database connection layer.

Root cause: the database connection layer decided whether to print the banner by checking whether stdin was a terminal. That misclassified `exasol connect -c ...` and `exasol connect -f ...` as interactive when run from a terminal.

## Related Issue

SPOT-31465

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Move version-banner output control to the connect command flow, where interactive vs non-interactive mode is already known.
- Keep the database layer from writing the banner unless an explicit output writer is configured.
- Add unit coverage for configured version-banner output.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

### Test Details

- `task tests-unit TEST=Connect`
- `task fmt`
- `task all`

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

Non-interactive result streams are no longer affected by the version banner. Interactive shell sessions still show the banner through stderr.