### PR TITLE
fix: end CREATE SCRIPT/FUNCTION on '/' so UDF bodies with semicolons parse

### DIFF
--- a/internal/connect/shell.go
+++ b/internal/connect/shell.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/exasol/exasol-personal/internal/connect/readline"
@@ -79,7 +80,7 @@ func (sh *shell) run() error {
 
 		trimmedLine := strings.TrimSpace(line)
 		if trimmedLine == exitCommand && strings.TrimSpace(sh.pendingStatementBuf) == "" {
-			slog.Debug("got the exit command, exitting")
+			slog.Debug("got the exit command, exiting")
 			return nil
 		}
 
@@ -98,7 +99,7 @@ func (sh *shell) processInputSemicolonMode(line string) {
 	}
 	sh.pendingStatementBuf += line
 
-	statements, remainder := splitSemicolonTerminatedStatements(sh.pendingStatementBuf)
+	statements, remainder := splitStatements(sh.pendingStatementBuf)
 	sh.pendingStatementBuf = remainder
 
 	for _, statement := range statements {
@@ -106,85 +107,208 @@ func (sh *shell) processInputSemicolonMode(line string) {
 	}
 }
 
-func splitSemicolonTerminatedStatements(sql string) ([]string, string) {
-	var (
-		statements     []string
-		start          int
-		inSingleQuotes bool
-		inDoubleQuotes bool
-		inLineComment  bool
-		inBlockComment bool
-	)
+// CREATE ... SCRIPT / FUNCTION definitions terminate on a lone '/' rather than ';' (EXAplus
+// rule), so semicolons inside a script body are not statement terminators.
+func splitStatements(sql string) ([]string, string) {
+	var statements []string
+	start := 0
 
-	for charIndex := 0; charIndex < len(sql); charIndex++ {
-		if inLineComment {
+	for start < len(sql) {
+		term, ok := findStatementTerminator(sql, start)
+		if !ok {
+			break
+		}
+		if statement := strings.TrimSpace(sql[start:term.statementEnd]); statement != "" {
+			statements = append(statements, statement)
+		}
+		start = term.nextStart
+	}
+
+	return statements, sql[start:]
+}
+
+func findStatementTerminator(sql string, from int) (terminator, bool) {
+	if looksLikeScriptDDL(sql[from:]) {
+		return findScriptTerminator(sql, from)
+	}
+
+	return findSemicolonTerminator(sql, from)
+}
+
+func findSemicolonTerminator(sql string, from int) (terminator, bool) {
+	var inSingleQuotes, inDoubleQuotes, inLineComment, inBlockComment bool
+
+	for charIndex := from; charIndex < len(sql); charIndex++ {
+		switch {
+		case inLineComment:
 			if sql[charIndex] == '\n' {
 				inLineComment = false
 			}
-
-			continue
-		}
-
-		if inBlockComment {
+		case inBlockComment:
 			if sql[charIndex] == '*' && charIndex+1 < len(sql) && sql[charIndex+1] == '/' {
 				inBlockComment = false
 				charIndex++
 			}
-
-			continue
-		}
-
-		if inSingleQuotes {
+		case inSingleQuotes:
 			if sql[charIndex] == '\'' && charIndex+1 < len(sql) && sql[charIndex+1] == '\'' {
 				charIndex++
-				continue
-			}
-			if sql[charIndex] == '\'' {
+			} else if sql[charIndex] == '\'' {
 				inSingleQuotes = false
 			}
-
-			continue
-		}
-
-		if inDoubleQuotes {
+		case inDoubleQuotes:
 			if sql[charIndex] == '"' && charIndex+1 < len(sql) && sql[charIndex+1] == '"' {
 				charIndex++
-				continue
-			}
-			if sql[charIndex] == '"' {
+			} else if sql[charIndex] == '"' {
 				inDoubleQuotes = false
 			}
-
-			continue
-		}
-
-		switch sql[charIndex] {
-		case '\'':
-			inSingleQuotes = true
-		case '"':
-			inDoubleQuotes = true
-		case '-':
-			if charIndex+1 < len(sql) && sql[charIndex+1] == '-' {
-				inLineComment = true
-				charIndex++
-			}
-		case '/':
-			if charIndex+1 < len(sql) && sql[charIndex+1] == '*' {
-				inBlockComment = true
-				charIndex++
-			}
-		case ';':
-			statement := strings.TrimSpace(sql[start:charIndex])
-			if statement != "" {
-				statements = append(statements, statement)
-			}
-			start = charIndex + 1
 		default:
-			continue
+			switch sql[charIndex] {
+			case '\'':
+				inSingleQuotes = true
+			case '"':
+				inDoubleQuotes = true
+			case '-':
+				if charIndex+1 < len(sql) && sql[charIndex+1] == '-' {
+					inLineComment = true
+					charIndex++
+				}
+			case '/':
+				if charIndex+1 < len(sql) && sql[charIndex+1] == '*' {
+					inBlockComment = true
+					charIndex++
+				}
+			case ';':
+				return terminator{statementEnd: charIndex, nextStart: charIndex + 1}, true
+			default:
+			}
 		}
 	}
 
-	return statements, sql[start:]
+	return terminator{}, false
+}
+
+// SCRIPT and FUNCTION bodies may contain ';', so they terminate on '/' instead.
+var scriptBodyKeywords = []string{"SCRIPT", "FUNCTION"}
+
+func looksLikeScriptDDL(sql string) bool {
+	token, pos := nextToken(sql, 0)
+	if token != "CREATE" {
+		return false
+	}
+
+	for {
+		token, pos = nextToken(sql, pos)
+		if token == "" || token == "AS" {
+			return false
+		}
+		if slices.Contains(scriptBodyKeywords, token) {
+			return true
+		}
+	}
+}
+
+func nextToken(sql string, from int) (string, int) {
+	start := skipSpaceAndComments(sql, from)
+	end := start
+	for end < len(sql) && !isTokenSeparator(sql, end) {
+		if sql[end] == '\'' || sql[end] == '"' {
+			end = skipQuoted(sql, end)
+
+			continue
+		}
+		end++
+	}
+	if end == start {
+		return "", end
+	}
+
+	return strings.ToUpper(sql[start:end]), end
+}
+
+func isTokenSeparator(sql string, pos int) bool {
+	return isSpaceByte(sql[pos]) || sql[pos] == '(' ||
+		strings.HasPrefix(sql[pos:], "--") || strings.HasPrefix(sql[pos:], "/*")
+}
+
+func skipQuoted(sql string, pos int) int {
+	quote := sql[pos]
+	for cursor := pos + 1; cursor < len(sql); cursor++ {
+		if sql[cursor] != quote {
+			continue
+		}
+		if cursor+1 < len(sql) && sql[cursor+1] == quote {
+			cursor++
+
+			continue
+		}
+
+		return cursor + 1
+	}
+
+	return len(sql)
+}
+
+func skipSpaceAndComments(sql string, from int) int {
+	for pos := from; pos < len(sql); {
+		switch {
+		case isSpaceByte(sql[pos]):
+			pos++
+		case strings.HasPrefix(sql[pos:], "--"):
+			newline := strings.IndexByte(sql[pos:], '\n')
+			if newline < 0 {
+				return len(sql)
+			}
+			pos += newline + 1
+		case strings.HasPrefix(sql[pos:], "/*"):
+			end := strings.Index(sql[pos:], "*/")
+			if end < 0 {
+				return len(sql)
+			}
+			pos += end + len("*/")
+		default:
+			return pos
+		}
+	}
+
+	return len(sql)
+}
+
+type terminator struct {
+	statementEnd int
+	nextStart    int
+}
+
+func findScriptTerminator(sql string, from int) (terminator, bool) {
+	for lineStart := from; lineStart < len(sql); {
+		newline := strings.IndexByte(sql[lineStart:], '\n')
+		line := sql[lineStart:]
+		if newline >= 0 {
+			line = sql[lineStart : lineStart+newline]
+		}
+		if strings.TrimSpace(line) == "/" {
+			if newline < 0 {
+				return terminator{
+					statementEnd: lineStart,
+					nextStart:    len(sql),
+				}, true
+			}
+
+			return terminator{
+				statementEnd: lineStart,
+				nextStart:    lineStart + newline + 1,
+			}, true
+		}
+		if newline < 0 {
+			break
+		}
+		lineStart += newline + 1
+	}
+
+	return terminator{}, false
+}
+
+func isSpaceByte(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\r' || b == '\n'
 }
 
 func getHistoryFilePath() (string, error) {
@@ -230,7 +354,7 @@ func runStatements(sql string, processInput ProcessInputFunc) error {
 }
 
 func nonInteractiveStatements(sql string) []string {
-	statements, remainder := splitSemicolonTerminatedStatements(sql)
+	statements, remainder := splitStatements(sql)
 	if trailing := strings.TrimSpace(remainder); trailing != "" {
 		statements = append(statements, trailing)
 	}

--- a/internal/connect/shell_test.go
+++ b/internal/connect/shell_test.go
@@ -285,7 +285,7 @@ func TestSplitSemicolonTerminatedStatements(t *testing.T) {
 	t.Run("keeps semicolons inside single quotes", func(t *testing.T) {
 		t.Parallel()
 
-		statements, remainder := splitSemicolonTerminatedStatements("SELECT 'a;b';")
+		statements, remainder := splitStatements("SELECT 'a;b';")
 		require.Equal(t, []string{"SELECT 'a;b'"}, statements)
 		require.Empty(t, remainder)
 	})
@@ -295,7 +295,7 @@ func TestSplitSemicolonTerminatedStatements(t *testing.T) {
 
 		sql := "OPEN SCHEMA foo;" +
 			"SELECT * FROM dual"
-		statements, remainder := splitSemicolonTerminatedStatements(sql)
+		statements, remainder := splitStatements(sql)
 		require.Equal(t, []string{"OPEN SCHEMA foo"}, statements)
 		require.Equal(t, "SELECT * FROM dual", remainder)
 	})
@@ -303,7 +303,7 @@ func TestSplitSemicolonTerminatedStatements(t *testing.T) {
 	t.Run("keeps semicolons inside double quotes", func(t *testing.T) {
 		t.Parallel()
 
-		statements, remainder := splitSemicolonTerminatedStatements(`SELECT "a;b";`)
+		statements, remainder := splitStatements(`SELECT "a;b";`)
 		require.Equal(t, []string{`SELECT "a;b"`}, statements)
 		require.Empty(t, remainder)
 	})
@@ -313,7 +313,7 @@ func TestSplitSemicolonTerminatedStatements(t *testing.T) {
 
 		sql := "SELECT 1 -- ; in comment\n" +
 			";SELECT 2;"
-		statements, remainder := splitSemicolonTerminatedStatements(sql)
+		statements, remainder := splitStatements(sql)
 		require.Equal(t, []string{"SELECT 1 -- ; in comment", "SELECT 2"}, statements)
 		require.Empty(t, remainder)
 	})
@@ -323,7 +323,7 @@ func TestSplitSemicolonTerminatedStatements(t *testing.T) {
 
 		sql := "SELECT 1 /* ; in comment */;" +
 			"SELECT 2;"
-		statements, remainder := splitSemicolonTerminatedStatements(sql)
+		statements, remainder := splitStatements(sql)
 		require.Equal(
 			t,
 			[]string{"SELECT 1 /* ; in comment */", "SELECT 2"},
@@ -331,4 +331,160 @@ func TestSplitSemicolonTerminatedStatements(t *testing.T) {
 		)
 		require.Empty(t, remainder)
 	})
+}
+
+func TestLooksLikeScriptDDL(t *testing.T) {
+	t.Parallel()
+
+	scripts := []string{
+		"CREATE SCRIPT foo AS",
+		"CREATE PYTHON3 SCALAR SCRIPT foo(x INT) RETURNS INT AS",
+		"CREATE OR REPLACE JAVA ADAPTER SCRIPT foo AS",
+		"CREATE FUNCTION bar (x INT) RETURN INT AS",
+		"create or replace python3 scalar script foo as",
+		"CREATE SOMEFUTURELANG SCALAR SCRIPT foo AS",
+		"-- comment\nCREATE JAVA SCALAR SCRIPT foo AS",
+		"CREATE /* lang */ JAVA SCALAR SCRIPT foo AS",
+		"CREATE/* lang */JAVA SCALAR SCRIPT foo AS",
+		"CREATE--x\nJAVA SCALAR SCRIPT foo AS",
+	}
+	for _, sql := range scripts {
+		require.Truef(t, looksLikeScriptDDL(sql), "expected script DDL: %q", sql)
+	}
+
+	notScripts := []string{
+		"SELECT 1",
+		"CREATE TABLE t (a INT)",
+		"CREATE TABLE script_log (a INT)",
+		"CREATE VIEW v AS SELECT 1",
+		"CREATE TABLE report AS SELECT id FROM script",
+		"CREATE SCHEMA s",
+		"ALTER TABLE t ADD COLUMN c INT",
+		"DROP SCRIPT foo",
+		"TRUNCATE TABLE t",
+		"CREATE /* a script */ TABLE t (id INT)",
+		"CREATE TABLE t -- function\nAS SELECT 1",
+		"CREATE CONNECTION c TO 'a script b'",
+		"CREATE USER u IDENTIFIED BY 'my function pw'",
+	}
+	for _, sql := range notScripts {
+		require.Falsef(t, looksLikeScriptDDL(sql), "expected not script DDL: %q", sql)
+	}
+}
+
+func TestSplitStatementsScriptDelimiter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("java body with semicolons and slashes terminated by slash line", func(t *testing.T) {
+		t.Parallel()
+
+		sql := "CREATE JAVA SCALAR SCRIPT m() RETURNS INT AS\n" +
+			"class M { int run() { return 6 / 2; } }\n/\n"
+		statements, remainder := splitStatements(sql)
+		require.Equal(t, []string{
+			"CREATE JAVA SCALAR SCRIPT m() RETURNS INT AS\n" +
+				"class M { int run() { return 6 / 2; } }",
+		}, statements)
+		require.Empty(t, strings.TrimSpace(remainder))
+	})
+
+	t.Run("script word inside a string literal splits on semicolon", func(t *testing.T) {
+		t.Parallel()
+
+		sql := "CREATE CONNECTION c TO 'a script b';\nSELECT 1;"
+		statements, _ := splitStatements(sql)
+		require.Equal(t, []string{"CREATE CONNECTION c TO 'a script b'", "SELECT 1"}, statements)
+	})
+
+	t.Run("comment glued to CREATE still detects the script", func(t *testing.T) {
+		t.Parallel()
+
+		sql := "CREATE/* c */JAVA SCALAR SCRIPT m() RETURNS INT AS\n" +
+			"class M { int run() { return 1; } }\n/\n"
+		statements, _ := splitStatements(sql)
+		require.Len(t, statements, 1)
+		require.Contains(t, statements[0], "return 1;")
+	})
+
+	t.Run("create table with script word in a comment splits on semicolon", func(t *testing.T) {
+		t.Parallel()
+
+		sql := "CREATE /* a script */ TABLE t (id INT);\nSELECT 1;"
+		statements, _ := splitStatements(sql)
+		require.Equal(t, []string{"CREATE /* a script */ TABLE t (id INT)", "SELECT 1"}, statements)
+	})
+
+	t.Run("mixed normal and script statements", func(t *testing.T) {
+		t.Parallel()
+
+		sql := "OPEN SCHEMA s;\n" +
+			"CREATE PYTHON3 SCALAR SCRIPT add1(x INT) RETURNS INT AS\n" +
+			"def run(c):\n return c.x + 1\n/\n" +
+			"SELECT add1(41) FROM dual;\n"
+		statements, _ := splitStatements(sql)
+		require.Len(t, statements, 3)
+	})
+
+	t.Run("script without slash is buffered, not split on body semicolons", func(t *testing.T) {
+		t.Parallel()
+
+		sql := "CREATE JAVA SCALAR SCRIPT m(x DOUBLE) RETURNS DOUBLE AS\n" +
+			"class M { double run() { return x * 2.0; } }\n"
+		statements, remainder := splitStatements(sql)
+		require.Empty(t, statements)
+		require.Equal(t, sql, remainder)
+	})
+
+	t.Run("buffered script without slash flushes whole at end of input", func(t *testing.T) {
+		t.Parallel()
+
+		sql := "CREATE JAVA SCALAR SCRIPT m(x DOUBLE) RETURNS DOUBLE AS\n" +
+			"class M { double run() { return x * 2.0; } }\n"
+		statements := nonInteractiveStatements(sql)
+		require.Len(t, statements, 1)
+		require.Contains(t, statements[0], "return x * 2.0;")
+	})
+}
+
+func TestScriptBufferedAcrossLinesUntilSlash(t *testing.T) {
+	t.Parallel()
+
+	processor := &mockInputsProcessor{}
+	sql := "CREATE JAVA SCALAR SCRIPT m(x DOUBLE) RETURNS DOUBLE AS\n" +
+		"class M { double run() { return x * 2.0; } }\n" +
+		"/\n" +
+		"SELECT m(5) FROM dual;\n"
+	err := runShellImpl(
+		readline.NewBuffered(strings.NewReader(sql)),
+		processor.processInput,
+		ShellOpts{ExecuteOnSemicolon: true},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, processor.inputs, 2)
+	require.Contains(t, processor.inputs[0], "return x * 2.0;")
+	require.Equal(t, "SELECT m(5) FROM dual", processor.inputs[1])
+}
+
+// An unterminated script is intentionally flushed whole at EOF (client flushes, DB validates).
+func TestScriptWithoutSlashFlushedWholeAtEOF(t *testing.T) {
+	t.Parallel()
+
+	processor := &mockInputsProcessor{}
+	sql := "CREATE JAVA SCALAR SCRIPT m(x DOUBLE) RETURNS DOUBLE AS\n" +
+		"class M { double run() { return x * 2.0; } }\n"
+	err := runShellImpl(
+		readline.NewBuffered(strings.NewReader(sql)),
+		processor.processInput,
+		ShellOpts{ExecuteOnSemicolon: true},
+	)
+
+	require.NoError(t, err)
+	require.Len(t, processor.inputs, 1)
+	require.Equal(
+		t,
+		"CREATE JAVA SCALAR SCRIPT m(x DOUBLE) RETURNS DOUBLE AS\n"+
+			"class M { double run() { return x * 2.0; } }",
+		processor.inputs[0],
+	)
 }

--- a/openspec/changes/add-connect-script-terminator/proposal.md
+++ b/openspec/changes/add-connect-script-terminator/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+`exasol connect` splits SQL input into statements on `;` (quote- and comment-aware). A
+`CREATE ... SCRIPT` / `CREATE ... FUNCTION` body is program code (Java/R, and some Python)
+where `;` is ordinary syntax (e.g. `return x * 2.0;`). Splitting on the first body `;`
+truncated the definition and sent an incomplete statement to the database, producing errors
+like `syntax error, unexpected '}'`. This blocked creating/testing Java and R UDFs through
+`exasol connect` (`-c`/`-f` and interactive) — a core part of the SLC workflow.
+
+We adopt the EXAplus rule for the terminator ([docs](https://docs.exasol.com/db/latest/connect_exasol/sql_clients/exaplus_cli/exaplus_cli.htm)): script and function definitions end with a `/`
+on a line by itself (not `;`), with body semicolons ignored — keeping `exasol connect`
+consistent with the client users already rely on for scripts.
+
+## What Changes
+
+- Script/function definitions terminate on a line containing only `/`, not `;`; semicolons
+  inside a script body are no longer statement terminators.
+- Detection of script DDL is whitespace- and comment-aware; a `CREATE` statement whose only
+  `SCRIPT`/`FUNCTION` occurrence is inside a comment is still treated as a normal statement.
+- An unterminated script (no `/` yet) is buffered until `/` arrives, and any buffered
+  remainder is flushed as a single statement at end of input.
+- All other statements continue to split on `;` exactly as before (no behavior change).
+
+## Impact
+
+- `internal/connect/shell.go`: statement splitter (`findStatementTerminator` dispatch,
+  `findSemicolonTerminator`, `findScriptTerminator`, `looksLikeScriptDDL`).
+- Backward compatible: non-script input splits byte-for-byte as before.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `connect-sql-input`: adds the script/function `/`-terminator rule to the shared splitting
+  behavior used by interactive input, `--command`, and `--file`.

--- a/openspec/changes/add-connect-script-terminator/specs/connect-sql-input/spec.md
+++ b/openspec/changes/add-connect-script-terminator/specs/connect-sql-input/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Script and function definitions terminate on a slash line
+
+`exasol connect` SHALL terminate `CREATE ... SCRIPT` and `CREATE ... FUNCTION` definitions at
+a line whose content is only `/`, rather than at `;`, so that semicolons inside a script or
+function body are not treated as statement terminators. This applies to interactive input and
+to `--command`/`--file`. All other statements SHALL continue to terminate at `;`.
+
+#### Scenario: Script body containing semicolons
+
+- **WHEN** a `CREATE JAVA SCALAR SCRIPT ... AS <body>` whose body contains `;` is submitted and terminated by a `/` on a line by itself
+- **THEN** the whole definition is executed as a single statement, with the body semicolons preserved
+
+#### Scenario: Normal statements still split on semicolons
+
+- **WHEN** semicolon-separated non-script statements are submitted
+- **THEN** they are split and executed on `;` exactly as before
+
+#### Scenario: A script or function keyword inside a comment is not misdetected
+
+- **WHEN** a non-script statement such as `CREATE /* a script */ TABLE t (id INT)` is submitted
+- **THEN** it is treated as a normal `;`-terminated statement, not as a script definition
+
+#### Scenario: Unterminated script definition is not split on body semicolons
+
+- **WHEN** a recognized script/function definition is submitted without a closing `/`
+- **THEN** it is not split at its body semicolons
+- **AND** it stays buffered until a `/` arrives, and any buffered remainder is executed as one statement at end of input

--- a/openspec/changes/add-connect-script-terminator/tasks.md
+++ b/openspec/changes/add-connect-script-terminator/tasks.md
@@ -1,0 +1,17 @@
+## 1. Statement splitting
+
+- [x] 1.1 Terminate `CREATE ... SCRIPT` / `CREATE ... FUNCTION` on a lone `/` line; ignore `;` in the body.
+- [x] 1.2 Keep `;` termination for all other statements, unchanged (quote- and comment-aware).
+- [x] 1.3 Make script-DDL detection whitespace- and comment-aware (a `SCRIPT`/`FUNCTION` word inside a comment is not a keyword).
+- [x] 1.4 Buffer a recognized script with no `/` yet; flush the whole definition at end of input.
+
+## 2. Tests
+
+- [x] 2.1 Java/R script with body semicolons terminated by `/` parses as one statement.
+- [x] 2.2 Normal statements, `ALTER`/`DROP`/`TRUNCATE`, CTAS, and `CREATE TABLE script_log` stay `;`-terminated.
+- [x] 2.3 `CREATE /* a script */ TABLE ...` is not misclassified as a script.
+- [x] 2.4 Unterminated script is buffered (parser) and flushed whole at EOF (interactive and non-interactive).
+
+## 3. Validation
+
+- [x] 3.1 Formatting, focused tests, and full-repo tests pass; OpenSpec validation for this change.


### PR DESCRIPTION
## Description

This PR fixes exasol connect so Java/R UDFs (and any CREATE ... SCRIPT / CREATE ... FUNCTION) can be submitted. Previously it split statements only on `;`. But a script/function body is program code (Java/R, some Python) where `;` is ordinary syntax. So the first body semicolon truncated the definition and the DB rejected it (`syntax error, unexpected '}'`). 

## Related Issue

[SPOT-31649](https://exasol.atlassian.net/browse/SPOT-31649)

Fixes #

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Updated statement splitting to select the terminator based on statement type. CREATE ... SCRIPT/FUNCTION statements now terminate on a standalone / line (ignoring ; within the body), while all other statements continue to terminate on ;.
- Improved script/function detection by inspecting only the leading statement keywords after skipping whitespace and comments, avoiding false positives from occurrences within comments.
- Ensured incomplete script/function definitions are buffered until the terminating / is encountered, or treated as a single statement at end of input, preventing mid-body splits.
- Added test coverage for the new parsing behavior and documented the statement termination rules in the OpenSpec.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

Manually Tested the changes. Logs for reference - [Dev_Testing_Support_Java_R_UDFs.txt](https://github.com/user-attachments/files/30120635/Dev_Testing_Support_Java_R_UDFs.txt)


## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format


[SPOT-31649]: https://exasol.atlassian.net/browse/SPOT-31649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ