### PR TITLE
fix(installer): clarify install location, PATH, and usage

### DIFF
--- a/scripts/personal-installer.sh
+++ b/scripts/personal-installer.sh
@@ -44,7 +44,7 @@ PACKAGE_DOWNLOAD_URL="$BASE_URL/$OS/$ARCH/latest/$DOWNLOAD_FILENAME"
 
 echo "Detected OS: $OS"
 echo "Detected Architecture: $ARCH"
-echo "Installing Exasol Personal binary to $INSTALL_DIR..."
+echo "Installing the Exasol Launcher (the 'exasol' command) to $INSTALL_DIR..."
 
 mkdir -p "$INSTALL_DIR"
 
@@ -58,35 +58,58 @@ chmod +x "$INSTALL_PATH"
 echo
 echo "Installation complete!"
 echo
+echo "The Exasol Launcher ('exasol') is the command-line tool that deploys and"
+echo "manages your Exasol databases. It was installed to:"
+echo "    $INSTALL_PATH"
+echo
 
+# Make sure the install dir is on PATH so 'exasol' can be run from anywhere.
 case ":$PATH:" in
     *":$INSTALL_DIR:"*)
+        echo "$INSTALL_DIR is on your PATH — you're ready to go."
         ;;
     *)
-        echo "  $INSTALL_DIR is not in your PATH. Add this to your shell config:"
+        echo "$INSTALL_DIR is NOT on your PATH yet. Add it so you can run 'exasol' from anywhere:"
         echo "    export PATH=\"\$HOME/.local/bin:\$PATH\""
         echo
         echo "  For zsh:  echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.zshrc"
         echo "  For bash: echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.bashrc"
-        echo
+        echo "  Then restart your shell."
         ;;
 esac
+echo
 
+if [ "$OS" = "macos" ]; then
 cat <<EOF
-Next steps:
-  1. Create a new deployment directory:
-       mkdir -p deployment && cd deployment
+Getting started:
 
-  2. Setup AWS Profile - Refer https://docs.exasol.com/db/latest/get_started/exasol_personal_aws_setup.htm
+  Run Exasol locally on your Mac — ready in seconds:
+      exasol install local
 
-  3. Run the installer from the deployment directory:
-       exasol install <infra preset name-or-path> [install preset name-or-path]
+  Or deploy to your own cloud (AWS, Azure, Exoscale, STACKIT), e.g.:
+      exasol install aws
 
-Where:
-  <infra preset name-or-path>   Infrastructure preset to use (e.g., aws)
-  [install preset name-or-path] Optional installation preset (e.g., ubuntu)
+  Then see how to connect, and open a SQL shell:
+      exasol info
+      exasol connect
 
-Examples:
-  exasol install aws
-  exasol install aws ubuntu
+Full documentation and all options:
+  https://github.com/exasol/exasol-personal
 EOF
+else
+cat <<EOF
+Getting started:
+
+  Deploy Exasol to your own cloud (AWS, Azure, Exoscale, STACKIT), e.g.:
+      exasol install aws
+
+  Then see how to connect, and open a SQL shell:
+      exasol info
+      exasol connect
+
+  (Local deployment is currently macOS only; Windows and Linux support is coming soon.)
+
+Full documentation and all options:
+  https://github.com/exasol/exasol-personal
+EOF
+fi


### PR DESCRIPTION
## Description

Improves the messaging printed by the `curl … | sh` install script (`scripts/personal-installer.sh`). It now explains what was installed and where, prompts the user to check their `PATH`, and gives a high-level usage overview — local-first on macOS, cloud on Linux — with a link to the GitHub repo. No change to what the script installs or how.

## Related Issue

N/A

## Type of Change

- [x] `docs`: Documentation update

(User-facing installer messaging only — behavior/download logic unchanged.)

## Changes Made

- After install, state **what** the binary is (the Exasol Launcher / `exasol` command) and **where** it went (`~/.local/bin/exasol`).
- PATH handling: now also **confirms** when `~/.local/bin` is already on `PATH` (previously silent) and adds a "restart your shell" hint when it isn't.
- Replaced the AWS-only "Next steps" (which told users to `mkdir deployment`, set up an AWS profile, then `exasol install aws`) with an OS-aware **Getting started** overview:
  - **macOS** — leads with `exasol install local` ("ready in seconds"), then cloud (`exasol install aws`, …), then `exasol info` / `exasol connect`.
  - **Linux** — cloud deployment, with a note that local is macOS-only (Windows & Linux coming soon).
- Points to `https://github.com/exasol/exasol-personal` for full documentation.

## Testing

- [x] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality — N/A (no automated tests exist for this script; see Additional Notes)
- [x] Manually tested the changes

### Test Details

`sh -n` syntax check and `shellcheck` both pass. The script was then run end-to-end in a sandbox that avoids touching the real environment: a temporary `HOME`, plus stub `curl` and `uname` executables placed first on `PATH` so nothing is downloaded and the OS/arch can be simulated. It was exercised across all four output branches:

- **macOS, `~/.local/bin` not on PATH** — shows the "NOT on your PATH" guidance and the local-first Getting started.
- **macOS, already on PATH** — shows "is on your PATH — you're ready to go".
- **Linux** — reports `Detected OS: linux` and shows the cloud Getting started with the "local is macOS-only" note.

The rendered output matched the intended text in every case.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [ ] Ran `task fmt` and `task lint` — N/A (shell script; `shellcheck` run manually instead)
- [x] Updated documentation (if applicable)
- [ ] Added/updated tests — N/A (no test harness for this script)
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

`scripts/personal-installer.sh` currently has **no automated test coverage** and isn't referenced by CI or release tooling, so this messaging isn't guarded against regressions — verification for this change was the manual sandbox run described under Test Details.
