### PR TITLE
Clean up Windows and Azure CI workflow warnings

### DIFF
--- a/.github/actions/setup-aws/action.yml
+++ b/.github/actions/setup-aws/action.yml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: Connect GitHub to AWS account
-      uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6
+      uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
       with:
         role-to-assume: ${{ inputs.aws-ci-role }}
         role-session-name: aws-role-for-exasol-launcher

--- a/.github/actions/setup-codesigntool/action.yml
+++ b/.github/actions/setup-codesigntool/action.yml
@@ -13,14 +13,14 @@ runs:
   using: "composite"
   steps:
     - name: Set up Java for CodeSignTool
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
       with:
         distribution: 'temurin'
         java-version: '11'
     
     - name: Cache CodeSignTool
       id: cache-codesigntool
-      uses: actions/cache@v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: /tmp/codesigntool
         key: codesigntool-${{ inputs.version }}-${{ runner.os }}

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -4,7 +4,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup Go
-      uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
         go-version-file: go.mod
 
@@ -27,7 +27,7 @@ runs:
         go tool tflint --init || true
 
     - name: Cache golangci-lint
-      uses: actions/cache@v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
           # List all platform cache paths; only existing ones will be cached.
@@ -38,7 +38,7 @@ runs:
           golangci-lint-${{ runner.os }}-
 
     - name: Cache tflint plugins
-      uses: actions/cache@v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
           # List all platform cache paths; only existing ones will be cached.

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -11,28 +11,23 @@ runs:
     - name: Setup Task
       uses: ./.github/actions/setup-task
 
-    # This needs to be done so that different jobs can share the cache of the "setup-go" action
-    # "setup-go" caches the entire go env but with a fixed key
-    # If "lint-go" would not build the main app, it would populate the cache entry with the main app deps and vice-versa
-    # So we ensure that ALL go deps defined in "go.mod" are downloaded and seen by every job
-    # 1) `go mod download` should download all the main app go deps
-    # 2) `go tool ...` downloads and builds the tool bins and their deps
-    # 3) `tflint --init` ensure the tflinter plugins are downloaded into the cahge
-    - name: Warm up Go module and build cache
+    - name: Configure cache directories
       shell: bash
       run: |
-        go mod download
-        go tool golangci-lint version || true
-        go tool tflint --version || true
-        go tool tflint --init || true
+        golangci_lint_cache="${RUNNER_TEMP}/golangci-lint-cache"
+        tflint_plugin_cache="${RUNNER_TEMP}/tflint-plugins"
+
+        mkdir -p "${golangci_lint_cache}" "${tflint_plugin_cache}"
+
+        {
+          echo "GOLANGCI_LINT_CACHE=${golangci_lint_cache}"
+          echo "TFLINT_PLUGIN_DIR=${tflint_plugin_cache}"
+        } >> "${GITHUB_ENV}"
 
     - name: Cache golangci-lint
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
-        path: |
-          # List all platform cache paths; only existing ones will be cached.
-          ~/.cache/golangci-lint
-          ${{ env.USERPROFILE }}\.cache\golangci-lint
+        path: ${{ env.GOLANGCI_LINT_CACHE }}
         key: golangci-lint-${{ runner.os }}-${{ hashFiles('go.sum') }}
         restore-keys: |
           golangci-lint-${{ runner.os }}-
@@ -40,8 +35,20 @@ runs:
     - name: Cache tflint plugins
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
-        path: |
-          # List all platform cache paths; only existing ones will be cached.
-          ~/.tflint.d/plugins
-          ${{ env.USERPROFILE }}\.tflint.d\plugins
+        path: ${{ env.TFLINT_PLUGIN_DIR }}
         key: tflint-${{ runner.os }}
+
+    # This needs to be done so that different jobs can share the cache of the "setup-go" action
+    # "setup-go" caches the entire go env but with a fixed key
+    # If "lint-go" would not build the main app, it would populate the cache entry with the main app deps and vice-versa
+    # So we ensure that ALL go deps defined in "go.mod" are downloaded and seen by every job
+    # 1) `go mod download` should download all the main app go deps
+    # 2) `go tool ...` downloads and builds the tool bins and their deps
+    # 3) `tflint --init` ensure the tflinter plugins are downloaded into the cache
+    - name: Warm up Go module and build cache
+      shell: bash
+      run: |
+        go mod download
+        go tool golangci-lint version || true
+        go tool tflint --version || true
+        go tool tflint --init || true

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -7,12 +7,12 @@ runs:
       uses: ./.github/actions/setup-task
 
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
       with:
         python-version: '3.13'
 
     - name: Cache Poetry dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
           # List all platform cache paths; only existing ones will be cached.

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -11,15 +11,25 @@ runs:
       with:
         python-version: '3.13'
 
+    - name: Configure cache directories
+      shell: bash
+      run: |
+        poetry_cache="${RUNNER_TEMP}/pypoetry-cache"
+        pip_cache="${RUNNER_TEMP}/pip-cache"
+
+        mkdir -p "${poetry_cache}" "${pip_cache}"
+
+        {
+          echo "POETRY_CACHE_DIR=${poetry_cache}"
+          echo "PIP_CACHE_DIR=${pip_cache}"
+        } >> "${GITHUB_ENV}"
+
     - name: Cache Poetry dependencies
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
-          # List all platform cache paths; only existing ones will be cached.
-          ~/.cache/pypoetry
-          ~/.cache/pip
-          ${{ env.USERPROFILE }}\.cache\pypoetry
-          ${{ env.USERPROFILE }}\.cache\pip
+          ${{ env.POETRY_CACHE_DIR }}
+          ${{ env.PIP_CACHE_DIR }}
         key: poetry-venv-${{ runner.os }}-${{ hashFiles('tests/poetry.lock') }}
         restore-keys: |
           poetry-venv-${{ runner.os }}-

--- a/.github/actions/setup-task/action.yml
+++ b/.github/actions/setup-task/action.yml
@@ -11,6 +11,6 @@ runs:
   using: "composite"
   steps:
     - name: Install Task
-      uses: go-task/setup-task@0ab1b2a65bc55236a3bc64cde78f80e20e8885c2 # v1
+      uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa # v2.1.0
       with:
         version: ${{ inputs.version }}

--- a/.github/actions/status-set/action.yml
+++ b/.github/actions/status-set/action.yml
@@ -16,7 +16,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+    - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         STATUS_INPUT: ${{ inputs.status }}
         DESCRIPTION_INPUT: ${{ inputs.description }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,6 @@ jobs:
           # this is need because we use "git describe" to get the latest version from git
           fetch-depth: 0
       - uses: ./.github/actions/build
-        with:
-          local-runner-token: ${{ secrets.EXASOL_NANO_VM_TOKEN }}
       # Upload the correct file depending on OS with a unique name
       - name: Upload file (Windows)
         if: startsWith(matrix.os, 'windows')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-go
       - name: Lint Go code
         run: task lint-golang
@@ -28,7 +28,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/setup-python
       - name: Lint ruff
         run: task lint-ruff
@@ -46,7 +46,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # this is need because we use "git describe" to get the latest version from git
           fetch-depth: 0
@@ -54,13 +54,13 @@ jobs:
       # Upload the correct file depending on OS with a unique name
       - name: Upload file (Windows)
         if: startsWith(matrix.os, 'windows')
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: exasol-${{ matrix.os }}
           path: bin/exasol.exe
       - name: Upload file (Ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: exasol-${{ matrix.os }}
           path: bin/exasol
@@ -71,7 +71,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/tests-unit
 
   tests-integration:
@@ -83,12 +83,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       # Download artifact based on OS
       - name: Download built artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: exasol-${{ matrix.os }}
           path: bin/

--- a/.github/workflows/dependabot-stabilization.yml
+++ b/.github/workflows/dependabot-stabilization.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # this is need because we use "git describe" to get the latest version from git       
           fetch-depth: 0
@@ -25,14 +25,14 @@ jobs:
 
       - name: Upload file
         if: ${{ !contains(matrix.os, 'windows') }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: exasol-${{ matrix.os }}
           path: bin/exasol
 
       - name: Upload file (Windows)
         if: ${{ contains(matrix.os, 'windows') }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: exasol-${{ matrix.os }}
           path: bin/exasol.exe

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -22,8 +22,6 @@ jobs:
           # this is need because we use "git describe" to get the latest version from git       
           fetch-depth: 0
       - uses: ./.github/actions/build
-        with:
-          local-runner-token: ${{ secrets.EXASOL_NANO_VM_TOKEN }}
 
       - name: Upload file
         if: ${{ !contains(matrix.os, 'windows') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - name: Set up Go

--- a/.github/workflows/tests-deployment.yml
+++ b/.github/workflows/tests-deployment.yml
@@ -81,7 +81,7 @@ jobs:
       contents: read # Required for actions/checkout
       statuses: write # Required for status updates
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           # this is need because we use "git describe" to get the latest version from git
           fetch-depth: 0
@@ -171,7 +171,7 @@ jobs:
       contents: read
       statuses: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - uses: ./.github/actions/status-set

--- a/.github/workflows/tests-deployment.yml
+++ b/.github/workflows/tests-deployment.yml
@@ -140,8 +140,6 @@ jobs:
       # and fetch it here. However, for now the build run time
       # is short and we can afford building it a second time.
       - uses: ./.github/actions/build
-        with:
-          local-runner-token: ${{ secrets.EXASOL_NANO_VM_TOKEN }}
       - uses: ./.github/actions/tests-deployment
         env:
           ARM_USE_OIDC: ${{ matrix.infra == 'azure' && 'true' || '' }}

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -52,7 +52,7 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.plan-tests-integration.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - uses: ./.github/actions/build

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -56,6 +56,4 @@ jobs:
         with:
           fetch-depth: 0
       - uses: ./.github/actions/build
-        with:
-          local-runner-token: ${{ secrets.EXASOL_NANO_VM_TOKEN }}
       - uses: ./.github/actions/tests-integration

--- a/tests/tests/conftest.py
+++ b/tests/tests/conftest.py
@@ -3,6 +3,12 @@
 
 import pytest
 
+_PROVIDER_MARKERS = {
+    "provider_aws": "aws",
+    "provider_azure": "azure",
+    "provider_stackit": "stackit",
+}
+
 
 def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption(
@@ -48,3 +54,26 @@ def stackit_project_id(request: pytest.FixtureRequest) -> str | None:
     if project_id is not None:
         return str(project_id)
     return None
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    selected_infra = str(config.getoption("--infra"))
+    selected_items: list[pytest.Item] = []
+    deselected_items: list[pytest.Item] = []
+
+    for item in items:
+        provider_infras = {
+            infra
+            for marker_name, infra in _PROVIDER_MARKERS.items()
+            if item.get_closest_marker(marker_name) is not None
+        }
+        if provider_infras and selected_infra not in provider_infras:
+            deselected_items.append(item)
+        else:
+            selected_items.append(item)
+
+    if deselected_items:
+        config.hook.pytest_deselected(items=deselected_items)
+        items[:] = selected_items


### PR DESCRIPTION
## Description

Clean up repository-owned workflow warnings surfaced by the Windows + Azure deployment CI path.

## Related Issue

Jira: https://exasol.atlassian.net/browse/SPOT-31531

## Type of Change

- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [x] `chore`: Maintenance tasks

## Changes Made

- Removed invalid `local-runner-token` inputs from build action calls.
- Updated GitHub Actions references to current stable SHA-pinned releases.
- Changed Go/Python cache setup to use explicit existing directories under `RUNNER_TEMP`.
- Deselect provider-specific deployment tests at collection time when they do not match `--infra`.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

### Test Details

- `env GOCACHE=/tmp/go-build-cache GOLANGCI_LINT_CACHE=/tmp/golangci-lint-cache task all`
- `cd tests && poetry run pytest --collect-only --infra=azure tests/deployment/test_custom.py tests/deployment/test_standard_deployment.py -q`
  - Result: `14/17 tests collected (3 deselected)`
- `git diff --check origin/main..HEAD`

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

`actionlint` is not installed locally, so workflow syntax validation relies on review plus GitHub CI.
