### PR TITLE
docs: separate launcher install into its own README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,21 +44,31 @@
 - **STACKIT** — [Set up a STACKIT account for Exasol Personal](./HOWTO_SETUP_STACKIT_ACCOUNT.md)
 
 
+## ⬇️ Install the Launcher
+
+The **Exasol Launcher** (`exasol`) is the command-line tool that deploys and manages your Exasol database, locally or in the cloud. It runs on macOS, Linux, and Windows.
+
+On macOS and Linux, install it with:
+```bash
+curl https://www.exasol.com/install/ | sh
+```
+This places the `exasol` binary in `~/.local/bin`. On most Linux distributions this directory is already in your `PATH`; on macOS, or if the installer reports that `~/.local/bin` is not in your `PATH`, follow the instructions it prints.
+
+On Windows, download the launcher from the [Exasol Download Portal](https://downloads.exasol.com/exasol-personal) and copy the `exasol` binary to a directory in your `PATH`.
+
+Verify the installation with `exasol version`.
+
+
 ## 🏎️ Quick Start — Run Exasol Locally
 
 The fastest way to try Exasol: a full database running on your own Mac.
 
 > **Currently macOS only.** Windows and Linux support is coming soon — to run Exasol on those platforms today, use a cloud deployment (see the **Deploy to the Cloud** section below).
 
-1. Download the launcher:
-   ```bash
-   curl https://www.exasol.com/install/ | sh
-   ```
-
-2. Start a local Exasol database:
-   ```bash
-   exasol install local
-   ```
+With the launcher installed (see **Install the Launcher** above), start a local Exasol database:
+```bash
+exasol install local
+```
 
 In a few seconds you'll have a local Exasol instance running. Run `exasol info` at any time to see how to connect, then head to the **Load Sample Data** section to start querying.
 
@@ -69,20 +79,11 @@ Prefer to run in your own cloud? See the **Deploy to the Cloud** section below.
 
 Deploy Exasol Personal to your own cloud account when you need more scale or a shared instance. Supported providers: AWS, Azure, Exoscale, and STACKIT.
 
-1. Download and install the Exasol Launcher for your platform.
+With the launcher installed (see **Install the Launcher** above):
 
-   On Linux and macOS, run:
-   ```bash
-   curl https://www.exasol.com/install/ | sh
-   ```
+1. Configure authentication for your provider. See the relevant account setup guide in the **Prerequisites** section for the environment variables and credentials required.
 
-   This installs the `exasol` binary to `~/.local/bin`. On most Linux distributions this directory is already in your `PATH`. On macOS, or if the installer reports that `~/.local/bin` is not in your `PATH`, follow its instructions.
-
-   On Windows: download the Exasol Launcher from the [Exasol Download Portal](https://downloads.exasol.com/exasol-personal) and copy the `exasol` binary to a directory in your `PATH`.
-
-2. Configure authentication for your provider. See the relevant account setup guide in the **Prerequisites** section for the environment variables and credentials required.
-
-3. To install Exasol Personal, run the following command with the preset for your cloud provider:
+2. To install Exasol Personal, run the following command with the preset for your cloud provider:
    ```bash
    exasol install aws        # Amazon Web Services
    exasol install azure      # Microsoft Azure


### PR DESCRIPTION
## Description

Separates launcher download/installation from the deployment instructions in the README. A new **Install the Launcher** section now covers getting the `exasol` CLI once, and the Quick Start and Deploy to the Cloud sections reference it instead of repeating the download steps. Documentation-only; no code changes.

## Related Issue

N/A

## Type of Change

- [x] `docs`: Documentation update

## Changes Made

- **New "⬇️ Install the Launcher" section** (between Prerequisites and Quick Start):
  - One-line description of what the Exasol Launcher (`exasol`) is.
  - Supported platforms: macOS, Linux, and Windows.
  - `curl … | sh` install for macOS/Linux, including that the binary lands in `~/.local/bin` and must be on your `PATH`.
  - Windows manual download via the Exasol Download Portal.
  - `exasol version` to verify.
- **Quick Start**: removed the download step; now starts from `exasol install local`, referencing the new section.
- **Deploy to the Cloud**: removed the duplicated download step and renumbered the remaining steps (configure auth → install `<preset>`), referencing the new section.
- Result: the launcher download/install instructions now appear exactly once.

## Testing

- [x] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality — N/A (documentation only)
- [x] Manually tested the changes (reviewed rendered README; verified section flow and that no duplicate install steps remain)

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [ ] Ran `task fmt` and `task lint` — N/A (no code changed)
- [x] Updated documentation (if applicable)
- [ ] Added/updated tests — N/A (documentation only)
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format