### PR TITLE
feat: Upgrade local VM runner on start for minor and patch versions

### DIFF
--- a/internal/localruntime/runner_reconciliation_test.go
+++ b/internal/localruntime/runner_reconciliation_test.go
@@ -1,0 +1,241 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package localruntime
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+)
+
+func TestReconcileRunner_InstallsMissingRunner(t *testing.T) {
+	t.Parallel()
+	requirePOSIXRunnerTest(t)
+
+	// Given
+	targetPath := filepath.Join(t.TempDir(), RunnerFileName)
+	embedded := versionedRunner("1.2.3", "embedded")
+
+	// When
+	err := reconcileRunner(context.Background(), targetPath, embedded)
+	// Then
+	assertRunnerContent(t, targetPath, embedded)
+	if err != nil {
+		t.Fatalf("expected missing runner installation to succeed, got %v", err)
+	}
+}
+
+func TestReconcileRunner_UpgradesUnversionedRunner(t *testing.T) {
+	t.Parallel()
+	requirePOSIXRunnerTest(t)
+
+	// Given
+	targetPath := filepath.Join(t.TempDir(), RunnerFileName)
+	writeExecutableTestFile(t, targetPath, []byte("#!/bin/sh\nexit 2\n"))
+	embedded := versionedRunner("1.2.3", "embedded")
+
+	// When
+	err := reconcileRunner(context.Background(), targetPath, embedded)
+	// Then
+	if err != nil {
+		t.Fatalf("expected unversioned runner upgrade to succeed, got %v", err)
+	}
+	assertRunnerContent(t, targetPath, embedded)
+}
+
+func TestReconcileRunner_UpgradesNewerMinorRunner(t *testing.T) {
+	t.Parallel()
+	requirePOSIXRunnerTest(t)
+
+	// Given
+	targetPath := filepath.Join(t.TempDir(), RunnerFileName)
+	writeExecutableTestFile(t, targetPath, versionedRunner("1.1.4", "installed"))
+	embedded := versionedRunner("1.2.0", "embedded")
+
+	// When
+	err := reconcileRunner(context.Background(), targetPath, embedded)
+	// Then
+	if err != nil {
+		t.Fatalf("expected compatible runner upgrade to succeed, got %v", err)
+	}
+	assertRunnerContent(t, targetPath, embedded)
+}
+
+func TestReconcileRunner_UpgradesNewerReleaseCandidate(t *testing.T) {
+	t.Parallel()
+	requirePOSIXRunnerTest(t)
+
+	// Given
+	targetPath := filepath.Join(t.TempDir(), RunnerFileName)
+	writeExecutableTestFile(t, targetPath, versionedRunner("1.2.3-rc1", "installed"))
+	embedded := versionedRunner("1.2.3-rc2", "embedded")
+
+	// When
+	err := reconcileRunner(context.Background(), targetPath, embedded)
+	// Then
+	if err != nil {
+		t.Fatalf("expected release-candidate runner upgrade to succeed, got %v", err)
+	}
+	assertRunnerContent(t, targetPath, embedded)
+}
+
+func TestReconcileRunner_DoesNotDowngradeRunner(t *testing.T) {
+	t.Parallel()
+	requirePOSIXRunnerTest(t)
+
+	// Given
+	targetPath := filepath.Join(t.TempDir(), RunnerFileName)
+	installed := versionedRunner("1.3.0", "installed")
+	writeExecutableTestFile(t, targetPath, installed)
+
+	// When
+	err := reconcileRunner(context.Background(), targetPath, versionedRunner("1.2.9", "embedded"))
+	// Then
+	if err != nil {
+		t.Fatalf("expected runner downgrade to be skipped, got %v", err)
+	}
+	assertRunnerContent(t, targetPath, installed)
+}
+
+func TestReconcileRunner_KeepsIdenticalRunner(t *testing.T) {
+	t.Parallel()
+	requirePOSIXRunnerTest(t)
+
+	// Given
+	targetPath := filepath.Join(t.TempDir(), RunnerFileName)
+	embedded := versionedRunner("1.2.3", "same")
+	writeExecutableTestFile(t, targetPath, embedded)
+
+	// When
+	err := reconcileRunner(context.Background(), targetPath, embedded)
+	// Then
+	if err != nil {
+		t.Fatalf("expected identical runner reconciliation to succeed, got %v", err)
+	}
+	assertRunnerContent(t, targetPath, embedded)
+}
+
+func TestReconcileRunner_RepairsDifferentRunnerWithSameVersion(t *testing.T) {
+	t.Parallel()
+	requirePOSIXRunnerTest(t)
+
+	// Given
+	targetPath := filepath.Join(t.TempDir(), RunnerFileName)
+	writeExecutableTestFile(t, targetPath, versionedRunner("1.2.3", "installed"))
+	embedded := versionedRunner("1.2.3", "embedded")
+
+	// When
+	err := reconcileRunner(context.Background(), targetPath, embedded)
+	// Then
+	if err != nil {
+		t.Fatalf("expected same-version runner repair to succeed, got %v", err)
+	}
+	assertRunnerContent(t, targetPath, embedded)
+}
+
+func TestReconcileRunner_PreservesRunnerAcrossMajorVersions(t *testing.T) {
+	t.Parallel()
+	requirePOSIXRunnerTest(t)
+
+	// Given
+	targetPath := filepath.Join(t.TempDir(), RunnerFileName)
+	installed := versionedRunner("1.9.0", "installed")
+	writeExecutableTestFile(t, targetPath, installed)
+
+	// When
+	err := reconcileRunner(context.Background(), targetPath, versionedRunner("2.0.0", "embedded"))
+	// Then
+	if err != nil {
+		t.Fatalf("expected major runner update to be skipped, got %v", err)
+	}
+	assertRunnerContent(t, targetPath, installed)
+}
+
+func TestReconcileRunner_RejectsInvalidEmbeddedRunnerWithoutChangingInstalled(t *testing.T) {
+	t.Parallel()
+	requirePOSIXRunnerTest(t)
+
+	// Given
+	targetPath := filepath.Join(t.TempDir(), RunnerFileName)
+	installed := versionedRunner("1.2.3", "installed")
+	writeExecutableTestFile(t, targetPath, installed)
+
+	// When
+	err := reconcileRunner(
+		context.Background(),
+		targetPath,
+		[]byte("#!/bin/sh\nprintf 'invalid-version\\n'\n"),
+	)
+	// Then
+	if err == nil ||
+		!strings.Contains(err.Error(), "embedded local runner does not report a valid version") {
+		t.Fatalf("expected invalid embedded runner error, got %v", err)
+	}
+	assertRunnerContent(t, targetPath, installed)
+}
+
+func TestReconcileRunnerExecutable_InternalOverrideForcesUnversionedRunnerUpdate(t *testing.T) {
+	requirePOSIXRunnerTest(t)
+
+	// Given
+	t.Setenv(forceRunnerReconciliationEnv, "1")
+	deployment := config.NewDeploymentDir(t.TempDir())
+	localRuntime := newRuntime(deployment, Config{})
+	embedded := []byte("#!/bin/sh\n# embedded\nexit 1\n")
+	localRuntime.embeddedRunner = embedded
+	localRuntime.embeddedRunnerExists = true
+	if err := os.MkdirAll(localRuntime.paths.WorkDir, dirMode); err != nil {
+		t.Fatalf("failed to create runner directory: %v", err)
+	}
+	writeExecutableTestFile(
+		t,
+		localRuntime.paths.RunnerPath,
+		[]byte("#!/bin/sh\n# installed\nexit 2\n"),
+	)
+
+	// When
+	err := localRuntime.reconcileRunnerExecutable(context.Background())
+	// Then
+	if err != nil {
+		t.Fatalf("expected internal override to force reconciliation, got %v", err)
+	}
+	assertRunnerContent(t, localRuntime.paths.RunnerPath, embedded)
+}
+
+func requirePOSIXRunnerTest(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == windowsGOOS {
+		t.Skip("fake local runner script is POSIX-only")
+	}
+}
+
+func versionedRunner(version, identity string) []byte {
+	return []byte("#!/bin/sh\n" +
+		"# " + identity + "\n" +
+		"if [ \"$1\" = version ]; then\n" +
+		"  printf 'v" + version + "\\n'\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 2\n")
+}
+
+func assertRunnerContent(t *testing.T, path string, expected []byte) {
+	t.Helper()
+	actual, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("expected runner %s to exist", path)
+		}
+		t.Fatalf("failed to read runner %s: %v", path, err)
+	}
+	if string(actual) != string(expected) {
+		t.Fatalf("expected runner content %q, got %q", string(expected), string(actual))
+	}
+}

--- a/internal/localruntime/runtime.go
+++ b/internal/localruntime/runtime.go
@@ -13,6 +13,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -21,6 +22,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/exasol/exasol-personal/assets/localruntimebin"
 	"github.com/exasol/exasol-personal/internal/config"
 	"github.com/exasol/exasol-personal/internal/util"
@@ -42,6 +44,8 @@ const (
 	privateFileMode    = 0o600
 	executableFileMode = 0o700
 	maxTCPPort         = 65535
+	// Internal escape hatch for development with embedded runners that predate version reporting.
+	forceRunnerReconciliationEnv = "EXASOL_LOCAL_FORCE_RUNNER_RECONCILIATION"
 )
 
 type Config struct {
@@ -233,16 +237,20 @@ func Destroy(ctx context.Context, deployment config.DeploymentDir, out, outErr i
 }
 
 type localRuntime struct {
-	deployment    config.DeploymentDir
-	paths         Paths
-	runtimeConfig Config
+	deployment           config.DeploymentDir
+	paths                Paths
+	runtimeConfig        Config
+	embeddedRunner       []byte
+	embeddedRunnerExists bool
 }
 
 func newRuntime(deployment config.DeploymentDir, runtimeConfig Config) *localRuntime {
 	return &localRuntime{
-		deployment:    deployment,
-		paths:         NewPaths(deployment),
-		runtimeConfig: runtimeConfig,
+		deployment:           deployment,
+		paths:                NewPaths(deployment),
+		runtimeConfig:        runtimeConfig,
+		embeddedRunner:       localruntimebin.RunnerBinary,
+		embeddedRunnerExists: localruntimebin.RunnerBinaryAvailable,
 	}
 }
 
@@ -253,7 +261,7 @@ func (runtime *localRuntime) prepare(
 	if err := os.MkdirAll(runtime.paths.WorkDir, dirMode); err != nil {
 		return fmt.Errorf("failed to create local runtime directory: %w", err)
 	}
-	if err := runtime.ensureRunnerExecutable(); err != nil {
+	if err := runtime.reconcileRunnerExecutable(ctx); err != nil {
 		return err
 	}
 	if err := runtime.ensureSSHKey(); err != nil {
@@ -298,10 +306,7 @@ func (runtime *localRuntime) toState(state *runnerState) (*State, error) {
 }
 
 func (runtime *localRuntime) ensureRunnerExecutable() error {
-	return writeEmbeddedRunner(runtime.paths.RunnerPath)
-}
-
-func writeEmbeddedRunner(targetPath string) error {
+	targetPath := runtime.paths.RunnerPath
 	if info, err := os.Stat(targetPath); err == nil {
 		if info.IsDir() {
 			return fmt.Errorf("local runner target is a directory: %s", targetPath)
@@ -312,6 +317,208 @@ func writeEmbeddedRunner(targetPath string) error {
 		return fmt.Errorf("failed to inspect local runner %s: %w", targetPath, err)
 	}
 
+	return writeEmbeddedRunner(targetPath)
+}
+
+func (runtime *localRuntime) reconcileRunnerExecutable(ctx context.Context) error {
+	if !runtime.embeddedRunnerExists || len(runtime.embeddedRunner) == 0 {
+		return runtime.ensureRunnerExecutable()
+	}
+
+	return reconcileRunner(ctx, runtime.paths.RunnerPath, runtime.embeddedRunner)
+}
+
+func reconcileRunner(ctx context.Context, targetPath string, embeddedRunner []byte) error {
+	if err := os.MkdirAll(filepath.Dir(targetPath), dirMode); err != nil {
+		return fmt.Errorf("failed to create local runner target directory: %w", err)
+	}
+
+	candidatePath, cleanup, err := writeRunnerCandidate(targetPath, embeddedRunner)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	candidateVersion, err := readRunnerVersion(ctx, candidatePath)
+	forceReconciliation := strings.TrimSpace(os.Getenv(forceRunnerReconciliationEnv)) == "1"
+	if err != nil && !forceReconciliation {
+		return fmt.Errorf("embedded local runner does not report a valid version: %w", err)
+	}
+	candidateVersionErr := err
+
+	installedData, err := os.ReadFile(targetPath)
+	if candidateVersionErr != nil && forceReconciliation {
+		if err == nil && bytes.Equal(installedData, embeddedRunner) {
+			return os.Chmod(targetPath, executableFileMode)
+		}
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("failed to inspect local runner %s: %w", targetPath, err)
+		}
+
+		return installUnversionedRunnerCandidate(
+			candidatePath,
+			targetPath,
+			candidateVersionErr,
+		)
+	}
+
+	if errors.Is(err, os.ErrNotExist) {
+		return installRunnerCandidate(
+			candidatePath,
+			targetPath,
+			candidateVersion,
+			"installing missing runner",
+		)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to inspect local runner %s: %w", targetPath, err)
+	}
+	if bytes.Equal(installedData, embeddedRunner) {
+		return os.Chmod(targetPath, executableFileMode)
+	}
+
+	installedVersion, err := readRunnerVersion(ctx, targetPath)
+	if err != nil {
+		return installRunnerCandidate(
+			candidatePath,
+			targetPath,
+			candidateVersion,
+			"upgrading unversioned legacy runner",
+		)
+	}
+
+	if installedVersion.Major != candidateVersion.Major {
+		slog.Warn(
+			"local runner major versions differ; automatic update skipped",
+			"installedVersion", installedVersion,
+			"embeddedVersion", candidateVersion,
+			"action", "use a compatible launcher or explicitly migrate the local deployment",
+		)
+
+		return nil
+	}
+
+	if installedVersion.GT(candidateVersion) {
+		slog.Info(
+			"installed local runner is newer than the embedded runner; downgrade skipped",
+			"installedVersion", installedVersion,
+			"embeddedVersion", candidateVersion,
+		)
+
+		return nil
+	}
+
+	reason := "repairing local runner from embedded binary"
+	if candidateVersion.GT(installedVersion) {
+		reason = "upgrading local runner"
+	}
+
+	return installRunnerCandidate(candidatePath, targetPath, candidateVersion, reason)
+}
+
+func writeRunnerCandidate(targetPath string, runner []byte) (string, func(), error) {
+	temporary, err := os.CreateTemp(filepath.Dir(targetPath), ".local-runner-candidate-*")
+	if err != nil {
+		return "", func() {}, fmt.Errorf("failed to create local runner candidate: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	cleanup := func() {
+		_ = os.Remove(temporaryPath)
+	}
+
+	if err := temporary.Chmod(executableFileMode); err != nil {
+		_ = temporary.Close()
+		cleanup()
+
+		return "", func() {}, fmt.Errorf(
+			"failed to make local runner candidate executable: %w",
+			err,
+		)
+	}
+	if _, err := temporary.Write(runner); err != nil {
+		_ = temporary.Close()
+		cleanup()
+
+		return "", func() {}, fmt.Errorf("failed to write local runner candidate: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		cleanup()
+
+		return "", func() {}, fmt.Errorf("failed to sync local runner candidate: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		cleanup()
+
+		return "", func() {}, fmt.Errorf("failed to close local runner candidate: %w", err)
+	}
+
+	return temporaryPath, cleanup, nil
+}
+
+func readRunnerVersion(ctx context.Context, runnerPath string) (semver.Version, error) {
+	cmd := exec.CommandContext(ctx, runnerPath, "version")
+	cmd.Dir = filepath.Dir(runnerPath)
+	output, err := cmd.Output()
+	if err != nil {
+		return semver.Version{}, fmt.Errorf("runner version command failed: %w", err)
+	}
+
+	version, err := semver.ParseTolerant(strings.TrimSpace(string(output)))
+	if err != nil {
+		return semver.Version{}, fmt.Errorf(
+			"invalid runner version %q: %w",
+			strings.TrimSpace(string(output)),
+			err,
+		)
+	}
+
+	return version, nil
+}
+
+func installRunnerCandidate(
+	candidatePath, targetPath string,
+	version semver.Version,
+	reason string,
+) error {
+	if err := replaceRunnerCandidate(candidatePath, targetPath); err != nil {
+		return err
+	}
+
+	slog.Info(reason, "version", version)
+
+	return nil
+}
+
+func installUnversionedRunnerCandidate(
+	candidatePath, targetPath string,
+	versionErr error,
+) error {
+	if err := replaceRunnerCandidate(candidatePath, targetPath); err != nil {
+		return err
+	}
+
+	slog.Warn(
+		"forced local runner reconciliation without version compatibility checks",
+		"environmentVariable", forceRunnerReconciliationEnv,
+		"versionError", versionErr,
+	)
+
+	return nil
+}
+
+func replaceRunnerCandidate(candidatePath, targetPath string) error {
+	if err := os.Rename(candidatePath, targetPath); err != nil {
+		return fmt.Errorf("failed to atomically replace local runner %s: %w", targetPath, err)
+	}
+	if err := os.Chmod(targetPath, executableFileMode); err != nil {
+		return fmt.Errorf("failed to set local runner permissions: %w", err)
+	}
+
+	return nil
+}
+
+func writeEmbeddedRunner(targetPath string) error {
 	if err := os.MkdirAll(filepath.Dir(targetPath), dirMode); err != nil {
 		return fmt.Errorf("failed to create local runner target directory: %w", err)
 	}

--- a/internal/localruntime/runtime_test.go
+++ b/internal/localruntime/runtime_test.go
@@ -4,6 +4,7 @@
 package localruntime
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
@@ -167,6 +168,9 @@ func TestPrepare_UsesExistingRunnerWithSSHKey(t *testing.T) {
 	existingRunner := `#!/bin/sh
 set -eu
 case "$1" in
+  version)
+    printf 'v1.0.0\n'
+    ;;
   init)
     if [ "$2" != "--ssh-key" ] || [ ! -f "$3" ]; then
       echo "expected init --ssh-key <private-key>, got: $*" >&2
@@ -181,6 +185,8 @@ case "$1" in
     ;;
 esac
 `
+	localRuntime.embeddedRunner = []byte(existingRunner)
+	localRuntime.embeddedRunnerExists = true
 	writeExecutableTestFile(t, localRuntime.paths.RunnerPath, []byte(existingRunner))
 
 	// When
@@ -516,8 +522,11 @@ func TestWriteEmbeddedRunner_WritesBundledRunner(t *testing.T) {
 	}
 }
 
-func TestWriteEmbeddedRunner_DoesNotOverwriteExistingRunner(t *testing.T) {
+func TestWriteEmbeddedRunner_OverwritesExistingRunner(t *testing.T) {
 	t.Parallel()
+	if !localruntimebin.RunnerBinaryAvailable {
+		t.Skip("embedded local runner is only available for macOS Apple Silicon builds")
+	}
 
 	// Given
 	targetPath := filepath.Join(t.TempDir(), RunnerFileName)
@@ -528,14 +537,14 @@ func TestWriteEmbeddedRunner_DoesNotOverwriteExistingRunner(t *testing.T) {
 	err := writeEmbeddedRunner(targetPath)
 	// Then
 	if err != nil {
-		t.Fatalf("expected existing runner to be accepted, got %v", err)
+		t.Fatalf("expected embedded runner write to succeed, got %v", err)
 	}
 	data, err := os.ReadFile(targetPath)
 	if err != nil {
 		t.Fatalf("expected existing runner to be readable, got %v", err)
 	}
-	if string(data) != string(existingContent) {
-		t.Fatalf("expected embedded runner not to overwrite existing runner, got %q", string(data))
+	if !bytes.Equal(data, localruntimebin.RunnerBinary) {
+		t.Fatal("expected embedded runner to overwrite existing runner")
 	}
 }
 

--- a/openspec/changes/archive/2026-07-21-upgrade-unversioned-local-runner/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-21-upgrade-unversioned-local-runner/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/openspec/changes/archive/2026-07-21-upgrade-unversioned-local-runner/design.md
+++ b/openspec/changes/archive/2026-07-21-upgrade-unversioned-local-runner/design.md
@@ -1,0 +1,75 @@
+## Context
+
+The launcher embeds one Exasol Local runner and copies it into each deployment's launcher-owned runtime directory. The current staging operation stops after finding any existing file, so deployments keep the runner from their first installation indefinitely. The runner shipped with Exasol Personal 2.0 predates runner version reporting; the migration runner and all future runners provide a side-effect-free `version` command whose trimmed stdout is a semantic version.
+
+Runner reconciliation happens through `internal/localruntime`, while the deployment workflow guarantees that `Prepare` runs after a deployment is permitted to start and before the runner's `init` or `start` command. Status and stop operations may execute while a daemon from the installed runner is active and therefore must not replace it.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Upgrade the one unversioned production runner to the embedded migration runner before start.
+- Automatically apply newer compatible runner patch and minor versions.
+- Avoid automatic runner downgrades and major-version changes.
+- Repair a same-version runner whose bytes differ from the trusted embedded binary.
+- Make replacement atomic and safe to retry after interruption.
+
+**Non-Goals:**
+
+- Add a user-facing command for opting into major runner migrations.
+- Update a runner while its VM daemon may be running.
+- Preserve unsupported user modifications inside the launcher-owned runner path.
+- Change cloud deployment lifecycle behavior.
+
+## Decisions
+
+### Probe the installed and embedded runners through the runner contract
+
+The launcher will materialize the embedded runner as a temporary executable in the runtime directory and invoke `version` on both candidates. Version output uses the project's `v`-prefixed semantic-version convention and is parsed tolerantly after trimming whitespace, including release-candidate suffixes. This keeps the runner binary authoritative and avoids duplicating its version in launcher source or parsing release URLs.
+
+Failure to obtain a valid version from the installed runner classifies it as the unversioned legacy runner and permits the one-time replacement. Failure to obtain a valid version from the embedded runner is a packaging error and blocks start.
+
+Alternative considered: identify the legacy runner by a checked-in digest. That distinguishes custom binaries, but adds historical release metadata solely for a one-time migration and is unnecessary because the runtime path is launcher-owned.
+
+### Reconcile only during prepare
+
+`Prepare` will reconcile the runner before VM initialization or start. Status, stop, and destroy retain the installed runner so a replacement cannot introduce a new CLI/daemon contract while the old daemon is active.
+
+Alternative considered: reconcile from the shared executable-presence check. That check is also used by status and stop, making its lifecycle timing unsafe for upgrades.
+
+### Apply an upgrade-only semantic-version policy
+
+An unversioned installed runner is replaced by the versioned embedded migration runner. For versioned runners, a newer embedded patch or minor within the same major is installed; an older embedded runner is never installed. Equal semantic versions with different bytes are repaired from the trusted embedded copy. A major mismatch preserves the installed runner and emits an actionable warning.
+
+Alternative considered: overwrite on every byte difference. That can silently downgrade runners or cross an incompatible major boundary.
+
+### Replace atomically from a same-directory temporary file
+
+The launcher writes the embedded bytes to an executable temporary file in the runner directory, validates its version, and renames it over the installed path when policy permits. A same-directory rename prevents a partially written runner from becoming the managed executable. Cleanup removes unused candidates.
+
+Alternative considered: truncate and rewrite the installed runner. Interruption could leave a deployment without an executable runner.
+
+### Provide a temporary internal forced-reconciliation bypass
+
+Setting `EXASOL_LOCAL_FORCE_RUNNER_RECONCILIATION=1` allows an embedded runner without a valid version to participate in reconciliation. When its bytes differ from the installed runner, the launcher atomically installs it without semantic-version compatibility checks and emits a warning; equal bytes remain a no-op. This enables migration testing before a versioned runner is available without weakening the default production path.
+
+Alternative considered: skip reconciliation when the embedded runner is unversioned. That would preserve the exact runner the migration build is intended to replace.
+
+## Risks / Trade-offs
+
+- A custom unversioned runner in the launcher-owned path is replaced → Treat that path as managed state and require development/test runners to implement `version` or be embedded as the candidate.
+- A version command fails for a reason other than being unsupported → The legacy rule repairs the installed runner from the trusted embedded copy; candidate failures still block start.
+- A future launcher retains the unversioned exception across a major boundary → Keep the exception tied to the migration-capable runner line and require explicit major-upgrade design before changing the embedded runner major.
+- Warning while retaining an older major assumes launcher compatibility → Preserve the narrow existing runner command contract and add an explicit major migration workflow before making incompatible calls.
+- The internal bypass can cross compatibility boundaries → Keep it undocumented for end users, require an exact opt-in value, and warn whenever it installs an unversioned runner.
+
+## Migration Plan
+
+1. Release a versioned migration runner through the existing embedded-runner packaging path.
+2. On the first subsequent install or start, replace the unversioned runner atomically before invoking it.
+3. On later starts, use semantic versions and content equality to select no-op, compatible upgrade, repair, or warning behavior.
+4. Roll back the launcher without downgrading the installed runner; an older bundled runner is retained rather than installed.
+
+## Open Questions
+
+None for the 2.0 migration. A future major runner release requires a separate explicit opt-in migration design.

--- a/openspec/changes/archive/2026-07-21-upgrade-unversioned-local-runner/proposal.md
+++ b/openspec/changes/archive/2026-07-21-upgrade-unversioned-local-runner/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Existing Exasol Local deployments retain the runner first staged into their runtime directory, so launcher releases cannot deliver runner bug fixes or migrations. The runner shipped with Exasol Personal 2.0 has no version command, requiring a bounded legacy upgrade rule before future runners can use semantic-version compatibility.
+
+## What Changes
+
+- Reconcile the launcher-managed local runner immediately before initializing or starting a stopped local VM.
+- Replace an unversioned legacy runner with the embedded migration-capable runner.
+- Use runner semantic versions to automatically apply newer patch and minor releases without downgrading.
+- Preserve an installed runner across major-version differences and report an actionable incompatibility instead of updating automatically.
+- Replace differing bytes for the same runner version from the trusted embedded copy.
+- Provide an internal development override that forces byte-based reconciliation when the embedded runner is temporarily unversioned.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `exasol-local-deployment`: Define version-aware staging, the bounded unversioned-runner migration, and major-version protection for launcher-owned local runners.
+
+## Impact
+
+The local runtime staging path, embedded runner metadata, local lifecycle diagnostics, fake-runner tests, and release packaging are affected. The runner contract gains a side-effect-free `version` command returning a semantic version; no cloud deployment behavior changes.

--- a/openspec/changes/archive/2026-07-21-upgrade-unversioned-local-runner/specs/exasol-local-deployment/spec.md
+++ b/openspec/changes/archive/2026-07-21-upgrade-unversioned-local-runner/specs/exasol-local-deployment/spec.md
@@ -1,0 +1,70 @@
+## MODIFIED Requirements
+
+### Requirement: Launcher-owned local runtime
+
+The system SHALL own the local VM runtime files, VM disk/data, and managed deployment share inside the deployment directory.
+
+#### Scenario: Embedded runner is staged
+
+- **WHEN** the launcher initializes or starts a local deployment without an installed runner
+- **THEN** it atomically writes the embedded macOS Exasol Local runner into the launcher-owned runtime directory before invoking it
+
+#### Scenario: Unversioned legacy runner is upgraded
+
+- **WHEN** the launcher prepares a stopped local deployment whose installed runner does not report a valid semantic version
+- **THEN** it atomically replaces that runner with the versioned embedded migration runner before invoking it
+
+#### Scenario: Compatible runner update is applied
+
+- **WHEN** the embedded runner is a newer patch or minor version within the installed runner's major version
+- **THEN** the launcher atomically replaces the installed runner before starting the local deployment
+
+#### Scenario: Release-candidate runner update is applied
+
+- **WHEN** a `v`-prefixed embedded runner release candidate has greater semantic precedence than the installed release candidate within the same major version
+- **THEN** the launcher atomically replaces the installed runner before starting the local deployment
+
+#### Scenario: Runner is not downgraded
+
+- **WHEN** the installed runner is newer than the embedded runner within the same major version
+- **THEN** the launcher retains the installed runner
+
+#### Scenario: Same-version runner content differs
+
+- **WHEN** the installed and embedded runners report the same semantic version but contain different bytes
+- **THEN** the launcher replaces the installed runner with the trusted embedded runner before starting the local deployment
+
+#### Scenario: Major runner update requires user action
+
+- **WHEN** the installed and embedded runners report different major versions
+- **THEN** the launcher retains the installed runner and informs the user that major runner updates are not automatic
+
+#### Scenario: Active runner is not replaced
+
+- **WHEN** the launcher performs status, stop, or destroy behavior for a local deployment
+- **THEN** it does not replace an existing runner before invoking the lifecycle behavior
+
+#### Scenario: Embedded runner version is invalid
+
+- **WHEN** the embedded runner does not report a valid semantic version during preparation
+- **THEN** the launcher fails before replacing or starting the installed runner
+
+#### Scenario: Internal forced-reconciliation bypass is enabled
+
+- **WHEN** development explicitly enables forced reconciliation with a differing unversioned embedded runner
+- **THEN** the launcher atomically installs the embedded runner without version compatibility checks and warns that reconciliation was forced
+
+#### Scenario: Runner VM sizing is prepared
+
+- **WHEN** the launcher initializes or starts a local deployment
+- **THEN** it exposes VM CPU, VM memory, and Exasol Local data disk sizing through the runner start command
+
+#### Scenario: Managed share is prepared
+
+- **WHEN** the launcher initializes a local deployment
+- **THEN** it creates a launcher-managed share for guest coordination and SSH key import
+
+#### Scenario: User shares are not exposed
+
+- **WHEN** the user initializes or starts a local deployment
+- **THEN** the launcher does not require or expose user-configurable shared folder settings

--- a/openspec/changes/archive/2026-07-21-upgrade-unversioned-local-runner/tasks.md
+++ b/openspec/changes/archive/2026-07-21-upgrade-unversioned-local-runner/tasks.md
@@ -1,0 +1,17 @@
+## 1. Runner Reconciliation
+
+- [x] 1.1 Add side-effect-free semantic-version probing for installed and embedded runner executables
+- [x] 1.2 Reconcile runners during prepare using legacy, compatible upgrade, same-version repair, downgrade, and major-mismatch policies
+- [x] 1.3 Replace eligible runners atomically without changing status, stop, or destroy staging behavior
+
+## 2. Behavioral Coverage
+
+- [x] 2.1 Add unit coverage for missing, unversioned, compatible newer, older, equal-content, same-version-different-content, major-mismatch, and invalid embedded runners
+- [x] 2.2 Update existing fake-runner coverage to satisfy the version contract without weakening lifecycle assertions
+- [x] 2.3 Add a warned internal development override that forces reconciliation with an unversioned embedded runner
+- [x] 2.4 Accept the project's `v`-prefixed runner versions and cover release-candidate upgrades
+
+## 3. Verification
+
+- [x] 3.1 Run formatting and focused Go unit tests for the local runtime and deployment workflow
+- [x] 3.2 Run repository unit tests and build the launcher with a versioned runner asset

--- a/openspec/specs/exasol-local-deployment/spec.md
+++ b/openspec/specs/exasol-local-deployment/spec.md
@@ -26,20 +26,65 @@ The system SHALL provide a local deployment option for macOS Apple Silicon that 
 
 The system SHALL own the local VM runtime files, VM disk/data, and managed deployment share inside the deployment directory.
 
-#### Scenario: Managed share is prepared
-
-- **WHEN** the launcher initializes a local deployment
-- **THEN** it creates a launcher-managed share for guest coordination and SSH key import
-
 #### Scenario: Embedded runner is staged
 
-- **WHEN** the launcher initializes or starts a local deployment
-- **THEN** it writes the embedded macOS Exasol Local runner into the launcher-owned runtime directory before invoking it
+- **WHEN** the launcher initializes or starts a local deployment without an installed runner
+- **THEN** it atomically writes the embedded macOS Exasol Local runner into the launcher-owned runtime directory before invoking it
+
+#### Scenario: Unversioned legacy runner is upgraded
+
+- **WHEN** the launcher prepares a stopped local deployment whose installed runner does not report a valid semantic version
+- **THEN** it atomically replaces that runner with the versioned embedded migration runner before invoking it
+
+#### Scenario: Compatible runner update is applied
+
+- **WHEN** the embedded runner is a newer patch or minor version within the installed runner's major version
+- **THEN** the launcher atomically replaces the installed runner before starting the local deployment
+
+#### Scenario: Release-candidate runner update is applied
+
+- **WHEN** a `v`-prefixed embedded runner release candidate has greater semantic precedence than the installed release candidate within the same major version
+- **THEN** the launcher atomically replaces the installed runner before starting the local deployment
+
+#### Scenario: Runner is not downgraded
+
+- **WHEN** the installed runner is newer than the embedded runner within the same major version
+- **THEN** the launcher retains the installed runner
+
+#### Scenario: Same-version runner content differs
+
+- **WHEN** the installed and embedded runners report the same semantic version but contain different bytes
+- **THEN** the launcher replaces the installed runner with the trusted embedded runner before starting the local deployment
+
+#### Scenario: Major runner update requires user action
+
+- **WHEN** the installed and embedded runners report different major versions
+- **THEN** the launcher retains the installed runner and informs the user that major runner updates are not automatic
+
+#### Scenario: Active runner is not replaced
+
+- **WHEN** the launcher performs status, stop, or destroy behavior for a local deployment
+- **THEN** it does not replace an existing runner before invoking the lifecycle behavior
+
+#### Scenario: Embedded runner version is invalid
+
+- **WHEN** the embedded runner does not report a valid semantic version during preparation
+- **THEN** the launcher fails before replacing or starting the installed runner
+
+#### Scenario: Internal forced-reconciliation bypass is enabled
+
+- **WHEN** development explicitly enables forced reconciliation with a differing unversioned embedded runner
+- **THEN** the launcher atomically installs the embedded runner without version compatibility checks and warns that reconciliation was forced
 
 #### Scenario: Runner VM sizing is prepared
 
 - **WHEN** the launcher initializes or starts a local deployment
 - **THEN** it exposes VM CPU, VM memory, and Exasol Local data disk sizing through the runner start command
+
+#### Scenario: Managed share is prepared
+
+- **WHEN** the launcher initializes a local deployment
+- **THEN** it creates a launcher-managed share for guest coordination and SSH key import
 
 #### Scenario: User shares are not exposed
 

--- a/tests/tests/integration/test_install.py
+++ b/tests/tests/integration/test_install.py
@@ -319,6 +319,10 @@ def test_deploy_local_with_prestaged_fake_runner(
         """#!/usr/bin/env sh
 set -eu
 case "$1" in
+  version)
+    # Keep the pre-staged test runner across production runner reconciliation.
+    printf 'v999.0.0\n'
+    ;;
   init)
     mkdir -p vm vm-shared
     ;;


### PR DESCRIPTION
## Description
Makes exasol personal auto-upgrade the runner on patch/minor version bumps, while keeping major version bumps untouched and gated behind a warning message.

Requires:
- https://github.com/exasol/exasol-local-vm/pull/46
- https://github.com/exasol/exasol-local-vm/pull/47
## Related Issue

<!-- Link to the related issue(s). Use "Fixes #123" or "Closes #123" to auto-close issues when PR is merged -->

Fixes #

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

<!-- List the key changes in this PR -->

- Checks runner version for patch/minor bumps and upgrades the extracted binary only on `start`
- exposes `EXASOL_LOCAL_FORCE_RUNNER_RECONCILIATION` to allow updating a deployment's runner with an unversioned asset.


## Testing

<!-- Describe how you tested your changes -->

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

<!-- Describe your testing approach -->

## Checklist

<!-- Mark completed items with an "x" -->

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

<!-- Any additional information, screenshots, or context -->
