### PR TITLE
feat(ci): Add SonarQube scanning

### DIFF
--- a/.github/actions/tests-unit/action.yml
+++ b/.github/actions/tests-unit/action.yml
@@ -7,4 +7,4 @@ runs:
       uses: ./.github/actions/setup-go
     - name: Run Unit Tests
       shell: bash
-      run: task tests-unit
+      run: task tests-unit COVERAGE=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,11 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/tests-unit
+      - name: Upload coverage report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-unit
+          path: coverage.out
 
   tests-integration:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,0 +1,39 @@
+name: SonarQube
+
+# Runs as a follow-up to "Push to PR or main - Run full CI" via workflow_run rather than
+# directly on pull_request/push. workflow_run always executes in this repo's own privileged
+# context (with access to secrets) regardless of whether the triggering run came from a fork
+# PR, so this is the only way to actually scan and gate fork-originated PRs: a plain
+# pull_request trigger never receives repo secrets for fork PRs, so it could never do more
+# than fail auth for external contributions.
+on:
+  workflow_run:
+    workflows: ["Push to PR or main - Run full CI"]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  run-sonarqube-action:
+    name: run SonarQube on the branch
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    permissions:
+      contents: read
+      actions: read # required to download the coverage artifact from the triggering run
+    steps:
+      - name: checkout the analyzed commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Download coverage report
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: coverage-unit
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -141,18 +141,15 @@ tasks:
       - deps-install-poetry
 
   tests-unit:
-    desc: Run unit tests (`task tests-unit TEST=Ready` or `task tests-unit TEST=*Ready*`)
+    desc: 'Run unit tests. TEST is a regex for `go test -run` (substring match, e.g. TEST=Ready). COVERAGE=true collects a coverage profile.'
     deps:
       - local-runner-placeholders
     vars:
       TEST: '{{default "" .TEST}}'
+      COVERAGE: '{{default "false" .COVERAGE}}'
     cmds:
-      - '{{if .TEST}}go test -v -race -run "{{.TEST}}" ./...{{else}}go test -v -race ./...{{end}}'
-      # Disabling coverage until it works with different toolchains
-      # Error that you get when running tests with coverage and when local go is older then what defined in go.mod:
-      # compile: version "go1.25.5" does not match go tool version "go1.25.1"
-      #- go test -v -race -coverprofile=coverage.out ./...
-      #- go tool cover -func=coverage.out
+      - go test -v -race{{if eq .COVERAGE "true"}} -coverprofile=coverage.out -covermode=atomic{{end}}{{if .TEST}} -run "{{.TEST}}"{{end}} ./...
+      - '{{if eq .COVERAGE "true"}}go tool cover -func=coverage.out{{end}}'
 
   tests-unit-find:
     desc: Find Go unit test names by wildcard on Linux (`task tests-unit-find TEST=*Ready*`)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,8 @@
+sonar.projectKey=com.exasol:exasol-personal
+sonar.organization=exasol
+sonar.sources=.
+sonar.exclusions=**/*_test.go
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go
+sonar.go.coverage.reportPaths=./coverage.out
+sonar.coverage.exclusions=**/*_test.go


### PR DESCRIPTION
## Description

Wires SonarQube static analysis into CI for Exasol Personal.

## Related Issue

[SPOT-31665](https://exasol.atlassian.net/browse/SPOT-31665)

## Type of Change

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Add `.github/workflows/sonarqube.yml`, triggered via `workflow_run` after "Push to PR or main - Run full CI" completes, running `SonarSource/sonarqube-scan-action` with `SONAR_TOKEN`.
- Add `sonar-project.properties` configuring Go coverage reporting (`coverage.out`) and standard exclusions.
- Update `ci.yml` to upload the `coverage-unit` artifact consumed by the SonarQube workflow.
- Add a `COVERAGE=true` option to `task tests-unit` and wire it through the CI unit-test action so coverage can be generated on demand.

## Testing

- [x] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [ ] Manually tested the changes

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [ ] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

CI will show the SonarQube job failing on auth until `SONAR_TOKEN` is added to this repo.


[SPOT-31665]: https://exasol.atlassian.net/browse/SPOT-31665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ