### PR TITLE
feat: Handle local VM ports not reachable on macOS

### DIFF
--- a/cmd/exasol/diagLocal.go
+++ b/cmd/exasol/diagLocal.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"os"
+
+	"github.com/exasol/exasol-personal/internal/deploy"
+	"github.com/spf13/cobra"
+)
+
+const diagLocalCmdShortDesc = "Report local deployment runtime and reachability state"
+
+const diagLocalCmdLongDesc = diagLocalCmdShortDesc + `
+
+Reports local VM status, reported guest IP, bound host ports, per-port
+forwarder reachability, database readiness, and local platform support.
+Safe to run at any time, whether or not the deployment is currently running.
+
+The output is formatted as JSON.
+`
+
+var diagLocalCmd = &cobra.Command{
+	Use:   "local",
+	Short: diagLocalCmdShortDesc,
+	Long:  diagLocalCmdLongDesc,
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		cmd.SilenceUsage = true
+		return deploy.DiagnoseLocal(cmd.Context(), commonFlags.Deployment(), os.Stdout)
+	},
+}
+
+// nolint: gochecknoinits
+func init() {
+	requireDefaultDeploymentCompatibility(diagLocalCmd)
+	requireInitializedDeploymentDir(diagLocalCmd)
+	registerDeploymentDirFlag(diagLocalCmd, commonFlags)
+	diagCmd.AddCommand(diagLocalCmd)
+}

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/exasol/exasol-personal/internal/config"
 	"github.com/exasol/exasol-personal/internal/connect/exasol"
@@ -82,6 +83,11 @@ const MaxRowsUnset = -1
 
 // interactivePreviewMaxRows is the default row cap for interactive sessions.
 const interactivePreviewMaxRows = 100
+
+// connectDialTimeout bounds the initial connection dial, which otherwise has
+// no timeout of its own: the underlying database/sql/driver.Open call takes
+// no context, so without this an unreachable endpoint hangs indefinitely.
+const connectDialTimeout = 30 * time.Second
 
 // effectiveMaxRows returns the explicit row limit when one was set, otherwise
 // the mode default. A negative requested value means "unset".
@@ -183,7 +189,9 @@ func Connect(
 		return err
 	}
 
-	if err := database.Connect(ctx); err != nil {
+	dialCtx, cancel := context.WithTimeout(ctx, connectDialTimeout)
+	defer cancel()
+	if err := database.Connect(dialCtx); err != nil {
 		return err
 	}
 

--- a/internal/connect/exasol/database.go
+++ b/internal/connect/exasol/database.go
@@ -100,7 +100,7 @@ func defaultConnectFunc(input string) (types.ExasolConnector, error) {
 func (db *Database) Connect(ctx context.Context) error {
 	slog.Debug("connecting to the database", "connection_string", db.connectionString)
 
-	conn, err := db.connect(db.connectionString)
+	conn, err := db.connectWithContext(ctx)
 	if err != nil {
 		return err
 	}
@@ -167,6 +167,40 @@ func (db *Database) Exec(
 	}
 
 	return result, nil
+}
+
+// connectWithContext runs db.connect in a goroutine so ctx's cancellation/
+// deadline is honored even though the underlying database/sql/driver.Open
+// signature has no context parameter of its own. The dial goroutine is not
+// forcibly stopped when ctx is done; it runs to completion in the background
+// and its (now-unused) result is discarded.
+func (db *Database) connectWithContext(ctx context.Context) (types.ExasolConnector, error) {
+	type dialResult struct {
+		conn types.ExasolConnector
+		err  error
+	}
+	resultCh := make(chan dialResult, 1)
+
+	go func() {
+		conn, err := db.connect(db.connectionString)
+		resultCh <- dialResult{conn, err}
+	}()
+
+	select {
+	case result := <-resultCh:
+		return result.conn, result.err
+	case <-ctx.Done():
+		// Avoid leaking a successful connection if the dial returns after ctx
+		// is done.
+		go func() {
+			result := <-resultCh
+			if result.conn != nil {
+				_ = result.conn.Close()
+			}
+		}()
+
+		return nil, ctx.Err()
+	}
 }
 
 // collectRows materializes up to maxRows rows from rows (maxRows == 0 means

--- a/internal/deploy/connect.go
+++ b/internal/deploy/connect.go
@@ -55,7 +55,11 @@ func Connect(ctx context.Context, opts *connect.Opts, deployment config.Deployme
 				return err
 			}
 
-			return connect.Connect(ctx, opts, deployment, connectionInfo)
+			if err := connect.Connect(ctx, opts, deployment, connectionInfo); err != nil {
+				return diagnoseLocalFailure(ctx, deployment, err)
+			}
+
+			return nil
 		})
 
 	return err

--- a/internal/deploy/deploymentControl.go
+++ b/internal/deploy/deploymentControl.go
@@ -146,6 +146,28 @@ func logLifecycleGuidance(message string) {
 	}
 }
 
+// markOperationInterrupted records that operation failed (for any reason, not
+// only a signal) so the deployment leaves WorkflowStateOperationInProgress
+// rather than getting stuck there permanently. It mirrors the signal handlers
+// already registered alongside each lifecycle operation, and Destroy's
+// pre-existing markDestroyInterrupted.
+func markOperationInterrupted(
+	exasolState *config.ExasolPersonalState,
+	deployment config.DeploymentDir,
+	operation string,
+	operationErr error,
+) error {
+	if stateErr := exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateInterrupted{
+		Error:                      operationErr.Error(),
+		InterruptedDuringOperation: operation,
+	}, deployment); stateErr != nil {
+		slog.Warn("failed to persist operation failure state",
+			"error", stateErr, "operation", operation)
+	}
+
+	return operationErr
+}
+
 //
 //nolint:revive
 func Start(
@@ -221,7 +243,9 @@ func Start(
 				externalCommandOutput,
 				waitTimeoutSeconds,
 			); err != nil {
-				return err
+				unregister()
+
+				return markOperationInterrupted(exasolState, deployment, config.StartOperation, err)
 			}
 
 			// Stop handling interrupts before committing final running state
@@ -378,7 +402,9 @@ func Stop(ctx context.Context, deployment config.DeploymentDir, verbose bool) er
 				externalCommandOutput,
 				externalCommandOutput,
 			); err != nil {
-				return err
+				unregister()
+
+				return markOperationInterrupted(exasolState, deployment, config.StopOperation, err)
 			}
 
 			// Stop handling interrupts before committing final stopped state

--- a/internal/deploy/destroy.go
+++ b/internal/deploy/destroy.go
@@ -101,13 +101,5 @@ func markDestroyInterrupted(
 	deployment config.DeploymentDir,
 	destroyErr error,
 ) error {
-	stateErr := exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateInterrupted{
-		Error:                      destroyErr.Error(),
-		InterruptedDuringOperation: config.DestroyOperation,
-	}, deployment)
-	if stateErr != nil {
-		slog.Warn("failed to persist destroy failure state", "error", stateErr)
-	}
-
-	return destroyErr
+	return markOperationInterrupted(exasolState, deployment, config.DestroyOperation, destroyErr)
 }

--- a/internal/deploy/diag_local.go
+++ b/internal/deploy/diag_local.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/localruntime"
+)
+
+// LocalDiagnostics is a read-only snapshot of the local deployment preset's
+// runtime and reachability state, usable at any time and not only on
+// failure.
+type LocalDiagnostics struct {
+	Platform          string            `json:"platform"`
+	PlatformSupported bool              `json:"platformSupported"`
+	VMRunning         *bool             `json:"vmRunning,omitempty"`
+	GuestIP           string            `json:"guestIp,omitempty"`
+	Ports             map[string]int    `json:"ports,omitempty"`
+	PortHealth        map[string]string `json:"portHealth,omitempty"`
+	DatabaseReady     *bool             `json:"databaseReady,omitempty"`
+	DatabaseError     string            `json:"databaseError,omitempty"`
+	Warning           string            `json:"warning,omitempty"`
+	Message           string            `json:"message,omitempty"`
+}
+
+func DiagnoseLocal(ctx context.Context, deployment config.DeploymentDir, writer io.Writer) error {
+	return withDeploymentSharedLock(ctx, deployment, func(deployment config.DeploymentDir) error {
+		diagnostics := diagnoseLocalUnsafe(ctx, deployment)
+
+		encoder := json.NewEncoder(writer)
+		encoder.SetIndent("", "  ")
+
+		return encoder.Encode(diagnostics)
+	})
+}
+
+// diagnoseLocalUnsafe never fails on its own: each check populates whatever
+// it can and stops at the first one that doesn't apply, so a diagnostic
+// command doesn't itself become another thing that can error out.
+func diagnoseLocalUnsafe(ctx context.Context, deployment config.DeploymentDir) *LocalDiagnostics {
+	diagnostics := &LocalDiagnostics{
+		Platform: fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+
+	allowUnsupported := os.Getenv(localAllowUnsupportedEnv)
+	if err := validateLocalPlatform(runtime.GOOS, runtime.GOARCH, allowUnsupported); err != nil {
+		diagnostics.Message = err.Error()
+		return diagnostics
+	}
+	diagnostics.PlatformSupported = true
+
+	if !isLocalDeployment(deployment) {
+		diagnostics.Message = "this deployment is not using the local preset"
+		return diagnostics
+	}
+
+	vmStatus, err := getLocalVMStatus(ctx, deployment)
+	if err != nil {
+		diagnostics.Message = fmt.Sprintf("could not determine local VM status: %s", err)
+		return diagnostics
+	}
+
+	running := vmStatus.Running
+	diagnostics.VMRunning = &running
+	if !running {
+		diagnostics.Message = "The platform is ready to run the local deployment. " +
+			"Run `exasol start` to start it, then run `exasol diag local` again for more detail."
+
+		return diagnostics
+	}
+
+	diagnostics.Warning = unexpectedRunningVMWarning(deployment)
+
+	if state, err := localruntime.ReadState(deployment); err == nil {
+		diagnostics.Ports = map[string]int{"ssh": state.SSHPort, "db": state.DBPort}
+		if state.UIPort != 0 {
+			diagnostics.Ports["ui"] = state.UIPort
+		}
+		diagnostics.GuestIP = state.VMIP
+	}
+
+	if health, err := localruntime.HealthCheck(ctx, deployment); err == nil {
+		diagnostics.PortHealth = make(map[string]string, len(health.Ports))
+		for name, portHealth := range health.Ports {
+			diagnostics.PortHealth[name] = string(portHealth.State)
+		}
+	}
+
+	dbCtx, cancel := context.WithTimeout(ctx, LocalDatabaseStartedDefaultTimeoutSeconds)
+	defer cancel()
+
+	dbErr := verifyDatabaseConnection(dbCtx, deployment)
+	ready := dbErr == nil
+	diagnostics.DatabaseReady = &ready
+	if dbErr != nil {
+		diagnostics.DatabaseError = dbErr.Error()
+	}
+
+	return diagnostics
+}
+
+// unexpectedRunningVMWarning returns a non-empty message when a local VM
+// process is running but the recorded workflow state doesn't expect one --
+// e.g. a daemon orphaned by a prior crash or a manually killed launcher
+// invocation, which can leave the next start/install failing with a VM
+// storage conflict instead of a clear explanation (see reconcileLocalVMState,
+// which deliberately only auto-corrects the opposite direction).
+//
+// DiagnoseLocal holds the deployment's shared lock for its whole run, and a
+// shared-lock acquisition blocks for as long as any real start/install/stop
+// is holding the exclusive lock (see internal/directorymutex). So by the
+// time this runs, no genuine concurrent operation can be in flight: any
+// mismatch found here reflects a stale process, not a live race with a
+// legitimate one.
+func unexpectedRunningVMWarning(deployment config.DeploymentDir) string {
+	exasolState, err := config.ReadExasolPersonalState(deployment)
+	if err != nil {
+		return ""
+	}
+
+	workflowState, err := exasolState.GetWorkflowState()
+	if err != nil {
+		return ""
+	}
+
+	if _, ok := workflowState.(*config.WorkflowStateRunning); ok {
+		return ""
+	}
+
+	return "a local VM process is running, but the recorded deployment state does not " +
+		"expect one. This is likely a process orphaned by an earlier crash or a manually " +
+		"killed launcher invocation, and can cause a future start/install to fail with a " +
+		"VM storage conflict. Look for a `mac-runner` process for this deployment and stop " +
+		"it, then retry."
+}

--- a/internal/deploy/diag_local_test.go
+++ b/internal/deploy/diag_local_test.go
@@ -1,0 +1,178 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/localruntime"
+)
+
+func TestDiagnoseLocalUnsafe_UnsupportedPlatform(t *testing.T) {
+	t.Parallel()
+
+	// Deliberately does not set localAllowUnsupportedEnv, unlike the
+	// "supported platform" tests below (which cannot run in parallel with
+	// each other since t.Setenv forbids that, but do not conflict with this
+	// test since Go runs all non-parallel tests to completion first).
+	deployment := newLocalTestDeployment(t)
+
+	diagnostics := diagnoseLocalUnsafe(context.Background(), deployment)
+
+	if diagnostics.PlatformSupported {
+		t.Fatalf("expected unsupported platform, got %+v", diagnostics)
+	}
+	if diagnostics.Message == "" {
+		t.Fatal("expected a message explaining the unsupported platform")
+	}
+}
+
+func TestDiagnoseLocalUnsafe_NonLocalDeployment(t *testing.T) {
+	t.Setenv(localAllowUnsupportedEnv, "1")
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := os.MkdirAll(deployment.InfrastructureDir(), 0o700); err != nil {
+		t.Fatalf("create infrastructure dir failed: %v", err)
+	}
+	writeTestFile(t, deployment.InfrastructureManifestPath(), `
+name: Test Infrastructure
+description: test infrastructure
+backend: tofu
+`)
+
+	diagnostics := diagnoseLocalUnsafe(context.Background(), deployment)
+
+	if !diagnostics.PlatformSupported {
+		t.Fatal("expected platform support to bypass via EXASOL_LOCAL_ALLOW_UNSUPPORTED_PLATFORM")
+	}
+	if diagnostics.VMRunning != nil {
+		t.Fatalf("expected no VM status check for a non-local deployment, got %+v", diagnostics)
+	}
+}
+
+func TestDiagnoseLocalUnsafe_VMNotRunning(t *testing.T) {
+	skipOnWindows(t)
+	t.Setenv(localAllowUnsupportedEnv, "1")
+
+	deployment := newLocalTestDeployment(t)
+	writeFakeCombinedRunner(t, deployment, `{"running":false}`, "")
+
+	diagnostics := diagnoseLocalUnsafe(context.Background(), deployment)
+
+	if diagnostics.VMRunning == nil || *diagnostics.VMRunning {
+		t.Fatalf("expected VMRunning to be false, got %+v", diagnostics)
+	}
+	if diagnostics.Message == "" {
+		t.Fatal("expected a concise ready-to-run message when the VM is not running")
+	}
+	if diagnostics.PortHealth != nil || diagnostics.DatabaseReady != nil {
+		t.Fatalf("expected no reachability/readiness checks when VM not running, got %+v",
+			diagnostics)
+	}
+}
+
+func TestDiagnoseLocalUnsafe_VMRunningReportsPortsAndHealth(t *testing.T) {
+	skipOnWindows(t)
+	t.Setenv(localAllowUnsupportedEnv, "1")
+
+	deployment := newLocalTestDeployment(t)
+	healthJSON := `{"ports":{"ssh":{"state":"reachable"},"db":{"state":"blocked"}}}`
+	writeFakeCombinedRunner(t, deployment, `{"running":true}`, healthJSON)
+	writeFakeVMState(t, deployment, "192.168.64.5", 20022, 28563, 0)
+
+	diagnostics := diagnoseLocalUnsafe(context.Background(), deployment)
+
+	if diagnostics.VMRunning == nil || !*diagnostics.VMRunning {
+		t.Fatalf("expected VMRunning to be true, got %+v", diagnostics)
+	}
+	if diagnostics.GuestIP != "192.168.64.5" {
+		t.Fatalf("expected guest IP to be reported, got %q", diagnostics.GuestIP)
+	}
+	if diagnostics.Ports["ssh"] != 20022 || diagnostics.Ports["db"] != 28563 {
+		t.Fatalf("expected bound host ports to be reported, got %+v", diagnostics.Ports)
+	}
+	if diagnostics.PortHealth["ssh"] != "reachable" || diagnostics.PortHealth["db"] != "blocked" {
+		t.Fatalf("expected per-port health to be reported, got %+v", diagnostics.PortHealth)
+	}
+	if diagnostics.DatabaseReady == nil {
+		t.Fatal("expected a database readiness check to have run")
+	}
+}
+
+func TestDiagnoseLocalUnsafe_VMRunningMatchesRunningState_NoWarning(t *testing.T) {
+	skipOnWindows(t)
+	t.Setenv(localAllowUnsupportedEnv, "1")
+
+	deployment := newLocalTestDeployment(t)
+	writeFakeCombinedRunner(t, deployment, `{"running":true}`, `{"ports":{}}`)
+	writeFakeWorkflowState(t, deployment, &config.WorkflowStateRunning{})
+
+	diagnostics := diagnoseLocalUnsafe(context.Background(), deployment)
+
+	if diagnostics.Warning != "" {
+		t.Fatalf("expected no warning when workflow state matches a running VM, got %q",
+			diagnostics.Warning)
+	}
+}
+
+func TestDiagnoseLocalUnsafe_VMRunningButStateNotRunning_Warning(t *testing.T) {
+	skipOnWindows(t)
+	t.Setenv(localAllowUnsupportedEnv, "1")
+
+	deployment := newLocalTestDeployment(t)
+	writeFakeCombinedRunner(t, deployment, `{"running":true}`, `{"ports":{}}`)
+	writeFakeWorkflowState(t, deployment, &config.WorkflowStateInterrupted{
+		Error:                      "boom",
+		InterruptedDuringOperation: "start",
+	})
+
+	diagnostics := diagnoseLocalUnsafe(context.Background(), deployment)
+
+	if diagnostics.Warning == "" {
+		t.Fatal("expected a warning when a VM is running but the workflow state doesn't expect one")
+	}
+}
+
+// writeFakeWorkflowState persists the given workflow state (one of the
+// config.WorkflowState* structs) to the deployment's launcher state file, so
+// diagnoseLocalUnsafe's orphaned-VM check has something concrete to compare
+// the fake runner's reported VM status against.
+func writeFakeWorkflowState(t *testing.T, deployment config.DeploymentDir, state any) {
+	t.Helper()
+
+	exasolState := &config.ExasolPersonalState{}
+	if err := exasolState.SetWorkflowStateAndWrite(state, deployment); err != nil {
+		t.Fatalf("failed to write fake workflow state: %v", err)
+	}
+}
+
+func writeFakeVMState(
+	t *testing.T,
+	deployment config.DeploymentDir,
+	vmIP string,
+	sshPort, dbPort, uiPort int,
+) {
+	t.Helper()
+
+	paths := localruntime.NewPaths(deployment)
+	data, err := json.Marshal(map[string]any{
+		"vm_name": "exasol-local-vm",
+		"vm_ip":   vmIP,
+		"ports": map[string]any{
+			"ssh": sshPort,
+			"db":  dbPort,
+			"ui":  uiPort,
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal fake VM state: %v", err)
+	}
+	if err := os.WriteFile(paths.StatePath, data, 0o600); err != nil {
+		t.Fatalf("failed to write fake VM state: %v", err)
+	}
+}

--- a/internal/deploy/local_backend.go
+++ b/internal/deploy/local_backend.go
@@ -326,7 +326,11 @@ func (b *localBackend) OpenHostShell(
 		return err
 	}
 
-	return sshRemote.Shell(ctx, os.Stdout, os.Stderr)
+	if err := sshRemote.Shell(ctx, os.Stdout, os.Stderr); err != nil {
+		return diagnoseLocalFailure(ctx, b.deployment, err)
+	}
+
+	return nil
 }
 
 func (b *localBackend) OpenCOSShell(ctx context.Context) error {
@@ -340,7 +344,11 @@ func (b *localBackend) OpenCOSShell(ctx context.Context) error {
 		return err
 	}
 
-	return sshRemote.RunInteractiveCommand(ctx, command, os.Stdout, os.Stderr)
+	if err := sshRemote.RunInteractiveCommand(ctx, command, os.Stdout, os.Stderr); err != nil {
+		return diagnoseLocalFailure(ctx, b.deployment, err)
+	}
+
+	return nil
 }
 
 func localContainerShellCommand() (string, error) {
@@ -422,7 +430,10 @@ func detectLocalHostMemoryMB(ctx context.Context) int {
 	// Host memory detection is only implemented for macOS today; other platforms
 	// return an error here and fall back to the fixed default, which keeps local
 	// sizing deterministic where local deployments are not yet supported.
+	//nolint:staticcheck // SA4023: See comment below.
 	memoryMB, err := util.GetTotalMemoryMB(ctx)
+	//nolint:staticcheck // SA4023: only true for the unsupported-platform build of
+	// util.GetTotalMemoryMB; on darwin it can succeed.
 	if err != nil {
 		return 0
 	}
@@ -495,13 +506,15 @@ func (b *localBackend) Deploy(
 		return err
 	}
 
-	return deployLocalRuntime(ctx, b.deployment, runtimeConfig, out, outErr)
+	// Deploy has no caller-supplied timeout in the backend interface, unlike
+	// Start; 0 falls back to LocalDatabaseStartedDefaultTimeoutSeconds.
+	return deployLocalRuntime(ctx, b.deployment, runtimeConfig, 0, out, outErr)
 }
 
 func (b *localBackend) Start(
 	ctx context.Context,
 	out, outErr io.Writer,
-	_ int,
+	waitTimeoutSeconds int,
 ) error {
 	if err := b.ValidateEnvironment(); err != nil {
 		return err
@@ -511,7 +524,7 @@ func (b *localBackend) Start(
 		return err
 	}
 
-	return startLocalRuntime(ctx, b.deployment, runtimeConfig, out, outErr)
+	return startLocalRuntime(ctx, b.deployment, runtimeConfig, waitTimeoutSeconds, out, outErr)
 }
 
 func (b *localBackend) Stop(

--- a/internal/deploy/local_reachability.go
+++ b/internal/deploy/local_reachability.go
@@ -1,0 +1,93 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/localruntime"
+)
+
+// ErrLocalReachability is the sentinel a localReachabilityError unwraps to,
+// so callers can errors.Is against it regardless of the exact message.
+var ErrLocalReachability = errors.New("local runtime reachability problem")
+
+// localReachabilityError carries the actionable, user-facing explanation for
+// a network-wide local runtime reachability problem, following the same
+// shape as blockedStateError: Error() is already the full message, Unwrap()
+// exposes the sentinel.
+type localReachabilityError struct{}
+
+func (*localReachabilityError) Error() string { return localReachabilityMessage }
+func (*localReachabilityError) Unwrap() error { return ErrLocalReachability }
+
+const localReachabilityMessage = "could not reach the local database endpoint because the " +
+	"host-to-VM network path appears blocked.\n\n" +
+	"This is usually caused by macOS's \"Local Network\" permission being denied to the " +
+	"terminal, editor, or agent environment that launched this command (for example iTerm2, " +
+	"kitty, VS Code, or a sandboxed agent host). That permission is required even though the " +
+	"reported endpoint is 127.0.0.1, because Exasol Personal forwards it from a VM over the " +
+	"local network.\n\n" +
+	"To fix this: open System Settings -> Privacy & Security -> Local Network, and enable " +
+	"access for that application. Then retry."
+
+// classifyLocalReachability inspects the local runtime's forwarded-port
+// health and returns a localReachabilityError when every forwarded port is
+// unreachable, which points at a network-wide problem rather than one
+// specific to the database. It returns nil (deferring to the caller's
+// original error) for non-local deployments, when the health-check itself is
+// unavailable (e.g. an old runner daemon that predates health-check
+// support), or when at least one port is reachable, since that means the
+// problem is not network-wide.
+func classifyLocalReachability(ctx context.Context, deployment config.DeploymentDir) error {
+	if !isLocalDeployment(deployment) {
+		return nil
+	}
+
+	result, err := localruntime.HealthCheck(ctx, deployment)
+	if err != nil {
+		slog.Debug("local health-check unavailable; skipping reachability classification",
+			"error", err)
+
+		return nil
+	}
+
+	if len(result.Ports) == 0 {
+		return nil
+	}
+
+	for _, port := range result.Ports {
+		switch port.State {
+		case localruntime.PortStateReachable, localruntime.PortStateRefused:
+			return nil
+		case localruntime.PortStateBlocked, localruntime.PortStateTimeout:
+			// Keep checking other ports.
+		default:
+			// Unknown state: don't risk misclassifying; defer to caller.
+			return nil
+		}
+	}
+
+	return &localReachabilityError{}
+}
+
+// diagnoseLocalFailure re-classifies a local-deployment operation failure
+// as a localReachabilityError when the local runtime's forwarded ports are
+// all unreachable, deferring to the original error otherwise. Callers that
+// dial out to the local VM (start, connect, shell) share this exact
+// fallback.
+func diagnoseLocalFailure(ctx context.Context, deployment config.DeploymentDir, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if reachabilityErr := classifyLocalReachability(ctx, deployment); reachabilityErr != nil {
+		return reachabilityErr
+	}
+
+	return err
+}

--- a/internal/deploy/local_reachability_test.go
+++ b/internal/deploy/local_reachability_test.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"context"
+	"errors"
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/localruntime"
+)
+
+// testRunnerExecutableMode is a named constant rather than an inline literal
+// so gosec's file-permission checks (which only pattern-match on literals)
+// don't flag these test fixtures for needing an executable fake runner.
+const testRunnerExecutableMode = 0o700
+
+func TestClassifyLocalReachability_AllPortsBlocked(t *testing.T) {
+	t.Parallel()
+	skipOnWindows(t)
+
+	deployment := newLocalTestDeployment(t)
+	blockedJSON := `{"ports":{"ssh":{"state":"blocked"},"db":{"state":"blocked"}}}`
+	writeFakeCombinedRunner(t, deployment, "", blockedJSON)
+
+	err := classifyLocalReachability(context.Background(), deployment)
+	if err == nil {
+		t.Fatal("expected a reachability error when every port is blocked")
+	}
+	if !errors.Is(err, ErrLocalReachability) {
+		t.Fatalf("expected errors.Is(err, ErrLocalReachability), got %v", err)
+	}
+}
+
+func TestClassifyLocalReachability_OnlyDatabasePortBlocked(t *testing.T) {
+	t.Parallel()
+	skipOnWindows(t)
+
+	// A reachable SSH port alongside a blocked database port means the
+	// network path itself is fine; the problem is database-specific.
+	deployment := newLocalTestDeployment(t)
+	mixedJSON := `{"ports":{"ssh":{"state":"reachable"},"db":{"state":"blocked"}}}`
+	writeFakeCombinedRunner(t, deployment, "", mixedJSON)
+
+	if err := classifyLocalReachability(context.Background(), deployment); err != nil {
+		t.Fatalf("expected no reachability error when at least one port is reachable, got %v", err)
+	}
+}
+
+func TestClassifyLocalReachability_NonLocalDeploymentIsNoop(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := os.MkdirAll(deployment.InfrastructureDir(), 0o700); err != nil {
+		t.Fatalf("create infrastructure dir failed: %v", err)
+	}
+	writeTestFile(t, deployment.InfrastructureManifestPath(), `
+name: Test Infrastructure
+description: test infrastructure
+backend: tofu
+`)
+
+	if err := classifyLocalReachability(context.Background(), deployment); err != nil {
+		t.Fatalf("expected no-op for non-local deployment, got %v", err)
+	}
+}
+
+func TestClassifyLocalReachability_HealthCheckUnavailableIsNoop(t *testing.T) {
+	t.Parallel()
+	skipOnWindows(t)
+
+	// An old runner daemon that predates health-check must not turn every
+	// local failure into a reachability error; the caller's original error
+	// should stand instead.
+	deployment := newLocalTestDeployment(t)
+	paths := localruntime.NewPaths(deployment)
+	if err := os.MkdirAll(paths.WorkDir, 0o750); err != nil {
+		t.Fatalf("failed to create local runtime directory: %v", err)
+	}
+	runnerScript := "#!/bin/sh\necho 'Unknown command: health-check' >&2\nexit 1\n"
+	if err := os.WriteFile(paths.RunnerPath, []byte(runnerScript), 0o600); err != nil {
+		t.Fatalf("failed to write fake runner: %v", err)
+	}
+	if err := os.Chmod(paths.RunnerPath, testRunnerExecutableMode); err != nil {
+		t.Fatalf("failed to mark fake runner executable: %v", err)
+	}
+
+	if err := classifyLocalReachability(context.Background(), deployment); err != nil {
+		t.Fatalf("expected no-op when health-check is unavailable, got %v", err)
+	}
+}
+
+func skipOnWindows(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake local runner script is POSIX-only")
+	}
+}
+
+func newLocalTestDeployment(t *testing.T) config.DeploymentDir {
+	t.Helper()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := os.MkdirAll(deployment.InfrastructureDir(), 0o700); err != nil {
+		t.Fatalf("create infrastructure dir failed: %v", err)
+	}
+	writeTestFile(t, deployment.InfrastructureManifestPath(), `
+name: Test Infrastructure
+description: test infrastructure
+backend: local
+`)
+
+	return deployment
+}
+
+// writeFakeCombinedRunner writes a single fake runner script that answers
+// both "status" and "health-check", since callers in this package may invoke
+// either against whatever binary is staged at the runner path. statusJSON is
+// the raw response body for "status" (e.g. `{"running":true}`).
+func writeFakeCombinedRunner(
+	t *testing.T,
+	deployment config.DeploymentDir,
+	statusJSON, healthCheckJSON string,
+) {
+	t.Helper()
+
+	paths := localruntime.NewPaths(deployment)
+	if err := os.MkdirAll(paths.WorkDir, 0o750); err != nil {
+		t.Fatalf("failed to create local runtime directory: %v", err)
+	}
+
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = status ]; then echo '" + statusJSON + "'; exit 0; fi\n" +
+		"if [ \"$1\" = health-check ]; then echo '" + healthCheckJSON + "'; exit 0; fi\n" +
+		"exit 1\n"
+	if err := os.WriteFile(paths.RunnerPath, []byte(script), 0o600); err != nil {
+		t.Fatalf("failed to write fake runner: %v", err)
+	}
+	if err := os.Chmod(paths.RunnerPath, testRunnerExecutableMode); err != nil {
+		t.Fatalf("failed to mark fake runner executable: %v", err)
+	}
+}

--- a/internal/deploy/local_runtime.go
+++ b/internal/deploy/local_runtime.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/exasol/exasol-personal/internal/config"
 	"github.com/exasol/exasol-personal/internal/localruntime"
@@ -24,15 +25,17 @@ func deployLocalRuntime(
 	ctx context.Context,
 	deployment config.DeploymentDir,
 	runtimeConfig localRuntimeConfig,
+	waitTimeoutSeconds int,
 	out, outErr io.Writer,
 ) error {
-	return startLocalRuntime(ctx, deployment, runtimeConfig, out, outErr)
+	return startLocalRuntime(ctx, deployment, runtimeConfig, waitTimeoutSeconds, out, outErr)
 }
 
 func startLocalRuntime(
 	ctx context.Context,
 	deployment config.DeploymentDir,
 	runtimeConfig localRuntimeConfig,
+	waitTimeoutSeconds int,
 	out, outErr io.Writer,
 ) error {
 	if err := localruntime.Prepare(
@@ -45,13 +48,16 @@ func startLocalRuntime(
 		return err
 	}
 
-	return startPreparedLocalRuntime(ctx, deployment, runtimeConfig, out, outErr)
+	return startPreparedLocalRuntime(
+		ctx, deployment, runtimeConfig, waitTimeoutSeconds, out, outErr,
+	)
 }
 
 func startPreparedLocalRuntime(
 	ctx context.Context,
 	deployment config.DeploymentDir,
 	runtimeConfig localRuntimeConfig,
+	waitTimeoutSeconds int,
 	out, outErr io.Writer,
 ) error {
 	paths := localruntime.NewPaths(deployment)
@@ -81,7 +87,7 @@ func startPreparedLocalRuntime(
 		out,
 		outErr,
 	); err != nil {
-		return err
+		return diagnoseLocalFailure(ctx, deployment, err)
 	}
 
 	state, err := localruntime.ReadState(deployment)
@@ -89,7 +95,7 @@ func startPreparedLocalRuntime(
 		return err
 	}
 
-	return writeLocalRuntimeArtifactsAndWait(ctx, deployment, state)
+	return writeLocalRuntimeArtifactsAndWait(ctx, deployment, state, waitTimeoutSeconds)
 }
 
 func localRunnerVersionCheckArgs(deployment config.DeploymentDir) ([]string, error) {
@@ -224,6 +230,7 @@ func writeLocalRuntimeArtifactsAndWait(
 	ctx context.Context,
 	deployment config.DeploymentDir,
 	state *localruntime.State,
+	waitTimeoutSeconds int,
 ) error {
 	if err := writeLocalDeploymentArtifacts(deployment, state); err != nil {
 		return err
@@ -232,7 +239,13 @@ func writeLocalRuntimeArtifactsAndWait(
 		return nil
 	}
 
-	return WaitForLocalDatabaseStarted(ctx, deployment)
+	if waitTimeoutSeconds <= 0 {
+		waitTimeoutSeconds = LocalDatabaseStartedDefaultTimeoutSeconds
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, time.Duration(waitTimeoutSeconds)*time.Second)
+	defer cancel()
+
+	return WaitForLocalDatabaseStarted(waitCtx, deployment)
 }
 
 func writeLocalDeploymentArtifacts(

--- a/internal/deploy/ready.go
+++ b/internal/deploy/ready.go
@@ -88,6 +88,12 @@ func WaitForLocalDatabaseStarted(
 	ctx context.Context,
 	deployment config.DeploymentDir,
 ) error {
+	// Fail fast on an already-blocked network path instead of waiting out the
+	// whole backoff window on a problem that will never resolve on its own.
+	if err := classifyLocalReachability(ctx, deployment); err != nil {
+		return err
+	}
+
 	return waitForDatabaseStartedWithBackoff(
 		ctx,
 		deployment,

--- a/internal/deploy/shared.go
+++ b/internal/deploy/shared.go
@@ -86,6 +86,9 @@ const (
 	LocalDatabaseStartedMaxBackoff     = 8
 	StartedInitialBackoff              = 10
 	StartedMaxBackoff                  = 60
+	// LocalDatabaseStartedDefaultTimeoutSeconds is shorter than the cloud
+	// default since a local VM boots in seconds, not minutes.
+	LocalDatabaseStartedDefaultTimeoutSeconds = 5 * 60
 )
 
 func Getn11Details(deployment config.DeploymentDir) (*config.SSHDetails, error) {

--- a/internal/localruntime/runtime.go
+++ b/internal/localruntime/runtime.go
@@ -144,22 +144,60 @@ type VMStatus struct {
 }
 
 func Status(ctx context.Context, deployment config.DeploymentDir) (*VMStatus, error) {
+	return runnerCommandJSON[VMStatus](ctx, deployment, "status")
+}
+
+// PortState is one of the runner's classified per-port reachability states,
+// treated as an opaque external contract: this package does not interpret
+// how the runner arrived at it, only which value it reported.
+type PortState string
+
+const (
+	PortStateReachable PortState = "reachable"
+	PortStateRefused   PortState = "refused"
+	PortStateBlocked   PortState = "blocked"
+	PortStateTimeout   PortState = "timeout"
+)
+
+type PortHealth struct {
+	State PortState `json:"state"`
+}
+
+type HealthCheckResult struct {
+	Ports map[string]PortHealth `json:"ports"`
+}
+
+// HealthCheck asks the runner to freshly probe every forwarded port's guest
+// reachability. Unlike Status, this can trigger real network dials on the
+// runner side, so callers should only invoke it when they actually need a
+// reachability diagnosis, not from routine/frequent code paths.
+func HealthCheck(ctx context.Context, deployment config.DeploymentDir) (*HealthCheckResult, error) {
+	return runnerCommandJSON[HealthCheckResult](ctx, deployment, "health-check")
+}
+
+// runnerCommandJSON is shared by Status and HealthCheck, which differ only
+// in the subcommand name and result shape.
+func runnerCommandJSON[T any](
+	ctx context.Context,
+	deployment config.DeploymentDir,
+	command string,
+) (*T, error) {
 	runtime := newRuntime(deployment, Config{})
 	if err := runtime.ensureRunnerExecutable(); err != nil {
 		return nil, err
 	}
 
-	stdout, err := runtime.runnerCommandWithOutput(ctx, []string{"status"})
+	stdout, err := runtime.runnerCommandWithOutput(ctx, []string{command})
 	if err != nil {
 		return nil, err
 	}
 
-	var status VMStatus
-	if err := json.Unmarshal([]byte(stdout), &status); err != nil {
-		return nil, fmt.Errorf("failed to parse local runner status output: %w", err)
+	var result T
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		return nil, fmt.Errorf("failed to parse local runner %s output: %w", command, err)
 	}
 
-	return &status, nil
+	return &result, nil
 }
 
 func Stop(ctx context.Context, deployment config.DeploymentDir, out, outErr io.Writer) error {

--- a/internal/localruntime/runtime_test.go
+++ b/internal/localruntime/runtime_test.go
@@ -376,6 +376,64 @@ func TestStop_InvokesOriginalRunnerStop(t *testing.T) {
 	}
 }
 
+func TestHealthCheck_ParsesPortStates(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == windowsGOOS {
+		t.Skip("fake local runner script is POSIX-only")
+	}
+
+	// Given
+	deployment := config.NewDeploymentDir(t.TempDir())
+	localRuntime := newRuntime(deployment, Config{})
+	if err := os.MkdirAll(localRuntime.paths.WorkDir, 0o750); err != nil {
+		t.Fatalf("failed to create local runtime directory: %v", err)
+	}
+
+	runnerScript := `#!/bin/sh
+echo '{"ports":{"ssh":{"state":"reachable"},"db":{"state":"blocked"}}}'
+`
+	writeExecutableTestFile(t, localRuntime.paths.RunnerPath, []byte(runnerScript))
+
+	// When
+	result, err := HealthCheck(context.Background(), deployment)
+	// Then
+	if err != nil {
+		t.Fatalf("expected health-check to succeed, got %v", err)
+	}
+	if result.Ports["ssh"].State != PortStateReachable {
+		t.Fatalf("ssh state = %q, want %q", result.Ports["ssh"].State, PortStateReachable)
+	}
+	if result.Ports["db"].State != PortStateBlocked {
+		t.Fatalf("db state = %q, want %q", result.Ports["db"].State, PortStateBlocked)
+	}
+}
+
+func TestHealthCheck_ReturnsErrorOnRunnerFailure(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == windowsGOOS {
+		t.Skip("fake local runner script is POSIX-only")
+	}
+
+	// Given: an old runner that does not understand "health-check" yet.
+	deployment := config.NewDeploymentDir(t.TempDir())
+	localRuntime := newRuntime(deployment, Config{})
+	if err := os.MkdirAll(localRuntime.paths.WorkDir, 0o750); err != nil {
+		t.Fatalf("failed to create local runtime directory: %v", err)
+	}
+
+	runnerScript := "#!/bin/sh\necho 'Unknown command: health-check' >&2\nexit 1\n"
+	writeExecutableTestFile(t, localRuntime.paths.RunnerPath, []byte(runnerScript))
+
+	// When
+	_, err := HealthCheck(context.Background(), deployment)
+	// Then
+	if err == nil {
+		t.Fatal("expected health-check against an unsupporting runner to fail")
+	}
+}
+
 func TestWaitForDaemonExit_IgnoresMissingPIDFile(t *testing.T) {
 	t.Parallel()
 

--- a/openspec/changes/archive/2026-07-14-improve-local-reachability-diagnostics/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-14-improve-local-reachability-diagnostics/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-09

--- a/openspec/changes/archive/2026-07-14-improve-local-reachability-diagnostics/design.md
+++ b/openspec/changes/archive/2026-07-14-improve-local-reachability-diagnostics/design.md
@@ -1,0 +1,95 @@
+## Context
+
+The local preset runs the Exasol database inside a macOS VM managed by an embedded runner binary (`internal/localruntime`), which the launcher invokes as a subprocess and communicates with via an embedded runner CLI and a small Unix-domain-socket status protocol (`{"request":"status"}` → `{"status":"running"}`). The runner forwards VM guest ports to `127.0.0.1` on the host.
+
+Investigation established that the launcher's own dial to `127.0.0.1:<port>` almost always succeeds regardless of macOS's Local Network permission state, because the forwarding listener is bound independently of guest reachability. The actual TCC-gated hop happens one level down, inside the runner's own connection to the VM's guest IP — a hop the launcher cannot observe directly today. This means the launcher cannot classify this failure from its own dial behavior alone; it needs the runner to tell it.
+
+Two existing gaps compound the problem:
+- `internal/deploy/local_backend.go`'s `Start` ignores its `waitTimeoutSeconds` parameter entirely (`_ int`), unlike the tofu-backed cloud path which applies it via `context.WithTimeout`. `Deploy` (used by `exasol install local`) has no timeout parameter in its interface signature at all (`DeployOptions` only carries an unrelated dependency-lockfile flag). Either way, a blocked local deployment polls forever rather than ever failing.
+- `internal/deploy/ready.go`'s `verifyDatabaseConnection` treats any non-SQLSTATE-08004 error as "not ready yet," so a permanently broken network path looks identical to a database that's still booting.
+- `exasol connect`'s dial (`internal/connect/exasol/database.go`) never receives `ctx` at all, so it has no timeout of its own either.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Distinguish "local runtime reachability problem" from "generic database/readiness failure" in the error shown for install/start, `exasol connect`, and `exasol shell host`/`container`.
+- Do this using only an external, versioned-together contract with the runner (a new status-socket request), not by inferring from the launcher's own loopback dial, which we've established is not a reliable signal.
+- Bound every local wait that currently has none.
+- Add a read-only `exasol diag local` surface usable independent of any failure.
+
+**Non-Goals:**
+- Redesigning the runner's VM/networking architecture (NAT, port forwarding mechanism) — out of scope for this change entirely.
+- Detecting or naming the specific invoking application (iTerm2, kitty, VS Code, etc.) via process-tree introspection. A generic, always-correct explanation is preferred over a sharper but fragile one.
+- A generic multi-backend `exasol diag <preset>` framework. This change adds `exasol diag local` specifically; extending diagnostics to cloud backends is future work.
+- Automated end-to-end reproduction of the real macOS permission block (see Risks).
+- Re-classifying reachability mid-poll: the fast-path check runs once, before the readiness backoff loop begins. A permission change that occurs after the wait has already started (e.g. granted partway through) is not detected until the next invocation.
+
+## Decisions
+
+### The runner's status socket gains a new, separate `health-check` request, not an extension of `status`
+
+`status` is called from routine, frequently-hit code paths (e.g. `reconcileLocalVMState`) purely to check whether the VM process is alive; it must stay cheap and side-effect-free. Reachability classification requires the runner to actively dial the VM guest network, which can be slow if a permission block manifests as a hang rather than an immediate error (unconfirmed — see Open Questions). Folding that into `status` would silently make every routine status check occasionally slow. Instead, this change assumes a new, distinct request (contract only, no runner internals):
+
+```
+Request:  {"request": "health-check"}
+Response: {
+  "ports": {
+    "ssh": {"state": "reachable" | "refused" | "blocked" | "timeout"},
+    "db":  {"state": "reachable" | "refused" | "blocked" | "timeout"}
+  }
+}
+```
+
+- `health-check` probes every forwarded port in one shot, not just the one the caller cares about — required for differential diagnosis (below). It runs only when explicitly requested; nothing in this change introduces periodic/background polling of the VM.
+- The launcher only consumes this classified `state` field. It does not know, and must not encode any assumption about, how the runner arrived at it (dial errno, timing heuristic, etc.) — that reasoning lives entirely on the runner side.
+- If the request is unsupported or the response fails to decode, the launcher falls back to today's generic failure path rather than erroring on unexpected shape. Because the runner is embedded and staged fresh with each launcher build (see `assets/localruntimebin`), version mismatch should only arise from an already-running runner daemon from before an upgrade — a real but narrow case, not a long-term compatibility surface to design around.
+
+**Alternatives considered**: Inferring reachability purely from the launcher's own loopback dial (rejected — shown not to reliably surface the real failure, since that dial usually succeeds regardless of the actual block). Encoding the raw OS error (errno/string) in the response and classifying it in the launcher (rejected — ties the launcher to OS/error-text specifics that belong on the runner side, and we've confirmed the SQL driver's own error already discards the underlying cause in at least one path, so the launcher would be no better positioned than the runner to do this classification anyway).
+
+### Differential diagnosis across ports is the primary classification signal
+
+A single port's failure is ambiguous: it could mean "database still starting," "database crashed," or "network path blocked." Comparing across ports resolves this:
+
+| SSH | DB | Diagnosis |
+|---|---|---|
+| reachable | reachable | healthy |
+| reachable | refused/timeout | database-specific problem (still booting, or crashed) |
+| blocked/timeout | blocked/timeout | network-wide reachability problem (the case this change targets) |
+| blocked | reachable | (should not occur; treat as reachability problem defensively) |
+
+Because normal operation never naturally generates SSH traffic during `start`/`connect` (only `shell host`/`container` do), this comparison is only possible because `health-check` deliberately probes every port on demand, not just the one in use.
+
+### New typed error, not reliance on unwrapping the SQL driver's error
+
+`exasol-driver-go`'s `NewConnectionFailedError` (the source of the `W-EGOD-14` error text seen during exploration) constructs its `DriverErr` with `cause: nil`, discarding the underlying `*net.OpError`/errno entirely. `errors.Is`/`errors.As` against that error can never recover the original cause. This change introduces a distinct error type (mirroring the existing `blockedStateError` pattern in `internal/deploy/shared.go`: `Error()` returns the complete, user-facing, actionable message; `Unwrap()` exposes a sentinel for `errors.Is` elsewhere) built directly from the `health-check` classification, independent of whatever the SQL driver or SSH client separately report.
+
+### Message content is generic, not app-detected
+
+The error names example invoking environments (iTerm2, kitty, VS Code, a sandboxed agent host) and explains that Local Network permission applies to the invoking terminal/editor/agent even though the target is `127.0.0.1`, plus how to grant it. Real process-tree detection was considered and rejected: it can be wrong, adds platform-fragile logic, and a generic explanation is always correct.
+
+### `exasol diag local`, not a generic multi-backend diagnostics command
+
+Local's failure modes are specific enough (platform/arch support, VM/runner lifecycle, port forwarding) that a local-specific command carries more useful information than a generic one would. It reports: VM status, guest IP, bound host ports, per-port `health-check` state, SQL-level readiness, and whether the current OS/architecture is supported at all (today, mac/arm64 only — a check that exists nowhere as user-facing diagnostics currently).
+
+### Scope: install/start, connect, shell host/container — not stop/destroy/status
+
+Investigation confirmed `stop`/`destroy`/`status` only invoke the runner's CLI/process-level control path and never dial a forwarded port, so they cannot exhibit this failure mode. No changes are needed there; this is a deliberate scope decision, not an oversight.
+
+### `Start`/`Stop` recovery reuses `Destroy`'s existing pattern
+
+`Destroy` already transitions a deployment to `WorkflowStateInterrupted` when its backend call fails, via `markDestroyInterrupted`. `Start` and `Stop` lacked the equivalent: a backend failure left the deployment in `WorkflowStateOperationInProgress` with no path back to a resolved state. Rather than duplicating `markDestroyInterrupted`'s logic a second and third time, this change generalizes it into a single `markOperationInterrupted` helper parameterized by operation name, and has `Destroy` delegate to it as well. This keeps all three lifecycle operations' failure-recovery behavior identical and defined in one place. This part of the change is backend-agnostic (it lives in the shared lifecycle-control code, not the local backend), unlike the rest of this proposal.
+
+## Risks / Trade-offs
+
+- **[Risk]** It is unconfirmed whether a genuine macOS Local Network permission denial produces a synchronous error or a silent hang on the runner's guest-IP dial, for privacy-motivated reasons Apple applies to other TCC gates. → **Mitigation**: the runner-side classification (out of scope for this proposal, but this proposal's contract must tolerate either) should treat persistence past a generous grace period as sufficient for a `blocked`/`timeout` verdict, not depend on catching a specific errno. This proposal's launcher-side logic is agnostic to which of `blocked`/`timeout` it receives — both map to the same reachability error.
+- **[Risk]** A genuine macOS permission denial cannot be exercised in automated CI. → **Mitigation**: the classification logic can be verified against synthetic runner responses; a real permission denial can be manually approximated with an OS-level sandbox that denies outbound network access while permitting loopback and local IPC, without needing an actual TCC grant/deny cycle.
+- **[Risk]** An already-running runner daemon from before an upgrade won't understand `health-check`. → **Mitigation**: covered by the generic-fallback behavior above; existing deployments are never forced to restart or lose VM state to benefit from this, they just don't get the sharper error until the runner is next restarted (which happens on `start`, without destroying data).
+- **[Risk, resolved]** The runner's own pre-existing internal SSH-readiness gate (used to confirm VM boot before reporting success) used to fail and return *before* the runner created any port forwarders, and used to tear down the VM and exit the daemon process entirely on that failure. If the network was blocked from the very start of a `start`/`install` run, `classifyLocalReachability` had no forwarder data left to classify against — so this one scenario surfaced the runner's raw error text instead of the polished reachability message. This shared a root cause with a separate bug: the VM-teardown call on that path could block indefinitely, leaving an orphaned daemon holding the VM disk and breaking the *next* `start` attempt with an unrelated storage conflict. → **Resolved** (runner-side change, see the reference proposal for exasol-local-vm): port forwarders are now created before the SSH-readiness gate runs, and a failure there no longer tears the VM down — the daemon stays alive and queryable so `health-check`/`diag local` can report real per-port reachability. The VM-teardown call used elsewhere is now bounded by a timeout so it can no longer block indefinitely.
+
+## Migration Plan
+
+No data migration. Purely additive behavior change: existing successful local deployments are unaffected (the localhost connection contract is unchanged); failures gain a more specific error message and, for install/start, an enforced timeout where none existed before. No flag or opt-in — this replaces the existing generic failure path outright once shipped, since the old behavior (indefinite hang, misleading generic message) has no one relying on it as correct.
+
+## Open Questions
+
+- Whether real TCC Local Network denial yields a synchronous error or a hang on the runner's own dial is unconfirmed (requires a GUI session to grant/deny the permission for a real invoking app). Recommended to settle before or shortly after implementation, but the design above does not depend on the answer.

--- a/openspec/changes/archive/2026-07-14-improve-local-reachability-diagnostics/proposal.md
+++ b/openspec/changes/archive/2026-07-14-improve-local-reachability-diagnostics/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+On macOS, the local deployment preset runs the database inside a VM and exposes it on `127.0.0.1:<port>` by forwarding traffic to the VM's guest network. When the process invoking `exasol` (a terminal, editor, or agent host) lacks macOS's "Local Network" permission, or is otherwise sandboxed away from it, the host-to-VM path breaks even though the VM and database are healthy. Today this surfaces as a generic database-startup timeout, an indefinite hang (the local backend's readiness wait has no timeout at all), or a raw driver/socket error — none of which point the user toward the actual cause. This sends users and agents investigating first-time evaluations toward the wrong areas (database startup, port conflicts, VM health) instead of the real one (macOS network permission for the invoking app).
+
+## What Changes
+
+- Apply the `waitTimeoutSeconds` deadline to the local backend's `Start` readiness wait, which today is silently ignored (`_ int`), and give the local backend's `Deploy` readiness wait (used by `exasol install local`, which has no timeout parameter in its interface at all today) the same bounded behavior — a blocked local deployment currently polls forever instead of ever reaching a failure.
+- Classify local database-connection failures during install/start (readiness polling), `exasol connect`, and `exasol shell host`/`exasol shell container` as either "local runtime reachability problem" or the existing generic failure, instead of always treating non-auth errors as "not ready yet."
+- Add a user-facing reachability error that explains macOS's Local Network permission applies to the invoking terminal/editor/agent (with examples: iTerm2, kitty, VS Code, a sandboxed agent host) even though the endpoint is `127.0.0.1`, and how to grant it.
+- Add a distinct diagnosis step that checks reachability of every forwarded port (not just the one currently in use) so a network-wide problem (all ports affected) can be distinguished from a database-specific problem (only the database port affected) or a still-booting VM (transient).
+- Add `exasol diag local`: a read-only command reporting local VM status, reported guest IP, bound host ports, per-port forwarder reachability, database readiness, and local platform/architecture support — usable at any time, not only on failure.
+- Fix `exasol connect`'s database dial, which today receives no context/timeout at all and can hang indefinitely on any failure, local or otherwise.
+- Fix `exasol start`/`exasol stop`: today, when the underlying backend call fails for any reason, the deployment is left permanently stuck reporting `operation_in_progress` — nothing ever transitions it to a resolved state, unlike `deploy`/`destroy`, which already do this correctly.
+
+## Capabilities
+
+### New Capabilities
+- `local-reachability-diagnostics`: classifying local database-connection failures as reachability problems vs. generic failures, and the `exasol diag local` read-only diagnostic command.
+- `deployment-lifecycle-recovery`: ensuring `start`/`stop` failures transition the deployment to a recoverable interrupted state instead of leaving it stuck reporting an in-progress operation.
+
+### Modified Capabilities
+- `exasol-local-deployment`: the "Start local deployment" scenario changes from "waits until database accepts connections" (unbounded) to a bounded wait that can report a reachability failure distinctly from a generic one; the "Connect to local database" scenario gains a bounded dial instead of an unbounded one.
+
+## Impact
+
+- `internal/deploy/local_reachability.go` (new): the reachability classifier and typed error.
+- `internal/deploy/ready.go`, `internal/deploy/shared.go`, `internal/deploy/local_backend.go`, `internal/deploy/local_runtime.go` (readiness polling, timeout application, classification wiring for install/start).
+- `internal/deploy/connect.go` (classification wiring for `exasol connect`); `internal/deploy/local_backend.go`'s `OpenHostShell`/`OpenCOSShell` (classification wiring for `exasol shell host`/`container`).
+- `internal/deploy/deploymentControl.go`, `internal/deploy/destroy.go` (stuck-`operation_in_progress` fix, applied consistently to `Start`/`Stop`/`Destroy`).
+- `internal/connect/connect.go`, `internal/connect/exasol/database.go` (bounded dial for `exasol connect`).
+- `internal/localruntime` (health-check client consumed by the classifier and by `diag local`).
+- `internal/deploy/diag_local.go`, `cmd/exasol/diagLocal.go` (new): the `exasol diag local` command surface.
+- Depends on the local runner exposing forwarder reachability over its existing status socket as an external interface — see `design.md` for the exact contract assumed. This proposal does not depend on or describe the runner's internal implementation.

--- a/openspec/changes/archive/2026-07-14-improve-local-reachability-diagnostics/specs/deployment-lifecycle-recovery/spec.md
+++ b/openspec/changes/archive/2026-07-14-improve-local-reachability-diagnostics/specs/deployment-lifecycle-recovery/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Start and Stop recover to an interrupted state on failure
+
+The system SHALL transition a deployment out of `operation_in_progress` when the underlying `start` or `stop` operation fails, rather than leaving it permanently stuck reporting an in-progress operation.
+
+#### Scenario: Start fails after the backend call errors
+
+- **WHEN** `exasol start` sets the deployment to `operation_in_progress` and the backend's start operation subsequently fails for any reason
+- **THEN** the deployment transitions to an interrupted state naming the failed operation, rather than remaining in `operation_in_progress`
+
+#### Scenario: Stop fails after the backend call errors
+
+- **WHEN** `exasol stop` sets the deployment to `operation_in_progress` and the backend's stop operation subsequently fails for any reason
+- **THEN** the deployment transitions to an interrupted state naming the failed operation, rather than remaining in `operation_in_progress`
+
+#### Scenario: Recovery is possible after interruption
+
+- **WHEN** a deployment is in an interrupted state following a failed start or stop
+- **THEN** `exasol status` reports actionable recovery guidance, and a subsequent `start` or `stop` is permitted to retry the operation

--- a/openspec/changes/archive/2026-07-14-improve-local-reachability-diagnostics/specs/exasol-local-deployment/spec.md
+++ b/openspec/changes/archive/2026-07-14-improve-local-reachability-diagnostics/specs/exasol-local-deployment/spec.md
@@ -1,0 +1,58 @@
+## MODIFIED Requirements
+
+### Requirement: Exasol Local deployment preset
+
+The system SHALL provide a local deployment option for macOS Apple Silicon that manages the Exasol Local VM through the standard launcher workflow.
+
+#### Scenario: Install local deployment
+
+- **WHEN** a user runs `exasol install local` in an empty deployment directory on supported macOS Apple Silicon
+- **THEN** the launcher initializes the deployment directory, starts the Exasol Local VM, waits up to a bounded timeout until the database accepts connections, and records the deployment as running
+
+#### Scenario: Install local deployment times out
+
+- **WHEN** a user runs `exasol install local` and the database does not become ready within the bounded timeout
+- **THEN** the launcher fails the command rather than waiting indefinitely
+
+#### Scenario: Reject unsupported local platform
+
+- **WHEN** a user runs `exasol install local` on an unsupported operating system or architecture
+- **THEN** the launcher fails before starting a VM and explains that the Exasol Local deployment is only supported on macOS Apple Silicon
+
+### Requirement: Local lifecycle commands
+
+The system SHALL support standard lifecycle commands for local deployments.
+
+#### Scenario: Stop local deployment
+
+- **WHEN** a local deployment is running and the user runs `exasol stop`
+- **THEN** the launcher stops the Exasol Local VM and records the deployment as stopped
+
+#### Scenario: Start local deployment
+
+- **WHEN** a local deployment is stopped and the user runs `exasol start`
+- **THEN** the launcher starts the Exasol Local VM, waits up to a bounded timeout until the database accepts connections, refreshes connection artifacts, and records the deployment as running
+
+#### Scenario: Start local deployment times out
+
+- **WHEN** a local deployment is stopped, the user runs `exasol start`, and the database does not become ready within the bounded timeout
+- **THEN** the launcher fails the command rather than waiting indefinitely
+
+#### Scenario: Destroy local deployment
+
+- **WHEN** a user runs `exasol destroy` for a local deployment
+- **THEN** the launcher stops the Exasol Local VM if needed, deletes the local VM disk/data and launcher-owned runtime artifacts, removes connection artifacts, and records the deployment as initialized
+
+### Requirement: Local SQL connection
+
+The system SHALL allow `exasol connect` to connect to the Exasol Local database using the local deployment artifacts.
+
+#### Scenario: Connect to local database
+
+- **WHEN** a local deployment is running and the user runs `exasol connect`
+- **THEN** the launcher connects to the Exasol Local database through the loopback database endpoint using the stored local credentials, within a bounded timeout
+
+#### Scenario: Local certificate validation mode
+
+- **WHEN** the launcher creates connection metadata for a local deployment without a stable database certificate fingerprint
+- **THEN** the metadata marks certificate validation as insecure for that local deployment

--- a/openspec/changes/archive/2026-07-14-improve-local-reachability-diagnostics/specs/local-reachability-diagnostics/spec.md
+++ b/openspec/changes/archive/2026-07-14-improve-local-reachability-diagnostics/specs/local-reachability-diagnostics/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: Local network reachability failures are classified distinctly
+
+The system SHALL distinguish a local-runtime network reachability problem from a generic database-startup or connection failure when a local deployment's forwarded ports cannot be confirmed reachable.
+
+#### Scenario: Reachability problem during install or start
+
+- **WHEN** `exasol install local` or `exasol start` is waiting for the local database to become ready and the local runtime reports the forwarded ports as not reachable (rather than an authentication response), for longer than a bounded grace period
+- **THEN** the launcher fails with a local runtime reachability error instead of a generic database-startup timeout or an indefinite wait
+
+#### Scenario: Reachability problem during connect
+
+- **WHEN** a local deployment is running and `exasol connect` cannot establish a connection because the local runtime reports the database port as not reachable
+- **THEN** the launcher fails with a local runtime reachability error instead of a raw driver error
+
+#### Scenario: Reachability problem during shell access
+
+- **WHEN** a local deployment is running and `exasol shell host` or `exasol shell container` cannot establish an SSH connection because the local runtime reports the SSH port as not reachable
+- **THEN** the launcher fails with a local runtime reachability error instead of a raw SSH connection error
+
+#### Scenario: Generic failure remains generic
+
+- **WHEN** a local database connection attempt fails and the local runtime reports the relevant port as reachable (the failure is not a network reachability problem)
+- **THEN** the launcher reports the existing generic failure behavior for that command, unchanged
+
+### Requirement: Reachability error explains the macOS Local Network permission cause
+
+The system SHALL explain, in the reachability error message, that macOS's Local Network permission applies to the invoking terminal, editor, or agent environment even though the affected endpoint is a loopback address.
+
+#### Scenario: Error names example invoking environments
+
+- **WHEN** the launcher reports a local runtime reachability error
+- **THEN** the message names example invoking environments (such as a terminal emulator, an editor, or an agent host) as the permission target, without asserting which specific application is actually responsible
+
+#### Scenario: Error explains the loopback nuance
+
+- **WHEN** the launcher reports a local runtime reachability error
+- **THEN** the message explains that granting the permission is required even though the reported database endpoint is `127.0.0.1`, because the launcher forwards it from a VM
+
+### Requirement: Reachability classification distinguishes network-wide from database-specific problems
+
+The system SHALL check reachability of every forwarded local port, not only the port relevant to the current command, when classifying a failure.
+
+#### Scenario: All forwarded ports unreachable
+
+- **WHEN** the local runtime reports every forwarded port as not reachable
+- **THEN** the launcher classifies the failure as a local runtime reachability problem
+
+#### Scenario: Only the database port is affected
+
+- **WHEN** the local runtime reports the SSH port as reachable but the database port as not reachable
+- **THEN** the launcher does not classify the failure as a local runtime reachability problem, and instead reports the existing generic database failure behavior
+
+### Requirement: Local diagnostics command
+
+The system SHALL provide a read-only command that reports the local deployment's runtime and reachability state independent of any command failure.
+
+#### Scenario: Diagnostics report runtime and reachability state
+
+- **WHEN** a user runs `exasol diag local` against a local deployment
+- **THEN** the launcher reports the local VM's running status, its reported guest IP, the bound host ports, the reachability of each forwarded port, and the database's SQL-level readiness
+
+#### Scenario: Diagnostics report platform support
+
+- **WHEN** a user runs `exasol diag local` on an unsupported operating system or architecture
+- **THEN** the launcher reports that the local deployment preset is unsupported on the current platform, without requiring a running deployment
+
+#### Scenario: Diagnostics on a supported platform with no VM running
+
+- **WHEN** a user runs `exasol diag local` on a supported operating system and architecture and the local VM is not running
+- **THEN** the launcher reports, concisely, that the platform is ready to run the local deployment, gives the simple instruction to start it, and notes that running `exasol diag local` again once it is running will report additional detail
+
+#### Scenario: Diagnostics available without a failure
+
+- **WHEN** a local deployment is healthy and reachable
+- **THEN** `exasol diag local` reports success for each checked aspect rather than requiring a prior failure to run
+
+#### Scenario: VM running inconsistently with the recorded deployment state
+
+- **WHEN** a user runs `exasol diag local` and the local VM is running, but the recorded deployment state does not expect one to be (e.g. a process orphaned by a prior crash or a manually killed launcher invocation)
+- **THEN** the launcher reports this inconsistency as an explicit warning, alongside whatever other diagnostics it can still gather, explaining that this can cause a future `start`/`install` to fail with a VM storage conflict and suggesting the user look for and stop the stray process before retrying

--- a/openspec/changes/archive/2026-07-14-improve-local-reachability-diagnostics/tasks.md
+++ b/openspec/changes/archive/2026-07-14-improve-local-reachability-diagnostics/tasks.md
@@ -1,0 +1,41 @@
+## 1. Bound the local readiness waits
+
+- [x] 1.1 Apply `waitTimeoutSeconds` in `internal/deploy/local_backend.go`'s `Start` (currently ignored via `_ int`) using `context.WithTimeout`, mirroring the tofu backend's existing pattern.
+- [x] 1.2 Give `Deploy` (used by `exasol install local`) an equivalent bounded wait for its readiness step, using a default timeout constant since its interface has no caller-supplied timeout. Added `LocalDatabaseStartedDefaultTimeoutSeconds` in `shared.go`; threaded a `waitTimeoutSeconds` parameter through `deployLocalRuntime`/`startLocalRuntime`/`startPreparedLocalRuntime`/`writeLocalRuntimeArtifactsAndWait`, applied via `context.WithTimeout` at the point the database wait starts.
+
+## 2. Consume the runner's health-check contract
+
+- [x] 2.1 Add a client method in `internal/localruntime` for the runner's `{"request":"health-check"}` status-socket request, returning a per-port classified state (`reachable`/`refused`/`blocked`/`timeout`) for every forwarded port. Treat this as an external contract, with no dependency on runner-internal implementation. Added `HealthCheck`, `PortState`, `PortHealth`, `HealthCheckResult` in `internal/localruntime/runtime.go`, invoking the runner's `health-check` CLI subcommand (the launcher only shells out to the runner binary and never dials its socket directly).
+- [x] 2.2 Handle a missing/unsupported/undecodable `health-check` response by falling back to the caller's original error rather than erroring, so an old already-running runner daemon degrades gracefully to today's generic behavior.
+- [x] 2.3 Unit test the client against a fake runner: a mixed per-port response (one reachable, one blocked) parses correctly, and a runner that doesn't recognize the request returns an error rather than a zero-value result.
+
+## 3. Classify reachability failures
+
+- [x] 3.1 Add a typed error (mirroring `blockedStateError` in `internal/deploy/shared.go`: `Error()` returns the full actionable message, `Unwrap()` exposes a sentinel) representing a local runtime reachability problem. `localReachabilityError`/`ErrLocalReachability` in new file `internal/deploy/local_reachability.go`.
+- [x] 3.2 Implement the differential-diagnosis rule: every forwarded port non-reachable classifies as a reachability error; any single port reachable defers to the existing generic failure, unchanged. `classifyLocalReachability`.
+- [x] 3.3 Wire the classification into `internal/deploy/ready.go`'s readiness wait for install/start as a fast pre-check, so a persistently network-wide-blocked deployment fails immediately rather than after the full backoff window.
+- [x] 3.4 Wire the same classification into the local runtime's own `start` invocation (`internal/deploy/local_runtime.go`), since the runner's internal SSH-readiness gate can fail before the SQL-readiness wait is ever reached.
+- [x] 3.5 Wire the same classification into `exasol connect` (`internal/deploy/connect.go`) and `exasol shell host`/`exasol shell container` (`internal/deploy/local_backend.go`'s `OpenHostShell`/`OpenCOSShell`) on failure.
+- [x] 3.6 Write the reachability error's message content: names example invoking environments (terminal emulator, editor, agent host) as the macOS Local Network permission target, and explains the loopback nuance (permission required even though the endpoint is `127.0.0.1`, since the launcher forwards it from a VM).
+- [x] 3.7 Unit test `classifyLocalReachability`: every port blocked classifies as a reachability error; only the database port blocked defers to the generic failure; a non-local deployment and an unavailable health-check both no-op (defer to the caller).
+
+## 4. Fix `exasol connect`'s missing dial timeout
+
+- [x] 4.1 Thread `ctx` through to the actual driver dial in `internal/connect/exasol/database.go`'s `Connect`, which previously ignored it. Added `connectWithContext`, which runs the (context-less) underlying dial call in a goroutine and selects on it vs. `ctx.Done()`.
+- [x] 4.2 Apply a bounded timeout to that dial so a non-reachability failure also fails predictably instead of hanging indefinitely. Added `connectDialTimeout` (30s) in `internal/connect/connect.go`.
+
+## 5. `exasol diag local` command
+
+- [x] 5.1 Add the `exasol diag local` command surface. `cmd/exasol/diagLocal.go`, mirroring the existing `diag info` command's structure (always-JSON output, version-compatibility and initialized-deployment guards, deployment-dir flag).
+- [x] 5.2 Report local VM status, reported guest IP, and bound host ports from existing runner state. `internal/deploy/diag_local.go`'s `diagnoseLocalUnsafe`.
+- [x] 5.3 Report per-port reachability via the health-check client from section 2.
+- [x] 5.4 Report database SQL-level readiness (a single check, without the polling/backoff wrapper used elsewhere).
+- [x] 5.5 Report current OS/architecture support for the local preset, usable even without a running deployment.
+- [x] 5.6 On a supported platform with no VM running, report a concise "ready to run" message with the instruction to start it, instead of reachability/readiness checks that don't apply yet.
+- [x] 5.7 Report a warning when the local VM is running but the recorded deployment workflow state doesn't expect one to be (e.g. a process orphaned by a prior crash), since this can cause a future `start`/`install` to fail with a VM storage conflict.
+- [x] 5.8 Test the command's output for: unsupported platform, non-local deployment, VM not running, VM running with ports/health/readiness reported, and the orphaned-VM warning present/absent.
+
+## 6. Fix deployments stuck in `operation_in_progress` on Start/Stop failure
+
+- [x] 6.1 `internal/deploy/deploymentControl.go`'s `Start` and `Stop` set `WorkflowStateOperationInProgress` before calling into the backend, but on failure returned the error directly without ever transitioning to a resolved state — unlike `Deploy`/`Destroy`, which already handle this correctly.
+- [x] 6.2 Added `markOperationInterrupted` in `deploymentControl.go`, generalizing `destroy.go`'s existing `markDestroyInterrupted`: sets `WorkflowStateInterrupted{Error, InterruptedDuringOperation}` on failure, unregistering the signal handler first to avoid a race with it. Wired into both `Start` and `Stop`; refactored `markDestroyInterrupted` to delegate to the same shared helper.

--- a/openspec/specs/deployment-lifecycle-recovery/spec.md
+++ b/openspec/specs/deployment-lifecycle-recovery/spec.md
@@ -1,0 +1,23 @@
+# deployment-lifecycle-recovery Specification
+
+## Purpose
+TBD - created by archiving change improve-local-reachability-diagnostics. Update Purpose after archive.
+## Requirements
+### Requirement: Start and Stop recover to an interrupted state on failure
+
+The system SHALL transition a deployment out of `operation_in_progress` when the underlying `start` or `stop` operation fails, rather than leaving it permanently stuck reporting an in-progress operation.
+
+#### Scenario: Start fails after the backend call errors
+
+- **WHEN** `exasol start` sets the deployment to `operation_in_progress` and the backend's start operation subsequently fails for any reason
+- **THEN** the deployment transitions to an interrupted state naming the failed operation, rather than remaining in `operation_in_progress`
+
+#### Scenario: Stop fails after the backend call errors
+
+- **WHEN** `exasol stop` sets the deployment to `operation_in_progress` and the backend's stop operation subsequently fails for any reason
+- **THEN** the deployment transitions to an interrupted state naming the failed operation, rather than remaining in `operation_in_progress`
+
+#### Scenario: Recovery is possible after interruption
+
+- **WHEN** a deployment is in an interrupted state following a failed start or stop
+- **THEN** `exasol status` reports actionable recovery guidance, and a subsequent `start` or `stop` is permitted to retry the operation

--- a/openspec/specs/exasol-local-deployment/spec.md
+++ b/openspec/specs/exasol-local-deployment/spec.md
@@ -10,7 +10,12 @@ The system SHALL provide a local deployment option for macOS Apple Silicon that 
 #### Scenario: Install local deployment
 
 - **WHEN** a user runs `exasol install local` in an empty deployment directory on supported macOS Apple Silicon
-- **THEN** the launcher initializes the deployment directory, starts the Exasol Local VM, and records the deployment as running
+- **THEN** the launcher initializes the deployment directory, starts the Exasol Local VM, waits up to a bounded timeout until the database accepts connections, and records the deployment as running
+
+#### Scenario: Install local deployment times out
+
+- **WHEN** a user runs `exasol install local` and the database does not become ready within the bounded timeout
+- **THEN** the launcher fails the command rather than waiting indefinitely
 
 #### Scenario: Reject unsupported local platform
 
@@ -67,7 +72,7 @@ The system SHALL allow `exasol connect` to connect to the Exasol Local database 
 #### Scenario: Connect to local database
 
 - **WHEN** a local deployment is running and the user runs `exasol connect`
-- **THEN** the launcher connects to the Exasol Local database through the loopback database endpoint using the stored local credentials
+- **THEN** the launcher connects to the Exasol Local database through the loopback database endpoint using the stored local credentials, within a bounded timeout
 
 #### Scenario: Local certificate validation mode
 
@@ -86,7 +91,12 @@ The system SHALL support standard lifecycle commands for local deployments.
 #### Scenario: Start local deployment
 
 - **WHEN** a local deployment is stopped and the user runs `exasol start`
-- **THEN** the launcher starts the Exasol Local VM, waits until the database accepts connections, refreshes connection artifacts, and records the deployment as running
+- **THEN** the launcher starts the Exasol Local VM, waits up to a bounded timeout until the database accepts connections, refreshes connection artifacts, and records the deployment as running
+
+#### Scenario: Start local deployment times out
+
+- **WHEN** a local deployment is stopped, the user runs `exasol start`, and the database does not become ready within the bounded timeout
+- **THEN** the launcher fails the command rather than waiting indefinitely
 
 #### Scenario: Destroy local deployment
 

--- a/openspec/specs/local-reachability-diagnostics/spec.md
+++ b/openspec/specs/local-reachability-diagnostics/spec.md
@@ -1,0 +1,85 @@
+# local-reachability-diagnostics Specification
+
+## Purpose
+TBD - created by archiving change improve-local-reachability-diagnostics. Update Purpose after archive.
+## Requirements
+### Requirement: Local network reachability failures are classified distinctly
+
+The system SHALL distinguish a local-runtime network reachability problem from a generic database-startup or connection failure when a local deployment's forwarded ports cannot be confirmed reachable.
+
+#### Scenario: Reachability problem during install or start
+
+- **WHEN** `exasol install local` or `exasol start` is waiting for the local database to become ready and the local runtime reports the forwarded ports as not reachable (rather than an authentication response), for longer than a bounded grace period
+- **THEN** the launcher fails with a local runtime reachability error instead of a generic database-startup timeout or an indefinite wait
+
+#### Scenario: Reachability problem during connect
+
+- **WHEN** a local deployment is running and `exasol connect` cannot establish a connection because the local runtime reports the database port as not reachable
+- **THEN** the launcher fails with a local runtime reachability error instead of a raw driver error
+
+#### Scenario: Reachability problem during shell access
+
+- **WHEN** a local deployment is running and `exasol shell host` or `exasol shell container` cannot establish an SSH connection because the local runtime reports the SSH port as not reachable
+- **THEN** the launcher fails with a local runtime reachability error instead of a raw SSH connection error
+
+#### Scenario: Generic failure remains generic
+
+- **WHEN** a local database connection attempt fails and the local runtime reports the relevant port as reachable (the failure is not a network reachability problem)
+- **THEN** the launcher reports the existing generic failure behavior for that command, unchanged
+
+### Requirement: Reachability error explains the macOS Local Network permission cause
+
+The system SHALL explain, in the reachability error message, that macOS's Local Network permission applies to the invoking terminal, editor, or agent environment even though the affected endpoint is a loopback address.
+
+#### Scenario: Error names example invoking environments
+
+- **WHEN** the launcher reports a local runtime reachability error
+- **THEN** the message names example invoking environments (such as a terminal emulator, an editor, or an agent host) as the permission target, without asserting which specific application is actually responsible
+
+#### Scenario: Error explains the loopback nuance
+
+- **WHEN** the launcher reports a local runtime reachability error
+- **THEN** the message explains that granting the permission is required even though the reported database endpoint is `127.0.0.1`, because the launcher forwards it from a VM
+
+### Requirement: Reachability classification distinguishes network-wide from database-specific problems
+
+The system SHALL check reachability of every forwarded local port, not only the port relevant to the current command, when classifying a failure.
+
+#### Scenario: All forwarded ports unreachable
+
+- **WHEN** the local runtime reports every forwarded port as not reachable
+- **THEN** the launcher classifies the failure as a local runtime reachability problem
+
+#### Scenario: Only the database port is affected
+
+- **WHEN** the local runtime reports the SSH port as reachable but the database port as not reachable
+- **THEN** the launcher does not classify the failure as a local runtime reachability problem, and instead reports the existing generic database failure behavior
+
+### Requirement: Local diagnostics command
+
+The system SHALL provide a read-only command that reports the local deployment's runtime and reachability state independent of any command failure.
+
+#### Scenario: Diagnostics report runtime and reachability state
+
+- **WHEN** a user runs `exasol diag local` against a local deployment
+- **THEN** the launcher reports the local VM's running status, its reported guest IP, the bound host ports, the reachability of each forwarded port, and the database's SQL-level readiness
+
+#### Scenario: Diagnostics report platform support
+
+- **WHEN** a user runs `exasol diag local` on an unsupported operating system or architecture
+- **THEN** the launcher reports that the local deployment preset is unsupported on the current platform, without requiring a running deployment
+
+#### Scenario: Diagnostics on a supported platform with no VM running
+
+- **WHEN** a user runs `exasol diag local` on a supported operating system and architecture and the local VM is not running
+- **THEN** the launcher reports, concisely, that the platform is ready to run the local deployment, gives the simple instruction to start it, and notes that running `exasol diag local` again once it is running will report additional detail
+
+#### Scenario: Diagnostics available without a failure
+
+- **WHEN** a local deployment is healthy and reachable
+- **THEN** `exasol diag local` reports success for each checked aspect rather than requiring a prior failure to run
+
+#### Scenario: VM running inconsistently with the recorded deployment state
+
+- **WHEN** a user runs `exasol diag local` and the local VM is running, but the recorded deployment state does not expect one to be (e.g. a process orphaned by a prior crash or a manually killed launcher invocation)
+- **THEN** the launcher reports this inconsistency as an explicit warning, alongside whatever other diagnostics it can still gather, explaining that this can cause a future `start`/`install` to fail with a VM storage conflict and suggesting the user look for and stop the stray process before retrying


### PR DESCRIPTION
## Description

In certain environments such as iTerm2 or AI agent sandboxes, the launcher lacks the Local Network permission, making it so the VM runner cannot communicate with the VM. This PR improves the error handling for this case and points the user towards a solution.

Depends on [exasol-local-vm#42](https://github.com/exasol/exasol-local-vm/pull/42).

## Related Issue

[SPOT-31542](https://exasol.atlassian.net/browse/SPOT-31542)

## Type of Change

- [x] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Add error detection for unreachable VM ports.
- Add `exasol diag local` command.
- Fix handling of errors during start/stop operations.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

This PR was tested under macOS's Seatbelt sandbox using the following rules:

```
# no-local-network.sb
(version 1)
(allow default)
(deny network-outbound)
(allow network-outbound (remote ip "localhost:*"))
(allow network-outbound (remote unix-socket))
```

#### Scenario 1: Install in sandbox.
```
sandbox-exec -f no-local-network.sb exasol install local
```

#### Scenario 2: Install outside sandbox, start in sandbox.
```
exasol install local
exasol stop
sandbox-exec -f no-local-network.sb exasol start
```

In both cases a message prompting the user to check the Local Network permission was displayed.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

[SPOT-31542]: https://exasol.atlassian.net/browse/SPOT-31542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ