### PR TITLE
fix: allow 2025 license package fetch from x-up

### DIFF
--- a/assets/infrastructure/aws/main.tf
+++ b/assets/infrastructure/aws/main.tf
@@ -271,6 +271,26 @@ resource "aws_iam_role_policy" "exasol_instance_role_s3" {
           "arn:aws:s3:::${local.archive_bucket_id}",
           "arn:aws:s3:::${local.archive_bucket_id}/*"
         ]
+      },
+      {
+        # Some older Exasol DB packages fetch the personal license from the
+        # Exasol x-up distribution bucket with c4 versions that sign even
+        # public S3 requests with the EC2 instance role. AWS then evaluates
+        # access as this role, so the role needs narrowly scoped read access
+        # for that compatibility path.
+        Sid    = "ExasolPackageBucketReadMetadata",
+        Effect = "Allow",
+        Action = [
+          "s3:ListBucket",
+          "s3:GetBucketLocation"
+        ],
+        Resource = ["arn:aws:s3:::x-up"]
+      },
+      {
+        Sid      = "ExasolPackageBucketRead",
+        Effect   = "Allow",
+        Action   = ["s3:GetObject"],
+        Resource = ["arn:aws:s3:::x-up/*"]
       }
     ]
   })


### PR DESCRIPTION
## Description

Adds narrowly scoped read permissions for the Exasol `x-up` distribution bucket to the AWS EC2 instance role.

Exasol DB 2025.1.x bundles a c4 version that signs even public S3 requests with the instance role when fetching `@license:personal`. AWS then evaluates the request as that role instead of as an anonymous public request, so the fetch fails with `403 AccessDenied` unless the role can read the object. Exasol DB 2026.1.0 no longer uses this path, which is why the defect was missed by tests that exercised only the default/current DB release.

A launcher-side prefetch was tested but is not robust: `c4 host play` can remove the prefetched package before the bundled c4 service fetches the license, and multi-node deployments would make a single-node prefetch insufficient anyway. The durable fix is to let the instance role used by every node read the package bucket/object directly.

## Related Issue

Fixes SPOT-31599

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Added scoped bucket-level `s3:ListBucket` and `s3:GetBucketLocation` permissions for `arn:aws:s3:::x-up`.
- Added scoped object-level `s3:GetObject` permission for `arn:aws:s3:::x-up/*`.
- Documented why a public bucket still needs an explicit role permission for older c4-based license fetches.
- Kept the permission read-only and limited to `x-up`; no bucket write, delete, or broad S3 access is added.

## Testing

- [ ] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

- `env GOCACHE=/tmp/go-build-cache XDG_CACHE_HOME=/tmp/exasol-personal-cache go run ./tools/tofu/main.go fmt -recursive assets/infrastructure/aws`
- `env GOCACHE=/tmp/go-build-cache XDG_CACHE_HOME=/tmp/exasol-personal-cache go test ./internal/presets ./internal/deploy`

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [ ] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [ ] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

This supersedes PR #201, which attempted to work around the issue by prefetching the license package before `c4 host play`. The policy intentionally includes the bucket-level read metadata permissions from the proven manual workaround, because older or future c4 fetch paths may query bucket metadata before reading the known object.
