### PR TITLE
feat: add slc support for local deployments

### DIFF
--- a/assets/resources/slc-catalog.yaml
+++ b/assets/resources/slc-catalog.yaml
@@ -2,7 +2,7 @@
 #
 # Image ref = {registry}:{tag_template}. {hash} is the SLC content hash (same as the release
 # tarball name), so new content -> new tag: we pin by tag and refresh hashes on a version bump.
-# aliases mirror each flavor's build_info/language_definitions.json (the DB's source of truth).
+# aliases mirror the aliases each flavor declares (the DB's source of truth).
 
 registry: docker.io/exasol/script-language-container
 tag_template: "standard-EXASOL-all-{flavor}-release_{arch}_{hash}"

--- a/assets/resources/slc-catalog.yaml
+++ b/assets/resources/slc-catalog.yaml
@@ -1,0 +1,29 @@
+# Official SLC catalog — official SLCs + local deployment -> Podman image mount into /exa/slc.
+#
+# Image ref = {registry}:{tag_template}. {hash} is the SLC content hash (same as the release
+# tarball name), so new content -> new tag: we pin by tag and refresh hashes on a version bump.
+# aliases mirror each flavor's build_info/language_definitions.json (the DB's source of truth).
+
+registry: docker.io/exasol/script-language-container
+tag_template: "standard-EXASOL-all-{flavor}-release_{arch}_{hash}"
+
+# arm64 only for now — local is darwin/arm64-only (internal/deploy/local_backend.go). Add an
+# amd64 block when local reaches Windows/Linux x86; the x86 tag arch token is `x64`, not `amd64`.
+architectures:
+  arm64:
+    default_version: "11.2.0"
+    versions:
+      "11.2.0":
+        languages:
+          python:
+            flavor: python-3.12
+            hash: GM7DI5JDDTJRRDVV2QPRSNDRDT5CCYHPPEZO7HPJSIX4B5ICISZQ
+            aliases: [PYTHON3, PYTHON312]
+          java:
+            flavor: java-17
+            hash: U5E3P6CRW2FH2HICAVKNSZYS6AU5O2AXTXFZNWIDMA5IYCGGCVHQ
+            aliases: [JAVA, JAVA17]
+          r:
+            flavor: r-4.4
+            hash: 3CS3CMHC3WE2K4GQLA6YPMTB3ECQLILLYEDRG7JAZEQBBZMR7H4A
+            aliases: [R, R44]

--- a/assets/resources/slc_catalog.go
+++ b/assets/resources/slc_catalog.go
@@ -1,0 +1,12 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package resources
+
+import _ "embed"
+
+// SLCCatalogYAML contains the embedded official script language container catalog
+// (official SLCs for exasol personal local deployments installed locally via Podman image mount).
+//
+//go:embed slc-catalog.yaml
+var SLCCatalogYAML []byte

--- a/cmd/exasol/preset_help.go
+++ b/cmd/exasol/preset_help.go
@@ -46,11 +46,12 @@ func embeddedPresetCompatibilityMatrix() string {
 		}
 	}
 
+	const compatibleCell = "yes"
 	columnWidths := map[string]int{}
 	for installID := range installManifests {
 		width := len(installID)
-		if width < len("yes") {
-			width = len("yes")
+		if width < len(compatibleCell) {
+			width = len(compatibleCell)
 		}
 		columnWidths[installID] = width
 	}
@@ -79,7 +80,7 @@ func embeddedPresetCompatibilityMatrix() string {
 			}
 			cell := "no"
 			if embeddedPresetPairCompatible(infraManifest, installManifest) {
-				cell = "yes"
+				cell = compatibleCell
 			}
 			_, _ = builder.WriteString(fmt.Sprintf("  %-*s", columnWidths[installID], cell))
 		}

--- a/cmd/exasol/slc.go
+++ b/cmd/exasol/slc.go
@@ -1,0 +1,394 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/exasol/exasol-personal/internal/deploy"
+	"github.com/exasol/exasol-personal/internal/util"
+	"github.com/spf13/cobra"
+)
+
+var slcInstallOpts = struct {
+	Yes       bool
+	NoRestart bool
+}{}
+
+var slcUpdateOpts = struct {
+	Yes       bool
+	NoRestart bool
+}{}
+
+var slcRemoveOpts = struct {
+	Yes       bool
+	NoRestart bool
+}{}
+
+const slcCmdShortDesc = "Manage script language containers (SLCs)"
+
+const slcCmdLongDesc = slcCmdShortDesc + `
+
+Script language containers provide the language runtimes used by UDFs.
+Local deployments ship without any SLC installed; install one to run UDFs in that language.
+`
+
+var slcCmd = &cobra.Command{
+	Use:   "slc",
+	Short: slcCmdShortDesc,
+	Long:  slcCmdLongDesc,
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return cmd.Help()
+	},
+}
+
+var slcInstallCmd = &cobra.Command{
+	Use:   "install <alias>",
+	Short: "Install an official script language container",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		alias := args[0]
+		result, err := deploy.InstallSLC(
+			cmd.Context(),
+			commonFlags.Deployment(),
+			alias,
+			commonFlags.DeployVerbose,
+			!slcInstallOpts.NoRestart,
+			slcConfirmFunc(cmd, slcInstallOpts.Yes, fmt.Sprintf("Installing %q", alias)),
+		)
+		if errors.Is(err, deploy.ErrSLCOperationCancelled) {
+			safePrint("Aborted; no changes were made.")
+
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		if result.AlreadyInstalled {
+			safePrint(fmt.Sprintf(
+				"%s is already installed and up to date (version %s, aliases: %s). Nothing to do.",
+				result.Entry.Flavor,
+				result.Entry.Version,
+				strings.Join(result.Entry.Aliases, ", "),
+			))
+
+			return nil
+		}
+
+		printSLCInstallResult(result)
+
+		return nil
+	},
+}
+
+var slcUpdateCmd = &cobra.Command{
+	Use:   "update <alias>",
+	Short: "Update an installed script language container to the catalog's current version",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		alias := args[0]
+		result, err := deploy.UpdateSLC(
+			cmd.Context(),
+			commonFlags.Deployment(),
+			alias,
+			commonFlags.DeployVerbose,
+			!slcUpdateOpts.NoRestart,
+			slcConfirmFunc(cmd, slcUpdateOpts.Yes, fmt.Sprintf("Updating %q", alias)),
+		)
+		if errors.Is(err, deploy.ErrSLCOperationCancelled) {
+			safePrint("Aborted; no changes were made.")
+
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		if !result.Found {
+			safePrint(fmt.Sprintf(
+				"No SLC matching %q is installed, so there is nothing to update.\n"+
+					"Run `exasol slc install %s` to install it.",
+				alias, alias,
+			))
+
+			return nil
+		}
+		if result.Unchanged {
+			safePrint(fmt.Sprintf(
+				"%s is already up to date (version %s). Nothing to do.",
+				result.Entry.Flavor,
+				result.Entry.Version,
+			))
+
+			return nil
+		}
+
+		printSLCUpdateResult(result)
+
+		return nil
+	},
+}
+
+var slcRemoveCmd = &cobra.Command{
+	Use:   "remove <alias>",
+	Short: "Remove a script language container",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		alias := args[0]
+		result, err := deploy.RemoveSLC(
+			cmd.Context(),
+			commonFlags.Deployment(),
+			alias,
+			commonFlags.DeployVerbose,
+			!slcRemoveOpts.NoRestart,
+			slcConfirmFunc(cmd, slcRemoveOpts.Yes, fmt.Sprintf("Removing %q", alias)),
+		)
+		if errors.Is(err, deploy.ErrSLCOperationCancelled) {
+			safePrint("Aborted; no changes were made.")
+
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+
+		if !result.Found {
+			safePrint(fmt.Sprintf(
+				"No SLC matching %q is installed, so there is nothing to remove.",
+				alias,
+			))
+
+			return nil
+		}
+
+		printSLCRemoveResult(result)
+
+		return nil
+	},
+}
+
+// slcConfirmFunc returns a confirmation callback for a database-restarting SLC operation.
+// It returns nil when the user passed --yes (pre-approved). Otherwise it warns and prompts
+// interactively, and refuses non-interactively so scripts never trigger a silent restart.
+//
+//nolint:revive // assumeYes reflects the user's --yes flag, not internal control coupling.
+func slcConfirmFunc(cmd *cobra.Command, assumeYes bool, action string) deploy.ConfirmFunc {
+	if assumeYes {
+		return nil
+	}
+
+	return func() (bool, error) {
+		if !util.IsInteractiveStdin() {
+			return false, errors.New(
+				"this restarts the database; re-run with --yes to confirm, " +
+					"or --no-restart to apply on the next start",
+			)
+		}
+
+		_, _ = fmt.Fprintf(
+			cmd.OutOrStdout(),
+			"%s will restart the database. Open connections will be dropped and running "+
+				"statements aborted.\nContinue? [y/N]: ",
+			action,
+		)
+
+		line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+		if err != nil && !errors.Is(err, io.EOF) {
+			return false, err
+		}
+
+		return confirmYes(line), nil
+	}
+}
+
+var slcListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List available script language containers and which are installed",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		cmd.SilenceUsage = true
+		statuses, err := deploy.SLCStatuses(commonFlags.Deployment())
+		if err != nil {
+			return err
+		}
+
+		if commonFlags.OutputJson {
+			return renderSLCListJSON(cmd.OutOrStdout(), statuses)
+		}
+
+		renderSLCListText(statuses)
+
+		return nil
+	},
+}
+
+type slcListJSONItem struct {
+	Language  string   `json:"language"`
+	Flavor    string   `json:"flavor"`
+	Version   string   `json:"version"`
+	Aliases   []string `json:"aliases"`
+	Installed bool     `json:"installed"`
+}
+
+func renderSLCListJSON(writer io.Writer, statuses []deploy.SLCStatus) error {
+	items := make([]slcListJSONItem, 0, len(statuses))
+	for _, status := range statuses {
+		items = append(items, slcListJSONItem{
+			Language:  status.Language,
+			Flavor:    status.Flavor,
+			Version:   status.Version,
+			Aliases:   status.Aliases,
+			Installed: status.Installed,
+		})
+	}
+
+	encoder := json.NewEncoder(writer)
+	encoder.SetIndent("", "  ")
+
+	return encoder.Encode(items)
+}
+
+func renderSLCListText(statuses []deploy.SLCStatus) {
+	if len(statuses) == 0 {
+		safePrint("No script language containers are available for this platform.")
+
+		return
+	}
+
+	var builder strings.Builder
+	const columnPadding = 2
+	writer := tabwriter.NewWriter(&builder, 0, 0, columnPadding, ' ', 0)
+	_, _ = fmt.Fprintln(writer, "FLAVOR\tALIASES\tVERSION\tINSTALLED")
+	for _, status := range statuses {
+		installed := "no"
+		if status.Installed {
+			installed = "yes"
+		}
+		_, _ = fmt.Fprintf(
+			writer,
+			"%s\t%s\t%s\t%s\n",
+			status.Flavor,
+			strings.Join(status.Aliases, ", "),
+			status.Version,
+			installed,
+		)
+	}
+	_ = writer.Flush()
+
+	safePrint(strings.TrimRight(builder.String(), "\n"))
+}
+
+func printSLCInstallResult(result *deploy.SLCInstallResult) {
+	verb := "Installed"
+	if result.Replaced {
+		verb = "Updated"
+	}
+	message := fmt.Sprintf(
+		"%s %s (aliases: %s).",
+		verb,
+		result.Entry.Flavor,
+		strings.Join(result.Entry.Aliases, ", "),
+	)
+
+	switch result.Outcome {
+	case deploy.SLCApplyRestarted:
+		message += " Database restarted; the language is ready to use."
+	case deploy.SLCApplyStarted:
+		message += " Database started; the language is ready to use."
+	case deploy.SLCApplyDeferred:
+		message += " It will become available on the next start."
+	default:
+		// No suffix for an unrecognized outcome.
+	}
+
+	safePrint(message)
+}
+
+func printSLCUpdateResult(result *deploy.SLCUpdateResult) {
+	message := fmt.Sprintf("Updated %s.", result.Entry.Flavor)
+	if result.FromFlavor != "" && result.FromFlavor != result.Entry.Flavor {
+		message = fmt.Sprintf("Updated %s to %s.", result.FromFlavor, result.Entry.Flavor)
+	}
+
+	switch result.Outcome {
+	case deploy.SLCApplyRestarted:
+		message += " Database restarted; the new version is ready to use."
+	case deploy.SLCApplyStarted:
+		message += " Database started; the new version is ready to use."
+	case deploy.SLCApplyDeferred:
+		message += " It will take effect on the next start."
+	default:
+		// No suffix for an unrecognized outcome.
+	}
+
+	safePrint(message)
+}
+
+func printSLCRemoveResult(result *deploy.SLCRemoveResult) {
+	message := fmt.Sprintf("Removed %s.", result.Entry.Flavor)
+
+	switch result.Outcome {
+	case deploy.SLCApplyRestarted:
+		message += " Database restarted; the language is no longer available."
+	case deploy.SLCApplyStarted:
+		message += " Database started."
+	case deploy.SLCApplyDeferred:
+		message += " It will no longer be loaded on the next start."
+	default:
+		// No suffix for an unrecognized outcome.
+	}
+
+	safePrint(message)
+}
+
+// nolint: gochecknoinits
+func init() {
+	requireDefaultDeploymentCompatibility(slcInstallCmd)
+	requireInitializedDeploymentDir(slcInstallCmd)
+	registerDeploymentDirFlag(slcInstallCmd, commonFlags)
+	registerVerboseFlag(slcInstallCmd, commonFlags)
+	slcInstallCmd.Flags().BoolVarP(&slcInstallOpts.Yes, "yes", "y", false,
+		"Do not prompt for confirmation before restarting the database")
+	slcInstallCmd.Flags().BoolVar(&slcInstallOpts.NoRestart, "no-restart", false,
+		"Record the SLC without restarting; it activates on the next start")
+
+	requireDefaultDeploymentCompatibility(slcUpdateCmd)
+	requireInitializedDeploymentDir(slcUpdateCmd)
+	registerDeploymentDirFlag(slcUpdateCmd, commonFlags)
+	registerVerboseFlag(slcUpdateCmd, commonFlags)
+	slcUpdateCmd.Flags().BoolVarP(&slcUpdateOpts.Yes, "yes", "y", false,
+		"Do not prompt for confirmation before restarting the database")
+	slcUpdateCmd.Flags().BoolVar(&slcUpdateOpts.NoRestart, "no-restart", false,
+		"Record the update without restarting; it applies on the next start")
+
+	requireDefaultDeploymentCompatibility(slcRemoveCmd)
+	requireInitializedDeploymentDir(slcRemoveCmd)
+	registerDeploymentDirFlag(slcRemoveCmd, commonFlags)
+	registerVerboseFlag(slcRemoveCmd, commonFlags)
+	slcRemoveCmd.Flags().BoolVarP(&slcRemoveOpts.Yes, "yes", "y", false,
+		"Do not prompt for confirmation before restarting the database")
+	slcRemoveCmd.Flags().BoolVar(&slcRemoveOpts.NoRestart, "no-restart", false,
+		"Record the removal without restarting; it applies on the next start")
+
+	registerDeploymentDirFlag(slcListCmd, commonFlags)
+	registerOutputFlags(slcListCmd, commonFlags)
+
+	slcCmd.AddCommand(slcInstallCmd)
+	slcCmd.AddCommand(slcListCmd)
+	slcCmd.AddCommand(slcUpdateCmd)
+	slcCmd.AddCommand(slcRemoveCmd)
+	rootCmd.AddCommand(slcCmd)
+}

--- a/cmd/exasol/slc.go
+++ b/cmd/exasol/slc.go
@@ -19,18 +19,18 @@ import (
 )
 
 var slcInstallOpts = struct {
-	Yes       bool
-	NoRestart bool
+	AutoApprove bool
+	NoRestart   bool
 }{}
 
 var slcUpdateOpts = struct {
-	Yes       bool
-	NoRestart bool
+	AutoApprove bool
+	NoRestart   bool
 }{}
 
 var slcRemoveOpts = struct {
-	Yes       bool
-	NoRestart bool
+	AutoApprove bool
+	NoRestart   bool
 }{}
 
 const slcCmdShortDesc = "Manage script language containers (SLCs)"
@@ -64,7 +64,7 @@ var slcInstallCmd = &cobra.Command{
 			alias,
 			commonFlags.DeployVerbose,
 			!slcInstallOpts.NoRestart,
-			slcConfirmFunc(cmd, slcInstallOpts.Yes, fmt.Sprintf("Installing %q", alias)),
+			slcConfirmFunc(cmd, slcInstallOpts.AutoApprove, fmt.Sprintf("Installing %q", alias)),
 		)
 		if errors.Is(err, deploy.ErrSLCOperationCancelled) {
 			safePrint("Aborted; no changes were made.")
@@ -105,7 +105,7 @@ var slcUpdateCmd = &cobra.Command{
 			alias,
 			commonFlags.DeployVerbose,
 			!slcUpdateOpts.NoRestart,
-			slcConfirmFunc(cmd, slcUpdateOpts.Yes, fmt.Sprintf("Updating %q", alias)),
+			slcConfirmFunc(cmd, slcUpdateOpts.AutoApprove, fmt.Sprintf("Updating %q", alias)),
 		)
 		if errors.Is(err, deploy.ErrSLCOperationCancelled) {
 			safePrint("Aborted; no changes were made.")
@@ -154,7 +154,7 @@ var slcRemoveCmd = &cobra.Command{
 			alias,
 			commonFlags.DeployVerbose,
 			!slcRemoveOpts.NoRestart,
-			slcConfirmFunc(cmd, slcRemoveOpts.Yes, fmt.Sprintf("Removing %q", alias)),
+			slcConfirmFunc(cmd, slcRemoveOpts.AutoApprove, fmt.Sprintf("Removing %q", alias)),
 		)
 		if errors.Is(err, deploy.ErrSLCOperationCancelled) {
 			safePrint("Aborted; no changes were made.")
@@ -181,19 +181,20 @@ var slcRemoveCmd = &cobra.Command{
 }
 
 // slcConfirmFunc returns a confirmation callback for a database-restarting SLC operation.
-// It returns nil when the user passed --yes (pre-approved). Otherwise it warns and prompts
-// interactively, and refuses non-interactively so scripts never trigger a silent restart.
+// It returns nil when the user passed --auto-approve (pre-approved). Otherwise it warns and
+// prompts interactively, and refuses non-interactively so scripts never trigger a silent
+// restart.
 //
-//nolint:revive // assumeYes reflects the user's --yes flag, not internal control coupling.
-func slcConfirmFunc(cmd *cobra.Command, assumeYes bool, action string) deploy.ConfirmFunc {
-	if assumeYes {
+//nolint:revive // autoApprove reflects the user's flag, not internal control coupling.
+func slcConfirmFunc(cmd *cobra.Command, autoApprove bool, action string) deploy.ConfirmFunc {
+	if autoApprove {
 		return nil
 	}
 
 	return func() (bool, error) {
 		if !util.IsInteractiveStdin() {
 			return false, errors.New(
-				"this restarts the database; re-run with --yes to confirm, " +
+				"this restarts the database; re-run with --auto-approve to confirm, " +
 					"or --no-restart to apply on the next start",
 			)
 		}
@@ -311,7 +312,6 @@ func printSLCInstallResult(result *deploy.SLCInstallResult) {
 	case deploy.SLCApplyDeferred:
 		message += " It will become available on the next start."
 	default:
-		// No suffix for an unrecognized outcome.
 	}
 
 	safePrint(message)
@@ -331,7 +331,6 @@ func printSLCUpdateResult(result *deploy.SLCUpdateResult) {
 	case deploy.SLCApplyDeferred:
 		message += " It will take effect on the next start."
 	default:
-		// No suffix for an unrecognized outcome.
 	}
 
 	safePrint(message)
@@ -348,7 +347,6 @@ func printSLCRemoveResult(result *deploy.SLCRemoveResult) {
 	case deploy.SLCApplyDeferred:
 		message += " It will no longer be loaded on the next start."
 	default:
-		// No suffix for an unrecognized outcome.
 	}
 
 	safePrint(message)
@@ -360,7 +358,7 @@ func init() {
 	requireInitializedDeploymentDir(slcInstallCmd)
 	registerDeploymentDirFlag(slcInstallCmd, commonFlags)
 	registerVerboseFlag(slcInstallCmd, commonFlags)
-	slcInstallCmd.Flags().BoolVarP(&slcInstallOpts.Yes, "yes", "y", false,
+	slcInstallCmd.Flags().BoolVar(&slcInstallOpts.AutoApprove, "auto-approve", false,
 		"Do not prompt for confirmation before restarting the database")
 	slcInstallCmd.Flags().BoolVar(&slcInstallOpts.NoRestart, "no-restart", false,
 		"Record the SLC without restarting; it activates on the next start")
@@ -369,7 +367,7 @@ func init() {
 	requireInitializedDeploymentDir(slcUpdateCmd)
 	registerDeploymentDirFlag(slcUpdateCmd, commonFlags)
 	registerVerboseFlag(slcUpdateCmd, commonFlags)
-	slcUpdateCmd.Flags().BoolVarP(&slcUpdateOpts.Yes, "yes", "y", false,
+	slcUpdateCmd.Flags().BoolVar(&slcUpdateOpts.AutoApprove, "auto-approve", false,
 		"Do not prompt for confirmation before restarting the database")
 	slcUpdateCmd.Flags().BoolVar(&slcUpdateOpts.NoRestart, "no-restart", false,
 		"Record the update without restarting; it applies on the next start")
@@ -378,7 +376,7 @@ func init() {
 	requireInitializedDeploymentDir(slcRemoveCmd)
 	registerDeploymentDirFlag(slcRemoveCmd, commonFlags)
 	registerVerboseFlag(slcRemoveCmd, commonFlags)
-	slcRemoveCmd.Flags().BoolVarP(&slcRemoveOpts.Yes, "yes", "y", false,
+	slcRemoveCmd.Flags().BoolVar(&slcRemoveOpts.AutoApprove, "auto-approve", false,
 		"Do not prompt for confirmation before restarting the database")
 	slcRemoveCmd.Flags().BoolVar(&slcRemoveOpts.NoRestart, "no-restart", false,
 		"Record the removal without restarting; it applies on the next start")

--- a/cmd/exasol/slc_test.go
+++ b/cmd/exasol/slc_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/deploy"
+)
+
+// On an unsupported architecture `slc list` degrades gracefully: SLCStatuses returns an
+// empty set (no error), which the renderers must present as the "none available" message
+// and an empty JSON array — never an error or a non-zero exit.
+
+//nolint:paralleltest // swaps the process-wide os.Stdout to capture safePrint output.
+func TestRenderSLCListTextNoneAvailable(t *testing.T) {
+	output := captureStdout(t, func() {
+		renderSLCListText([]deploy.SLCStatus{})
+	})
+
+	if strings.TrimSpace(
+		output,
+	) != "No script language containers are available for this platform." {
+		t.Fatalf("unexpected text output: %q", output)
+	}
+}
+
+func TestRenderSLCListJSONEmptyIsArray(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	if err := renderSLCListJSON(&buf, []deploy.SLCStatus{}); err != nil {
+		t.Fatalf("expected json render to succeed, got %v", err)
+	}
+
+	if got := strings.TrimSpace(buf.String()); got != "[]" {
+		t.Fatalf("expected empty JSON array, got %q", got)
+	}
+}
+
+// captureStdout runs emit with os.Stdout redirected to a pipe and returns what it wrote.
+func captureStdout(t *testing.T, emit func()) string {
+	t.Helper()
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	original := os.Stdout
+	os.Stdout = writer
+	t.Cleanup(func() { os.Stdout = original })
+
+	emit()
+	_ = writer.Close()
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, reader); err != nil {
+		t.Fatalf("failed to read captured output: %v", err)
+	}
+
+	return buf.String()
+}

--- a/internal/config/exasol_launcher_state.go
+++ b/internal/config/exasol_launcher_state.go
@@ -90,18 +90,12 @@ type ExasolPersonalState struct {
 // InstalledSLC records one installed script language container so the launcher can
 // re-apply its image mount on every start and enforce alias uniqueness across the set.
 type InstalledSLC struct {
-	// Language is the catalog key (e.g. "python").
-	Language string `json:"language"`
-	// Flavor is the image flavor token (e.g. "python-3.12").
-	Flavor string `json:"flavor"`
-	// Version is the catalog version this SLC was resolved from.
-	Version string `json:"version"`
-	// Image is the full container image reference to mount.
-	Image string `json:"image"`
-	// Target is the mount destination inside the database container.
-	Target string `json:"target"`
-	// Aliases are all aliases the SLC declares (used for collision detection).
-	Aliases []string `json:"aliases"`
+	Language string   `json:"language"`
+	Flavor   string   `json:"flavor"`
+	Version  string   `json:"version"`
+	Image    string   `json:"image"`
+	Target   string   `json:"target"`
+	Aliases  []string `json:"aliases"`
 }
 
 // DirectoryExasolPersonalStatefile.

--- a/internal/config/exasol_launcher_state.go
+++ b/internal/config/exasol_launcher_state.go
@@ -79,6 +79,29 @@ type ExasolPersonalState struct {
 	// backend one). Backends may still receive CreatedAt via DeploymentMetadata
 	// and persist it for their own purposes (e.g. resource tagging).
 	CreatedAt time.Time `json:"createdAt,omitempty"`
+	// InstalledSLCs is the set of official script language containers installed into
+	// this (local) deployment. Image mounts are container-run arguments and do not
+	// persist across container recreation, so this set is the source of truth that the
+	// launcher re-applies on every start.
+	//nolint:tagliatelle // JSON key mirrors the "SLC" domain abbreviation.
+	InstalledSLCs []InstalledSLC `json:"installedSlcs,omitempty"`
+}
+
+// InstalledSLC records one installed script language container so the launcher can
+// re-apply its image mount on every start and enforce alias uniqueness across the set.
+type InstalledSLC struct {
+	// Language is the catalog key (e.g. "python").
+	Language string `json:"language"`
+	// Flavor is the image flavor token (e.g. "python-3.12").
+	Flavor string `json:"flavor"`
+	// Version is the catalog version this SLC was resolved from.
+	Version string `json:"version"`
+	// Image is the full container image reference to mount.
+	Image string `json:"image"`
+	// Target is the mount destination inside the database container.
+	Target string `json:"target"`
+	// Aliases are all aliases the SLC declares (used for collision detection).
+	Aliases []string `json:"aliases"`
 }
 
 // DirectoryExasolPersonalStatefile.

--- a/internal/deploy/local_runtime.go
+++ b/internal/deploy/local_runtime.go
@@ -72,6 +72,11 @@ func startPreparedLocalRuntime(
 		return err
 	}
 	startArgs = append(startArgs, versionCheckArgs...)
+	slcArgs, err := localRunnerSlcArgs(deployment)
+	if err != nil {
+		return err
+	}
+	startArgs = append(startArgs, slcArgs...)
 	if localConfig.Ports != "" {
 		startArgs = append(startArgs, "--ports", localConfig.Ports)
 	}

--- a/internal/deploy/slc.go
+++ b/internal/deploy/slc.go
@@ -1,0 +1,606 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/exasol/exasol-personal/assets/resources"
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/slc"
+)
+
+// ErrSLCNotSupported is returned when SLC management is attempted on a backend that does
+// not support it (only local deployments do, via Podman image mount).
+var ErrSLCNotSupported = errors.New(
+	"script language container management is only supported for local deployments",
+)
+
+// ErrSLCOperationCancelled is returned when the user declines the database-restart prompt.
+var ErrSLCOperationCancelled = errors.New("operation cancelled")
+
+// ErrDeploymentNotPresent is returned when an SLC change operation (install/update/remove)
+// is attempted on a deployment that has only been initialized, never deployed. SLC
+// management operates on a deployed database, so there is nothing to change — and, crucially,
+// no launcher state is recorded in this case.
+var ErrDeploymentNotPresent = errors.New(
+	"deployment is not present; run `exasol deploy` first",
+)
+
+// requireDeploymentPresent rejects an SLC change operation when the deployment has been
+// initialized but not deployed yet. It is called before any state is read for modification
+// so a not-yet-deployed deployment fails cleanly without recording anything.
+func requireDeploymentPresent(deployment config.DeploymentDir) error {
+	state, err := config.ReadExasolPersonalState(deployment)
+	if err != nil {
+		return err
+	}
+	workflowState, err := state.GetWorkflowState()
+	if err != nil {
+		return err
+	}
+	if _, notDeployed := workflowState.(*config.WorkflowStateInitialized); notDeployed {
+		return ErrDeploymentNotPresent
+	}
+
+	return nil
+}
+
+// ConfirmFunc asks the user to confirm a database restart. It is invoked only when an
+// operation would restart a *running* database, after validation and before any state is
+// written. Returning false aborts with ErrSLCOperationCancelled. A nil ConfirmFunc means
+// "already confirmed" (e.g. the caller passed --yes).
+type ConfirmFunc func() (bool, error)
+
+func confirmOrCancel(confirm ConfirmFunc) error {
+	if confirm == nil {
+		return nil
+	}
+	ok, err := confirm()
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return ErrSLCOperationCancelled
+	}
+
+	return nil
+}
+
+// SLCApplyOutcome describes how an install/remove was applied to the running state.
+type SLCApplyOutcome int
+
+const (
+	// SLCApplyRestarted means the running database was stopped and started again.
+	SLCApplyRestarted SLCApplyOutcome = iota
+	// SLCApplyStarted means a stopped database was started to apply the change.
+	SLCApplyStarted
+	// SLCApplyDeferred means the change was persisted but the (stopped) database was not
+	// started; it will take effect on the next start.
+	SLCApplyDeferred
+)
+
+// SLCInstallResult reports the outcome of an install.
+type SLCInstallResult struct {
+	Entry config.InstalledSLC
+	// AlreadyInstalled is true when the exact resolved image is already installed, so the
+	// install was a no-op (no state change, no restart).
+	AlreadyInstalled bool
+	Replaced         bool
+	Outcome          SLCApplyOutcome
+}
+
+// SLCRemoveResult reports the outcome of a remove.
+type SLCRemoveResult struct {
+	Found   bool
+	Entry   config.InstalledSLC
+	Outcome SLCApplyOutcome
+}
+
+// SLCUpdateResult reports the outcome of an update.
+type SLCUpdateResult struct {
+	// Found is false when no installed SLC matches the alias.
+	Found bool
+	// Unchanged is true when the resolved image already matches the installed one.
+	Unchanged bool
+	// FromFlavor/FromVersion describe the previously installed SLC (for reporting).
+	FromFlavor  string
+	FromVersion string
+	// Entry is the newly installed SLC.
+	Entry   config.InstalledSLC
+	Outcome SLCApplyOutcome
+}
+
+// SLCStatus describes one catalog SLC and whether it is installed in this deployment.
+type SLCStatus struct {
+	Language  string
+	Flavor    string
+	Version   string
+	Aliases   []string
+	Installed bool
+}
+
+// InstallSLC resolves an alias against the official SLC catalog, records the SLC in
+// launcher state, and applies it by (re)starting the local database. It returns a
+// clear error (leaving the SLC configured for a later start) if the database cannot be
+// brought up with the mount, rather than reporting success.
+//
+//nolint:revive // restart is a user-controlled flag (--no-restart), not internal control coupling.
+func InstallSLC(
+	ctx context.Context,
+	deployment config.DeploymentDir,
+	alias string,
+	verbose bool,
+	restart bool,
+	confirm ConfirmFunc,
+) (*SLCInstallResult, error) {
+	if !isLocalDeployment(deployment) {
+		return nil, ErrSLCNotSupported
+	}
+	if err := requireDeploymentPresent(deployment); err != nil {
+		return nil, err
+	}
+
+	catalog, err := slc.Load(resources.SLCCatalogYAML)
+	if err != nil {
+		return nil, err
+	}
+	entry, err := catalog.Resolve(alias, runtime.GOARCH)
+	if err != nil {
+		return nil, err
+	}
+
+	state, err := config.ReadExasolPersonalState(deployment)
+	if err != nil {
+		return nil, err
+	}
+
+	// No-op if the exact resolved image is already installed.
+	// no state change and, crucially, no needless database restart.
+	if idx := findInstalledByImage(state.InstalledSLCs, entry.Image); idx >= 0 {
+		return &SLCInstallResult{Entry: state.InstalledSLCs[idx], AlreadyInstalled: true}, nil
+	}
+
+	replaces, err := slc.CheckInstallable(installedEntries(state), entry)
+	if err != nil {
+		return nil, err
+	}
+
+	// Confirm before disrupting a running database. Only prompt when a restart will
+	// actually happen; validation above has already succeeded, so we never prompt for an
+	// install that would fail anyway.
+	if restart && isLocalDeploymentRunning(ctx, deployment) {
+		if err := confirmOrCancel(confirm); err != nil {
+			return nil, err
+		}
+	}
+
+	state.InstalledSLCs = upsertInstalledSLC(state.InstalledSLCs, toInstalledSLC(entry))
+	if err := config.WriteExasolPersonalState(state, deployment); err != nil {
+		return nil, err
+	}
+
+	if !restart {
+		slog.Info(
+			alias+" script language container recorded; it will activate on the next start",
+			"flavor", entry.Flavor,
+		)
+
+		return &SLCInstallResult{
+			Entry:    toInstalledSLC(entry),
+			Replaced: replaces,
+			Outcome:  SLCApplyDeferred,
+		}, nil
+	}
+
+	slog.Info(
+		"installing "+alias+" script language container (this may take a few minutes)",
+		"flavor", entry.Flavor,
+	)
+
+	outcome, err := applySLCChange(ctx, deployment, verbose, true)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to activate SLC %s (it is recorded and will be retried on the next start): %w",
+			entry.Flavor, err,
+		)
+	}
+
+	slog.Info(alias + " script language container is installed")
+
+	return &SLCInstallResult{
+		Entry:    toInstalledSLC(entry),
+		Replaced: replaces,
+		Outcome:  outcome,
+	}, nil
+}
+
+// RemoveSLC removes an installed SLC (matched by alias, language, or flavor) and, if
+// the database is running, restarts it so the change takes effect.
+//
+//nolint:revive // restart is a user-controlled flag (--no-restart), not internal control coupling.
+func RemoveSLC(
+	ctx context.Context,
+	deployment config.DeploymentDir,
+	alias string,
+	verbose bool,
+	restart bool,
+	confirm ConfirmFunc,
+) (*SLCRemoveResult, error) {
+	if !isLocalDeployment(deployment) {
+		return nil, ErrSLCNotSupported
+	}
+	if err := requireDeploymentPresent(deployment); err != nil {
+		return nil, err
+	}
+
+	state, err := config.ReadExasolPersonalState(deployment)
+	if err != nil {
+		return nil, err
+	}
+
+	index := findInstalledSLC(state.InstalledSLCs, alias)
+	if index < 0 {
+		return &SLCRemoveResult{Found: false}, nil
+	}
+
+	// Confirm before disrupting a running database (only when a restart will happen).
+	if restart && isLocalDeploymentRunning(ctx, deployment) {
+		if err := confirmOrCancel(confirm); err != nil {
+			return nil, err
+		}
+	}
+
+	removed := state.InstalledSLCs[index]
+	state.InstalledSLCs = append(
+		state.InstalledSLCs[:index:index],
+		state.InstalledSLCs[index+1:]...,
+	)
+	if err := config.WriteExasolPersonalState(state, deployment); err != nil {
+		return nil, err
+	}
+
+	if !restart {
+		slog.Info(
+			alias+" script language container recorded for removal; it applies on the next start",
+			"flavor", removed.Flavor,
+		)
+
+		return &SLCRemoveResult{Found: true, Entry: removed, Outcome: SLCApplyDeferred}, nil
+	}
+
+	if isLocalDeploymentRunning(ctx, deployment) {
+		slog.Info(
+			"removing "+alias+" script language container (this may take a few minutes)",
+			"flavor", removed.Flavor,
+		)
+	}
+
+	outcome, err := applySLCChange(ctx, deployment, verbose, false)
+	if err != nil {
+		return nil, err
+	}
+
+	if outcome == SLCApplyDeferred {
+		slog.Info(
+			alias+" script language container removed; it will no longer load on the next start",
+			"flavor", removed.Flavor,
+		)
+	} else {
+		slog.Info(alias + " script language container is removed")
+	}
+
+	return &SLCRemoveResult{Found: true, Entry: removed, Outcome: outcome}, nil
+}
+
+// UpdateSLC re-resolves an installed SLC against the catalog and, if the resolved image
+// has changed, replaces the installed one and restarts the database to apply it.
+//
+//nolint:revive // restart is a user-controlled flag (--no-restart), not internal control coupling.
+func UpdateSLC(
+	ctx context.Context,
+	deployment config.DeploymentDir,
+	alias string,
+	verbose bool,
+	restart bool,
+	confirm ConfirmFunc,
+) (*SLCUpdateResult, error) {
+	if !isLocalDeployment(deployment) {
+		return nil, ErrSLCNotSupported
+	}
+	if err := requireDeploymentPresent(deployment); err != nil {
+		return nil, err
+	}
+
+	catalog, err := slc.Load(resources.SLCCatalogYAML)
+	if err != nil {
+		return nil, err
+	}
+	entry, err := catalog.Resolve(alias, runtime.GOARCH)
+	if err != nil {
+		return nil, err
+	}
+
+	state, err := config.ReadExasolPersonalState(deployment)
+	if err != nil {
+		return nil, err
+	}
+
+	index := findInstalledSLC(state.InstalledSLCs, alias)
+	if index < 0 {
+		return &SLCUpdateResult{Found: false}, nil
+	}
+	installed := state.InstalledSLCs[index]
+
+	// Shared no-op test with install: an unchanged (content-addressed) image is nothing to
+	// update.
+	if findInstalledByImage(state.InstalledSLCs, entry.Image) >= 0 {
+		return &SLCUpdateResult{Found: true, Unchanged: true, Entry: installed}, nil
+	}
+
+	// An update can move to a new flavor (e.g. the unversioned alias shifting from
+	// python-3.12 to python-3.13). Check alias-disjointness against the *other* installed
+	// SLCs so replacing this one never falsely collides with itself.
+	remaining := make([]config.InstalledSLC, 0, len(state.InstalledSLCs)-1)
+	remaining = append(remaining, state.InstalledSLCs[:index]...)
+	remaining = append(remaining, state.InstalledSLCs[index+1:]...)
+	if _, err := slc.CheckInstallable(entriesFromInstalled(remaining), entry); err != nil {
+		return nil, err
+	}
+
+	if restart && isLocalDeploymentRunning(ctx, deployment) {
+		if err := confirmOrCancel(confirm); err != nil {
+			return nil, err
+		}
+	}
+
+	result := &SLCUpdateResult{
+		Found:       true,
+		FromFlavor:  installed.Flavor,
+		FromVersion: installed.Version,
+		Entry:       toInstalledSLC(entry),
+	}
+
+	state.InstalledSLCs = upsertInstalledSLC(remaining, toInstalledSLC(entry))
+	if err := config.WriteExasolPersonalState(state, deployment); err != nil {
+		return nil, err
+	}
+
+	if !restart {
+		slog.Info(
+			alias+" script language container update recorded; it will apply on the next start",
+			"flavor", entry.Flavor,
+		)
+		result.Outcome = SLCApplyDeferred
+
+		return result, nil
+	}
+
+	slog.Info(
+		"updating "+alias+" script language container (this may take a few minutes)",
+		"flavor", entry.Flavor,
+	)
+	outcome, err := applySLCChange(ctx, deployment, verbose, true)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to activate updated SLC %s (it is recorded and will be "+
+				"retried on the next start): %w",
+			entry.Flavor,
+			err,
+		)
+	}
+	slog.Info(alias + " script language container is updated")
+	result.Outcome = outcome
+
+	return result, nil
+}
+
+// SLCStatuses returns every SLC in the catalog (for the current architecture) with its
+// installation status in this deployment.
+func SLCStatuses(deployment config.DeploymentDir) ([]SLCStatus, error) {
+	catalog, err := slc.Load(resources.SLCCatalogYAML)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := catalog.List(runtime.GOARCH)
+	// `slc list` degrades gracefully on architectures the catalog has no SLCs for: it
+	// reports "none available" rather than failing (unlike install/update, which need a
+	// concrete SLC and let this error surface).
+	if errors.Is(err, slc.ErrArchitectureUnsupported) {
+		return []SLCStatus{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	installed, err := installedFlavors(deployment)
+	if err != nil {
+		return nil, err
+	}
+
+	statuses := make([]SLCStatus, 0, len(entries))
+	for _, entry := range entries {
+		statuses = append(statuses, SLCStatus{
+			Language:  entry.Language,
+			Flavor:    entry.Flavor,
+			Version:   entry.Version,
+			Aliases:   entry.Aliases,
+			Installed: installed[strings.ToLower(entry.Flavor)],
+		})
+	}
+
+	return statuses, nil
+}
+
+// installedFlavors returns the set of installed SLC flavors (lower-cased) for a deployment.
+// A missing state file is tolerated as "nothing installed" so `slc list` works before the
+// deployment is initialized; a present-but-unreadable state file surfaces as an error rather
+// than silently reporting everything as not installed.
+func installedFlavors(deployment config.DeploymentDir) (map[string]bool, error) {
+	installed := make(map[string]bool)
+
+	has, err := config.HasExasolPersonalStateFile(deployment)
+	if err != nil {
+		return nil, err
+	}
+	if !has {
+		return installed, nil
+	}
+
+	state, err := config.ReadExasolPersonalState(deployment)
+	if err != nil {
+		return nil, err
+	}
+	for _, inst := range state.InstalledSLCs {
+		installed[strings.ToLower(inst.Flavor)] = true
+	}
+
+	return installed, nil
+}
+
+// localRunnerSlcArgs builds the runner "--slc <image>=<target>" start flags from the
+// installed SLC set. This is the mechanism that re-applies mounts on every start.
+func localRunnerSlcArgs(deployment config.DeploymentDir) ([]string, error) {
+	state, err := config.ReadExasolPersonalState(deployment)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read installed SLCs: %w", err)
+	}
+
+	const argsPerSLC = 2 // each SLC contributes "--slc" plus its "<image>=<target>" value
+	args := make([]string, 0, len(state.InstalledSLCs)*argsPerSLC)
+	for _, installed := range state.InstalledSLCs {
+		args = append(args, "--slc", installed.Image+"="+installed.Target)
+	}
+
+	return args, nil
+}
+
+// applySLCChange (re)starts the local database so a changed SLC set takes effect. Success
+// is verified through the readiness wait inside Start: init-db.sh fails - and the database
+// never becomes ready - if an image cannot be pulled or two SLCs collide, so a successful
+// start confirms the change applied.
+//
+//nolint:revive // ensureRunning selects apply semantics (start vs. defer), not internal control coupling.
+func applySLCChange(
+	ctx context.Context,
+	deployment config.DeploymentDir,
+	verbose bool,
+	ensureRunning bool,
+) (SLCApplyOutcome, error) {
+	if isLocalDeploymentRunning(ctx, deployment) {
+		if err := Stop(ctx, deployment, verbose); err != nil {
+			return 0, err
+		}
+		if err := Start(ctx, deployment, verbose, StartedDefaultTimeoutSeconds); err != nil {
+			return 0, err
+		}
+
+		return SLCApplyRestarted, nil
+	}
+
+	if !ensureRunning {
+		return SLCApplyDeferred, nil
+	}
+
+	if err := Start(ctx, deployment, verbose, StartedDefaultTimeoutSeconds); err != nil {
+		return 0, err
+	}
+
+	return SLCApplyStarted, nil
+}
+
+func isLocalDeploymentRunning(ctx context.Context, deployment config.DeploymentDir) bool {
+	status, err := getLocalVMStatus(ctx, deployment)
+	if err != nil {
+		return false
+	}
+
+	return status.Running
+}
+
+func installedEntries(state *config.ExasolPersonalState) []slc.Entry {
+	return entriesFromInstalled(state.InstalledSLCs)
+}
+
+func entriesFromInstalled(installed []config.InstalledSLC) []slc.Entry {
+	entries := make([]slc.Entry, 0, len(installed))
+	for _, inst := range installed {
+		entries = append(entries, slc.Entry{
+			Language: inst.Language,
+			Flavor:   inst.Flavor,
+			Version:  inst.Version,
+			Image:    inst.Image,
+			Target:   inst.Target,
+			Aliases:  inst.Aliases,
+		})
+	}
+
+	return entries
+}
+
+func toInstalledSLC(entry slc.Entry) config.InstalledSLC {
+	return config.InstalledSLC{
+		Language: entry.Language,
+		Flavor:   entry.Flavor,
+		Version:  entry.Version,
+		Image:    entry.Image,
+		Target:   entry.Target,
+		Aliases:  entry.Aliases,
+	}
+}
+
+func upsertInstalledSLC(
+	existing []config.InstalledSLC,
+	entry config.InstalledSLC,
+) []config.InstalledSLC {
+	updated := make([]config.InstalledSLC, 0, len(existing)+1)
+	for _, s := range existing {
+		if strings.EqualFold(s.Flavor, entry.Flavor) {
+			continue
+		}
+		updated = append(updated, s)
+	}
+	updated = append(updated, entry)
+	sort.Slice(updated, func(i, j int) bool {
+		return updated[i].Flavor < updated[j].Flavor
+	})
+
+	return updated
+}
+
+// findInstalledByImage returns the index of an installed SLC whose image reference exactly
+// matches, or -1. SLC images are content-addressed (the tag embeds a content hash), so an
+// identical reference means identical content — this is the shared no-op test used by both
+// install and update.
+func findInstalledByImage(installed []config.InstalledSLC, image string) int {
+	for idx, inst := range installed {
+		if inst.Image == image {
+			return idx
+		}
+	}
+
+	return -1
+}
+
+func findInstalledSLC(installed []config.InstalledSLC, alias string) int {
+	needle := strings.TrimSpace(alias)
+	for idx, inst := range installed {
+		if strings.EqualFold(inst.Language, needle) || strings.EqualFold(inst.Flavor, needle) {
+			return idx
+		}
+		for _, declared := range inst.Aliases {
+			if strings.EqualFold(declared, needle) {
+				return idx
+			}
+		}
+	}
+
+	return -1
+}

--- a/internal/deploy/slc.go
+++ b/internal/deploy/slc.go
@@ -56,7 +56,7 @@ func requireDeploymentPresent(deployment config.DeploymentDir) error {
 // ConfirmFunc asks the user to confirm a database restart. It is invoked only when an
 // operation would restart a *running* database, after validation and before any state is
 // written. Returning false aborts with ErrSLCOperationCancelled. A nil ConfirmFunc means
-// "already confirmed" (e.g. the caller passed --yes).
+// "already confirmed" (e.g. the caller passed --auto-approve).
 type ConfirmFunc func() (bool, error)
 
 func confirmOrCancel(confirm ConfirmFunc) error {
@@ -89,9 +89,7 @@ const (
 
 // SLCInstallResult reports the outcome of an install.
 type SLCInstallResult struct {
-	Entry config.InstalledSLC
-	// AlreadyInstalled is true when the exact resolved image is already installed, so the
-	// install was a no-op (no state change, no restart).
+	Entry            config.InstalledSLC
 	AlreadyInstalled bool
 	Replaced         bool
 	Outcome          SLCApplyOutcome
@@ -106,16 +104,12 @@ type SLCRemoveResult struct {
 
 // SLCUpdateResult reports the outcome of an update.
 type SLCUpdateResult struct {
-	// Found is false when no installed SLC matches the alias.
-	Found bool
-	// Unchanged is true when the resolved image already matches the installed one.
-	Unchanged bool
-	// FromFlavor/FromVersion describe the previously installed SLC (for reporting).
+	Found       bool
+	Unchanged   bool
 	FromFlavor  string
 	FromVersion string
-	// Entry is the newly installed SLC.
-	Entry   config.InstalledSLC
-	Outcome SLCApplyOutcome
+	Entry       config.InstalledSLC
+	Outcome     SLCApplyOutcome
 }
 
 // SLCStatus describes one catalog SLC and whether it is installed in this deployment.
@@ -162,8 +156,7 @@ func InstallSLC(
 		return nil, err
 	}
 
-	// No-op if the exact resolved image is already installed.
-	// no state change and, crucially, no needless database restart.
+	// An identical already-installed image is a no-op: no state change, no restart.
 	if idx := findInstalledByImage(state.InstalledSLCs, entry.Image); idx >= 0 {
 		return &SLCInstallResult{Entry: state.InstalledSLCs[idx], AlreadyInstalled: true}, nil
 	}
@@ -483,9 +476,9 @@ func localRunnerSlcArgs(deployment config.DeploymentDir) ([]string, error) {
 }
 
 // applySLCChange (re)starts the local database so a changed SLC set takes effect. Success
-// is verified through the readiness wait inside Start: init-db.sh fails - and the database
-// never becomes ready - if an image cannot be pulled or two SLCs collide, so a successful
-// start confirms the change applied.
+// is verified through the readiness wait inside Start: startup fails, and the database never
+// becomes ready, if an image cannot be pulled or two SLCs collide, so a successful start
+// confirms the change applied.
 //
 //nolint:revive // ensureRunning selects apply semantics (start vs. defer), not internal control coupling.
 func applySLCChange(

--- a/internal/deploy/slc_test.go
+++ b/internal/deploy/slc_test.go
@@ -1,0 +1,200 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+)
+
+func TestInstalledFlavors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing state file is tolerated as nothing installed", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := installedFlavors(config.NewDeploymentDir(t.TempDir()))
+		if err != nil {
+			t.Fatalf("expected no error for a missing state file, got %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("expected an empty set, got %v", got)
+		}
+	})
+
+	t.Run("installed flavors are reported lower-cased", func(t *testing.T) {
+		t.Parallel()
+
+		deployment := config.NewDeploymentDir(t.TempDir())
+		state := &config.ExasolPersonalState{
+			DeploymentVersion: "0.0.0",
+			InstalledSLCs:     []config.InstalledSLC{{Flavor: "Python-3.12"}},
+		}
+		if err := config.WriteExasolPersonalState(state, deployment); err != nil {
+			t.Fatalf("failed to write state: %v", err)
+		}
+
+		got, err := installedFlavors(deployment)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !got["python-3.12"] {
+			t.Fatalf("expected python-3.12 to be reported installed, got %v", got)
+		}
+	})
+
+	t.Run("corrupt state file surfaces an error", func(t *testing.T) {
+		t.Parallel()
+
+		deployment := config.NewDeploymentDir(t.TempDir())
+		path := deployment.ExasolPersonalStatePath()
+		if err := os.WriteFile(path, []byte("{not json"), 0o600); err != nil {
+			t.Fatalf("failed to write corrupt state: %v", err)
+		}
+
+		if _, err := installedFlavors(deployment); err == nil {
+			t.Fatal("expected an error for a corrupt state file, got nil")
+		}
+	})
+}
+
+// requireDeploymentPresent guards SLC change operations: a deployment that has only been
+// initialized (never deployed) must be rejected with ErrDeploymentNotPresent, and only a
+// deployed deployment is allowed to proceed.
+func TestRequireDeploymentPresent(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		state   any
+		wantErr bool
+	}{
+		"initialized but not deployed": {state: &config.WorkflowStateInitialized{}, wantErr: true},
+		"deployed and stopped":         {state: &config.WorkflowStateStopped{}, wantErr: false},
+		"deployed and running":         {state: &config.WorkflowStateRunning{}, wantErr: false},
+	}
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			deployment := config.NewDeploymentDir(t.TempDir())
+			state := &config.ExasolPersonalState{DeploymentVersion: "0.0.0"}
+			if err := state.SetWorkflowStateAndWrite(test.state, deployment); err != nil {
+				t.Fatalf("failed to write launcher state: %v", err)
+			}
+
+			err := requireDeploymentPresent(deployment)
+			if test.wantErr && !errors.Is(err, ErrDeploymentNotPresent) {
+				t.Fatalf("expected ErrDeploymentNotPresent, got %v", err)
+			}
+			if !test.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestUpsertInstalledSLCAppendsSortedAndReplacesSameFlavor(t *testing.T) {
+	t.Parallel()
+
+	existing := []config.InstalledSLC{
+		{Language: "python", Flavor: "python-3.12", Image: "img:old", Aliases: []string{"PYTHON3"}},
+	}
+
+	withJava := upsertInstalledSLC(existing, config.InstalledSLC{
+		Language: "java", Flavor: "java-17", Image: "img:java", Aliases: []string{"JAVA"},
+	})
+	if len(withJava) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(withJava))
+	}
+	if withJava[0].Flavor != "java-17" || withJava[1].Flavor != "python-3.12" {
+		t.Errorf("expected sorted [java-17, python-3.12], got [%s, %s]",
+			withJava[0].Flavor, withJava[1].Flavor)
+	}
+
+	replaced := upsertInstalledSLC(withJava, config.InstalledSLC{
+		Language: "python", Flavor: "python-3.12", Image: "img:new",
+		Aliases: []string{"PYTHON3", "PYTHON312"},
+	})
+	if len(replaced) != 2 {
+		t.Fatalf("expected replace to keep 2 entries, got %d", len(replaced))
+	}
+	for _, entry := range replaced {
+		if entry.Flavor == "python-3.12" && entry.Image != "img:new" {
+			t.Errorf("expected python-3.12 image to be replaced with img:new, got %q", entry.Image)
+		}
+	}
+}
+
+func TestFindInstalledSLCMatchesAliasLanguageAndFlavor(t *testing.T) {
+	t.Parallel()
+
+	installed := []config.InstalledSLC{
+		{Language: "python", Flavor: "python-3.12", Aliases: []string{"PYTHON3", "PYTHON312"}},
+	}
+
+	cases := map[string]int{
+		"python3":     0,
+		"PYTHON312":   0,
+		"python":      0,
+		"python-3.12": 0,
+		"java":        -1,
+	}
+	for needle, want := range cases {
+		if got := findInstalledSLC(installed, needle); got != want {
+			t.Errorf("findInstalledSLC(%q) = %d, want %d", needle, got, want)
+		}
+	}
+}
+
+func TestFindInstalledByImage(t *testing.T) {
+	t.Parallel()
+
+	installed := []config.InstalledSLC{
+		{Flavor: "python-3.12", Image: "docker.io/x:pytag"},
+		{Flavor: "java-17", Image: "docker.io/x:javatag"},
+	}
+
+	if got := findInstalledByImage(installed, "docker.io/x:javatag"); got != 1 {
+		t.Errorf("findInstalledByImage(existing) = %d, want 1", got)
+	}
+	if got := findInstalledByImage(installed, "docker.io/x:missing"); got != -1 {
+		t.Errorf("findInstalledByImage(missing) = %d, want -1", got)
+	}
+}
+
+func TestLocalRunnerSlcArgsFromState(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	state := &config.ExasolPersonalState{
+		InstalledSLCs: []config.InstalledSLC{
+			{Flavor: "python-3.12", Image: "docker.io/x:pytag", Target: "/exa/slc/python-3.12"},
+			{Flavor: "java-17", Image: "docker.io/x:javatag", Target: "/exa/slc/java-17"},
+		},
+	}
+	if err := config.WriteExasolPersonalState(state, deployment); err != nil {
+		t.Fatalf("failed to write state: %v", err)
+	}
+
+	args, err := localRunnerSlcArgs(deployment)
+	if err != nil {
+		t.Fatalf("localRunnerSlcArgs error: %v", err)
+	}
+
+	want := []string{
+		"--slc", "docker.io/x:pytag=/exa/slc/python-3.12",
+		"--slc", "docker.io/x:javatag=/exa/slc/java-17",
+	}
+	if len(args) != len(want) {
+		t.Fatalf("args = %v, want %v", args, want)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Errorf("args[%d] = %q, want %q", i, args[i], want[i])
+		}
+	}
+}

--- a/internal/slc/catalog.go
+++ b/internal/slc/catalog.go
@@ -43,7 +43,7 @@ type Version struct {
 }
 
 // Language describes a single flavor: its image flavor token, content hash, and the
-// aliases it declares in build_info/language_definitions.json.
+// aliases it declares.
 type Language struct {
 	Flavor  string   `yaml:"flavor"`
 	Hash    string   `yaml:"hash"`
@@ -52,18 +52,12 @@ type Language struct {
 
 // Entry is a fully resolved SLC ready to be mounted.
 type Entry struct {
-	// Language is the catalog key (e.g. "python").
 	Language string
-	// Flavor is the image flavor token (e.g. "python-3.12").
-	Flavor string
-	// Version is the catalog version the entry was resolved from.
-	Version string
-	// Image is the full container image reference (registry:tag).
-	Image string
-	// Target is the mount destination inside the database container.
-	Target string
-	// Aliases are all aliases the SLC declares.
-	Aliases []string
+	Flavor   string
+	Version  string
+	Image    string
+	Target   string
+	Aliases  []string
 }
 
 // ErrArchitectureUnsupported reports that the catalog has no SLCs for a given

--- a/internal/slc/catalog.go
+++ b/internal/slc/catalog.go
@@ -1,0 +1,212 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+// Package slc implements the launcher-owned script language container component:
+// parsing the official SLC catalog, resolving a user-supplied alias to a concrete
+// container image, and enforcing the alias-uniqueness rule that lets multiple SLCs
+// coexist. It is deliberately free of deployment/backend dependencies so the logic
+// is pure and unit-testable; the deploy layer bridges it to launcher state and the
+// local runtime.
+package slc
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// slcMountRoot is the directory the database scans for built-in script language
+// containers. Each SLC is mounted at slcMountRoot/<flavor>.
+const slcMountRoot = "/exa/slc"
+
+// Catalog is the parsed representation of slc-catalog.yaml.
+type Catalog struct {
+	Registry string `yaml:"registry"`
+	//nolint:tagliatelle // YAML schema uses snake_case field names.
+	TagTemplate   string                  `yaml:"tag_template"`
+	Architectures map[string]Architecture `yaml:"architectures"`
+}
+
+// Architecture holds the SLCs available for one container architecture.
+type Architecture struct {
+	//nolint:tagliatelle // YAML schema uses snake_case field names.
+	DefaultVersion string             `yaml:"default_version"`
+	Versions       map[string]Version `yaml:"versions"`
+}
+
+// Version groups the language flavors shipped in one script-languages-release version.
+type Version struct {
+	Languages map[string]Language `yaml:"languages"`
+}
+
+// Language describes a single flavor: its image flavor token, content hash, and the
+// aliases it declares in build_info/language_definitions.json.
+type Language struct {
+	Flavor  string   `yaml:"flavor"`
+	Hash    string   `yaml:"hash"`
+	Aliases []string `yaml:"aliases"`
+}
+
+// Entry is a fully resolved SLC ready to be mounted.
+type Entry struct {
+	// Language is the catalog key (e.g. "python").
+	Language string
+	// Flavor is the image flavor token (e.g. "python-3.12").
+	Flavor string
+	// Version is the catalog version the entry was resolved from.
+	Version string
+	// Image is the full container image reference (registry:tag).
+	Image string
+	// Target is the mount destination inside the database container.
+	Target string
+	// Aliases are all aliases the SLC declares.
+	Aliases []string
+}
+
+// ErrArchitectureUnsupported reports that the catalog has no SLCs for a given
+// architecture. Callers that must degrade gracefully (e.g. `slc list`) can test for it
+// with errors.Is; operations that require a concrete SLC (install/update) let it surface.
+var ErrArchitectureUnsupported = errors.New("architecture is not supported")
+
+// UnknownAliasError reports an alias that matches no catalog entry.
+type UnknownAliasError struct {
+	Alias        string
+	ValidAliases []string
+}
+
+func (e *UnknownAliasError) Error() string {
+	if len(e.ValidAliases) == 0 {
+		return fmt.Sprintf("unknown SLC alias %q", e.Alias)
+	}
+
+	return fmt.Sprintf(
+		"unknown SLC alias %q; available aliases: %s",
+		e.Alias,
+		strings.Join(e.ValidAliases, ", "),
+	)
+}
+
+// Load parses an SLC catalog from its YAML representation.
+func Load(data []byte) (*Catalog, error) {
+	var catalog Catalog
+	if err := yaml.Unmarshal(data, &catalog); err != nil {
+		return nil, fmt.Errorf("failed to parse SLC catalog: %w", err)
+	}
+
+	if strings.TrimSpace(catalog.Registry) == "" {
+		return nil, errors.New("SLC catalog is missing 'registry'")
+	}
+	if strings.TrimSpace(catalog.TagTemplate) == "" {
+		return nil, errors.New("SLC catalog is missing 'tag_template'")
+	}
+
+	return &catalog, nil
+}
+
+// Resolve maps a user-supplied alias (matched case-insensitively) to a concrete SLC in
+// the architecture's default version.
+func (c *Catalog) Resolve(alias, goarch string) (Entry, error) {
+	normalized := strings.TrimSpace(alias)
+	if normalized == "" {
+		return Entry{}, errors.New("no SLC alias provided")
+	}
+
+	entries, err := c.entries(goarch)
+	if err != nil {
+		return Entry{}, err
+	}
+
+	for _, entry := range entries {
+		for _, candidate := range entry.Aliases {
+			if strings.EqualFold(candidate, normalized) {
+				return entry, nil
+			}
+		}
+	}
+
+	return Entry{}, &UnknownAliasError{
+		Alias:        normalized,
+		ValidAliases: aliasList(entries),
+	}
+}
+
+// List returns every SLC available in the architecture's default version, sorted by
+// language for a stable presentation.
+func (c *Catalog) List(goarch string) ([]Entry, error) {
+	return c.entries(goarch)
+}
+
+func (c *Catalog) entries(goarch string) ([]Entry, error) {
+	arch, ok := c.Architectures[goarch]
+	if !ok {
+		return nil, fmt.Errorf(
+			"no SLCs available for architecture %q: %w",
+			goarch,
+			ErrArchitectureUnsupported,
+		)
+	}
+
+	version := strings.TrimSpace(arch.DefaultVersion)
+	if version == "" {
+		return nil, fmt.Errorf("no default_version set for architecture %q", goarch)
+	}
+
+	langs, ok := arch.Versions[version]
+	if !ok {
+		return nil, fmt.Errorf("default_version %q not found for architecture %q", version, goarch)
+	}
+
+	names := make([]string, 0, len(langs.Languages))
+	for name := range langs.Languages {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	entries := make([]Entry, 0, len(names))
+	for _, name := range names {
+		lang := langs.Languages[name]
+		entries = append(entries, Entry{
+			Language: name,
+			Flavor:   lang.Flavor,
+			Version:  version,
+			Image:    c.imageRef(lang.Flavor, goarch, lang.Hash),
+			Target:   targetDir(lang.Flavor),
+			Aliases:  lang.Aliases,
+		})
+	}
+
+	return entries, nil
+}
+
+func (c *Catalog) imageRef(flavor, goarch, hash string) string {
+	tag := c.TagTemplate
+	tag = strings.ReplaceAll(tag, "{flavor}", flavor)
+	tag = strings.ReplaceAll(tag, "{arch}", goarch)
+	tag = strings.ReplaceAll(tag, "{hash}", hash)
+
+	return c.Registry + ":" + tag
+}
+
+func targetDir(flavor string) string {
+	return slcMountRoot + "/" + flavor
+}
+
+func aliasList(entries []Entry) []string {
+	seen := make(map[string]struct{})
+	var all []string
+	for _, entry := range entries {
+		for _, alias := range entry.Aliases {
+			if _, ok := seen[alias]; ok {
+				continue
+			}
+			seen[alias] = struct{}{}
+			all = append(all, alias)
+		}
+	}
+	sort.Strings(all)
+
+	return all
+}

--- a/internal/slc/catalog_test.go
+++ b/internal/slc/catalog_test.go
@@ -1,0 +1,229 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package slc_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/exasol/exasol-personal/assets/resources"
+	"github.com/exasol/exasol-personal/internal/slc"
+)
+
+const testCatalog = `
+registry: docker.io/exasol/script-language-container
+tag_template: "standard-EXASOL-all-{flavor}-release_{arch}_{hash}"
+architectures:
+  arm64:
+    default_version: "11.2.0"
+    versions:
+      "11.2.0":
+        languages:
+          python:
+            flavor: python-3.12
+            hash: PYHASH
+            aliases: [PYTHON3, PYTHON312]
+          java:
+            flavor: java-17
+            hash: JAVAHASH
+            aliases: [JAVA, JAVA17]
+          r:
+            flavor: r-4.4
+            hash: RHASH
+            aliases: [R, R44]
+`
+
+func mustLoad(t *testing.T) *slc.Catalog {
+	t.Helper()
+	catalog, err := slc.Load([]byte(testCatalog))
+	if err != nil {
+		t.Fatalf("Load returned unexpected error: %v", err)
+	}
+
+	return catalog
+}
+
+func TestResolveResolvesAliasToImageAndTarget(t *testing.T) {
+	t.Parallel()
+
+	catalog := mustLoad(t)
+
+	entry, err := catalog.Resolve("python3", "arm64")
+	if err != nil {
+		t.Fatalf("Resolve returned unexpected error: %v", err)
+	}
+
+	wantImage := "docker.io/exasol/script-language-container:" +
+		"standard-EXASOL-all-python-3.12-release_arm64_PYHASH"
+	if entry.Image != wantImage {
+		t.Errorf("Image = %q, want %q", entry.Image, wantImage)
+	}
+	if entry.Target != "/exa/slc/python-3.12" {
+		t.Errorf("Target = %q, want %q", entry.Target, "/exa/slc/python-3.12")
+	}
+	if entry.Flavor != "python-3.12" {
+		t.Errorf("Flavor = %q, want %q", entry.Flavor, "python-3.12")
+	}
+}
+
+func TestResolveIsCaseInsensitiveAndMatchesVersionedAlias(t *testing.T) {
+	t.Parallel()
+
+	catalog := mustLoad(t)
+
+	lower, err := catalog.Resolve("python3", "arm64")
+	if err != nil {
+		t.Fatalf("Resolve(python3) error: %v", err)
+	}
+	upper, err := catalog.Resolve("PYTHON3", "arm64")
+	if err != nil {
+		t.Fatalf("Resolve(PYTHON3) error: %v", err)
+	}
+	versioned, err := catalog.Resolve("python312", "arm64")
+	if err != nil {
+		t.Fatalf("Resolve(python312) error: %v", err)
+	}
+
+	if lower.Flavor != upper.Flavor || lower.Flavor != versioned.Flavor {
+		t.Errorf("expected python3/PYTHON3/python312 to resolve to the same flavor, got %q/%q/%q",
+			lower.Flavor, upper.Flavor, versioned.Flavor)
+	}
+}
+
+func TestResolveUnknownAliasListsValidAliases(t *testing.T) {
+	t.Parallel()
+
+	catalog := mustLoad(t)
+
+	_, err := catalog.Resolve("nodejs", "arm64")
+
+	var unknown *slc.UnknownAliasError
+	if !errors.As(err, &unknown) {
+		t.Fatalf("expected UnknownAliasError, got %v", err)
+	}
+	if len(unknown.ValidAliases) == 0 {
+		t.Error("expected UnknownAliasError to list valid aliases")
+	}
+}
+
+func TestResolveUnsupportedArchitecture(t *testing.T) {
+	t.Parallel()
+
+	catalog := mustLoad(t)
+
+	_, err := catalog.Resolve("python3", "amd64")
+	if err == nil {
+		t.Fatal("expected an error resolving on an unsupported architecture")
+	}
+	if !errors.Is(err, slc.ErrArchitectureUnsupported) {
+		t.Errorf("expected ErrArchitectureUnsupported, got %v", err)
+	}
+}
+
+func TestListUnsupportedArchitectureReturnsSentinel(t *testing.T) {
+	t.Parallel()
+
+	catalog := mustLoad(t)
+
+	_, err := catalog.List("amd64")
+	if !errors.Is(err, slc.ErrArchitectureUnsupported) {
+		t.Errorf("expected ErrArchitectureUnsupported, got %v", err)
+	}
+}
+
+func TestListReturnsAllFlavorsSorted(t *testing.T) {
+	t.Parallel()
+
+	catalog := mustLoad(t)
+
+	entries, err := catalog.List("arm64")
+	if err != nil {
+		t.Fatalf("List error: %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(entries))
+	}
+	if entries[0].Language != "java" || entries[1].Language != "python" ||
+		entries[2].Language != "r" {
+		t.Errorf("expected entries sorted java,python,r; got %q,%q,%q",
+			entries[0].Language, entries[1].Language, entries[2].Language)
+	}
+}
+
+func TestEmbeddedCatalogResolvesPython3(t *testing.T) {
+	t.Parallel()
+
+	catalog, err := slc.Load(resources.SLCCatalogYAML)
+	if err != nil {
+		t.Fatalf("failed to load embedded SLC catalog: %v", err)
+	}
+
+	entry, err := catalog.Resolve("python3", "arm64")
+	if err != nil {
+		t.Fatalf("failed to resolve python3 against embedded catalog: %v", err)
+	}
+	if entry.Flavor != "python-3.12" {
+		t.Errorf("embedded catalog python3 Flavor = %q, want python-3.12", entry.Flavor)
+	}
+}
+
+func TestCheckInstallableRejectsSharedAliasAcrossFlavors(t *testing.T) {
+	t.Parallel()
+
+	installed := []slc.Entry{
+		{Flavor: "python-3.12", Aliases: []string{"PYTHON3", "PYTHON312"}},
+	}
+	candidate := slc.Entry{Flavor: "python-3.10", Aliases: []string{"PYTHON3", "PYTHON310"}}
+
+	if _, err := slc.CheckInstallable(installed, candidate); err == nil {
+		t.Error("expected collision error for shared PYTHON3 alias across flavors")
+	}
+}
+
+func TestCheckInstallableRejectsSharedVersionedAlias(t *testing.T) {
+	t.Parallel()
+
+	installed := []slc.Entry{
+		{Flavor: "python-3.12", Aliases: []string{"PYTHON312"}},
+	}
+	candidate := slc.Entry{Flavor: "other-flavor", Aliases: []string{"PYTHON312"}}
+
+	if _, err := slc.CheckInstallable(installed, candidate); err == nil {
+		t.Error("expected collision error for a shared versioned alias, not only unversioned")
+	}
+}
+
+func TestCheckInstallableSameFlavorReplaces(t *testing.T) {
+	t.Parallel()
+
+	installed := []slc.Entry{
+		{Flavor: "python-3.12", Aliases: []string{"PYTHON3", "PYTHON312"}},
+	}
+	candidate := slc.Entry{Flavor: "python-3.12", Aliases: []string{"PYTHON3", "PYTHON312"}}
+
+	replaces, err := slc.CheckInstallable(installed, candidate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !replaces {
+		t.Error("expected replacesFlavor=true when reinstalling the same flavor")
+	}
+}
+
+func TestCheckInstallableDisjointIsAllowed(t *testing.T) {
+	t.Parallel()
+
+	installed := []slc.Entry{
+		{Flavor: "python-3.12", Aliases: []string{"PYTHON3", "PYTHON312"}},
+	}
+	candidate := slc.Entry{Flavor: "java-17", Aliases: []string{"JAVA", "JAVA17"}}
+
+	replaces, err := slc.CheckInstallable(installed, candidate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if replaces {
+		t.Error("expected replacesFlavor=false for a disjoint new flavor")
+	}
+}

--- a/internal/slc/collision.go
+++ b/internal/slc/collision.go
@@ -11,9 +11,8 @@ import (
 // CheckInstallable determines whether a candidate SLC can be installed given the set of
 // already-installed SLCs.
 //
-// The database refuses to start if two mounted SLCs declare the same alias
-// (SlcConfig::createBuiltinNameMap throws at engine init), so the installed set must stay
-// disjoint across all declared aliases.
+// The database refuses to start if two mounted SLCs declare the same alias (it throws at
+// engine init), so the installed set must stay disjoint across all declared aliases.
 //
 // It returns replacesFlavor=true when the candidate is a (new version of an)
 // already-installed flavor; the caller should then replace that entry rather than add a

--- a/internal/slc/collision.go
+++ b/internal/slc/collision.go
@@ -1,0 +1,53 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package slc
+
+import (
+	"fmt"
+	"strings"
+)
+
+// CheckInstallable determines whether a candidate SLC can be installed given the set of
+// already-installed SLCs.
+//
+// The database refuses to start if two mounted SLCs declare the same alias
+// (SlcConfig::createBuiltinNameMap throws at engine init), so the installed set must stay
+// disjoint across all declared aliases.
+//
+// It returns replacesFlavor=true when the candidate is a (new version of an)
+// already-installed flavor; the caller should then replace that entry rather than add a
+// second one. It returns an error when the candidate shares any alias with a *different*
+// installed flavor.
+//
+//nolint:nonamedreturns // named returns document the replace-vs-add / collision result.
+func CheckInstallable(installed []Entry, candidate Entry) (replacesFlavor bool, err error) {
+	for _, existing := range installed {
+		if strings.EqualFold(existing.Flavor, candidate.Flavor) {
+			replacesFlavor = true
+
+			continue
+		}
+
+		if shared := sharedAlias(existing.Aliases, candidate.Aliases); shared != "" {
+			return false, fmt.Errorf(
+				"cannot install %s: alias %q is already provided by installed SLC %s",
+				candidate.Flavor, shared, existing.Flavor,
+			)
+		}
+	}
+
+	return replacesFlavor, nil
+}
+
+func sharedAlias(a, b []string) string {
+	for _, x := range a {
+		for _, y := range b {
+			if strings.EqualFold(x, y) {
+				return strings.ToUpper(x)
+			}
+		}
+	}
+
+	return ""
+}

--- a/openspec/changes/add-local-slc-support/design.md
+++ b/openspec/changes/add-local-slc-support/design.md
@@ -1,0 +1,196 @@
+# Design — Local SLC support (Workflow 1: official, local, image mount)
+
+## Context
+
+Local deployments run nano inside a QEMU VM managed by an embedded runner
+(`exasol-local-vm`). The launcher never runs Podman directly; the runner boots the VM and
+`init-db.sh` (from the runner's embedded assets) issues the single `podman run` that
+starts the nano database container. Script language aliases are read by the database from
+each SLC's `build_info/language_definitions.json`; the nano `admini` component scans
+`/exa/slc` on start and auto-registers builtin aliases (verified in code:
+`db/COSMock/src/admini`). No `ALTER SYSTEM` is required for official SLCs.
+
+This change adds official SLC installation for local deployments only. It is deliberately
+one lane of the broader SLC design (custom SLCs, cloud, and the tarball + `ALTER SYSTEM`
+path are out of scope here).
+
+## Goals
+
+- `exasol slc install <alias>` / `list` / `update <alias>` / `remove <alias>` for official
+  SLCs, local only.
+- Activation with no manual SQL (rely on the builtin `/exa/slc` scan).
+- Robust database-container recreation (an install must never leave the DB unable to start).
+
+## Non-Goals
+
+- Custom (user-built) SLCs, and the tarball-unpack + `ALTER SYSTEM` path.
+- Cloud / tofu backends; amd64 / Windows / Linux hosts (local is darwin/arm64 only today).
+- Explicit version pinning UX (`alias@version`); the alias always resolves to the
+  catalog's `default_version`. Retained older versions exist only for future rollback.
+- Simultaneous multiple versions of the same flavor (they share aliases and cannot coexist).
+- Consuming a release manifest (none exists yet); the pinned static catalog is the interim.
+
+## Install flow
+
+```
+exasol slc install python3
+  1. launcher resolves alias -> {image, target} from slc-catalog.yaml
+  2. launcher collision-check: installed set must stay alias-disjoint
+  3. launcher records the SLC in launcher state
+  4. launcher stops then starts the deployment (via the runner)
+  5. runner writes vm-shared/slc.json from --slc start flags
+  6. init-db.sh reads slc.json, force-recreates the container with --mount type=image
+     (podman pulls the image inside the VM), mounting it at /exa/slc/<target>
+  7. nano admini scans /exa/slc -> registers PYTHON3; launcher waits-for-ready and verifies
+```
+
+Image mounts are `podman run` arguments and are not persisted into `/exa`; the launcher
+therefore re-passes the full installed set on every start (step 4-5), reconstructed from
+launcher state — analogous to how version-check settings are re-passed today.
+
+## Cross-repo contract (exasol-local-vm)
+
+The runner change is small and additive. Backward compatibility rule: when no SLCs are
+requested, behavior is byte-for-byte identical to today.
+
+**1. Runner `start` flag (mac runner, `launcher/mac/main.go`).**
+Add a repeatable `--slc` flag; each value encodes one mount as `<image>=<target>` (image
+references contain no `=`; targets are absolute paths with no `=`, so `=` is an
+unambiguous separator — split on the first `=`). The launcher passes one `--slc` per
+installed SLC. Mirror `writeVersionCheckRuntimeConfig`: add `writeSlcRuntimeConfig` that
+writes the shared file.
+
+**2. `vm-shared/slc.json`** (written by the runner, read by `init-db.sh`):
+```json
+{ "slc": [ { "image": "docker.io/exasol/script-language-container:standard-EXASOL-all-python-3.12-release_arm64_GM7DI5...ISZQ",
+             "target": "/exa/slc/python312" } ] }
+```
+Absent or `{"slc":[]}` means "no SLCs" and must be treated identically to today.
+
+**3. `init-db.sh` — read the list.** After the existing config parsing, add:
+```sh
+SLC_CONFIG_FILE="$EXASOL_VM_HOST_SHARED_DIR/slc.json"
+build_slc_mount_args() {   # prints repeated: --mount type=image,source=<img>,destination=<dst>
+  [ -f "$SLC_CONFIG_FILE" ] || return 0
+  count=$(jq -r '.slc // [] | length' "$SLC_CONFIG_FILE") || return 1
+  i=0
+  while [ "$i" -lt "$count" ]; do
+    img=$(jq -er ".slc[$i].image"  "$SLC_CONFIG_FILE") || return 1
+    dst=$(jq -er ".slc[$i].target" "$SLC_CONFIG_FILE") || return 1
+    printf '%s\n' "--mount" "type=image,source=$img,destination=$dst"
+    i=$((i + 1))
+  done
+}
+```
+Accumulate into positional parameters (the file already uses the `set --` idiom) so values
+are never re-split by the shell.
+
+**4. `init-db.sh` — harden the recreate.** Replace the current soft removal
+(`podman rm … || true`, lines ~350-353) with a forced, verified removal, and add
+`--replace` to `podman run`:
+```sh
+if podman container exists "$DB_CONTAINER_NAME"; then
+  log_msg "Removing existing container $DB_CONTAINER_NAME to recreate it fresh"
+  podman rm -f "$DB_CONTAINER_NAME" || { log_msg "Error: failed to remove $DB_CONTAINER_NAME"; log_diagnostics; exit 1; }
+fi
+if podman container exists "$DB_CONTAINER_NAME"; then
+  log_msg "Error: $DB_CONTAINER_NAME still present after removal; aborting"; exit 1
+fi
+# podman run -d --replace ... <existing args> $SLC_MOUNT_ARGS "$@"
+```
+Rationale: a stale container (from an unclean VM kill) otherwise makes `podman run --name`
+fail with a name conflict, so the new SLC-mounted container never starts. `rm -f` handles
+any container state; the post-removal check and `exit 1` replace the failure-swallowing
+`|| true`; `--replace` is defense-in-depth against a race.
+
+**5. Re-embed the runner** into exasol-personal via `tools/localrunner` after the change.
+
+## exasol-personal design
+
+- **Catalog** (`assets/resources/slc-catalog.yaml`, already added): embedded like
+  `resources.yaml`. Loader resolves an alias to `{image ref, target dir, declared aliases}`
+  using `default_version` and the flavor's `aliases` list.
+- **Alias resolution**: case-insensitive match against declared aliases
+  (`PYTHON3, PYTHON312, JAVA, JAVA17, R, R44`). Unknown alias → error listing valid aliases.
+- **Target directory**: derived deterministically from the flavor (e.g.
+  `/exa/slc/python312`); free-form as far as the DB is concerned (aliases come from the
+  image), must be unique per installed SLC, and MUST NOT start with `current-` (that prefix
+  is reserved by the runner's managed `current-java` anchor and is skipped by the scan).
+- **State**: the installed SLC set is persisted in launcher state in the deployment
+  directory and is the source of truth re-applied on every start.
+- **Collision rule (full alias-disjointness)**: the set of mounted SLCs MUST be disjoint
+  across *all* declared aliases — versioned and unversioned — because the DB throws at
+  engine init on *any* duplicate alias (`SlcConfig::createBuiltinNameMap`), not only on a
+  duplicated unversioned one. Before an install the launcher compares the candidate SLC's
+  full alias set against that of every already-installed SLC: a newer version of an
+  already-installed flavor **replaces** the incumbent; any other overlap is **rejected**
+  with a clear message naming the conflicting alias and the SLC that already owns it. Alias
+  sets are read per installed `(version, flavor)` from the catalog, because the owner of an
+  unversioned alias can shift between releases (e.g. `PYTHON3` moving from python-3.12 to a
+  newer flavor), so a flavor's alias set is not release-invariant.
+- **Update semantics (digest diff, no version ordering)**: `update <alias>` re-resolves the
+  alias against the catalog and compares the resolved **image reference** (content-addressed,
+  so an identical reference means identical content) with the installed one. Unchanged → a
+  no-op with no restart. Changed → replace the installed entry and restart, exactly like an
+  install. Because a version bump can move the unversioned alias to a new flavor (e.g.
+  `python-3.12` → `python-3.13`), the replaced entry is identified by the alias match and the
+  collision check runs against the *other* installed SLCs so the update never self-collides.
+  Rollback/downgrade is out of scope, so update deliberately has no
+  "older version" guard — it installs whatever the catalog resolves to now.
+- **Restart + verify**: install/update/remove performs a genuine stop→start (a plain start
+  no-ops if the container is already running, so the mount would not apply), waits for
+  readiness, and verifies the change took effect before reporting success.
+- **Restart confirmation**: because activation restarts a running database (dropping open
+  connections and aborting running statements), install/update/remove warn and require
+  confirmation first. `--yes` skips the prompt (required for automation) and `--no-restart`
+  records the change to apply on the next start without restarting now. The prompt is shown
+  only when a restart will actually occur (running database) and only after validation
+  (unknown alias / collision fail before any prompt); a non-interactive session without
+  `--yes`/`--no-restart` is refused rather than silently restarting. A guard against
+  restarting during a backup/critical operation was considered but deferred: Personal-local
+  has no reliable "operation in progress" signal to detect today, so confirmation is the v1
+  safeguard.
+- **Backend scoping**: only the local (darwin/arm64) backend supports these commands; other
+  backends return a clear "unsupported" error.
+
+## Error handling / edge cases
+
+- Unknown alias → error with the list of valid aliases; no state change, no restart.
+- Non-local backend → unsupported error; no state change.
+- Alias collision → rejected with the conflicting alias/flavor named; no state change.
+- Image pull / container recreate fails on start → `init-db.sh` exits non-zero; the launcher
+  reports the failure and that the SLC is configured-but-not-active (never a false success).
+- Re-install of an already-installed alias → no-op (same version) or replace (different
+  version), idempotent either way.
+- Removing a not-installed alias → clear message, no restart.
+
+## Storage hygiene
+
+On replace or removal, the recreated container drops the old mount but the old SLC image
+would otherwise remain in the VM's Podman store, growing it unboundedly across install
+cycles (a concern the broader SLC design explicitly called out). `init-db.sh`
+(`prune_unreferenced_slc_images`) reclaims it: after the desired images are pulled and
+before `podman run` — the point at which the outgoing DB container is already removed, so
+old images are unreferenced — it removes any `exasol/script-language-container` image whose
+reference is not listed in the current `slc.json`. The prune is deliberately narrow and
+safe:
+
+- **Scoped to the SLC repository.** Only images whose reference contains
+  `exasol/script-language-container` are eligible; the DB image and any unrelated images are
+  never considered.
+- **Authoritative-set only.** It runs only when `slc.json` exists. An absent file means
+  "SLC-unaware" (an older launcher, or today's default), so the store is left untouched
+  rather than pruned against an unknown desired set.
+- **Best-effort, never fatal.** A removal that fails (image still in use, or shared layers)
+  is logged and skipped; pruning can never abort database startup.
+
+Dangling (`<none>`) SLC layers left by an overwritten tag are out of scope — each SLC
+version carries a unique content-hash tag, so replaced/removed images retain their
+`repo:tag` and are matched by reference.
+
+## Risks
+
+- Image mounts are non-persistent → correctness depends on the launcher re-passing the full
+  installed set on every start. State is the single source of truth.
+- The runner change requires rebuilding and re-embedding the runner binary; the darwin/arm64
+  runner is `go:embed`-ed and staged via `tools/localrunner`.

--- a/openspec/changes/add-local-slc-support/design.md
+++ b/openspec/changes/add-local-slc-support/design.md
@@ -2,13 +2,11 @@
 
 ## Context
 
-Local deployments run nano inside a QEMU VM managed by an embedded runner
-(`exasol-local-vm`). The launcher never runs Podman directly; the runner boots the VM and
-`init-db.sh` (from the runner's embedded assets) issues the single `podman run` that
-starts the nano database container. Script language aliases are read by the database from
-each SLC's `build_info/language_definitions.json`; the nano `admini` component scans
-`/exa/slc` on start and auto-registers builtin aliases (verified in code:
-`db/COSMock/src/admini`). No `ALTER SYSTEM` is required for official SLCs.
+Local deployments run the database inside a macOS Virtualization.framework VM managed by an
+embedded runner. The launcher never manages containers directly; it drives the runner, which
+boots the VM and starts the database container. The database auto-registers a script
+language container's aliases by scanning the `/exa/slc` mount directory on start, so no
+`ALTER SYSTEM` is required for official SLCs.
 
 This change adds official SLC installation for local deployments only. It is deliberately
 one lane of the broader SLC design (custom SLCs, cloud, and the tarball + `ALTER SYSTEM`
@@ -37,73 +35,31 @@ exasol slc install python3
   1. launcher resolves alias -> {image, target} from slc-catalog.yaml
   2. launcher collision-check: installed set must stay alias-disjoint
   3. launcher records the SLC in launcher state
-  4. launcher stops then starts the deployment (via the runner)
-  5. runner writes vm-shared/slc.json from --slc start flags
-  6. init-db.sh reads slc.json, force-recreates the container with --mount type=image
-     (podman pulls the image inside the VM), mounting it at /exa/slc/<target>
-  7. nano admini scans /exa/slc -> registers PYTHON3; launcher waits-for-ready and verifies
+  4. launcher stops then starts the deployment, passing the installed set as --slc flags
+  5. the runner mounts each requested image at /exa/slc/<target> in the database container
+  6. the database scans /exa/slc, registers the aliases; launcher waits-for-ready and verifies
 ```
 
-Image mounts are `podman run` arguments and are not persisted into `/exa`; the launcher
-therefore re-passes the full installed set on every start (step 4-5), reconstructed from
-launcher state — analogous to how version-check settings are re-passed today.
+Image mounts are container-run arguments and are not persisted; the launcher therefore
+re-passes the full installed set on every start (step 4), reconstructed from launcher state
+— analogous to how version-check settings are re-passed today.
 
-## Cross-repo contract (exasol-local-vm)
+## Runner interface
 
-The runner change is small and additive. Backward compatibility rule: when no SLCs are
-requested, behavior is byte-for-byte identical to today.
+The launcher depends on a small, additive runner interface. **Backward compatibility
+rule:** when no SLCs are requested, behavior is identical to today.
 
-**1. Runner `start` flag (mac runner, `launcher/mac/main.go`).**
-Add a repeatable `--slc` flag; each value encodes one mount as `<image>=<target>` (image
-references contain no `=`; targets are absolute paths with no `=`, so `=` is an
-unambiguous separator — split on the first `=`). The launcher passes one `--slc` per
-installed SLC. Mirror `writeVersionCheckRuntimeConfig`: add `writeSlcRuntimeConfig` that
-writes the shared file.
+**1. `start` flag.** The runner accepts a repeatable `--slc` flag; each value encodes one
+mount as `<image>=<target>`. Image references contain no `=` and targets are absolute paths
+with no `=`, so the first `=` is an unambiguous separator. The launcher passes one `--slc`
+per installed SLC.
 
-**2. `vm-shared/slc.json`** (written by the runner, read by `init-db.sh`):
-```json
-{ "slc": [ { "image": "docker.io/exasol/script-language-container:standard-EXASOL-all-python-3.12-release_arm64_GM7DI5...ISZQ",
-             "target": "/exa/slc/python312" } ] }
-```
-Absent or `{"slc":[]}` means "no SLCs" and must be treated identically to today.
+**2. Mount semantics.** The runner mounts each requested image into the database container
+at its target path. An empty request set is treated identically to today (no SLC mounts).
 
-**3. `init-db.sh` — read the list.** After the existing config parsing, add:
-```sh
-SLC_CONFIG_FILE="$EXASOL_VM_HOST_SHARED_DIR/slc.json"
-build_slc_mount_args() {   # prints repeated: --mount type=image,source=<img>,destination=<dst>
-  [ -f "$SLC_CONFIG_FILE" ] || return 0
-  count=$(jq -r '.slc // [] | length' "$SLC_CONFIG_FILE") || return 1
-  i=0
-  while [ "$i" -lt "$count" ]; do
-    img=$(jq -er ".slc[$i].image"  "$SLC_CONFIG_FILE") || return 1
-    dst=$(jq -er ".slc[$i].target" "$SLC_CONFIG_FILE") || return 1
-    printf '%s\n' "--mount" "type=image,source=$img,destination=$dst"
-    i=$((i + 1))
-  done
-}
-```
-Accumulate into positional parameters (the file already uses the `set --` idiom) so values
-are never re-split by the shell.
-
-**4. `init-db.sh` — harden the recreate.** Replace the current soft removal
-(`podman rm … || true`, lines ~350-353) with a forced, verified removal, and add
-`--replace` to `podman run`:
-```sh
-if podman container exists "$DB_CONTAINER_NAME"; then
-  log_msg "Removing existing container $DB_CONTAINER_NAME to recreate it fresh"
-  podman rm -f "$DB_CONTAINER_NAME" || { log_msg "Error: failed to remove $DB_CONTAINER_NAME"; log_diagnostics; exit 1; }
-fi
-if podman container exists "$DB_CONTAINER_NAME"; then
-  log_msg "Error: $DB_CONTAINER_NAME still present after removal; aborting"; exit 1
-fi
-# podman run -d --replace ... <existing args> $SLC_MOUNT_ARGS "$@"
-```
-Rationale: a stale container (from an unclean VM kill) otherwise makes `podman run --name`
-fail with a name conflict, so the new SLC-mounted container never starts. `rm -f` handles
-any container state; the post-removal check and `exit 1` replace the failure-swallowing
-`|| true`; `--replace` is defense-in-depth against a race.
-
-**5. Re-embed the runner** into exasol-personal via `tools/localrunner` after the change.
+**3. Runner version.** The embedded runner in `assets/resources/resources.yaml` must be
+bumped to a release that supports `--slc` before this feature is enabled; an older runner
+rejects the unknown flag and fails to start.
 
 ## exasol-personal design
 
@@ -115,17 +71,17 @@ any container state; the post-removal check and `exit 1` replace the failure-swa
 - **Target directory**: derived deterministically from the flavor (e.g.
   `/exa/slc/python312`); free-form as far as the DB is concerned (aliases come from the
   image), must be unique per installed SLC, and MUST NOT start with `current-` (that prefix
-  is reserved by the runner's managed `current-java` anchor and is skipped by the scan).
+  is reserved by the runner and is skipped by the scan).
 - **State**: the installed SLC set is persisted in launcher state in the deployment
   directory and is the source of truth re-applied on every start.
 - **Collision rule (full alias-disjointness)**: the set of mounted SLCs MUST be disjoint
   across *all* declared aliases — versioned and unversioned — because the DB throws at
-  engine init on *any* duplicate alias (`SlcConfig::createBuiltinNameMap`), not only on a
-  duplicated unversioned one. Before an install the launcher compares the candidate SLC's
-  full alias set against that of every already-installed SLC: a newer version of an
-  already-installed flavor **replaces** the incumbent; any other overlap is **rejected**
-  with a clear message naming the conflicting alias and the SLC that already owns it. Alias
-  sets are read per installed `(version, flavor)` from the catalog, because the owner of an
+  engine init on *any* duplicate alias, not only on a duplicated unversioned one. Before an
+  install the launcher compares the candidate SLC's full alias set against that of every
+  already-installed SLC: a newer version of an already-installed flavor **replaces** the
+  incumbent; any other overlap is **rejected** with a clear message naming the conflicting
+  alias and the SLC that already owns it. Alias sets are read per installed
+  `(version, flavor)` from the catalog, because the owner of an
   unversioned alias can shift between releases (e.g. `PYTHON3` moving from python-3.12 to a
   newer flavor), so a flavor's alias set is not release-invariant.
 - **Update semantics (digest diff, no version ordering)**: `update <alias>` re-resolves the
@@ -142,11 +98,11 @@ any container state; the post-removal check and `exit 1` replace the failure-swa
   readiness, and verifies the change took effect before reporting success.
 - **Restart confirmation**: because activation restarts a running database (dropping open
   connections and aborting running statements), install/update/remove warn and require
-  confirmation first. `--yes` skips the prompt (required for automation) and `--no-restart`
+  confirmation first. `--auto-approve` skips the prompt (required for automation) and `--no-restart`
   records the change to apply on the next start without restarting now. The prompt is shown
   only when a restart will actually occur (running database) and only after validation
   (unknown alias / collision fail before any prompt); a non-interactive session without
-  `--yes`/`--no-restart` is refused rather than silently restarting. A guard against
+  `--auto-approve`/`--no-restart` is refused rather than silently restarting. A guard against
   restarting during a backup/critical operation was considered but deferred: Personal-local
   has no reliable "operation in progress" signal to detect today, so confirmation is the v1
   safeguard.
@@ -158,7 +114,7 @@ any container state; the post-removal check and `exit 1` replace the failure-swa
 - Unknown alias → error with the list of valid aliases; no state change, no restart.
 - Non-local backend → unsupported error; no state change.
 - Alias collision → rejected with the conflicting alias/flavor named; no state change.
-- Image pull / container recreate fails on start → `init-db.sh` exits non-zero; the launcher
+- Image pull / container recreate fails on start → the runner start fails; the launcher
   reports the failure and that the SLC is configured-but-not-active (never a false success).
 - Re-install of an already-installed alias → no-op (same version) or replace (different
   version), idempotent either way.
@@ -166,27 +122,12 @@ any container state; the post-removal check and `exit 1` replace the failure-swa
 
 ## Storage hygiene
 
-On replace or removal, the recreated container drops the old mount but the old SLC image
-would otherwise remain in the VM's Podman store, growing it unboundedly across install
-cycles (a concern the broader SLC design explicitly called out). `init-db.sh`
-(`prune_unreferenced_slc_images`) reclaims it: after the desired images are pulled and
-before `podman run` — the point at which the outgoing DB container is already removed, so
-old images are unreferenced — it removes any `exasol/script-language-container` image whose
-reference is not listed in the current `slc.json`. The prune is deliberately narrow and
-safe:
-
-- **Scoped to the SLC repository.** Only images whose reference contains
-  `exasol/script-language-container` are eligible; the DB image and any unrelated images are
-  never considered.
-- **Authoritative-set only.** It runs only when `slc.json` exists. An absent file means
-  "SLC-unaware" (an older launcher, or today's default), so the store is left untouched
-  rather than pruned against an unknown desired set.
-- **Best-effort, never fatal.** A removal that fails (image still in use, or shared layers)
-  is logged and skipped; pruning can never abort database startup.
-
-Dangling (`<none>`) SLC layers left by an overwritten tag are out of scope — each SLC
-version carries a unique content-hash tag, so replaced/removed images retain their
-`repo:tag` and are matched by reference.
+On replace or removal the old SLC image would otherwise accumulate in the VM's image store,
+growing it unboundedly across install cycles. Reclaiming those unreferenced images is the
+runner's responsibility during recreation; the launcher's contribution is to pass the
+authoritative installed set on every start, so the runner always knows which SLC images are
+still wanted and which are safe to drop. Each SLC version carries a unique content-hash tag,
+so replaced or removed images are matched by their exact reference.
 
 ## Risks
 

--- a/openspec/changes/add-local-slc-support/proposal.md
+++ b/openspec/changes/add-local-slc-support/proposal.md
@@ -22,8 +22,8 @@ to install an official SLC into a local deployment.
   install is rejected.
 - Scope to local (darwin/arm64) deployments only; other backends report the operation as
   unsupported.
-- Depends on a companion change in the runner (`exasol-local-vm`) to accept SLC image
-  mounts on `start` and to harden database-container recreation. See `design.md`.
+- Depends on a companion change in the embedded runner to accept SLC image mounts on
+  `start` and to harden database-container recreation. See `design.md`.
 
 ## Capabilities
 
@@ -42,8 +42,8 @@ to install an official SLC into a local deployment.
 - `internal/deploy`, `internal/localruntime`: pass installed SLC mounts to the runner
   `start` command; persist installed-SLC state; restart and verify on install/update/remove.
 - `assets/resources`: embed and load `slc-catalog.yaml`.
-- `exasol-local-vm` (external dependency, re-embedded via `tools/localrunner`): new `--slc`
-  start flag written to `slc.json`; `init-db.sh` reads it and adds `--mount type=image`;
-  hardened container cleanup. Detailed in `design.md`.
+- the embedded runner (external dependency, re-embedded via `tools/localrunner`): new `--slc`
+  start flag that mounts each requested image into the database container, plus hardened
+  container cleanup. The interface the launcher depends on is described in `design.md`.
 - Tests: catalog resolution, alias and collision logic, command behavior, and
   local-runtime integration.

--- a/openspec/changes/add-local-slc-support/proposal.md
+++ b/openspec/changes/add-local-slc-support/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+Local Exasol Personal deployments ship no script language containers (SLCs): the nano
+image omits them to stay within its size and download budget. As a result a `PYTHON3`,
+`JAVA`, or `R` UDF fails until the user provisions an SLC by hand, even though most
+examples online assume those languages exist. Users need a first-class, one-command way
+to install an official SLC into a local deployment.
+
+## What Changes
+
+- Add an `exasol slc` command group: `install <alias>`, `list`, `update <alias>`, and `remove <alias>`.
+- Resolve the requested alias (e.g. `python3`) against an embedded, pinned catalog of
+  official SLCs (`assets/resources/slc-catalog.yaml`) to a concrete container image
+  reference.
+- On install, mount the official SLC image into the local database at `/exa/slc/<dir>`
+  (Podman image mount). The database activates the language through its built-in scan of
+  `/exa/slc` on start — no `ALTER SYSTEM`.
+- Persist the set of installed SLCs in launcher state and re-apply it on every start,
+  because image mounts are container-run arguments and do not persist across recreation.
+- Enforce alias uniqueness across the installed set: two SLCs exposing the same
+  unversioned alias (e.g. `PYTHON3`) prevent the database from starting, so a conflicting
+  install is rejected.
+- Scope to local (darwin/arm64) deployments only; other backends report the operation as
+  unsupported.
+- Depends on a companion change in the runner (`exasol-local-vm`) to accept SLC image
+  mounts on `start` and to harden database-container recreation. See `design.md`.
+
+## Capabilities
+
+### New Capabilities
+
+- `local-slc-management`: install, list, update, and remove official script language containers
+  in local deployments.
+
+### Modified Capabilities
+
+<!-- None. -->
+
+## Impact
+
+- `cmd/exasol`: new `slc` command group (`install`, `list`, `update`, `remove`).
+- `internal/deploy`, `internal/localruntime`: pass installed SLC mounts to the runner
+  `start` command; persist installed-SLC state; restart and verify on install/update/remove.
+- `assets/resources`: embed and load `slc-catalog.yaml`.
+- `exasol-local-vm` (external dependency, re-embedded via `tools/localrunner`): new `--slc`
+  start flag written to `slc.json`; `init-db.sh` reads it and adds `--mount type=image`;
+  hardened container cleanup. Detailed in `design.md`.
+- Tests: catalog resolution, alias and collision logic, command behavior, and
+  local-runtime integration.

--- a/openspec/changes/add-local-slc-support/specs/local-slc-management/spec.md
+++ b/openspec/changes/add-local-slc-support/specs/local-slc-management/spec.md
@@ -98,7 +98,7 @@ the change in effect.
 ### Requirement: A restart of a running database is confirmed or deferred
 
 `exasol slc install`, `exasol slc update`, and `exasol slc remove` SHALL require confirmation
-before restarting a running database, and SHALL offer `--yes` to skip the prompt and
+before restarting a running database, and SHALL offer `--auto-approve` to skip the prompt and
 `--no-restart` to record the change for the next start instead of restarting now.
 
 #### Scenario: Confirmation is required before restarting a running database
@@ -107,9 +107,9 @@ before restarting a running database, and SHALL offer `--yes` to skip the prompt
 - **THEN** the command warns that the database will be restarted and open connections dropped
 - **AND** it proceeds only after the user confirms; declining makes no changes
 
-#### Scenario: `--yes` skips the prompt
+#### Scenario: `--auto-approve` skips the prompt
 
-- **WHEN** `exasol slc install python3 --yes` is run on a running deployment
+- **WHEN** `exasol slc install python3 --auto-approve` is run on a running deployment
 - **THEN** the database is restarted to apply the SLC without prompting
 
 #### Scenario: `--no-restart` defers activation without restarting
@@ -120,8 +120,8 @@ before restarting a running database, and SHALL offer `--yes` to skip the prompt
 
 #### Scenario: Non-interactive use without confirmation is refused
 
-- **WHEN** `exasol slc install python3` is run without a TTY and without `--yes` or `--no-restart` on a running deployment
-- **THEN** the command fails asking for `--yes` or `--no-restart`
+- **WHEN** `exasol slc install python3` is run without a TTY and without `--auto-approve` or `--no-restart` on a running deployment
+- **THEN** the command fails asking for `--auto-approve` or `--no-restart`
 - **AND** the database is not restarted
 
 #### Scenario: No confirmation when the database is stopped
@@ -132,10 +132,10 @@ before restarting a running database, and SHALL offer `--yes` to skip the prompt
 ### Requirement: Unreferenced SLC images are reclaimed
 
 Replacing or removing an SLC SHALL NOT leave the replaced or removed image occupying
-storage indefinitely; the launcher SHALL remove SLC images that are no longer referenced by
-the installed set. Reclamation MUST be limited to official SLC images and MUST NOT remove
-the database image or any unrelated image, and a failure to remove an image MUST NOT fail
-the operation.
+storage indefinitely; SLC images that are no longer referenced by the installed set SHALL
+be reclaimed. Reclamation MUST be limited to official SLC images and MUST NOT remove the
+database image or any unrelated image, and a failure to remove an image MUST NOT fail the
+operation.
 
 #### Scenario: Replacing an SLC removes the old image
 

--- a/openspec/changes/add-local-slc-support/specs/local-slc-management/spec.md
+++ b/openspec/changes/add-local-slc-support/specs/local-slc-management/spec.md
@@ -1,0 +1,212 @@
+## ADDED Requirements
+
+### Requirement: Install an official script language container by alias
+
+`exasol slc install <alias>` SHALL resolve the alias against the official SLC catalog and
+make the corresponding language available in the local deployment, without the user running
+any SQL.
+
+#### Scenario: Install a known alias
+
+- **WHEN** `exasol slc install python3` is run against a local deployment
+- **THEN** the resolved official SLC is mounted into the database
+- **AND** the command reports success only after the database is ready with the SLC active
+
+#### Scenario: Alias matching is case-insensitive
+
+- **WHEN** `exasol slc install PYTHON3` and `exasol slc install python3` are run
+- **THEN** both resolve to the same catalog entry
+
+#### Scenario: Unknown alias is rejected
+
+- **WHEN** `exasol slc install nodejs` is run and `nodejs` is not in the catalog
+- **THEN** the command fails with an error listing the valid aliases
+- **AND** no deployment state is changed and no restart occurs
+
+#### Scenario: Unsupported on non-local backends
+
+- **WHEN** `exasol slc install python3` is run against a non-local deployment
+- **THEN** the command fails with a clear "unsupported" message
+- **AND** no deployment state is changed
+
+#### Scenario: Not-yet-deployed deployment is refused
+
+- **WHEN** an SLC change (`install`, `update`, or `remove`) is run against a deployment that is initialized but not deployed yet
+- **THEN** the command fails asking the user to run `exasol deploy` first
+- **AND** no deployment state is changed and no SLC is recorded
+
+#### Scenario: Installing an already-installed image is a no-op
+
+- **WHEN** `exasol slc install python3` is run and the resolved image is already installed
+- **THEN** the command reports it is already installed and up to date
+- **AND** no deployment state is changed and no restart occurs
+
+### Requirement: Installed languages activate without manual SQL
+
+After a successful install, the language SHALL be usable through the database's built-in
+alias mechanism, with no `ALTER SYSTEM` or other manual SQL.
+
+#### Scenario: Installed Python is usable
+
+- **WHEN** `exasol slc install python3` has completed successfully
+- **THEN** a `CREATE PYTHON3 SCALAR SCRIPT ...` statement succeeds and the script runs
+
+### Requirement: Alias uniqueness is enforced across installed SLCs
+
+The launcher SHALL keep the installed SLC set disjoint across all declared aliases — both
+unversioned (e.g. `PYTHON3`) and versioned (e.g. `PYTHON312`) — because the database fails
+to start if two installed SLCs declare the same alias. An install that would introduce a
+duplicate alias SHALL be rejected, except a newer version of an already-installed flavor,
+which replaces it.
+
+#### Scenario: Conflicting install is rejected
+
+- **WHEN** an SLC exposing `PYTHON3` is already installed
+- **AND** the user installs a different flavor that also exposes `PYTHON3`
+- **THEN** the command fails naming the conflicting alias
+- **AND** the existing installation and deployment state are unchanged
+
+#### Scenario: Any shared alias conflicts, not only the unversioned one
+
+- **WHEN** an installed SLC and a candidate SLC of a different flavor share any declared alias
+- **THEN** the install is rejected naming the shared alias
+
+#### Scenario: Same-flavor version change replaces the incumbent
+
+- **WHEN** an SLC for a flavor is already installed
+- **AND** the user installs a newer version of the same flavor
+- **THEN** the newer version replaces the existing one rather than being added alongside it
+
+### Requirement: Install, update, and remove apply through a verified database restart
+
+`exasol slc install`, `exasol slc update`, and `exasol slc remove` SHALL restart the local
+database to apply the change, and SHALL report success only after the database is ready with
+the change in effect.
+
+#### Scenario: Install restarts and verifies
+
+- **WHEN** `exasol slc install python3` is run on a running deployment
+- **THEN** the database is restarted with the SLC mounted
+- **AND** success is reported only after readiness and activation are verified
+
+#### Scenario: A failed apply does not report success
+
+- **WHEN** the database fails to come up with the SLC mounted (e.g. the image cannot be pulled)
+- **THEN** the command reports the failure
+- **AND** it indicates the SLC is configured but not active, rather than reporting success
+
+### Requirement: A restart of a running database is confirmed or deferred
+
+`exasol slc install`, `exasol slc update`, and `exasol slc remove` SHALL require confirmation
+before restarting a running database, and SHALL offer `--yes` to skip the prompt and
+`--no-restart` to record the change for the next start instead of restarting now.
+
+#### Scenario: Confirmation is required before restarting a running database
+
+- **WHEN** `exasol slc install python3` is run interactively on a running deployment
+- **THEN** the command warns that the database will be restarted and open connections dropped
+- **AND** it proceeds only after the user confirms; declining makes no changes
+
+#### Scenario: `--yes` skips the prompt
+
+- **WHEN** `exasol slc install python3 --yes` is run on a running deployment
+- **THEN** the database is restarted to apply the SLC without prompting
+
+#### Scenario: `--no-restart` defers activation without restarting
+
+- **WHEN** `exasol slc install python3 --no-restart` is run on a running deployment
+- **THEN** the SLC is recorded and the database is not restarted
+- **AND** the SLC becomes active on the next start
+
+#### Scenario: Non-interactive use without confirmation is refused
+
+- **WHEN** `exasol slc install python3` is run without a TTY and without `--yes` or `--no-restart` on a running deployment
+- **THEN** the command fails asking for `--yes` or `--no-restart`
+- **AND** the database is not restarted
+
+#### Scenario: No confirmation when the database is stopped
+
+- **WHEN** `exasol slc install python3` is run on a stopped deployment
+- **THEN** no restart confirmation is required, because no running database is disrupted
+
+### Requirement: Unreferenced SLC images are reclaimed
+
+Replacing or removing an SLC SHALL NOT leave the replaced or removed image occupying
+storage indefinitely; the launcher SHALL remove SLC images that are no longer referenced by
+the installed set. Reclamation MUST be limited to official SLC images and MUST NOT remove
+the database image or any unrelated image, and a failure to remove an image MUST NOT fail
+the operation.
+
+#### Scenario: Replacing an SLC removes the old image
+
+- **WHEN** an installed SLC is replaced by a newer version of the same flavor
+- **THEN** the newer image is mounted
+- **AND** the previous, now-unreferenced SLC image is removed from storage
+
+#### Scenario: Removing an SLC removes its image
+
+- **WHEN** an installed SLC is removed
+- **THEN** its image is removed from storage on the next database (re)start
+
+#### Scenario: Images still in use are left in place
+
+- **WHEN** an SLC image cannot be removed because it is still referenced
+- **THEN** the removal is skipped without failing the install or remove
+
+### Requirement: Update an installed SLC to the catalog's current version
+
+`exasol slc update <alias>` SHALL re-resolve the alias against the catalog and compare the
+resolved image with the installed one. When the resolved image is unchanged the command
+SHALL be a no-op with no restart; when it has changed the command SHALL replace the installed
+SLC and apply it through a database restart. Update SHALL NOT order versions or guard against
+"older" images — rollback is out of scope, so it installs whatever the catalog resolves to.
+
+#### Scenario: Update with no catalog change is a no-op
+
+- **WHEN** `exasol slc update python3` is run and the resolved image matches the installed one
+- **THEN** the command reports it is already up to date
+- **AND** no deployment state is changed and no restart occurs
+
+#### Scenario: Update applies a changed image
+
+- **WHEN** `exasol slc update python3` is run and the catalog resolves to a different image
+- **THEN** the installed SLC is replaced with the newly resolved one
+- **AND** success is reported only after the database is ready with the new image active
+
+#### Scenario: Update of a not-installed SLC
+
+- **WHEN** `exasol slc update python3` is run and `python3` is not installed
+- **THEN** the command reports that nothing is installed for that alias
+- **AND** no restart occurs
+
+### Requirement: List available and installed SLCs
+
+`exasol slc list` SHALL show the official SLCs available in the catalog and which of them are
+currently installed.
+
+#### Scenario: List reflects install state
+
+- **WHEN** `exasol slc list` is run before and after installing `python3`
+- **THEN** the entry for `python3` is shown as not installed before, and installed after
+
+#### Scenario: Unsupported architecture yields an empty list, not an error
+
+- **WHEN** `exasol slc list` is run where the catalog has no SLCs for the current architecture
+- **THEN** the command reports that no containers are available (empty text message, `[]` in JSON)
+- **AND** it exits successfully rather than failing, unlike install/update/remove
+
+### Requirement: Remove an installed SLC
+
+`exasol slc remove <alias>` SHALL remove the SLC from the installed set and deactivate the
+language after the database restarts.
+
+#### Scenario: Remove an installed SLC
+
+- **WHEN** `python3` is installed and `exasol slc remove python3` is run
+- **THEN** the SLC is removed and, after restart, `PYTHON3` is no longer available
+
+#### Scenario: Remove a not-installed SLC
+
+- **WHEN** `exasol slc remove python3` is run and `python3` is not installed
+- **THEN** the command reports that nothing was installed for that alias
+- **AND** no restart occurs

--- a/openspec/changes/add-local-slc-support/tasks.md
+++ b/openspec/changes/add-local-slc-support/tasks.md
@@ -1,0 +1,48 @@
+## 1. Catalog and alias resolution
+
+- [x] 1.1 Embed and load `assets/resources/slc-catalog.yaml` (mirror the `resources.yaml` embed pattern).
+- [x] 1.2 Resolve an alias (case-insensitive) via `default_version` and the flavor `aliases` list to `{image ref, target dir, declared aliases}`.
+- [x] 1.3 Return a clear error for an unknown alias, listing the valid aliases.
+
+## 2. Installed-SLC state and collisions
+
+- [x] 2.1 Persist the installed SLC set in launcher state in the deployment directory.
+- [x] 2.2 Reject an install whose unversioned alias collides with an already-installed SLC; treat a same-flavor version change as a replace. (Generalized to full alias-disjointness.)
+
+## 3. CLI (`cmd/exasol`)
+
+- [x] 3.1 `exasol slc install <alias>` — no-op (no state change, no restart) when the exact resolved image is already installed; shared image-comparison helper with `update`.
+- [x] 3.2 `exasol slc list` (with `--json`).
+- [x] 3.3 `exasol slc remove <alias>`.
+- [x] 3.4 `exasol slc update <alias>` — re-resolve against the catalog; no-op if the resolved image is unchanged, otherwise replace + restart. Digest/image comparison, not version ordering; no downgrade guard (rollback is out of scope).
+- [x] 3.5 Guard to local (darwin/arm64) backend only; clear "unsupported" message otherwise.
+- [x] 3.6 `exasol slc list` degrades gracefully on an unsupported architecture: no error, a "none available" text message + `[]` JSON, exit 0 (unlike install/update/remove, which fail explicitly).
+- [x] 3.7 install/update/remove refuse cleanly on an initialized-but-not-deployed deployment ("deployment is not present; run `exasol deploy` first"), recording no state.
+
+## 4. Local-runtime wiring (`internal/deploy`, `internal/localruntime`)
+
+- [x] 4.1 Build runner `--slc <image>=<target>` start args from launcher state (mirror `localRunnerVersionCheckArgs`).
+- [x] 4.2 Install/update/remove = update state → genuine stop → start.
+- [x] 4.3 After restart, wait for readiness (readiness == applied: init-db.sh fails and the DB never becomes ready if an image cannot be pulled or two SLCs collide); report a clear error (never a false success) if not.
+- [x] 4.4 Warn + confirm before restarting a running database; `--yes` skips the prompt, `--no-restart` defers activation to the next start, non-interactive without either is refused. Confirmation happens after validation and only when a restart will actually occur.
+
+## 5. Runner change (`exasol-local-vm`)
+
+- [x] 5.1 Add a repeatable `--slc` `start` flag; write `vm-shared/slc.json` (`writeSlcRuntimeConfig`, mirroring `writeVersionCheckRuntimeConfig`).
+- [x] 5.2 `init-db.sh`: read `slc.json` and add one `--mount type=image,source=,destination=` per entry, accumulated via the existing `set --` idiom.
+- [x] 5.3 `init-db.sh`: harden recreate — `podman rm -f` + post-removal existence check + fail-fast (remove the failure-swallowing `|| true`), and add `--replace` to `podman run`.
+- [x] 5.4 Backward compatibility: absent/empty `slc.json` produces the exact current behavior.
+- [ ] 5.5 Rebuild and re-embed the runner into exasol-personal via `tools/localrunner` (requires a macOS build host: the runner depends on the darwin-only `vz` framework).
+- [x] 5.6 Extend `init-db-test.sh` with cases: mount present, mount absent, stale-container cleanup, unreferenced-image pruning, and no-prune-without-slc.json.
+
+## 6. Storage hygiene
+
+- [x] 6.1 Remove now-unreferenced SLC images (`podman rmi`) on replace and remove. Implemented in `init-db.sh` (`prune_unreferenced_slc_images`): after pulling the desired set and before `podman run`, remove any `exasol/script-language-container` image not listed in the current `slc.json`. Scoped to the SLC repository only (never the DB or unrelated images), skipped entirely when `slc.json` is absent (SLC-unaware behavior), and best-effort (a failed removal is logged and skipped, never fatal).
+
+## 7. Tests and validation
+
+- [x] 7.1 Unit tests for catalog load and alias resolution (including case-insensitivity and unknown alias).
+- [x] 7.2 Unit tests for the collision rule (reject vs replace, including versioned-alias overlap).
+- [x] 7.3 Command wiring verified (registration + flags + help); deploy-side helpers unit-tested (`upsertInstalledSLC`, `findInstalledSLC`, `localRunnerSlcArgs`).
+- [x] 7.4 Local-runtime start-arg construction covered via `localRunnerSlcArgs` state round-trip test.
+- [x] 7.5 Run formatting, focused tests, and OpenSpec validation for this change.

--- a/openspec/changes/add-local-slc-support/tasks.md
+++ b/openspec/changes/add-local-slc-support/tasks.md
@@ -23,21 +23,21 @@
 
 - [x] 4.1 Build runner `--slc <image>=<target>` start args from launcher state (mirror `localRunnerVersionCheckArgs`).
 - [x] 4.2 Install/update/remove = update state → genuine stop → start.
-- [x] 4.3 After restart, wait for readiness (readiness == applied: init-db.sh fails and the DB never becomes ready if an image cannot be pulled or two SLCs collide); report a clear error (never a false success) if not.
-- [x] 4.4 Warn + confirm before restarting a running database; `--yes` skips the prompt, `--no-restart` defers activation to the next start, non-interactive without either is refused. Confirmation happens after validation and only when a restart will actually occur.
+- [x] 4.3 After restart, wait for readiness (readiness == applied: the runner start fails and the DB never becomes ready if an image cannot be pulled or two SLCs collide); report a clear error (never a false success) if not.
+- [x] 4.4 Warn + confirm before restarting a running database; `--auto-approve` skips the prompt, `--no-restart` defers activation to the next start, non-interactive without either is refused. Confirmation happens after validation and only when a restart will actually occur.
 
-## 5. Runner change (`exasol-local-vm`)
+## 5. Runner interface (external dependency)
 
-- [x] 5.1 Add a repeatable `--slc` `start` flag; write `vm-shared/slc.json` (`writeSlcRuntimeConfig`, mirroring `writeVersionCheckRuntimeConfig`).
-- [x] 5.2 `init-db.sh`: read `slc.json` and add one `--mount type=image,source=,destination=` per entry, accumulated via the existing `set --` idiom.
-- [x] 5.3 `init-db.sh`: harden recreate — `podman rm -f` + post-removal existence check + fail-fast (remove the failure-swallowing `|| true`), and add `--replace` to `podman run`.
-- [x] 5.4 Backward compatibility: absent/empty `slc.json` produces the exact current behavior.
+- [x] 5.1 Add a repeatable `--slc <image>=<target>` start flag to the runner.
+- [x] 5.2 Mount each requested image into the database container at its target path.
+- [x] 5.3 Harden container recreation so a stale container from an unclean shutdown cannot block startup.
+- [x] 5.4 Backward compatibility: an empty request set produces the exact current behavior.
 - [ ] 5.5 Rebuild and re-embed the runner into exasol-personal via `tools/localrunner` (requires a macOS build host: the runner depends on the darwin-only `vz` framework).
-- [x] 5.6 Extend `init-db-test.sh` with cases: mount present, mount absent, stale-container cleanup, unreferenced-image pruning, and no-prune-without-slc.json.
+- [x] 5.6 Cover the runner interface with tests: mount present, mount absent, stale-container cleanup, unreferenced-image pruning, and no-prune when SLC-unaware.
 
 ## 6. Storage hygiene
 
-- [x] 6.1 Remove now-unreferenced SLC images (`podman rmi`) on replace and remove. Implemented in `init-db.sh` (`prune_unreferenced_slc_images`): after pulling the desired set and before `podman run`, remove any `exasol/script-language-container` image not listed in the current `slc.json`. Scoped to the SLC repository only (never the DB or unrelated images), skipped entirely when `slc.json` is absent (SLC-unaware behavior), and best-effort (a failed removal is logged and skipped, never fatal).
+- [x] 6.1 Reclaim unreferenced SLC images on replace and remove. Handled by the runner during recreation: scoped to the SLC image repository only (never the DB or unrelated images), skipped when SLC-unaware, and best-effort (a failed removal is logged and skipped, never fatal).
 
 ## 7. Tests and validation
 


### PR DESCRIPTION
## Description

This PR introduces launcher-owned official Script Language Container (SLC) management for local deployments (workflow 1). Users can install the currenlty supported runtimes used by UDFs with a single command via a new `exasol slc` command group.

Pairs with exasol-local-vm PR [PR# 43](https://github.com/exasol/exasol-local-vm/pull/43 ), which mounts the SLC images into the database container.

## Related Issue

[SPOT-30976](https://exasol.atlassian.net/browse/SPOT-30976)

Fixes #

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

## Change details

- Adds a new `exasol slc` command group — `install`, `list`, `update`, `remove` — to manage script language containers on a local deployment without any SQL.
- Ships an embedded official SLC catalog (`assets/resources/slc-catalog.yaml`) that `internal/slc` parses and resolves.
- Resolves a user-supplied alias case-insensitively to a specific content-addressed image.
- Enforces an alias-uniqueness rule so two installed SLCs can never claim the same alias.
- Records the installed SLC set in launcher state and re-applies it on every start.
- Applies each change through a genuine stop→start, reporting success only after the database is ready.
- Requires confirmation before restarting a running DB; `--yes` skips the prompt and `--no-restart` defers to the next start.
- Refuses a non-interactive change with neither `--yes` nor `--no-restart` instead of silently restarting.
- On an unsupported architecture `slc list` prints the no available message, returns `[]` with --json, and exits 0.
- Fails the change commands explicitly on an unsupported architecture, unlike `list`.
- Refuses change commands on a not-yet-deployed deployment ("deployment is not present; run `exasol deploy` first"), recording no state.
- Treats installing an already-installed image, or updating to an unchanged image, as a no-op — no state change, no restart.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

Manually tested the changes by embedding the VM launcher changes with exasol launcher.

[Personal_Local_With_Official_SLC_Test_Logs.txt](https://github.com/user-attachments/files/30040747/Personal_Local_With_Official_SLC_Test_Logs.txt)

## Checklist

<!-- Mark completed items with an "x" -->

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format


[SPOT-30976]: https://exasol.atlassian.net/browse/SPOT-30976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ