### PR TITLE
fix: prefetch personal license before c4 host play

### DIFF
--- a/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/installExasol.sh
+++ b/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/installExasol.sh
@@ -52,6 +52,7 @@ else
 fi
 
 exasol_working_copy="@exasol-${exasol_version}"
+license_package="@license:personal"
 
 cat << CONFEOF | tee ./config > /dev/null
 CCC_HOST_ADDRS="${host_addrs}"
@@ -65,7 +66,7 @@ CCC_PLAY_DB_PASSWORD=$(quote_b64 "${db_password_b64}")
 CCC_ADMINUI_START_SERVER=true
 CCC_ADMINUI_ADMIN_PASSWORD=$(quote_b64 "${adminui_password_b64}")
 CCC_AWS_PROFILE=none
-CCC_PLAY_LICENSE=@license:personal
+CCC_PLAY_LICENSE=${license_package}
 CCC_PLAY_VERSION_UPDATE_CHECK=${db_version_check_enabled}
 CONFEOF
 
@@ -80,6 +81,12 @@ fi
 
 log_substep_info "Starting Exasol installation using c4"
 
+# Older c4 versions bundled by some DB packages still sign public x-up S3
+# requests even with CCC_AWS_PROFILE=none. The fetch command does not consume
+# the host-play config file, so pass the AWS profile explicitly and fetch with
+# launcher c4 first. Host play can then reuse the cached package after
+# switching to the bundled c4 version.
+CCC_AWS_PROFILE=none ./c4 fetch "${license_package}"
 ./c4 host play -i ./config
 
 log_step_info "Exasol installation completed"


### PR DESCRIPTION
## Description

Prefetch `@license:personal` with the launcher-provided c4 before starting `c4 host play` on Ubuntu deployments.

Exasol DB 2025.1.12 switches the install flow to the c4 version bundled with that DB package, c4 v4.28.8. That c4 version still signs public `x-up` S3 requests even with `CCC_AWS_PROFILE=none`, so AWS evaluates the request against the EC2 instance role and returns `403 AccessDenied` because the role is scoped to deployment-owned resources.

The `x-up` bucket is public and should not require customer-side IAM permissions. Prefetching the license with launcher c4 keeps the first request anonymous and lets the old bundled c4 reuse the cached package.

## Related Issue

Fixes SPOT-31599

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Reuse a `license_package` variable for the personal license package reference.
- Fetch `@license:personal` with launcher c4 before `c4 host play`.
- Document why this avoids broadening AWS IAM for the public `x-up` bucket.

## Testing

- [x] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [ ] Manually tested the changes

### Test Details

- `bash -n assets/installation/ubuntu/files/opt/exasol_launcher/scripts/installExasol.sh`
- `env GOCACHE=/tmp/go-build-cache XDG_CACHE_HOME=/tmp/exasol-personal-cache go test ./internal/presets ./internal/deploy`
- `task fmt`

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [ ] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [ ] Added/updated tests
- [ ] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

This keeps AWS IAM scoped to deployment resources and localizes the compatibility workaround to the install step that crosses from launcher c4 into the DB-bundled c4.
