### PR TITLE
fix: use stable deployment compatibility baseline

### DIFF
--- a/cmd/exasol/compatibility.go
+++ b/cmd/exasol/compatibility.go
@@ -23,20 +23,30 @@ const (
 		"compatibility but is missing annotation %q"
 )
 
-func requireMinorVersionCompatibility(
+// requireMinorBaselineDeploymentCompatibility declares a minimum deployment
+// version at minor-release granularity, for example "2.1.7" becomes "2.1.0".
+func requireMinorBaselineDeploymentCompatibility(
 	cmd *cobra.Command,
-	minSupportedDeploymentMinorVersion string,
+	minSupportedDeploymentVersion string,
 ) {
-	minSupported, err := normalizeVersionToMinor(minSupportedDeploymentMinorVersion)
+	minSupported, err := normalizeVersionToMinor(minSupportedDeploymentVersion)
 	if err != nil {
 		// Do not panic here: this helper is used when defining commands.
 		// If the version is invalid, keep it as-is so the compatibility enforcement
 		// returns a structured InvalidVersionError at runtime.
-		requireVersionCompatibility(cmd, minSupportedDeploymentMinorVersion)
+		requireDeploymentCompatibility(cmd, minSupportedDeploymentVersion)
 		return
 	}
 
-	requireVersionCompatibility(cmd, minSupported)
+	requireDeploymentCompatibility(cmd, minSupported)
+}
+
+// requireDefaultDeploymentCompatibility declares the normal command contract:
+// commands are compatible with any deployment version unless they opt into a
+// higher, named minimum because older deployment directories are unsafe for
+// that command.
+func requireDefaultDeploymentCompatibility(cmd *cobra.Command) {
+	requireDeploymentCompatibility(cmd, minSupportedDeploymentVersionBaseline)
 }
 
 func normalizeVersionToMinor(raw string) (string, error) {
@@ -45,8 +55,7 @@ func normalizeVersionToMinor(raw string) (string, error) {
 		return "", err
 	}
 
-	// Compatibility requirements are expressed at minor granularity:
-	// keep major/minor and normalize patch to 0.
+	// Minor-baseline requirements keep major/minor and normalize patch to 0.
 	ver.Patch = 0
 
 	// Keep normalization consistent with internal compatibility logic:
@@ -57,7 +66,7 @@ func normalizeVersionToMinor(raw string) (string, error) {
 	return ver.String(), nil
 }
 
-func requireVersionCompatibility(cmd *cobra.Command, minSupportedDeploymentVersion string) {
+func requireDeploymentCompatibility(cmd *cobra.Command, minSupportedDeploymentVersion string) {
 	if cmd.Annotations == nil {
 		cmd.Annotations = map[string]string{}
 	}

--- a/cmd/exasol/compatibility_test.go
+++ b/cmd/exasol/compatibility_test.go
@@ -22,7 +22,7 @@ func TestEnforceDeploymentDirectoryCompatibility_FailsEarlyWhenNotInitialized(t 
 	// requires an initialized deployment directory.
 	tmp := t.TempDir()
 	cmd := &cobra.Command{Use: "deploy"}
-	requireVersionCompatibility(cmd, minSupportedDeploymentVersionBaseline)
+	requireDeploymentCompatibility(cmd, minSupportedDeploymentVersionBaseline)
 	requireInitializedDeploymentDir(cmd)
 
 	// When: compatibility enforcement runs.
@@ -57,7 +57,7 @@ func TestEnforceDeploymentDirectoryCompatibility_HintsLegacyWorkflowStateLayout(
 	// Given: an init-like command that may operate on uninitialized directories
 	// (so it must not require an initialized deployment dir).
 	cmd := &cobra.Command{Use: "some_init_like_command"}
-	requireVersionCompatibility(cmd, minSupportedDeploymentVersionBaseline)
+	requireDeploymentCompatibility(cmd, minSupportedDeploymentVersionBaseline)
 
 	// When: compatibility enforcement runs.
 	err = enforceDeploymentDirectoryCompatibility(cmd, config.NewDeploymentDir(tmp))
@@ -79,14 +79,14 @@ func TestEnforceDeploymentDirectoryCompatibility_HintsLegacyWorkflowStateLayout(
 	}
 }
 
-func TestRequireMinorVersionDeploymentCompatibility_NormalizesPatchToZero(t *testing.T) {
+func TestRequireMinorBaselineDeploymentCompatibility_NormalizesPatchToZero(t *testing.T) {
 	t.Parallel()
 
 	// Given: a command and a semver string that includes patch, prerelease and build metadata.
 	cmd := &cobra.Command{Use: "deploy"}
 
 	// When: the command declares a minor-level minimum.
-	requireMinorVersionCompatibility(cmd, "1.2.3-rc1+build.7")
+	requireMinorBaselineDeploymentCompatibility(cmd, "1.2.3-rc1+build.7")
 
 	// Then: the stored minimum is normalized to major.minor.0 and compatibility is required.
 	if !deploymentCompatibilityIsRequired(cmd) {
@@ -98,13 +98,70 @@ func TestRequireMinorVersionDeploymentCompatibility_NormalizesPatchToZero(t *tes
 	}
 }
 
-func TestDeploymentCompatibilityRules_MinorMinimumAndNeverNewerThanLauncher(t *testing.T) {
+func TestRequireDefaultDeploymentCompatibilityUsesStableBaseline(t *testing.T) {
+	t.Parallel()
+
+	// Given: a command uses the default deployment compatibility declaration.
+	cmd := &cobra.Command{Use: "status"}
+
+	// When: the command declares compatibility requirements.
+	requireDefaultDeploymentCompatibility(cmd)
+
+	// Then: it uses the stable baseline instead of the current launcher version.
+	if !deploymentCompatibilityIsRequired(cmd) {
+		t.Fatal("expected deployment compatibility to be required")
+	}
+	if got := minSupportedDeploymentVersionFromAnnotations(cmd); got != "0.0.0" {
+		t.Fatalf("expected min supported deployment version to be 0.0.0, got %q", got)
+	}
+}
+
+func TestDeploymentCompatibilityRules_DefaultRequirementAllowsOlderCompatibleDeployment(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	// Given: a default-compatible command running in a newer launcher minor.
+	cmd := &cobra.Command{Use: "destroy"}
+	requireDefaultDeploymentCompatibility(cmd)
+	req := deploymentcompatibility.Requirement{
+		CommandName:                   cmd.Name(),
+		MinSupportedDeploymentVersion: minSupportedDeploymentVersionFromAnnotations(cmd),
+	}
+
+	// When: a 2.1 launcher checks a deployment created by a 1.4 launcher.
+	res := deploymentcompatibility.Check("1.4.1", "2.1.0", req)
+	// Then: the deployment is allowed because the command has no higher minimum.
+	if !res.Allowed {
+		t.Fatalf("expected older compatible deployment to be allowed, got: %v", res.Err)
+	}
+
+	// When: the deployment was created by a newer launcher than the current one.
+	res = deploymentcompatibility.Check("2.2.0", "2.1.0", req)
+	// Then: the forward-compatibility guard still rejects it.
+	if res.Allowed {
+		t.Fatal("expected newer deployment to be rejected")
+	}
+	var inc *deploymentcompatibility.IncompatibleError
+	if !errors.As(res.Err, &inc) {
+		t.Fatalf("expected IncompatibleError, got %T: %v", res.Err, res.Err)
+	}
+	if inc.Reason != deploymentcompatibility.ReasonDeploymentNewerThanLauncher {
+		t.Fatalf(
+			"expected reason %q, got %q",
+			deploymentcompatibility.ReasonDeploymentNewerThanLauncher,
+			inc.Reason,
+		)
+	}
+}
+
+func TestDeploymentCompatibilityRules_MinorBaselineAndNeverNewerThanLauncher(t *testing.T) {
 	t.Parallel()
 
 	// Given: a command declares a minor-level minimum (patch is ignored) and we build
 	// the compatibility requirement from the command annotations.
 	cmd := &cobra.Command{Use: "deploy"}
-	requireMinorVersionCompatibility(cmd, "1.2.5")
+	requireMinorBaselineDeploymentCompatibility(cmd, "1.2.5")
 
 	req := deploymentcompatibility.Requirement{
 		CommandName:                   cmd.Name(),
@@ -197,7 +254,7 @@ func TestDeploymentCompatibilityRules_StrictRevisionRequirement(t *testing.T) {
 
 	// Given: a command declares a strict (patch-accurate) minimum.
 	cmd := &cobra.Command{Use: "deploy"}
-	requireVersionCompatibility(cmd, "1.2.5")
+	requireDeploymentCompatibility(cmd, "1.2.5")
 
 	req := deploymentcompatibility.Requirement{
 		CommandName:                   cmd.Name(),
@@ -230,7 +287,7 @@ func TestDeploymentCompatibilityRules_StrictRevisionRequirement(t *testing.T) {
 	}
 }
 
-func TestDeploymentCompatibilityRules_OlderMinorMinimumAllowsNewerDeploymentsUpToLauncher(
+func TestDeploymentCompatibilityRules_OlderMinorBaselineAllowsNewerDeploymentsUpToLauncher(
 	t *testing.T,
 ) {
 	t.Parallel()
@@ -238,7 +295,7 @@ func TestDeploymentCompatibilityRules_OlderMinorMinimumAllowsNewerDeploymentsUpT
 	// Given: a command declares that it still supports deployments as old as 1.1.*,
 	// while the launcher is already in 1.3.*.
 	cmd := &cobra.Command{Use: "status"}
-	requireMinorVersionCompatibility(cmd, "1.1.9")
+	requireMinorBaselineDeploymentCompatibility(cmd, "1.1.9")
 
 	req := deploymentcompatibility.Requirement{
 		CommandName:                   cmd.Name(),
@@ -275,12 +332,12 @@ func TestDeploymentCompatibilityRules_OlderMinorMinimumAllowsNewerDeploymentsUpT
 	}
 }
 
-func TestRequireMinorVersionDeploymentCompatibility_DoesNotPanicOnInvalidVersion(t *testing.T) {
+func TestRequireMinorBaselineDeploymentCompatibility_DoesNotPanicOnInvalidVersion(t *testing.T) {
 	t.Parallel()
 
 	// Given: an invalid version string is used while defining command compatibility.
 	cmd := &cobra.Command{Use: "deploy"}
-	requireMinorVersionCompatibility(cmd, "not-a-version")
+	requireMinorBaselineDeploymentCompatibility(cmd, "not-a-version")
 
 	// When: the runtime compatibility checker runs using the requirement stored in the command.
 	req := deploymentcompatibility.Requirement{

--- a/cmd/exasol/config.go
+++ b/cmd/exasol/config.go
@@ -109,7 +109,7 @@ var configResetCmd = &cobra.Command{
 // nolint: gochecknoinits
 func init() {
 	for _, cmd := range []*cobra.Command{configCmd, configGetCmd, configSetCmd, configResetCmd} {
-		requireMinorVersionCompatibility(cmd, CurrentLauncherVersion)
+		requireDefaultDeploymentCompatibility(cmd)
 		requireInitializedDeploymentDir(cmd)
 		requireDeploymentFileLogging(cmd)
 	}

--- a/cmd/exasol/config_test.go
+++ b/cmd/exasol/config_test.go
@@ -15,9 +15,9 @@ import (
 func TestConfigCommandsDeclareDeploymentPreRunRequirements(t *testing.T) {
 	t.Parallel()
 
-	expectedVersion, err := normalizeVersionToMinor(CurrentLauncherVersion)
+	expectedVersion, err := normalizeVersionToMinor(minSupportedDeploymentVersionBaseline)
 	if err != nil {
-		expectedVersion = CurrentLauncherVersion
+		expectedVersion = minSupportedDeploymentVersionBaseline
 	}
 
 	for _, cmd := range []*cobra.Command{configCmd, configGetCmd, configSetCmd, configResetCmd} {

--- a/cmd/exasol/connect.go
+++ b/cmd/exasol/connect.go
@@ -131,7 +131,7 @@ func registerConnectFlags() {
 
 // nolint: gochecknoinits
 func init() {
-	requireMinorVersionCompatibility(connectCmd, CurrentLauncherVersion)
+	requireDefaultDeploymentCompatibility(connectCmd)
 	requireInitializedDeploymentDir(connectCmd)
 	registerConnectFlags()
 	registerDeploymentDirFlag(connectCmd, commonFlags)

--- a/cmd/exasol/deploy.go
+++ b/cmd/exasol/deploy.go
@@ -43,7 +43,7 @@ var deployCmd = &cobra.Command{
 
 // nolint: gochecknoinits
 func init() {
-	requireMinorVersionCompatibility(deployCmd, CurrentLauncherVersion)
+	requireDefaultDeploymentCompatibility(deployCmd)
 	requireInitializedDeploymentDir(deployCmd)
 	requireDeploymentFileLogging(deployCmd)
 	registerDeploymentDirFlag(deployCmd, commonFlags)

--- a/cmd/exasol/deploymentControl.go
+++ b/cmd/exasol/deploymentControl.go
@@ -120,7 +120,7 @@ func registerStartFlags() {
 
 // nolint: gochecknoinits
 func init() {
-	requireMinorVersionCompatibility(startCmd, CurrentLauncherVersion)
+	requireDefaultDeploymentCompatibility(startCmd)
 	requireInitializedDeploymentDir(startCmd)
 	requireDeploymentFileLogging(startCmd)
 	registerStartFlags()
@@ -129,7 +129,7 @@ func init() {
 	registerOutputFlags(startCmd, commonFlags)
 	rootCmd.AddCommand(startCmd)
 
-	requireMinorVersionCompatibility(stopCmd, CurrentLauncherVersion)
+	requireDefaultDeploymentCompatibility(stopCmd)
 	requireInitializedDeploymentDir(stopCmd)
 	requireDeploymentFileLogging(stopCmd)
 	registerVerboseFlag(stopCmd, commonFlags)

--- a/cmd/exasol/destroy.go
+++ b/cmd/exasol/destroy.go
@@ -90,7 +90,7 @@ func destroyConfirmationPrompt(localRemovalTarget string) string {
 
 // nolint: gochecknoinits
 func init() {
-	requireMinorVersionCompatibility(destroyCmd, CurrentLauncherVersion)
+	requireDefaultDeploymentCompatibility(destroyCmd)
 	requireInitializedDeploymentDir(destroyCmd)
 	requireDeploymentFileLogging(destroyCmd)
 	registerDeploymentDirFlag(destroyCmd, commonFlags)

--- a/cmd/exasol/diagInfo.go
+++ b/cmd/exasol/diagInfo.go
@@ -30,7 +30,7 @@ var infoCmd = &cobra.Command{
 
 // nolint: gochecknoinits
 func init() {
-	requireMinorVersionCompatibility(infoCmd, CurrentLauncherVersion)
+	requireDefaultDeploymentCompatibility(infoCmd)
 	requireInitializedDeploymentDir(infoCmd)
 	registerDeploymentDirFlag(infoCmd, commonFlags)
 	diagCmd.AddCommand(infoCmd)

--- a/cmd/exasol/diagShell.go
+++ b/cmd/exasol/diagShell.go
@@ -48,7 +48,7 @@ func registerDiagShellFlags() {
 
 // nolint: gochecknoinits
 func init() {
-	requireMinorVersionCompatibility(diagShellCmd, CurrentLauncherVersion)
+	requireDefaultDeploymentCompatibility(diagShellCmd)
 	requireInitializedDeploymentDir(diagShellCmd)
 	registerDiagShellFlags()
 	registerDeploymentDirFlag(diagShellCmd, commonFlags)

--- a/cmd/exasol/hidden.go
+++ b/cmd/exasol/hidden.go
@@ -38,10 +38,7 @@ var printConnectionInstructions = &cobra.Command{
 
 // nolint: gochecknoinits
 func init() {
-	requireMinorVersionCompatibility(
-		printConnectionInstructions,
-		minSupportedDeploymentVersionBaseline,
-	)
+	requireDefaultDeploymentCompatibility(printConnectionInstructions)
 	requireInitializedDeploymentDir(printConnectionInstructions)
 	registerDeploymentDirFlag(printConnectionInstructions, commonFlags)
 	rootCmd.AddCommand(printConnectionInstructions)

--- a/cmd/exasol/info.go
+++ b/cmd/exasol/info.go
@@ -96,7 +96,7 @@ var deploymentInfoCmd = &cobra.Command{
 
 // nolint: gochecknoinits
 func init() {
-	requireMinorVersionCompatibility(deploymentInfoCmd, CurrentLauncherVersion)
+	requireDefaultDeploymentCompatibility(deploymentInfoCmd)
 	registerDeploymentDirFlag(deploymentInfoCmd, commonFlags)
 	registerOutputFlags(deploymentInfoCmd, commonFlags)
 	rootCmd.AddCommand(deploymentInfoCmd)

--- a/cmd/exasol/init.go
+++ b/cmd/exasol/init.go
@@ -62,7 +62,7 @@ func init() {
 	// Init creates the deployment directory state; if a deployment directory already
 	// exists, the compatibility check protects against operating on an incompatible
 	// deployment.
-	requireMinorVersionCompatibility(initCmd, minSupportedDeploymentVersionBaseline)
+	requireDefaultDeploymentCompatibility(initCmd)
 	requireDeploymentFileLogging(initCmd)
 
 	// Augment long help with embedded preset names so users know what they can pass.

--- a/cmd/exasol/install.go
+++ b/cmd/exasol/install.go
@@ -133,7 +133,7 @@ func init() {
 	// init runs in PreRunE, deploy runs in PersistentPostRunE
 	installCmd.RunE = func(_ *cobra.Command, _ []string) error { return nil }
 
-	requireMinorVersionCompatibility(installCmd, CurrentLauncherVersion)
+	requireDefaultDeploymentCompatibility(installCmd)
 	registerInitFlags(installCmd, commonFlags)
 	registerDeploymentDirFlag(installCmd, commonFlags)
 	registerVerboseFlag(installCmd, commonFlags)

--- a/cmd/exasol/shellContainer.go
+++ b/cmd/exasol/shellContainer.go
@@ -29,7 +29,7 @@ var shellContainerCmd = &cobra.Command{
 
 // nolint: gochecknoinits
 func init() {
-	requireMinorVersionCompatibility(shellContainerCmd, CurrentLauncherVersion)
+	requireDefaultDeploymentCompatibility(shellContainerCmd)
 	requireInitializedDeploymentDir(shellContainerCmd)
 	registerDeploymentDirFlag(shellContainerCmd, commonFlags)
 	shellRootCmd.AddCommand(shellContainerCmd)

--- a/cmd/exasol/shellHost.go
+++ b/cmd/exasol/shellHost.go
@@ -42,7 +42,7 @@ func registerShellHostFlags() {
 
 // nolint: gochecknoinits
 func init() {
-	requireMinorVersionCompatibility(shellHostCmd, CurrentLauncherVersion)
+	requireDefaultDeploymentCompatibility(shellHostCmd)
 	requireInitializedDeploymentDir(shellHostCmd)
 	registerShellHostFlags()
 	registerDeploymentDirFlag(shellHostCmd, commonFlags)

--- a/cmd/exasol/status.go
+++ b/cmd/exasol/status.go
@@ -73,7 +73,7 @@ func registerStatusFlags() {
 
 // nolint: gochecknoinits
 func init() {
-	requireMinorVersionCompatibility(statusCmd, CurrentLauncherVersion)
+	requireDefaultDeploymentCompatibility(statusCmd)
 	registerStatusFlags()
 	registerDeploymentDirFlag(statusCmd, commonFlags)
 	registerOutputFlags(statusCmd, commonFlags)

--- a/cmd/exasol/unlock.go
+++ b/cmd/exasol/unlock.go
@@ -36,7 +36,7 @@ var unlockCmd = &cobra.Command{
 
 // nolint: gochecknoinits
 func init() {
-	requireMinorVersionCompatibility(unlockCmd, minSupportedDeploymentVersionBaseline)
+	requireDefaultDeploymentCompatibility(unlockCmd)
 	requireInitializedDeploymentDir(unlockCmd)
 	registerDeploymentDirFlag(unlockCmd, commonFlags)
 	diagCmd.AddCommand(unlockCmd)


### PR DESCRIPTION
## Description

Fixes the deployment compatibility gate so launcher commands no longer derive their minimum supported deployment version from `CurrentLauncherVersion`. Default deployment-directory commands now assume compatibility with older deployment versions unless a command explicitly opts into a higher named minimum because older deployment directories are unsafe for that command.

## Related Issue

Fixes SPOT-31550

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Added `requireDefaultDeploymentCompatibility()` for the normal command contract.
- Renamed the explicit minor-floor helper to `requireMinorBaselineDeploymentCompatibility()` so its intent is opt-in and clear.
- Switched deployment-directory commands from current-launcher floors to the default stable baseline.
- Kept the existing forward-compatibility guard: deployments newer than the launcher are still rejected.
- Added regression tests for older compatible deployments and newer-than-launcher rejection.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

- `env XDG_CACHE_HOME=/tmp/exasol-test-cache GOCACHE=/tmp/go-build-cache GOLANGCI_LINT_CACHE=/tmp/golangci-lint-cache go test ./cmd/exasol`
- `env GOCACHE=/tmp/go-build-cache GOLANGCI_LINT_CACHE=/tmp/golangci-lint-cache task all`
- Manual live AWS validation: actual AWS deployment created with launcher `1.4.1` was managed successfully with launcher `2.0.0`.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

Root cause: `requireMinorVersionCompatibility(cmd, CurrentLauncherVersion)` normalized the running launcher version into a minimum deployment version. That made each launcher minor release reject deployments from older launcher minors, even when the command implementation remained compatible.
