### PR TITLE
Add user-facing changelog

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -46,6 +46,7 @@ Fixes #
 - [ ] Code follows the project's [coding guidelines](doc/best_practices.md)
 - [ ] Ran `task fmt` and `task lint`
 - [ ] Updated documentation (if applicable)
+- [ ] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
 - [ ] Added/updated tests
 - [ ] All tests pass locally
 - [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,123 @@
+# Changelog
+
+Notable user-facing changes to Exasol Personal are documented here.
+
+## Unreleased
+
+### Added
+
+- Added named deployment selection with `--deployment` / `-d`, so users can manage multiple deployments under the default Exasol Personal deployment root without passing full directory paths.
+
+  Example: `exasol status --deployment demo` targets the named `demo` deployment. `--deployment` and `--deployment-dir` cannot be used together.
+
+- Added `exasol deployments list` to show default and named deployment directories, their status, and which deployment is currently active.
+
+  The list helps users distinguish the default deployment from named deployments and spot missing or inactive deployment directories.
+
+- Added this changelog as the user-facing release history for Exasol Personal. Release candidates now have a single in-repo place where users can see which features, behavior changes, fixes, and breaking changes may affect them.
+
+### Changed
+
+- Improved README guidance to emphasize local deployment as the fastest way to try Exasol Personal.
+
+### Fixed
+
+- Fixed the personal installer script so it remains compatible with POSIX shell environments.
+
+### Breaking Changes
+
+- None.
+
+## 2.1.0 - 2026-07-09
+
+### Added
+
+- Added support for external preset sources. Presets can now be resolved through the runtime artifact system from local files, HTTP sources, and Git repositories, including SSH-backed repositories and zip archives.
+
+  Example: `exasol install https://github.com/org/exasol-preset.git@v1.0.0` lets users install from a preset repository instead of only using bundled presets.
+
+- Added lifecycle JSON ready signals for automation around deployment start and stop commands.
+
+  Example: `exasol start --json` gives scripts a machine-readable readiness signal instead of requiring them to scrape human-oriented terminal output.
+
+- Added Azure support to the deployment cleanup tooling.
+
+- Surfaced the local preset and quick-start path in top-level help so users can discover the fastest local deployment flow earlier.
+
+  Example: `exasol --help` now points users toward the local deployment path instead of requiring them to find it in deeper command help.
+
+### Changed
+
+- Improved blocked-deployment recovery guidance across install, deploy, connect, start, and stop flows so users get more actionable next steps when local state prevents an operation.
+
+- Changed the release workflow to publish from explicit, pre-pushed tags instead of creating tags inside the release workflow.
+
+### Fixed
+
+- Fixed `exasol config set` error handling so invalid deployment-directory state is reported with the standard not-a-deployment-directory guidance.
+
+- Suppressed the database version banner for non-interactive `connect` usage, keeping scripted output cleaner.
+
+- Made lifecycle commands idempotent for repeated start and stop operations.
+
+- Fixed deployment compatibility checks to use the stable release baseline.
+
+### Breaking Changes
+
+- None.
+
+## 2.0.0 - 2026-07-06
+
+### Added
+
+- Added local Exasol deployments for macOS through the local VM runtime. Users can run a local database with the local preset, and the launcher manages the local runtime, deployment share, memory defaults, port overrides, and recovery after improper VM shutdown.
+
+  Example: `exasol install local` starts the local setup flow on supported macOS hosts.
+
+- Added the default deployment directory flow and safe reuse of deployment directories. Users can run common commands without repeatedly passing a deployment directory, while the launcher protects existing state from incompatible preset changes.
+
+  Example: after installing once, `exasol status` uses the default deployment directory when run outside another deployment directory.
+
+- Added STACKIT as a supported cloud infrastructure provider, including account setup documentation and cleanup support.
+
+- Added non-interactive SQL execution and richer output formats to `exasol connect`: inline commands with `-c`, file execution with `-f`, JSON output, CSV output, and standardized JSON results for multi-statement invocations and SQL errors.
+
+  Example: `exasol connect --json -c "SELECT 1"` produces machine-readable output suitable for scripts and agent workflows.
+
+- Added runtime artifact management so OpenTofu and runtime resources can be downloaded on demand and reused through a per-user cache. New cache commands and diagnostics help users inspect and clean cached artifacts.
+
+  Example: `exasol cache list` shows downloaded runtime artifacts, and `exasol diag cache` checks cache health.
+
+- Added improved `exasol info` guidance and JSON output so users can more easily find connection details and next steps.
+
+  Example: `exasol info --json` returns connection details in a script-friendly format.
+
+### Changed
+
+- Moved OpenTofu resolution to runtime instead of requiring platform-specific OpenTofu binaries to be embedded in every launcher build.
+
+- Updated cloud deployment defaults and refactored preset/backend handling so infrastructure resources are resolved more consistently.
+
+- Updated README and help text around local deployment, system requirements, limitations, and Exasol Personal positioning.
+
+- Changed local deployment key handling to use EdDSA keys and OpenSSH-compatible connection keys.
+
+### Fixed
+
+- Fixed large SQL result retrieval so result sets larger than 1,000 rows are fetched correctly.
+
+- Fixed `exasol info` for stopped deployments that no longer have a reachable host.
+
+- Fixed diagnostic logs leaking into default command output.
+
+- Fixed typed JSON output preservation for `exasol connect`.
+
+- Fixed launcher update checks to compare versions semantically.
+
+- Fixed help output for preset-specific CLI arguments.
+
+- Fixed Azure bootstrap blob upload from the deploying client and improved cleanup reliability for Exoscale and STACKIT resources.
+
+### Breaking Changes
+
+- None.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@ Thank you for your interest in contributing! We welcome contributions from the c
 - **Write clear descriptions** - explain what and why, not just how
 - **Fold cleanup into the related commit** - do not create separate commits for lint, formatting, or typo fixes
 - **Explain CLI changes with examples** - when changing CLI commands or behavior, describe the user-visible behavior in the PR description and include example invocations or output
+- **Update the changelog for user-facing changes** - add an entry to [CHANGELOG.md](CHANGELOG.md) under `Unreleased` when a change affects CLI behavior, deployment behavior, supported platforms/providers, user-visible errors, documentation that changes how users operate the tool, or compatibility/breaking behavior. Use the existing `Added`, `Changed`, `Fixed`, and `Breaking Changes` sections, and include a short command example for new or changed CLI behavior when useful.
 - **Use the [pull request template](.github/pull_request_template.md)** when submitting a pull request
 - **Use semantic commit messages** - follow [Conventional Commits](https://www.conventionalcommits.org/) format:
   - `feat:` new features

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 [![Community](https://img.shields.io/badge/community-exasol-green)](https://community.exasol.com)
 [![Downloads](https://img.shields.io/badge/downloads-exasol.com-orange)](https://downloads.exasol.com/exasol-personal)
 
+[Changelog](CHANGELOG.md)
+
 </div>
 
 ## 🔥 Key Features

--- a/doc/release.md
+++ b/doc/release.md
@@ -27,7 +27,24 @@ Before tagging a release, ensure deployment directory compatibility constraints 
 - If the release introduces a breaking change in deployment directory semantics (state layout, workflow invariants, marker files, etc.), add a new minimum supported deployment version constant in the cmd layer (see `cmd/exasol/compatibility_versions.go`) and apply it to the affected commands.
 - Release-candidate versions (for example `1.2.0-rc1`) must not appear in those constants. Compatibility comparisons treat prerelease/build suffixes as irrelevant and compare only the base version (so `1.2.0-rc1` behaves like `1.2.0`).
 
-### 1. Tag the Release
+Before tagging a stable release, finalize the user-facing [changelog](../CHANGELOG.md). The in-repo changelog is the durable release history for users; generated GitHub release notes are useful for publishing, but they are not a substitute for maintaining the curated changelog.
+
+Move all applicable entries from `Unreleased` into a new versioned section such as `2.2.0 - 2026-07-16`, grouped by `Added`, `Changed`, `Fixed`, and `Breaking Changes`. Commit that release-prep change first, then create the stable release tag on that commit. Automating this step is desirable, but the manual release-prep commit is the required fallback.
+
+Pre-release tags such as `v2.2.0-rc1` do not require this extra changelog-finalization commit. Their entries may remain under `Unreleased` until the stable release is prepared.
+
+### 1. Finalize the Changelog
+
+```bash
+# Edit CHANGELOG.md:
+# - create the version section for the release
+# - move all shipped entries from Unreleased into that section
+# - leave Unreleased ready for the next cycle
+git add CHANGELOG.md
+git commit -m "docs: finalize changelog for v1.2.3"
+```
+
+### 2. Tag the Release
 
 ```bash
 # Create an annotated tag with semantic versioning
@@ -37,7 +54,7 @@ git tag -a v1.2.3 -m "Release v1.2.3"
 git push origin v1.2.3
 ```
 
-### 2. Automated Build
+### 3. Automated Build
 
 GitHub Actions will automatically:
 1. Checkout the tagged commit
@@ -47,7 +64,7 @@ GitHub Actions will automatically:
 5. Generate release notes
 6. Publish the release on GitHub
 
-### 3. Monitor the Release
+### 4. Monitor the Release
 
 Watch the GitHub Actions workflow to ensure it completes successfully:
 - Navigate to the [Actions tab](https://github.com/exasol/exasol-personal/actions)
@@ -92,9 +109,10 @@ Follow [Semantic Versioning](https://semver.org/):
 
 ## Release Checklist
 
-Before creating a release:
+Before creating a stable release:
 
 - [ ] All tests pass locally (`task all`)
+- [ ] Changelog is finalized for this version and committed before the tag
 - [ ] Documentation is up to date
 - [ ] Version number follows semantic versioning
 - [ ] All changes merged to main branch


### PR DESCRIPTION
## Description

Adds a user-facing changelog for Exasol Personal and makes it discoverable from the README. The changelog is curated by release rather than copied from commit history, starts with the stable 2.0.0 and 2.1.0 releases, and keeps current post-2.1.0 user-facing changes under `Unreleased`.

The change also documents how contributors and release owners maintain the changelog: pull requests update `Unreleased` for user-facing changes, and stable release preparation moves those entries into a versioned section before tagging. Pre-release tags can leave entries under `Unreleased`.

## Related Issue

https://exasol.atlassian.net/browse/SPOT-31658

## Type of Change

- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [x] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Added `CHANGELOG.md` with `Unreleased`, `2.1.0`, and `2.0.0` sections.
- Linked the changelog from `README.md`.
- Documented changelog maintenance in `CONTRIBUTING.md`, the PR template, and the release process.

## Testing

- [ ] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [ ] Manually tested the changes

### Test Details

- Ran `git diff --check`.
- Scanned edited Markdown files for trailing whitespace.
- Did not run `task all`; this is docs/process-only.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [ ] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [ ] Added/updated tests
- [ ] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

The changelog-finalization commit is required for stable releases. Pre-release tags may keep entries under `Unreleased`.
