### PR TITLE
chore: enable smart semver tag sorting in goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,6 +6,9 @@ version: 2
 
 project_name: exasol-personal
 
+git:
+  tag_sort: smartsemver
+
 before:
   hooks:
     - go mod tidy


### PR DESCRIPTION
Quick fix to allow Goreleaser to pickup the correct tags