### PR TITLE
fix: make personal installer POSIX shell compatible

### DIFF
--- a/scripts/personal-installer.sh
+++ b/scripts/personal-installer.sh
@@ -1,5 +1,5 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 
 S3_URL="x-up.s3.eu-west-1.amazonaws.com"
 BASE_URL="https://$S3_URL/releases/exasol-personal"


### PR DESCRIPTION
## Description

Make the Linux/macOS personal installer run with a POSIX-compatible shell instead of requiring Bash. This helps users whose environment invokes the installer via `sh` or another non-Bash shell implementation, including stricter POSIX shells such as `dash`.

## Related Issue

N/A

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Changed `scripts/personal-installer.sh` shebang from Bash to POSIX `sh`.
- Replaced Bash-only `pipefail` strict mode with portable `set -eu`.
- Kept installer behavior unchanged otherwise.

## Testing

- [ ] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

- Ran POSIX shell syntax check with `sh -n scripts/personal-installer.sh`.
- Ran Bash syntax check with `bash -n scripts/personal-installer.sh`.
- Ran ShellCheck in POSIX shell mode with `shellcheck -s sh scripts/personal-installer.sh`.
- Ran an offline mocked installer execution via `sh scripts/personal-installer.sh` with a fake `curl`, verifying the target `exasol` binary was created and marked executable.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [ ] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [ ] Added/updated tests
- [ ] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

-
