### PR TITLE
Add lifecycle JSON ready signals

### DIFF
--- a/cmd/exasol/deploymentControl.go
+++ b/cmd/exasol/deploymentControl.go
@@ -4,6 +4,9 @@
 package main
 
 import (
+	"encoding/json"
+	"io"
+	"os"
 	"time"
 
 	"github.com/exasol/exasol-personal/internal/deploy"
@@ -23,6 +26,15 @@ If the database does not become ready within the timeout, the command fails.`
 var startOpts = struct {
 	WaitTimeoutMin int
 }{}
+
+type lifecycleCompletionOutput struct {
+	DeploymentState string `json:"deploymentState"`
+	DatabaseReady   bool   `json:"databaseReady"`
+}
+
+func renderLifecycleCompletionJSON(writer io.Writer, output lifecycleCompletionOutput) error {
+	return json.NewEncoder(writer).Encode(output)
+}
 
 const stopCmdShortDesc = `Stop a deployment`
 
@@ -52,6 +64,13 @@ var startCmd = &cobra.Command{
 			return err
 		}
 
+		if commonFlags.OutputJson {
+			return renderLifecycleCompletionJSON(os.Stdout, lifecycleCompletionOutput{
+				DeploymentState: deploy.StatusRunning,
+				DatabaseReady:   true,
+			})
+		}
+
 		return addConnectionInstructionsTerminalOutput(deployment)
 	},
 }
@@ -66,11 +85,22 @@ var stopCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		deployment := commonFlags.Deployment()
 
-		return deploy.Stop(
+		if err := deploy.Stop(
 			cmd.Context(),
 			deployment,
 			commonFlags.DeployVerbose,
-		)
+		); err != nil {
+			return err
+		}
+
+		if commonFlags.OutputJson {
+			return renderLifecycleCompletionJSON(os.Stdout, lifecycleCompletionOutput{
+				DeploymentState: deploy.StatusStopped,
+				DatabaseReady:   false,
+			})
+		}
+
+		return nil
 	},
 }
 
@@ -91,6 +121,7 @@ func init() {
 	registerStartFlags()
 	registerVerboseFlag(startCmd, commonFlags)
 	registerDeploymentDirFlag(startCmd, commonFlags)
+	registerOutputFlags(startCmd, commonFlags)
 	rootCmd.AddCommand(startCmd)
 
 	requireMinorVersionCompatibility(stopCmd, CurrentLauncherVersion)
@@ -98,5 +129,6 @@ func init() {
 	requireDeploymentFileLogging(stopCmd)
 	registerVerboseFlag(stopCmd, commonFlags)
 	registerDeploymentDirFlag(stopCmd, commonFlags)
+	registerOutputFlags(stopCmd, commonFlags)
 	rootCmd.AddCommand(stopCmd)
 }

--- a/cmd/exasol/deploymentControl_test.go
+++ b/cmd/exasol/deploymentControl_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/deploy"
+	"github.com/spf13/cobra"
+)
+
+func TestRenderLifecycleCompletionJSON(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name            string
+		output          lifecycleCompletionOutput
+		deploymentState string
+		databaseReady   bool
+	}{
+		{
+			name: "start completion",
+			output: lifecycleCompletionOutput{
+				DeploymentState: deploy.StatusRunning,
+				DatabaseReady:   true,
+			},
+			deploymentState: deploy.StatusRunning,
+			databaseReady:   true,
+		},
+		{
+			name: "stop completion",
+			output: lifecycleCompletionOutput{
+				DeploymentState: deploy.StatusStopped,
+				DatabaseReady:   false,
+			},
+			deploymentState: deploy.StatusStopped,
+			databaseReady:   false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Given
+			var buf bytes.Buffer
+
+			// When
+			err := renderLifecycleCompletionJSON(&buf, test.output)
+			// Then
+			if err != nil {
+				t.Fatalf("expected lifecycle completion JSON to render: %v", err)
+			}
+			var decoded lifecycleCompletionOutput
+			if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+				t.Fatalf("expected valid JSON, got %q: %v", buf.String(), err)
+			}
+			if decoded.DeploymentState != test.deploymentState {
+				t.Fatalf(
+					"expected deployment state %q, got %q",
+					test.deploymentState,
+					decoded.DeploymentState,
+				)
+			}
+			if decoded.DatabaseReady != test.databaseReady {
+				t.Fatalf(
+					"expected databaseReady %t, got %t",
+					test.databaseReady,
+					decoded.DatabaseReady,
+				)
+			}
+		})
+	}
+}
+
+func TestLifecycleCommandsRegisterJSONFlag(t *testing.T) {
+	t.Parallel()
+
+	for name, cmd := range map[string]*cobra.Command{
+		"start": startCmd,
+		"stop":  stopCmd,
+	} {
+		if cmd.Flags().Lookup("json") == nil {
+			t.Fatalf("expected %s to register json output flag", name)
+		}
+	}
+}

--- a/openspec/changes/start-stop-json-ready-signal/.openspec.yaml
+++ b/openspec/changes/start-stop-json-ready-signal/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-05

--- a/openspec/changes/start-stop-json-ready-signal/design.md
+++ b/openspec/changes/start-stop-json-ready-signal/design.md
@@ -1,0 +1,38 @@
+## Context
+
+`exasol start` and `exasol stop` currently accept only human-oriented lifecycle flags. They run deployment operations, write logs through the normal logging path, and `start` queues connection instructions as final terminal output after the database is ready. Automation users need a completion signal on stdout that remains parseable when logs are emitted to stderr.
+
+The repository already has command-level JSON patterns for `status`, `info`, `cache`, `version`, and `connect`. Lifecycle commands should follow the same boundary: command code owns user-visible rendering, while deployment code owns state changes and backend orchestration.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add `--json` to `exasol start` and `exasol stop`.
+- Emit one final JSON document to stdout after successful completion.
+- Keep deployment logs, notices, and connection instructions out of stdout in JSON mode.
+- Preserve existing non-JSON lifecycle behavior.
+- Cover the contract with focused tests for flag registration, rendering, and stdout cleanliness.
+
+**Non-Goals:**
+
+- No reduction of start or stop duration.
+- No change to `exasol status --json`.
+- No NDJSON or streaming progress protocol.
+- No backend-specific JSON schema beyond lifecycle completion state.
+
+## Decisions
+
+**Render lifecycle JSON in `cmd/exasol`.** The command layer will register `--json`, call the existing deployment operation, and render a small completion document after success. This matches existing command output ownership and avoids making `internal/deploy` depend on CLI presentation concerns. Alternative: have `deploy.Start` and `deploy.Stop` return serialized JSON. Rejected because deployment orchestration should remain independent from terminal output formats.
+
+**Use a compact completion schema.** The JSON document will include `deploymentState` and `databaseReady`. For `start`, the state is `running` and `databaseReady` is `true`. For `stop`, the state is `stopped` and `databaseReady` is `false`. Alternative: reuse the full `info` or `status` report. Rejected because the story asks for a final ready signal, and a minimal schema is easier for scripts to consume.
+
+**Suppress connection instructions only in lifecycle JSON mode.** `start` currently prints refreshed connection instructions after success. In JSON mode, those instructions would corrupt stdout, so the command will skip `addConnectionInstructionsTerminalOutput` and emit only the completion document. Non-JSON behavior remains unchanged.
+
+**Leave error handling unchanged.** If start or stop fails, the command exits non-zero through the existing error path. The JSON contract applies to successful completion; structured lifecycle failure JSON is out of scope for this story. Alternative: wrap errors in JSON when `--json` is set. Rejected because the acceptance criteria only require exit status to reflect failure, not a new error schema.
+
+## Risks / Trade-offs
+
+- **Global `commonFlags.OutputJson` is shared across commands** -> Register the existing output flag on lifecycle commands and add focused tests so future commands do not accidentally omit it.
+- **Terminal notices can be added by root pre-run** -> Because notices print to stderr and primary output prints to stdout, stdout remains machine-readable; tests should exercise command rendering directly.
+- **The schema is intentionally small** -> Future consumers may ask for more fields, but the minimal document satisfies readiness automation without committing to full deployment metadata.

--- a/openspec/changes/start-stop-json-ready-signal/proposal.md
+++ b/openspec/changes/start-stop-json-ready-signal/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Automation users need `exasol start` and `exasol stop` to provide a stable readiness signal without scraping human log output or polling `exasol status --json` in a loop. This matters now because app builders and CI pipelines use lifecycle commands in scripted workflows where stdout must remain machine-readable.
+
+## What Changes
+
+- Add `--json` support to `exasol start` and `exasol stop`.
+- Emit exactly one final JSON document on stdout after a successful lifecycle command completes.
+- Include deployment state and database readiness fields so callers can wait for running or stopped outcomes without parsing logs.
+- Keep default non-JSON lifecycle output unchanged.
+- Keep logs, notices, and connection instructions out of stdout when lifecycle JSON mode is selected.
+
+## Capabilities
+
+### New Capabilities
+
+- `lifecycle-json-output`: machine-readable completion output for deployment lifecycle commands.
+
+### Modified Capabilities
+
+<!-- None. -->
+
+## Impact
+
+- `cmd/exasol`: register lifecycle JSON flags and route JSON output to stdout.
+- `internal/deploy`: expose or reuse lifecycle completion state data for rendering.
+- Tests: add focused command/unit coverage and integration coverage for stdout JSON cleanliness.

--- a/openspec/changes/start-stop-json-ready-signal/specs/lifecycle-json-output/spec.md
+++ b/openspec/changes/start-stop-json-ready-signal/specs/lifecycle-json-output/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Lifecycle commands emit machine-readable completion signals
+
+`exasol start --json` and `exasol stop --json` SHALL emit exactly one JSON document to stdout after successful completion.
+
+#### Scenario: Start emits running ready signal
+
+- **WHEN** a stopped deployment is successfully started with `exasol start --json`
+- **THEN** stdout contains exactly one JSON document
+- **AND** the document includes `deploymentState` with value `running`
+- **AND** the document includes `databaseReady` with value `true`
+
+#### Scenario: Stop emits stopped ready signal
+
+- **WHEN** a running deployment is successfully stopped with `exasol stop --json`
+- **THEN** stdout contains exactly one JSON document
+- **AND** the document includes `deploymentState` with value `stopped`
+- **AND** the document includes `databaseReady` with value `false`
+
+### Requirement: Lifecycle JSON output keeps stdout machine-readable
+
+When lifecycle JSON mode is selected, command stdout SHALL contain only the lifecycle completion JSON document.
+
+#### Scenario: Logs do not corrupt lifecycle JSON stdout
+
+- **WHEN** `exasol start --json` or `exasol stop --json` runs with normal lifecycle logging
+- **THEN** human-readable logs are not written to stdout
+- **AND** stdout remains parseable as a single JSON document
+
+#### Scenario: Start connection instructions are omitted from JSON stdout
+
+- **WHEN** `exasol start --json` completes successfully
+- **THEN** refreshed connection instructions are not written to stdout
+- **AND** stdout contains only the lifecycle completion JSON document

--- a/openspec/changes/start-stop-json-ready-signal/tasks.md
+++ b/openspec/changes/start-stop-json-ready-signal/tasks.md
@@ -1,0 +1,17 @@
+## 1. Lifecycle JSON Contract
+
+- [x] 1.1 Add a lifecycle completion output type and JSON renderer for `running`/ready and `stopped`/not-ready outcomes.
+- [x] 1.2 Register the existing `--json` output flag on `start` and `stop`.
+- [x] 1.3 Route successful `start --json` and `stop --json` to emit exactly one JSON document on stdout.
+
+## 2. Output Compatibility
+
+- [x] 2.1 Keep non-JSON `start` behavior, including final connection instructions, unchanged.
+- [x] 2.2 Suppress start connection instructions from stdout when JSON mode is selected.
+- [x] 2.3 Ensure existing logging continues to use stderr or deployment log routing, not lifecycle JSON stdout.
+
+## 3. Tests and Validation
+
+- [x] 3.1 Add focused Go tests for lifecycle JSON rendering and flag registration.
+- [x] 3.2 Add or update integration coverage for `start --json` and `stop --json` using the local fake runtime path.
+- [x] 3.3 Run formatting, focused tests, and repository validation appropriate for this change.

--- a/tests/tests/integration/test_install.py
+++ b/tests/tests/integration/test_install.py
@@ -16,6 +16,15 @@ LOCAL_TEST_DB_PORT = 28563
 LOCAL_MINIMUM_MEMORY_MB = 4096
 
 
+def assert_lifecycle_json_signal(
+    stdout: str, deployment_state: str, *, database_ready: bool
+) -> None:
+    assert json.loads(stdout) == {
+        "deploymentState": deployment_state,
+        "databaseReady": database_ready,
+    }
+
+
 def test_install_requires_infra_preset_arg(exasol_path: str) -> None:
     # Given the install command
 
@@ -364,17 +373,34 @@ esac
     status_data = json.loads(status_result.stdout)
     assert status_data["status"] == "database_connection_failed"
 
-    # Then stop updates the persisted local deployment state
+    # Then stop updates persisted state and emits a JSON ready signal
     stop_result = run_command(
         [
             exasol_path,
             "stop",
+            "--json",
             "--deployment-dir",
             str(deployment_dir),
         ],
         env=env,
     )
     assert stop_result.returncode == 0
+    assert_lifecycle_json_signal(stop_result.stdout, "stopped", database_ready=False)
     deployment_data = json.loads((deployment_dir / "deployment.json").read_text())
     assert deployment_data["deploymentState"] == "stopped"
     assert deployment_data["clusterState"] == "stopped"
+
+    # Then start emits only the JSON ready signal on stdout
+    start_result = run_command(
+        [
+            exasol_path,
+            "start",
+            "--json",
+            "--deployment-dir",
+            str(deployment_dir),
+        ],
+        env=env,
+    )
+    assert start_result.returncode == 0
+    assert_lifecycle_json_signal(start_result.stdout, "running", database_ready=True)
+    assert "Connection Instructions" not in start_result.stdout


### PR DESCRIPTION
## Description

Add machine-readable JSON completion output for deployment lifecycle commands so automation can wait on `exasol start` and `exasol stop` without scraping logs or polling status in a loop.

## Related Issue

SPOT-31231

## Type of Change

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Added `--json` support to `exasol start` and `exasol stop`.
- Added lifecycle completion JSON output: running/ready for start, stopped/not-ready for stop.
- Suppressed start connection instructions from stdout when JSON mode is used.
- Added OpenSpec artifacts for `start-stop-json-ready-signal`.
- Added Go and integration coverage for lifecycle JSON output.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

- `go test ./cmd/exasol`
- `poetry run pytest -vv --exasol-path=../bin/exasol tests/integration/test_install.py::test_deploy_local_with_prestaged_fake_runner`
- `task fmt`
- `task all`
- `openspec validate --changes start-stop-json-ready-signal`

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint` via `task all`
- [x] Updated documentation/spec artifacts (OpenSpec)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

Draft PR opened for review before marking ready.