### PR TITLE
chore(ci, windows): restore piped stdin and graceful interrupt for launcher

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ Thank you for your interest in contributing! We welcome contributions from the c
 
 - **Keep PRs focused** - one feature or fix per PR
 - **Write clear descriptions** - explain what and why, not just how
+- **Fold cleanup into the related commit** - do not create separate commits for lint, formatting, or typo fixes
 - **Explain CLI changes with examples** - when changing CLI commands or behavior, describe the user-visible behavior in the PR description and include example invocations or output
 - **Use the [pull request template](.github/pull_request_template.md)** when submitting a pull request
 - **Use semantic commit messages** - follow [Conventional Commits](https://www.conventionalcommits.org/) format:

--- a/internal/connect/readline/buffered.go
+++ b/internal/connect/readline/buffered.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package readline
+
+import (
+	"bufio"
+	"io"
+	"strings"
+
+	"github.com/exasol/exasol-personal/internal/connect/types"
+)
+
+type Buffered struct {
+	reader *bufio.Reader
+}
+
+func NewBuffered(input io.Reader) types.LineReader {
+	return &Buffered{
+		reader: bufio.NewReader(input),
+	}
+}
+
+func (reader *Buffered) Readline() (string, error) {
+	line, err := reader.reader.ReadString('\n')
+	if err != nil {
+		if err == io.EOF && line != "" {
+			return strings.TrimRight(line, "\r\n"), nil
+		}
+
+		return "", err
+	}
+
+	return strings.TrimRight(line, "\r\n"), nil
+}
+
+func (*Buffered) Close() error {
+	return nil
+}

--- a/internal/connect/shell.go
+++ b/internal/connect/shell.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/exasol/exasol-personal/internal/connect/readline"
 	"github.com/exasol/exasol-personal/internal/connect/types"
+	"github.com/exasol/exasol-personal/internal/util"
 )
 
 const exitCommand = "exit"
@@ -246,15 +247,28 @@ func RunShell(processInput ProcessInputFunc) error {
 }
 
 func RunShellWithOpts(processInput ProcessInputFunc, opts ShellOpts) error {
-	historyFilePath, err := getHistoryFilePath()
-	if err != nil {
-		return fmt.Errorf("couldn't get the history file path: %w", err)
+	if !util.IsInteractiveStdin() {
+		return runShellImpl(readline.NewBuffered(os.Stdin), processInput, opts)
 	}
 
-	lineReader, err := readline.New(historyFilePath)
+	lineReader, err := newInteractiveLineReader()
 	if err != nil {
 		return err
 	}
 
 	return runShellImpl(lineReader, processInput, opts)
+}
+
+func newInteractiveLineReader() (types.LineReader, error) {
+	historyFilePath, err := getHistoryFilePath()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get the history file path: %w", err)
+	}
+
+	lineReader, err := readline.New(historyFilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return lineReader, nil
 }

--- a/internal/connect/shell_test.go
+++ b/internal/connect/shell_test.go
@@ -6,8 +6,10 @@ package connect
 import (
 	"errors"
 	"io"
+	"strings"
 	"testing"
 
+	"github.com/exasol/exasol-personal/internal/connect/readline"
 	"github.com/exasol/exasol-personal/internal/connect/types"
 	"github.com/exasol/exasol-personal/internal/connect/types/typesfakes"
 	"github.com/stretchr/testify/require"
@@ -209,6 +211,24 @@ func TestRunShell(t *testing.T) {
 			test.then(t, mocks, err)
 		})
 	}
+}
+
+func TestNonInteractiveLineReader(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	processor := &mockInputsProcessor{}
+
+	// When
+	err := runShellImpl(readline.NewBuffered(
+		strings.NewReader("SELECT * FROM Dual;\nexit\n"),
+	), processor.processInput, ShellOpts{
+		ExecuteOnSemicolon: true,
+	})
+
+	// Then
+	require.NoError(t, err)
+	require.Equal(t, []string{"SELECT * FROM Dual"}, processor.inputs)
 }
 
 func TestRunStatements(t *testing.T) {

--- a/tests/framework/launcher.py
+++ b/tests/framework/launcher.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import subprocess
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from subprocess import CompletedProcess, Popen
@@ -68,6 +69,12 @@ class Launcher:
     ) -> Popen[str]:
         logging.info("Running launcher command: %s", command)
 
+        platform_kwargs: dict[str, object] = {}
+        if sys.platform.startswith("win"):
+            # Own process group so a CTRL_BREAK_EVENT can target this process
+            # without also hitting the test runner.
+            platform_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+
         return subprocess.Popen(  # type: ignore[call-overload,no-any-return]
             [
                 self.launcher_path,
@@ -79,6 +86,7 @@ class Launcher:
             **{
                 "text": True,
                 "encoding": "utf-8",
+                **platform_kwargs,
                 **kwargs,
             },
         )

--- a/tests/framework/launcher.py
+++ b/tests/framework/launcher.py
@@ -54,6 +54,7 @@ class Launcher:
                 deployment_dir,
             ],
             text=True,
+            encoding="utf-8",
             check=True,
             **kwargs,
         )
@@ -77,6 +78,7 @@ class Launcher:
             ],
             **{
                 "text": True,
+                "encoding": "utf-8",
                 **kwargs,
             },
         )

--- a/tests/framework/types.py
+++ b/tests/framework/types.py
@@ -10,6 +10,7 @@ class SubprocessRunKwargs(TypedDict, total=False):
     input: str  # The input to pass over stdin.
     check: bool  # Raise an error on non-0 exit status.
     capture_output: bool  # Capture stdout and stder.
+    encoding: str  # Encoding for text-mode subprocess streams.
     stdin: StdIO
     stdout: StdIO
     stderr: StdIO

--- a/tests/tests/deployment/test_custom.py
+++ b/tests/tests/deployment/test_custom.py
@@ -5,7 +5,6 @@
 
 import logging
 import subprocess
-import sys
 import textwrap
 from collections.abc import Iterator
 from typing import Final
@@ -130,9 +129,6 @@ def test_custom_deployment_rejects_small_instance_types(
         pytest.fail(f"Unexpected exception type: {type(unexpected).__name__}")
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
-)
 def test_custom_deployment_success(
     custom_deployment: tuple[Deployment, DeploymentConfig],
     infra: str,

--- a/tests/tests/deployment/test_standard_deployment.py
+++ b/tests/tests/deployment/test_standard_deployment.py
@@ -125,14 +125,6 @@ def test_connectable(reusable_deployment: Deployment) -> None:
     assert reusable_deployment.db_connectable()
 
 
-# All DB-related tests are skipped on Windows, because the SQL shell
-# does not output query results, only displaying an empty prompt.
-# On Linux, the expected result is shown.
-
-
-@pytest.mark.skipif(
-    sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
-)
 @pytest.mark.installation_e2e
 @pytest.mark.local_e2e
 def test_single_query(reusable_deployment: Deployment) -> None:
@@ -153,9 +145,6 @@ def test_single_query(reusable_deployment: Deployment) -> None:
     assert stdout.strip("\n") == expected.strip("\n")
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
-)
 @pytest.mark.installation_e2e
 @pytest.mark.local_e2e
 def test_exit_command(reusable_deployment: Deployment) -> None:
@@ -172,9 +161,6 @@ def test_exit_command(reusable_deployment: Deployment) -> None:
     assert len(stdout) == 0
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
-)
 @pytest.mark.installation_e2e
 @pytest.mark.local_e2e
 def test_multiple_queries(reusable_deployment: Deployment) -> None:
@@ -212,9 +198,6 @@ def test_multiple_queries(reusable_deployment: Deployment) -> None:
     assert stdout.strip("\n") == expected.strip("\n")
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
-)
 @pytest.mark.installation_e2e
 @pytest.mark.local_e2e
 def test_file_import(reusable_deployment: Deployment) -> None:

--- a/tests/tests/deployment/test_standard_deployment.py
+++ b/tests/tests/deployment/test_standard_deployment.py
@@ -508,9 +508,6 @@ def test_stop_and_start(reusable_deployment: Deployment) -> None:
         assert connect_result.returncode == 0
 
 
-@pytest.mark.skipif(
-    sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
-)
 @pytest.mark.infrastructure_e2e
 def test_start_interrupt_sets_interrupted_state(
     reusable_deployment: Deployment,
@@ -528,7 +525,9 @@ def test_start_interrupt_sets_interrupted_state(
     if platform.system() != "Windows":
         os.kill(stop_proc.pid, signal.SIGINT)
     else:
-        stop_proc.terminate()
+        # stop_proc runs in its own process group (see Launcher.start_command),
+        # so CTRL_BREAK_EVENT reaches only it, not the test runner too.
+        os.kill(stop_proc.pid, signal.CTRL_BREAK_EVENT)  # type: ignore[attr-defined]
 
     stop_proc.wait(timeout=30)
 
@@ -552,7 +551,7 @@ def test_start_interrupt_sets_interrupted_state(
     if platform.system() != "Windows":
         os.kill(start_proc.pid, signal.SIGINT)
     else:
-        start_proc.terminate()
+        os.kill(start_proc.pid, signal.CTRL_BREAK_EVENT)  # type: ignore[attr-defined]
 
     start_proc.wait(timeout=30)
 


### PR DESCRIPTION
## Description

`exasol connect` is expected to support scripted SQL through stdin, for example:

```bash
printf 'SELECT * FROM DUAL;\n' | exasol connect
```

On Windows, this non-interactive input mode did not produce query output. The command behaved like an interactive shell session even though stdin was a pipe, so piped SQL was not consumed correctly.

The affected deployment tests had been skipped on Windows because they exercise this scripted stdin behavior and assert the rendered table output. Re-enabling them is part of the fix: the launcher now treats piped stdin as non-interactive input while preserving the normal interactive shell behavior for terminal sessions.

The Windows deployment tests also need to capture launcher output as UTF-8 so the rendered table characters are decoded consistently across platforms.

Separately, `test_start_interrupt_sets_interrupted_state` was skipped on Windows because interrupting the no-block launcher process via `Popen.terminate()` (`TerminateProcess`) hard-kills it, bypassing the console control handler entirely — so the deployment never reaches `interrupted` state. Go's Windows runtime already funnels `CTRL_BREAK_EVENT` into the same `SIGINT` the launcher listens for, so no launcher change is needed; the no-block launcher processes now start in their own process group so the test can send `CTRL_BREAK_EVENT` directly instead of hard-killing them.

## Related Issue

https://exasol.atlassian.net/browse/SPOT-31454
https://exasol.atlassian.net/browse/SPOT-31455

## Type of Change

- [x] `chore`: Maintenance tasks
- [x] `fix`: Bug fix
- [x] `test`: Test additions or changes
- [x] `docs`: Documentation update

## Changes Made

- Added non-interactive stdin handling for the SQL shell.
- Preserved interactive shell behavior for terminal sessions.
- Made the deployment test framework decode launcher output as UTF-8.
- Added a Go unit test for scripted non-interactive shell input.
- Removed Windows skips from the piped-input deployment tests covered by SPOT-31454.
- Documented that lint, formatting, and typo fixes must be folded into the related commit.
- Spawned no-block launcher test processes in their own Windows process group and switched the interrupt test to send `CTRL_BREAK_EVENT` instead of hard-killing via `terminate()`; removed the Windows skip covered by SPOT-31455.

## Testing

- [ ] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

### Test Details

- `env GOCACHE=/tmp/go-build-cache GOLANGCI_LINT_CACHE=/tmp/golangci-lint-cache task lint-golang`
- `env GOCACHE=/tmp/go-build-cache go test -race ./internal/connect/... ./internal/util/...`
- `poetry run mypy .`
- `poetry run ruff check tests/deployment/test_custom.py tests/deployment/test_standard_deployment.py tests/framework/launcher.py`
- `poetry run ruff format --check tests/deployment/test_standard_deployment.py tests/framework/launcher.py`
- `git diff --check`

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [ ] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [x] Added/updated tests
- [ ] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

Deployment tests were not run locally because they require real infrastructure. This PR is draft so the Windows + Azure job can validate the fix.
