### PR TITLE
ci(release): drive releases from manual workflow with explicit tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,11 @@
 # .github/workflows/release.yml
-name: Create GH release (tag + GoReleaser)
+name: Create GH release (from existing tag)
 
 on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag to create (e.g. v2.1.0 or v2.1.0-rc1). A hyphen marks it as a pre-release."
-        required: true
-      source_ref:
-        description: "Ref/commit to tag and release from (e.g. main, a SHA, or v2.1.0-rc1 when promoting an rc to final)."
+        description: "Existing release tag to publish (e.g. v2.1.0 or v2.1.0-rc1). Create and push it first (admins only). A hyphen marks it as a pre-release."
         required: true
       previous_tag:
         description: "Previous tag for the changelog base (e.g. v2.0.0). Leave blank to auto-detect the last stable release."
@@ -24,24 +21,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout
+      - name: Checkout release tag
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          ref: ${{ inputs.source_ref }}
-
-      - name: Create and push tag
-        run: |
-          set -euo pipefail
-          TAG='${{ inputs.tag }}'
-          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
-            echo "::error::Tag ${TAG} already exists. Choose a new tag or delete the existing one first."
-            exit 1
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "${TAG}" -m "Release ${TAG}"
-          git push origin "refs/tags/${TAG}"
+          ref: refs/tags/${{ inputs.tag }}
 
       - name: Determine previous tag for changelog
         id: prev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,18 @@
 # .github/workflows/release.yml
-name: Version tag pushed - Create GH release
+name: Create GH release (tag + GoReleaser)
 
 on:
-  push:
-    # run only against version tags
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to create (e.g. v2.1.0 or v2.1.0-rc1). A hyphen marks it as a pre-release."
+        required: true
+      source_ref:
+        description: "Ref/commit to tag and release from (e.g. main, a SHA, or v2.1.0-rc1 when promoting an rc to final)."
+        required: true
+      previous_tag:
+        description: "Previous tag for the changelog base (e.g. v2.0.0). Leave blank to auto-detect the last stable release."
+        required: false
 
 permissions: {}
 
@@ -21,19 +28,52 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          ref: ${{ inputs.source_ref }}
+
+      - name: Create and push tag
+        run: |
+          set -euo pipefail
+          TAG='${{ inputs.tag }}'
+          if git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "::error::Tag ${TAG} already exists. Choose a new tag or delete the existing one first."
+            exit 1
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${TAG}" -m "Release ${TAG}"
+          git push origin "refs/tags/${TAG}"
+
+      - name: Determine previous tag for changelog
+        id: prev
+        run: |
+          set -euo pipefail
+          TAG='${{ inputs.tag }}'
+          INPUT_PREV='${{ inputs.previous_tag }}'
+          if [ -n "${INPUT_PREV}" ]; then
+            PREV="${INPUT_PREV}"
+          else
+            # Highest stable (non-prerelease) tag reachable from the release tag, excluding the tag itself.
+            PREV="$(git tag --merged "${TAG}" --sort=-version:refname \
+              | grep -vE '-' \
+              | grep -vFx "${TAG}" \
+              | head -n1 || true)"
+          fi
+          echo "Previous tag for changelog: '${PREV:-<auto-detect by GoReleaser>}'"
+          echo "tag=${PREV}" >> "$GITHUB_OUTPUT"
+
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: go.mod
       - name: Setup Task
         uses: ./.github/actions/setup-task
-      
+
       - name: Setup CodeSignTool for Windows signing
         uses: ./.github/actions/setup-codesigntool
         with:
           version: v1.3.2
           checksum-sha256: f14b1e1ef14bfa1fd00279c363aab0debbf5dcfba0e4bcdce5d22bb771de0e3a
-      
+
       - name: Setup macOS signing certificate
         id: macos-signing
         uses: ./.github/actions/setup-macos-signing
@@ -43,12 +83,13 @@ jobs:
           application-cert: ${{ secrets.IOS_CER_DEVELOPERID_APPLICATION_BASE64_ENCODED }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
-        if: startsWith(github.ref, 'refs/tags/')
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release --clean       
+          args: release --clean
         env:
+          GORELEASER_CURRENT_TAG: ${{ inputs.tag }}
+          GORELEASER_PREVIOUS_TAG: ${{ steps.prev.outputs.tag }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LOCAL_RUNNER_GITHUB_TOKEN: ${{ secrets.EXASOL_NANO_VM_TOKEN }}
           MACOS_SIGN_P12: ${{ steps.macos-signing.outputs.p12-path }}
@@ -60,4 +101,3 @@ jobs:
           SSLCOM_PASSWORD: ${{ secrets.ESIGN_PASSWORD }}
           SSLCOM_CREDENTIAL_ID: ${{ secrets.ESIGN_CREDENTIAL_ID }}
           SSLCOM_TOTP_SECRET: ${{ secrets.ESIGN_TOTP_SECRET }}
-      


### PR DESCRIPTION
## Description

Releases were triggered by tag pushes and relied on GoReleaser inferring the current/previous tags from git. When a release and its `-rc` tag point at the same commit, GoReleaser could publish the rc instead of the intended release and produce an empty changelog. This replaces the trigger with a manual `workflow_dispatch` that publishes an **already-pushed** tag, passing it to GoReleaser explicitly so there is no ambiguity — without GoReleaser Pro (`smartsemver`).

Tag creation stays with admins (enforced by the existing "version / release tags only for admins" tag ruleset); the workflow only consumes the tag, so it needs no ruleset changes and only `contents: write` to create the GitHub release.

## Related Issue

Jira: SPOT-31563

## Type of Change

- [x] `chore`: Maintenance tasks

## Changes Made

- Trigger `release.yml` via `workflow_dispatch` with a required `tag` and optional `previous_tag` input (was: push on `v*` tags).
- Check out `refs/tags/<tag>` and run GoReleaser with `GORELEASER_CURRENT_TAG`/`GORELEASER_PREVIOUS_TAG` so it publishes exactly the intended release and changelog even when a release and its rc share a commit.
- Auto-detect the last stable (non-prerelease) tag as changelog base when `previous_tag` is blank.
- The workflow does **not** create tags — an admin pushes the tag first (respecting the tag ruleset).

## Release flow (for maintainers)

1. Admin creates and pushes the tag (e.g. `git tag v2.1.0 v2.1.0-rc1 && git push origin v2.1.0`). No dummy commit needed — the env vars disambiguate.
2. Run the **Create GH release** workflow (Actions → Run workflow, or `gh workflow run release.yml -f tag=v2.1.0`), optionally setting `previous_tag`.

## Access control

- `workflow_dispatch` is restricted to users with **write** access (GitHub built-in) — not the public/forks.
- Creating `v*` tags remains **admin-only** via the existing tag ruleset.
- Recommended follow-up (repo Settings, not in this PR): add **required reviewers** to the `release` environment for a hard admin-approval gate before signing secrets are exposed.

## Testing

- [x] Workflow YAML validated (parses cleanly).
- Not applicable: `task all` / `task fmt` / `task lint` — no Go/Python/Terraform code changed; lint tasks don't cover GitHub Actions YAML.
- End-to-end verification requires a real dispatch run (produces a GitHub release), so it will be exercised on the next actual release.

## Additional Notes

Behavior change for maintainers: pushing a `v*` tag no longer triggers a release — use the **Run workflow** button (or `gh workflow run release.yml -f tag=…`).
