### PR TITLE
fix(cmd/exasol): clear error when config set cannot load deployment options

### DIFF
--- a/cmd/exasol/config_set_options_error_test.go
+++ b/cmd/exasol/config_set_options_error_test.go
@@ -66,13 +66,19 @@ func TestConfigSetClearErrorWhenDeploymentNotInitialized(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected a clear error, got nil")
 	}
-	if !strings.Contains(err.Error(), dir) {
-		t.Errorf("error should name the deployment directory %q, got: %v", dir, err)
-	}
-	for _, want := range []string{"exasol init", "--deployment-dir"} {
+	for _, want := range []string{
+		dir, // names the offending directory
+		"not an Exasol Personal deployment directory", // reuses the standard phrasing
+		"exasol init",
+		"--deployment-dir",
+	} {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("error should mention %q, got: %v", want, err)
 		}
+	}
+	// It must not leak internal implementation detail such as manifest file names.
+	if strings.Contains(err.Error(), "infrastructure.yaml") {
+		t.Errorf("error should not expose internal manifest details, got: %v", err)
 	}
 }
 

--- a/cmd/exasol/config_set_options_error_test.go
+++ b/cmd/exasol/config_set_options_error_test.go
@@ -1,0 +1,128 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+// root_preregister_test.go, so they must run sequentially.
+//
+//nolint:paralleltest // These tests exercise the package-global rootCmd/configSetCmd, like
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+)
+
+const localInfrastructureManifestForConfigSet = `name: Exasol Local on macOS
+description: Exasol Local deployment using the macOS Apple Silicon VM runner.
+backend: local
+
+local:
+  cpuCount: 2
+  dataSizeGB: 100
+`
+
+// writeInitializedLocalDeployment creates a deployment directory that looks like a
+// local deployment in the initialized state (the state a deployment returns to after
+// `exasol destroy`), so `config set` can resolve its infrastructure options.
+func writeInitializedLocalDeployment(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	dep := config.NewDeploymentDir(dir)
+
+	if err := os.MkdirAll(filepath.Dir(dep.InfrastructureManifestPath()), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(
+		dep.InfrastructureManifestPath(),
+		[]byte(localInfrastructureManifestForConfigSet),
+		0o600,
+	); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	state := &config.ExasolPersonalState{DeploymentId: "local", ClusterIdentity: "local"}
+	if err := state.SetWorkflowState(&config.WorkflowStateInitialized{}); err != nil {
+		t.Fatalf("set state: %v", err)
+	}
+	if err := config.WriteExasolPersonalState(state, dep); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+
+	return dir
+}
+
+// A non-help `config set` against a directory that is not an initialized deployment must
+// fail with a clear error that names the directory, instead of silently registering no
+// flags (which would later surface as a misleading "unknown flag" parse error). SPOT-31462.
+func TestConfigSetClearErrorWhenDeploymentNotInitialized(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "not-a-deployment")
+
+	err := prepareConfigSetInfrastructureVariableFlags(
+		[]string{"config", "set", "--ports", "db:8000", "--deployment-dir", dir},
+	)
+	if err == nil {
+		t.Fatal("expected a clear error, got nil")
+	}
+	if !strings.Contains(err.Error(), dir) {
+		t.Errorf("error should name the deployment directory %q, got: %v", dir, err)
+	}
+	for _, want := range []string{"exasol init", "--deployment-dir"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention %q, got: %v", want, err)
+		}
+	}
+}
+
+// `config set --help` must remain non-fatal even when options cannot be loaded, so help
+// can render.
+func TestConfigSetHelpRendersWithoutResolvableDeployment(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "not-a-deployment")
+
+	if err := prepareConfigSetInfrastructureVariableFlags(
+		[]string{"config", "set", "--help", "--deployment-dir", dir},
+	); err != nil {
+		t.Fatalf("expected help to render (nil error), got: %v", err)
+	}
+}
+
+// A destroyed (i.e. initialized) local deployment must still resolve its infrastructure
+// options for `config set`, so pre-registration succeeds and registers the option flags.
+func TestConfigSetRegistersOptionsForInitializedLocalDeployment(t *testing.T) {
+	originalFlagMap := infraFlagToVarName
+	infraFlagToVarName = map[string]string{}
+	t.Cleanup(func() { infraFlagToVarName = originalFlagMap })
+
+	dir := writeInitializedLocalDeployment(t)
+
+	if err := prepareConfigSetInfrastructureVariableFlags(
+		[]string{"config", "set", "--ports", "db:8000", "--deployment-dir", dir},
+	); err != nil {
+		t.Fatalf("unexpected error resolving options for initialized deployment: %v", err)
+	}
+	if configSetCmd.Flags().Lookup("ports") == nil {
+		t.Error("expected --ports to be registered on `config set`")
+	}
+}
+
+func TestRawArgsRequestHelp(t *testing.T) {
+	cases := map[string]struct {
+		args []string
+		want bool
+	}{
+		"long help":       {[]string{"config", "set", "--help"}, true},
+		"short help":      {[]string{"config", "set", "-h"}, true},
+		"help subcommand": {[]string{"help", "config", "set"}, true},
+		"no help":         {[]string{"config", "set", "--ports", "db:8000"}, false},
+		"empty":           {[]string{}, false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := rawArgsRequestHelp(tc.args); got != tc.want {
+				t.Errorf("rawArgsRequestHelp(%v) = %v, want %v", tc.args, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/exasol/infra_variables.go
+++ b/cmd/exasol/infra_variables.go
@@ -123,15 +123,15 @@ func prepareConfigSetInfrastructureVariableFlags(args []string) error {
 			return nil
 		}
 
-		// Surface the failure instead of silently registering no flags. Otherwise the
-		// supplied options fail Cobra's flag parsing later as misleading "unknown flag"
-		// errors before the initialized-deployment pre-run gate can explain the problem.
+		// Fail with a clear message instead of silently registering no flags. Otherwise the
+		// supplied options fail Cobra's flag parsing later as a misleading "unknown flag"
+		// error before the initialized-deployment pre-run gate can explain the problem.
 		return fmt.Errorf(
-			"cannot load configuration options for deployment directory %q: %w\n"+
-				"Run `exasol init` or `exasol install` in that directory, "+
+			"%w: %q\n"+
+				"Run `exasol init` or `exasol install` there, "+
 				"or pass --deployment-dir pointing to an existing deployment directory",
+			deploy.ErrNotExasolPersonalDeploymentDirectory,
 			deployment.Root(),
-			resolveErr,
 		)
 	}
 

--- a/cmd/exasol/infra_variables.go
+++ b/cmd/exasol/infra_variables.go
@@ -106,18 +106,52 @@ func prepareConfigSetInfrastructureVariableFlags(args []string) error {
 		return nil
 	}
 
-	if deployment, err := deploymentDirFromRawArgs(args); err == nil {
-		resolution, resolveErr := resolveInfrastructureVariablesFromDeployment(deployment)
-		if resolveErr == nil {
-			return registerInfrastructureVariableFlags(
-				[]*cobra.Command{configSetCmd},
-				resolution.Variables,
-				resolution.PresetLabel,
-			)
+	deployment, err := deploymentDirFromRawArgs(args)
+	if err != nil {
+		if rawArgsRequestHelp(args) {
+			return nil
+		}
+
+		return fmt.Errorf("cannot determine deployment directory for `config set`: %w", err)
+	}
+
+	resolution, resolveErr := resolveInfrastructureVariablesFromDeployment(deployment)
+	if resolveErr != nil {
+		// Keep `config set --help` working even when options cannot be loaded:
+		// render the base help instead of failing.
+		if rawArgsRequestHelp(args) {
+			return nil
+		}
+
+		// Surface the failure instead of silently registering no flags. Otherwise the
+		// supplied options fail Cobra's flag parsing later as misleading "unknown flag"
+		// errors before the initialized-deployment pre-run gate can explain the problem.
+		return fmt.Errorf(
+			"cannot load configuration options for deployment directory %q: %w\n"+
+				"Run `exasol init` or `exasol install` in that directory, "+
+				"or pass --deployment-dir pointing to an existing deployment directory",
+			deployment.Root(),
+			resolveErr,
+		)
+	}
+
+	return registerInfrastructureVariableFlags(
+		[]*cobra.Command{configSetCmd},
+		resolution.Variables,
+		resolution.PresetLabel,
+	)
+}
+
+// rawArgsRequestHelp reports whether the raw command-line args request help, in which
+// case flag pre-registration must stay non-fatal so help can render.
+func rawArgsRequestHelp(args []string) bool {
+	for _, arg := range args {
+		if arg == "--help" || arg == "-h" {
+			return true
 		}
 	}
 
-	return nil
+	return len(args) > 0 && args[0] == helpCommandName
 }
 
 func registerInfrastructureVariableFlags(

--- a/openspec/changes/fix-config-set-options-error/.openspec.yaml
+++ b/openspec/changes/fix-config-set-options-error/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-05

--- a/openspec/changes/fix-config-set-options-error/design.md
+++ b/openspec/changes/fix-config-set-options-error/design.md
@@ -1,0 +1,51 @@
+## Context
+
+`config set` accepts preset-specific infrastructure options as flags. Because the available
+options depend on the deployment's persisted preset, the launcher registers those flags
+dynamically at startup — before Cobra parses arguments — by resolving the options from the
+target deployment directory. The other config subcommands (`get`, `reset`) take positional
+option names rather than option flags, so they are unaffected.
+
+The dynamic registration currently swallows any resolution error: if the deployment directory
+cannot be resolved or is not initialized, no option flags are registered and the failure is
+invisible. Cobra then parses the user's `--<option>` and reports `unknown flag`, which runs
+before the command's "deployment must be initialized" pre-run gate can produce a helpful
+message. The result is a misleading error (SPOT-31462).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Replace the misleading `unknown flag: --<option>` with a clear, actionable error that names
+  the resolved deployment directory and the corrective action.
+- Keep `config set --help` working when options cannot be loaded.
+- Keep genuine unknown-option errors intact for typos against a resolvable deployment.
+
+**Non-Goals:**
+- No change to which deployment states permit configuration (running/stopped stay refused by
+  design; initialized/destroyed keep working).
+- No change to configuration semantics or to `config get` / `config reset`.
+- No change that would make `config set` in the stopped state succeed (a separate design
+  question).
+
+## Decisions
+
+**Surface the resolution error at pre-registration instead of swallowing it.**
+When the invocation is `config set` and it is not a help request, a failure to resolve the
+deployment's configurable options is reported as a clear error naming the resolved deployment
+directory, rather than being discarded. This fires before Cobra's flag parsing, so the user
+never sees the `unknown flag` message for a dir that simply could not be loaded.
+
+**Keep help resilient.**
+For `config set --help` (or `help config set`), resolution failures remain non-fatal so the
+base help still renders; when options resolve, they are shown as before.
+
+**Do not mask real unknown options.**
+When the deployment resolves successfully, its options are registered and Cobra's normal
+unknown-flag handling continues to reject misspelled or unsupported options.
+
+## Risks / Trade-offs
+
+- The clear error fires earlier (at flag registration) than the existing initialized-deployment
+  pre-run gate; wording is kept consistent with that gate so users get one coherent message.
+- Message text may evolve; tests assert on stable, meaningful substrings rather than exact
+  strings where practical.

--- a/openspec/changes/fix-config-set-options-error/proposal.md
+++ b/openspec/changes/fix-config-set-options-error/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+`exasol config set` exposes preset-specific infrastructure options (`--cpu-count`,
+`--memory-mb`, `--data-size-gb`, `--ports`) dynamically: it resolves them from the target
+deployment directory before Cobra parses arguments. When that resolution fails — because
+`--deployment-dir` was omitted (and the current directory is not a deployment) or the target
+directory is not an initialized deployment — the options are silently not registered, and the
+command then fails during flag parsing with a misleading `unknown flag: --<option>`. Users
+conclude the option was removed and that `config set` is broken (SPOT-31462).
+
+## What Changes
+
+- When `config set` cannot load the target deployment's configurable options, fail with a
+  clear, actionable error that names the resolved deployment directory and tells the user to
+  initialize it (`exasol init` / `exasol install`) or point `--deployment-dir` at an existing
+  deployment — instead of reporting supplied options as unknown flags.
+- Preserve `config set --help`: it still renders (base help when options cannot be loaded, the
+  full option list when they can).
+- Preserve normal unknown-option errors for genuinely misspelled options against a resolvable
+  deployment.
+- No change to state gates: `config set` in an initialized deployment (including after
+  `destroy`, which returns the deployment to the initialized state) continues to work; running
+  and stopped deployments remain refused by design.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `deployment-reconfiguration`: clarifies the error behaviour of `config set` when configurable
+  options cannot be loaded for the target deployment directory.
+
+## Impact
+
+- User-facing error message for `exasol config set` when the deployment directory cannot be
+  resolved or is not initialized.
+- No change to configuration semantics, deployment state gates, or the other config
+  subcommands (`get`, `reset`).

--- a/openspec/changes/fix-config-set-options-error/specs/deployment-reconfiguration/spec.md
+++ b/openspec/changes/fix-config-set-options-error/specs/deployment-reconfiguration/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Config set SHALL report a clear error when configurable options cannot be loaded
+The `config set` command SHALL resolve the target deployment's configurable infrastructure
+options before parsing supplied option flags. When it cannot load those options because no
+initialized deployment directory can be resolved, it SHALL fail with a clear, actionable error
+that identifies the resolved deployment directory and directs the user to initialize it or to
+supply `--deployment-dir`, rather than reporting supplied infrastructure options as unknown
+flags.
+
+#### Scenario: Config set names the unresolved deployment directory
+- **WHEN** a user runs `exasol config set <infrastructure-options>` and no initialized
+  deployment directory can be resolved (for example `--deployment-dir` is omitted and the
+  current directory is not a deployment, or the target directory is not initialized)
+- **THEN** the command fails with an error identifying the resolved deployment directory
+- **AND** the error tells the user to initialize it with `exasol init` or `exasol install`, or
+  to pass `--deployment-dir` pointing to an existing deployment
+- **AND** the error does not report the supplied infrastructure options as unknown flags
+
+#### Scenario: Config set help renders without a resolvable deployment
+- **WHEN** a user runs `exasol config set --help` and the deployment's configurable options
+  cannot be loaded
+- **THEN** the command prints help without failing
+
+#### Scenario: Config set still rejects genuinely unknown options
+- **WHEN** a user runs `exasol config set` against an initialized deployment and supplies an
+  option that the deployment's presets do not define
+- **THEN** the command fails reporting that option as unknown

--- a/openspec/changes/fix-config-set-options-error/tasks.md
+++ b/openspec/changes/fix-config-set-options-error/tasks.md
@@ -1,0 +1,19 @@
+## 1. Clear error for unresolved config set options
+
+- [x] 1.1 Surface a clear, actionable error when `config set` cannot load the target
+      deployment's configurable options (non-help invocation), naming the resolved deployment
+      directory and the corrective action, instead of registering no flags.
+- [x] 1.2 Preserve `config set --help` (and `help config set`): render help when options cannot
+      be loaded, show options when they can.
+- [x] 1.3 Preserve normal unknown-option errors for misspelled options against a resolvable
+      deployment.
+
+## 2. Verification
+
+- [x] 2.1 Add coverage for the clear error when the deployment directory is not initialized or
+      cannot be resolved.
+- [x] 2.2 Add coverage that `config set --help` still renders without a resolvable deployment.
+- [x] 2.3 Add regression coverage that a destroyed (i.e. initialized) local deployment still
+      registers its infrastructure options for `config set`.
+- [x] 2.4 Run repository validation used for the pull request (`task fmt`, `task lint`,
+      `task build`, `task tests-unit`; `task tests-integration` deferred — needs cloud creds).


### PR DESCRIPTION
## Description

`exasol config set` exposes preset-specific infrastructure options (`--cpu-count`, `--memory-mb`, `--data-size-gb`, `--ports`) as flags that are registered dynamically — before Cobra parses arguments — by resolving them from the target deployment directory. When that resolution failed (because `--deployment-dir` was omitted and the current directory isn't a deployment, the directory doesn't exist, or it isn't an initialized deployment), the error was silently swallowed, no option flags were registered, and the command then failed during flag parsing with a misleading `Error: unknown flag: --ports`. Users concluded the option had been removed and that `config set` was broken.

This surfaces a clear, actionable error naming the offending directory instead, while keeping `config set --help` working and preserving genuine unknown-option errors for typos against a resolvable deployment. Deployment **state gates are unchanged** — `config set` in an initialized deployment (including after `destroy`, which returns it to the initialized state) keeps working; running/stopped remain refused by design.

## Related Issue

SPOT-31462 (linked via the branch name; no GitHub issue).

## Type of Change

- [x] `fix`: Bug fix

## Changes Made

- `prepareConfigSetInfrastructureVariableFlags` no longer discards the option-resolution error: for a non-`--help` `config set` it fails with the standard `not an Exasol Personal deployment directory` error (reused from `exasol remove`), naming the directory and pointing to `exasol init` / `--deployment-dir`.
- Added `rawArgsRequestHelp` so `config set --help` (and `help config set`) still render when options can't be loaded.
- Added regression tests (`cmd/exasol/config_set_options_error_test.go`).
- Added OpenSpec change `fix-config-set-options-error` (modifies the `deployment-reconfiguration` capability).

### Example

Before (misleading):
```
$ exasol config set --ports db:8000        # no deployment resolved
Error: unknown flag: --ports
```
After (clear):
```
$ exasol config set --ports db:8000
not an Exasol Personal deployment directory: "/…/exasol-local"
Run `exasol init` or `exasol install` there, or pass --deployment-dir pointing to an existing deployment directory
```

## Testing

- [x] All existing tests pass (`task tests-unit` — `go test -race ./...`)
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

### Test Details

`task fmt`, `task lint` (0 issues), `task build`, and `task tests-unit` all pass locally. `task tests-integration` was not run (requires cloud credentials). New tests cover: the clear error for a missing/uninitialized directory (including asserting it does not leak internal manifest details), `config set --help` still rendering, a destroyed(=initialized) local deployment still registering its options, and `rawArgsRequestHelp`.

## Checklist

- [x] Code follows the project's coding guidelines
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (OpenSpec change)
- [x] Added/updated tests
- [x] All tests pass locally (unit; integration needs cloud creds)
- [x] Commit messages follow Conventional Commits format