### PR TITLE
Fix low-hanging SonarQube findings

### DIFF
--- a/.github/scripts/run-deployment-tests.sh
+++ b/.github/scripts/run-deployment-tests.sh
@@ -6,18 +6,18 @@ SUITE="${2:-all}"
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 if [[ "$BRANCH" == "HEAD" ]]; then
-    echo "ERROR: Cannot trigger workflow from a detached HEAD — check out a branch first"
+    echo "ERROR: Cannot trigger workflow from a detached HEAD — check out a branch first" >&2
     exit 1
 fi
 
 LOCAL_SHA=$(git rev-parse HEAD)
 REMOTE_SHA=$(git rev-parse "origin/${BRANCH}" 2>/dev/null) || {
-    echo "ERROR: Branch '${BRANCH}' has not been pushed to origin"
+    echo "ERROR: Branch '${BRANCH}' has not been pushed to origin" >&2
     exit 1
 }
 
 if [[ "$LOCAL_SHA" != "$REMOTE_SHA" ]]; then
-    echo "ERROR: Local commit ${LOCAL_SHA:0:7} has not been pushed (origin/${BRANCH} is at ${REMOTE_SHA:0:7})"
+    echo "ERROR: Local commit ${LOCAL_SHA:0:7} has not been pushed (origin/${BRANCH} is at ${REMOTE_SHA:0:7})" >&2
     exit 1
 fi
 

--- a/.github/scripts/run-integration-tests.sh
+++ b/.github/scripts/run-integration-tests.sh
@@ -5,18 +5,18 @@ OS="${1:-all}"
 
 BRANCH=$(git rev-parse --abbrev-ref HEAD)
 if [[ "$BRANCH" == "HEAD" ]]; then
-    echo "ERROR: Cannot trigger workflow from a detached HEAD — check out a branch first"
+    echo "ERROR: Cannot trigger workflow from a detached HEAD — check out a branch first" >&2
     exit 1
 fi
 
 LOCAL_SHA=$(git rev-parse HEAD)
 REMOTE_SHA=$(git rev-parse "origin/${BRANCH}" 2>/dev/null) || {
-    echo "ERROR: Branch '${BRANCH}' has not been pushed to origin"
+    echo "ERROR: Branch '${BRANCH}' has not been pushed to origin" >&2
     exit 1
 }
 
 if [[ "$LOCAL_SHA" != "$REMOTE_SHA" ]]; then
-    echo "ERROR: Local commit ${LOCAL_SHA:0:7} has not been pushed (origin/${BRANCH} is at ${REMOTE_SHA:0:7})"
+    echo "ERROR: Local commit ${LOCAL_SHA:0:7} has not been pushed (origin/${BRANCH} is at ${REMOTE_SHA:0:7})" >&2
     exit 1
 fi
 

--- a/.github/scripts/sign-windows-binary.sh
+++ b/.github/scripts/sign-windows-binary.sh
@@ -21,8 +21,8 @@ echo "Signing Windows binary: $BINARY_PATH"
 
 # Verify required environment variables
 if [[ -z "$SSLCOM_USERNAME" ]] || [[ -z "$SSLCOM_PASSWORD" ]] || [[ -z "$SSLCOM_TOTP_SECRET" ]]; then
-    echo "ERROR: SSL.com credentials not set in environment"
-    echo "Required: SSLCOM_USERNAME, SSLCOM_PASSWORD, SSLCOM_TOTP_SECRET"
+    echo "ERROR: SSL.com credentials not set in environment" >&2
+    echo "Required: SSLCOM_USERNAME, SSLCOM_PASSWORD, SSLCOM_TOTP_SECRET" >&2
     exit 1
 fi
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -7,10 +7,6 @@ on:
     - cron: "0 */6 * * *"
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   auto-merge-pr:
     if: >-
@@ -18,6 +14,9 @@ jobs:
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     env:
       MERGE_DELAY_DAYS: "7"
     steps:
@@ -106,6 +105,9 @@ jobs:
   scheduled-recheck:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     env:
       GH_TOKEN: ${{ github.token }}
       MERGE_DELAY_DAYS: "7"

--- a/assets/infrastructure/local/files/container_shell.sh
+++ b/assets/infrastructure/local/files/container_shell.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 container_name="exasol-local-db"
 if ! podman container exists "$container_name"; then
   echo "Exasol Local database container not found" >&2

--- a/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/config.sh
+++ b/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/config.sh
@@ -16,12 +16,15 @@ INSTALL_JSON='/etc/exasol_launcher/installation.json'
 
 infra_jq() {
   jq "$@" "${INFRA_JSON}"
+  return
 }
 
 node_jq() {
   jq "$@" "${NODE_JSON}"
+  return
 }
 
 install_jq() {
   jq "$@" "${INSTALL_JSON}"
+  return
 }

--- a/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/logging.sh
+++ b/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/logging.sh
@@ -8,12 +8,15 @@ fi
 
 log_step_info() {
   printf 'EXASOL-INSTALL-STEP: %s\n' "$*"
+  return
 }
 
 log_substep_info() {
   printf 'EXASOL-INSTALL-SUBSTEP: %s\n' "$*"
+  return
 }
 
 log_error() {
   printf 'EXASOL-INSTALL-ERROR: %s\n' "$*" >&2
+  return
 }

--- a/assets/localruntimebin/localruntimebin_darwin_arm64.go
+++ b/assets/localruntimebin/localruntimebin_darwin_arm64.go
@@ -5,7 +5,7 @@
 
 package localruntimebin
 
-import _ "embed"
+import _ "embed" // required for the go:embed directive below
 
 //go:embed generated/darwin/arm64/mac-runner-aarch64
 var RunnerBinary []byte

--- a/assets/resources/resources.go
+++ b/assets/resources/resources.go
@@ -3,7 +3,7 @@
 
 package resources
 
-import _ "embed"
+import _ "embed" // required for the go:embed directive below
 
 // ResourcesYAML contains the embedded runtime resource specification.
 //

--- a/assets/resources/slc_catalog.go
+++ b/assets/resources/slc_catalog.go
@@ -3,7 +3,7 @@
 
 package resources
 
-import _ "embed"
+import _ "embed" // required for the go:embed directive below
 
 // SLCCatalogYAML contains the embedded official script language container catalog
 // (official SLCs for exasol personal local deployments installed locally via Podman image mount).

--- a/cmd/exasol/config.go
+++ b/cmd/exasol/config.go
@@ -276,8 +276,7 @@ func formatConfigurationScalar(value any) string {
 }
 
 func hasConfigurationVariableOverrides(
-	infraVars map[string]string,
-	installVars map[string]string,
+	infraVars, installVars map[string]string,
 ) bool {
 	return len(infraVars) > 0 || len(installVars) > 0
 }

--- a/cmd/exasol/deployments.go
+++ b/cmd/exasol/deployments.go
@@ -120,7 +120,7 @@ func listDeploymentDirectories() ([]deploymentListEntry, error) {
 // entry is reported as not_initialized rather than aborting the whole
 // listing. A permission error on the deployments root itself, by contrast,
 // is surfaced by listDeploymentDirectories as a command failure.
-func deploymentListEntryFor(name string, path string, activePath string) deploymentListEntry {
+func deploymentListEntryFor(name, path, activePath string) deploymentListEntry {
 	entry := deploymentListEntry{
 		Name:   name,
 		Path:   path,

--- a/cmd/exasol/info.go
+++ b/cmd/exasol/info.go
@@ -5,7 +5,7 @@ package main
 
 import (
 	"context"
-	_ "embed"
+	_ "embed" // required for the go:embed directive below
 	"encoding/json"
 	"io"
 	"os"

--- a/cmd/exasol/infra_variables.go
+++ b/cmd/exasol/infra_variables.go
@@ -61,8 +61,7 @@ func (*numberFlag) Type() string {
 }
 
 func resolveInfrastructureVariables(
-	infraPresetName string,
-	infraPresetPath string,
+	infraPresetName, infraPresetPath string,
 ) (deploy.ConfigVariableResolution, error) {
 	preset := deploy.PresetRef{Name: infraPresetName, Path: infraPresetPath}
 

--- a/cmd/exasol/install_variables.go
+++ b/cmd/exasol/install_variables.go
@@ -25,8 +25,7 @@ var installFlagToVarName = map[string]string{}
 const installPresetLabelAnnotationKey = "exasol.installationPresetLabel"
 
 func resolveInstallationVariables(
-	installPresetName string,
-	installPresetPath string,
+	installPresetName, installPresetPath string,
 ) (map[string]*presets.VariableDef, string, error) {
 	var (
 		manifest *presets.InstallManifest

--- a/cmd/exasol/presets_export.go
+++ b/cmd/exasol/presets_export.go
@@ -56,7 +56,7 @@ func embeddedPresetExists(ids []string, name string) bool {
 	return false
 }
 
-func resolveEmbeddedPresetHandler(presetName string, typeOpt string) (*presetTypeHandler, error) {
+func resolveEmbeddedPresetHandler(presetName, typeOpt string) (*presetTypeHandler, error) {
 	needle := strings.TrimSpace(presetName)
 	if needle == "" {
 		return nil, errors.New("missing preset name")

--- a/cmd/exasol/slc.go
+++ b/cmd/exasol/slc.go
@@ -33,6 +33,14 @@ var slcRemoveOpts = struct {
 	NoRestart   bool
 }{}
 
+const slcOperationAbortedMessage = "Aborted; no changes were made."
+
+const slcAutoApproveFlagName = "auto-approve"
+
+const slcAutoApproveFlagDesc = "Do not prompt for confirmation before restarting the database"
+
+const slcNoRestartFlagName = "no-restart"
+
 const slcCmdShortDesc = "Manage script language containers (SLCs)"
 
 const slcCmdLongDesc = slcCmdShortDesc + `
@@ -67,7 +75,7 @@ var slcInstallCmd = &cobra.Command{
 			slcConfirmFunc(cmd, slcInstallOpts.AutoApprove, fmt.Sprintf("Installing %q", alias)),
 		)
 		if errors.Is(err, deploy.ErrSLCOperationCancelled) {
-			safePrint("Aborted; no changes were made.")
+			safePrint(slcOperationAbortedMessage)
 
 			return nil
 		}
@@ -108,7 +116,7 @@ var slcUpdateCmd = &cobra.Command{
 			slcConfirmFunc(cmd, slcUpdateOpts.AutoApprove, fmt.Sprintf("Updating %q", alias)),
 		)
 		if errors.Is(err, deploy.ErrSLCOperationCancelled) {
-			safePrint("Aborted; no changes were made.")
+			safePrint(slcOperationAbortedMessage)
 
 			return nil
 		}
@@ -157,7 +165,7 @@ var slcRemoveCmd = &cobra.Command{
 			slcConfirmFunc(cmd, slcRemoveOpts.AutoApprove, fmt.Sprintf("Removing %q", alias)),
 		)
 		if errors.Is(err, deploy.ErrSLCOperationCancelled) {
-			safePrint("Aborted; no changes were made.")
+			safePrint(slcOperationAbortedMessage)
 
 			return nil
 		}
@@ -358,27 +366,27 @@ func init() {
 	requireInitializedDeploymentDir(slcInstallCmd)
 	registerDeploymentDirFlag(slcInstallCmd, commonFlags)
 	registerVerboseFlag(slcInstallCmd, commonFlags)
-	slcInstallCmd.Flags().BoolVar(&slcInstallOpts.AutoApprove, "auto-approve", false,
-		"Do not prompt for confirmation before restarting the database")
-	slcInstallCmd.Flags().BoolVar(&slcInstallOpts.NoRestart, "no-restart", false,
+	slcInstallCmd.Flags().BoolVar(&slcInstallOpts.AutoApprove, slcAutoApproveFlagName, false,
+		slcAutoApproveFlagDesc)
+	slcInstallCmd.Flags().BoolVar(&slcInstallOpts.NoRestart, slcNoRestartFlagName, false,
 		"Record the SLC without restarting; it activates on the next start")
 
 	requireDefaultDeploymentCompatibility(slcUpdateCmd)
 	requireInitializedDeploymentDir(slcUpdateCmd)
 	registerDeploymentDirFlag(slcUpdateCmd, commonFlags)
 	registerVerboseFlag(slcUpdateCmd, commonFlags)
-	slcUpdateCmd.Flags().BoolVar(&slcUpdateOpts.AutoApprove, "auto-approve", false,
-		"Do not prompt for confirmation before restarting the database")
-	slcUpdateCmd.Flags().BoolVar(&slcUpdateOpts.NoRestart, "no-restart", false,
+	slcUpdateCmd.Flags().BoolVar(&slcUpdateOpts.AutoApprove, slcAutoApproveFlagName, false,
+		slcAutoApproveFlagDesc)
+	slcUpdateCmd.Flags().BoolVar(&slcUpdateOpts.NoRestart, slcNoRestartFlagName, false,
 		"Record the update without restarting; it applies on the next start")
 
 	requireDefaultDeploymentCompatibility(slcRemoveCmd)
 	requireInitializedDeploymentDir(slcRemoveCmd)
 	registerDeploymentDirFlag(slcRemoveCmd, commonFlags)
 	registerVerboseFlag(slcRemoveCmd, commonFlags)
-	slcRemoveCmd.Flags().BoolVar(&slcRemoveOpts.AutoApprove, "auto-approve", false,
-		"Do not prompt for confirmation before restarting the database")
-	slcRemoveCmd.Flags().BoolVar(&slcRemoveOpts.NoRestart, "no-restart", false,
+	slcRemoveCmd.Flags().BoolVar(&slcRemoveOpts.AutoApprove, slcAutoApproveFlagName, false,
+		slcAutoApproveFlagDesc)
+	slcRemoveCmd.Flags().BoolVar(&slcRemoveOpts.NoRestart, slcNoRestartFlagName, false,
 		"Record the removal without restarting; it applies on the next start")
 
 	registerDeploymentDirFlag(slcListCmd, commonFlags)

--- a/cmd/exasol/terminal_notice.go
+++ b/cmd/exasol/terminal_notice.go
@@ -39,7 +39,7 @@ func printTerminalMessages() {
 	writeTerminalMessages(os.Stdout, os.Stderr)
 }
 
-func writeTerminalMessages(stdout io.Writer, stderr io.Writer) {
+func writeTerminalMessages(stdout, stderr io.Writer) {
 	for _, message := range terminalNotices {
 		_, _ = fmt.Fprintln(stderr, message)
 	}

--- a/cmd/exasol/version.go
+++ b/cmd/exasol/version.go
@@ -4,7 +4,7 @@
 package main
 
 import (
-	_ "embed"
+	_ "embed" // required for the go:embed directive below
 	"encoding/json"
 	"strings"
 	"text/template"

--- a/internal/compatibility/compatibility.go
+++ b/internal/compatibility/compatibility.go
@@ -88,7 +88,7 @@ func Check(deploymentVersion, launcherVersion string, req Requirement) Result {
 	return Result{Allowed: true, Err: nil}
 }
 
-func parseRequiredVersion(raw string, label string) (semver.Version, error) {
+func parseRequiredVersion(raw, label string) (semver.Version, error) {
 	if raw == "" {
 		return semver.Version{}, &InvalidVersionError{
 			Label: label,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,7 +20,7 @@ var ErrNoFileMatchedGlobPattern = errors.New("no file matched the pattern")
 //
 // It returns (fullPath, true, nil) if the file exists, (fullPath, false, nil)
 // if it does not exist, and ("", false, err) for unexpected errors.
-func findExistingFile(dir string, filename string) (string, bool, error) {
+func findExistingFile(dir, filename string) (string, bool, error) {
 	fullPath := filepath.Join(dir, filename)
 	_, err := os.Stat(fullPath)
 	if err == nil {
@@ -94,7 +94,7 @@ func writeConfig(config any, path string, name string) error {
 	return nil
 }
 
-func readConfig[T any](path string, name string) (*T, error) {
+func readConfig[T any](path, name string) (*T, error) {
 	configFile, err := os.Open(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {

--- a/internal/config/exasol_launcher_state_test.go
+++ b/internal/config/exasol_launcher_state_test.go
@@ -28,7 +28,7 @@ func TestWorkflowState(t *testing.T) {
 	t.Run("Invalid state panics", func(t *testing.T) {
 		t.Parallel()
 		defer func() {
-			if r := recover(); r == nil {
+			if recover() == nil {
 				t.Fatal("expected panic for invalid workflow state, got none")
 			}
 		}()

--- a/internal/deploy/configuration.go
+++ b/internal/deploy/configuration.go
@@ -266,7 +266,7 @@ func installationManifestDescription(manifest *presets.InstallManifest) string {
 }
 
 func presetIdentityInfo(
-	selector string, displayName string, description string,
+	selector, displayName, description string,
 ) PresetIdentityInfo {
 	info := PresetIdentityInfo{
 		Selector:    strings.TrimSpace(selector),
@@ -405,8 +405,7 @@ func resetAllConfigurationValues(values []DeploymentConfigValue) {
 }
 
 func newDeploymentConfigurationFromRaw(
-	infraVars map[string]string,
-	installVars map[string]string,
+	infraVars, installVars map[string]string,
 ) DeploymentConfiguration {
 	return DeploymentConfiguration{
 		Infrastructure: DeploymentConfigurationSection{Options: rawConfigValues(infraVars)},

--- a/internal/deploy/connection_instructions.go
+++ b/internal/deploy/connection_instructions.go
@@ -6,7 +6,7 @@ package deploy
 import (
 	"bytes"
 	"context"
-	_ "embed"
+	_ "embed" // required for the go:embed directive below
 	"fmt"
 	"os"
 	"text/template"

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -254,9 +254,9 @@ type nodeLookupImpl struct {
 	deployment config.DeploymentDir
 }
 
-var _ task_runner.NodeLookup = &nodeLookupImpl{}
+var _ task_runner.NodeFinder = &nodeLookupImpl{}
 
-func NewNodeLookup(deployment config.DeploymentDir) task_runner.NodeLookup {
+func NewNodeLookup(deployment config.DeploymentDir) task_runner.NodeFinder {
 	return &nodeLookupImpl{
 		deployment: deployment,
 	}

--- a/internal/deploy/init.go
+++ b/internal/deploy/init.go
@@ -346,7 +346,7 @@ func validateInstallationPreset(installationPreset PresetRef) error {
 	)
 }
 
-func validatePresetDir(dir string, requiredFile string) error {
+func validatePresetDir(dir, requiredFile string) error {
 	info, err := os.Stat(dir)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {

--- a/internal/deploy/installation_variables.go
+++ b/internal/deploy/installation_variables.go
@@ -120,7 +120,7 @@ func isReservedInstallationVariableName(name string) bool {
 	}
 }
 
-func parseInstallVarValue(varType string, raw string) (any, error) {
+func parseInstallVarValue(varType, raw string) (any, error) {
 	varType = strings.TrimSpace(varType)
 	switch varType {
 	case "bool":

--- a/internal/deploy/preset_validation.go
+++ b/internal/deploy/preset_validation.go
@@ -11,8 +11,7 @@ import (
 )
 
 func ValidatePresetSelection(
-	infrastructurePreset PresetRef,
-	installationPreset PresetRef,
+	infrastructurePreset, installationPreset PresetRef,
 ) error {
 	if err := validateInfrastructurePreset(infrastructurePreset); err != nil {
 		return err

--- a/internal/deploy/remove.go
+++ b/internal/deploy/remove.go
@@ -122,7 +122,7 @@ func validateDeploymentDirectoryRemovalContext(
 	return nil
 }
 
-func pathIsInside(parent string, child string) bool {
+func pathIsInside(parent, child string) bool {
 	parent = filepath.Clean(parent)
 	child = filepath.Clean(child)
 

--- a/internal/deploy/slc.go
+++ b/internal/deploy/slc.go
@@ -26,6 +26,8 @@ var ErrSLCNotSupported = errors.New(
 // ErrSLCOperationCancelled is returned when the user declines the database-restart prompt.
 var ErrSLCOperationCancelled = errors.New("operation cancelled")
 
+const slcOperationInProgressSuffix = " script language container (this may take a few minutes)"
+
 // ErrDeploymentNotPresent is returned when an SLC change operation (install/update/remove)
 // is attempted on a deployment that has only been initialized, never deployed. SLC
 // management operates on a deployed database, so there is nothing to change — and, crucially,
@@ -194,7 +196,7 @@ func InstallSLC(
 	}
 
 	slog.Info(
-		"installing "+alias+" script language container (this may take a few minutes)",
+		"installing "+alias+slcOperationInProgressSuffix,
 		"flavor", entry.Flavor,
 	)
 
@@ -271,7 +273,7 @@ func RemoveSLC(
 
 	if isLocalDeploymentRunning(ctx, deployment) {
 		slog.Info(
-			"removing "+alias+" script language container (this may take a few minutes)",
+			"removing "+alias+slcOperationInProgressSuffix,
 			"flavor", removed.Flavor,
 		)
 	}
@@ -377,7 +379,7 @@ func UpdateSLC(
 	}
 
 	slog.Info(
-		"updating "+alias+" script language container (this may take a few minutes)",
+		"updating "+alias+slcOperationInProgressSuffix,
 		"flavor", entry.Flavor,
 	)
 	outcome, err := applySLCChange(ctx, deployment, verbose, true)

--- a/internal/directorymutex/directorymutex.go
+++ b/internal/directorymutex/directorymutex.go
@@ -355,7 +355,7 @@ func (m *DirectoryMutex) findMarker() (*markerInfo, error) {
 	return match, nil
 }
 
-func parseMarker(name string, directory string) (*markerInfo, error) {
+func parseMarker(name, directory string) (*markerInfo, error) {
 	if name == exclusiveMarkerName {
 		return &markerInfo{
 			name: name,

--- a/internal/presets/install_manifest.go
+++ b/internal/presets/install_manifest.go
@@ -190,7 +190,7 @@ func (s *InstallSteps) UnmarshalYAML(unmarshal func(any) error) error {
 		data, err2 := yaml.Marshal(raw)
 		if err2 == nil {
 			var ss InstallStep
-			if err3 := yaml.Unmarshal(data, &ss); err3 == nil {
+			if yaml.Unmarshal(data, &ss) == nil {
 				*s = []InstallStep{ss}
 				return nil
 			}

--- a/internal/presets/operations.go
+++ b/internal/presets/operations.go
@@ -20,7 +20,7 @@ var (
 	ErrUnknownInstallation   = errors.New("the specified installation preset does not exist")
 )
 
-func WriteInfrastructureDir(infrastructureName string, outDir string) error {
+func WriteInfrastructureDir(infrastructureName, outDir string) error {
 	entries, err := assets.InfrastructureAssets.ReadDir(assets.InfrastructureAssetDir)
 	if err != nil {
 		return err
@@ -38,7 +38,7 @@ func WriteInfrastructureDir(infrastructureName string, outDir string) error {
 	return ErrUnknownInfrastructure
 }
 
-func WriteInstallDir(installName string, outDir string) error {
+func WriteInstallDir(installName, outDir string) error {
 	entries, err := assets.InstallationAssets.ReadDir(assets.InstallationAssetDir)
 	if err != nil {
 		return err

--- a/internal/remote/ssh.go
+++ b/internal/remote/ssh.go
@@ -43,11 +43,11 @@ func (s *SSHRemote) Shell(ctx context.Context, out io.Writer, errOut io.Writer) 
 	}
 	defer restore()
 
-	shell_session_ctx, cancel := context.WithCancel(ctx)
+	shellSessionCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	go func() {
-		<-shell_session_ctx.Done()
+		<-shellSessionCtx.Done()
 		session.Close() // nolint: gosec
 	}()
 

--- a/internal/runtimeartifacts/cache.go
+++ b/internal/runtimeartifacts/cache.go
@@ -37,7 +37,7 @@ var (
 	ErrCacheLocked        = errors.New("runtime artifact cache is locked")
 )
 
-type clock interface {
+type clocker interface {
 	Now() time.Time
 }
 
@@ -55,7 +55,7 @@ type CacheConfig struct {
 type Cache struct {
 	root       string
 	configPath string
-	clock      clock
+	clock      clocker
 }
 
 type CacheEntryInfo struct {
@@ -161,7 +161,7 @@ func NewCache(root, configPath string) *Cache {
 	return newCacheWithClock(root, configPath, systemClock{})
 }
 
-func newCacheWithClock(root, configPath string, clk clock) *Cache {
+func newCacheWithClock(root, configPath string, clk clocker) *Cache {
 	return &Cache{root: filepath.Clean(root), configPath: filepath.Clean(configPath), clock: clk}
 }
 

--- a/internal/task_runner/local_command_runner.go
+++ b/internal/task_runner/local_command_runner.go
@@ -26,12 +26,12 @@ func (*LocalCommandRunnerImpl) Run(
 	workingDir string,
 	stdout, stderr io.Writer,
 ) error {
-	command_proc := exec.CommandContext(ctx, command[0], command[1:]...)
+	commandProc := exec.CommandContext(ctx, command[0], command[1:]...)
 
-	command_proc.Stdout = stdout
-	command_proc.Stderr = stderr
+	commandProc.Stdout = stdout
+	commandProc.Stderr = stderr
 
-	command_proc.Dir = workingDir
+	commandProc.Dir = workingDir
 
-	return command_proc.Run()
+	return commandProc.Run()
 }

--- a/internal/task_runner/log_buffer.go
+++ b/internal/task_runner/log_buffer.go
@@ -96,7 +96,7 @@ func (logBuffer *LogBuffer) writePartsRecursive(data []byte) int {
 		logBuffer.newRecord()
 	}
 
-	bytes_consumed := len(data) - len(remainder)
+	bytesConsumed := len(data) - len(remainder)
 
-	return bytes_consumed + logBuffer.writePartsRecursive(remainder)
+	return bytesConsumed + logBuffer.writePartsRecursive(remainder)
 }

--- a/internal/task_runner/task_runner.go
+++ b/internal/task_runner/task_runner.go
@@ -24,7 +24,7 @@ type TaskRunner interface {
 	) error
 }
 
-type NodeLookup interface {
+type NodeFinder interface {
 	Find(
 		nodeNameGlob string,
 	) ([]RunScriptNode, error)
@@ -38,7 +38,7 @@ type RunScriptNode struct {
 func NewTaskRunner(
 	localCommandRunner LocalCommandRunner,
 	remoteScriptRunner RemoteScriptRunner,
-	nodeLookup NodeLookup,
+	nodeLookup NodeFinder,
 ) TaskRunner {
 	return &TaskRunnerImpl{
 		localCommandRunner: localCommandRunner,
@@ -50,7 +50,7 @@ func NewTaskRunner(
 type TaskRunnerImpl struct {
 	localCommandRunner LocalCommandRunner
 	remoteScriptRunner RemoteScriptRunner
-	nodeLookup         NodeLookup
+	nodeLookup         NodeFinder
 }
 
 func (s *TaskRunnerImpl) RunTasks(

--- a/internal/task_runner/task_runner_mocks/task_runner_mocks.go
+++ b/internal/task_runner/task_runner_mocks/task_runner_mocks.go
@@ -100,7 +100,7 @@ type NodeLookupMock struct {
 	Directory []task_runner.RunScriptNode
 }
 
-var _ task_runner.NodeLookup = &NodeLookupMock{}
+var _ task_runner.NodeFinder = &NodeLookupMock{}
 
 func NewNodeLookupMock(directory []task_runner.RunScriptNode) *NodeLookupMock {
 	return &NodeLookupMock{
@@ -123,7 +123,7 @@ func NewNodeLookupDirectory(n int) []task_runner.RunScriptNode {
 	return directory
 }
 
-// Find implements task_runner.NodeLookup.
+// Find implements task_runner.NodeFinder.
 func (n *NodeLookupMock) Find(nodeNameGlob string) ([]task_runner.RunScriptNode, error) {
 	slog.Debug("Looking up node glob", "glob", nodeNameGlob, "directorySize", len(n.Directory))
 	results := []task_runner.RunScriptNode{}

--- a/internal/tofu/runner.go
+++ b/internal/tofu/runner.go
@@ -13,6 +13,10 @@ import (
 
 var execCommandContext = exec.CommandContext
 
+const varFileArgPrefix = "-var-file="
+
+const stateArgPrefix = "-state="
+
 type LockfileMode int
 
 const (
@@ -95,10 +99,10 @@ func (s *tofuRunnerImpl) Plan(
 	args := []string{
 		"plan",
 		"-out=" + planFilePath,
-		"-var-file=" + varsFilePath,
+		varFileArgPrefix + varsFilePath,
 	}
 	if stateFilePath != "" {
-		args = append(args, "-state="+stateFilePath, "-state-out="+stateFilePath)
+		args = append(args, stateArgPrefix+stateFilePath, "-state-out="+stateFilePath)
 	}
 
 	return s.exec(ctx, args)
@@ -112,10 +116,10 @@ func (s *tofuRunnerImpl) Apply(ctx context.Context, opts ApplyOptions) error {
 		}
 	}
 	if opts.VarsFilePath != "" {
-		args = append(args, "-var-file="+opts.VarsFilePath)
+		args = append(args, varFileArgPrefix+opts.VarsFilePath)
 	}
 	if opts.StateFilePath != "" {
-		args = append(args, "-state="+opts.StateFilePath)
+		args = append(args, stateArgPrefix+opts.StateFilePath)
 	}
 	if opts.PlanFilePath != "" {
 		args = append(args, opts.PlanFilePath)
@@ -127,11 +131,11 @@ func (s *tofuRunnerImpl) Apply(ctx context.Context, opts ApplyOptions) error {
 func (s *tofuRunnerImpl) Destroy(ctx context.Context, varsFilePath, stateFilePath string) error {
 	args := []string{
 		"destroy",
-		"-var-file=" + varsFilePath,
+		varFileArgPrefix + varsFilePath,
 		"--auto-approve",
 	}
 	if stateFilePath != "" {
-		args = append(args, "-state="+stateFilePath)
+		args = append(args, stateArgPrefix+stateFilePath)
 	}
 
 	return s.exec(ctx, args)

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -175,7 +175,7 @@ func (e *CopyDirError) Unwrap() error {
 	return e.Err
 }
 
-func CopyDir(src string, dst string) error {
+func CopyDir(src, dst string) error {
 	srcInfo, err := os.Stat(src)
 	if err != nil {
 		return &CopyDirError{

--- a/scripts/personal-installer.sh
+++ b/scripts/personal-installer.sh
@@ -49,7 +49,7 @@ echo "Installing the Exasol Launcher (the 'exasol' command) to $INSTALL_DIR..."
 mkdir -p "$INSTALL_DIR"
 
 if ! curl -fSL --progress-bar "$PACKAGE_DOWNLOAD_URL" -o "$INSTALL_PATH"; then
-    echo "Error: Failed to download from $PACKAGE_DOWNLOAD_URL"
+    echo "Error: Failed to download from $PACKAGE_DOWNLOAD_URL" >&2
     exit 1
 fi
 

--- a/scripts/personal-installer.sh
+++ b/scripts/personal-installer.sh
@@ -48,7 +48,7 @@ echo "Installing the Exasol Launcher (the 'exasol' command) to $INSTALL_DIR..."
 
 mkdir -p "$INSTALL_DIR"
 
-if ! curl -fSL --progress-bar "$PACKAGE_DOWNLOAD_URL" -o "$INSTALL_PATH"; then
+if ! curl -fSL --proto '=https' --progress-bar "$PACKAGE_DOWNLOAD_URL" -o "$INSTALL_PATH"; then
     echo "Error: Failed to download from $PACKAGE_DOWNLOAD_URL" >&2
     exit 1
 fi

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,8 +1,8 @@
 sonar.projectKey=com.exasol:exasol-personal
 sonar.organization=exasol
 sonar.sources=.
-sonar.exclusions=**/*_test.go
+sonar.exclusions=**/*_test.go,**/*_mocks.go,tests/**/*.py
 sonar.tests=.
-sonar.test.inclusions=**/*_test.go
+sonar.test.inclusions=**/*_test.go,**/*_mocks.go,tests/**/*.py
 sonar.go.coverage.reportPaths=./coverage.out
-sonar.coverage.exclusions=**/*_test.go
+sonar.coverage.exclusions=**/*_test.go,tests/**/*.py

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,4 +5,4 @@ sonar.exclusions=**/*_test.go,**/*_mocks.go,tests/**/*.py
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go,**/*_mocks.go,tests/**/*.py
 sonar.go.coverage.reportPaths=./coverage.out
-sonar.coverage.exclusions=**/*_test.go,tests/**/*.py
+sonar.coverage.exclusions=**/*_test.go,tests/**/*.py,tools/cleanup/**

--- a/tests/mock_version_server.py
+++ b/tests/mock_version_server.py
@@ -11,6 +11,8 @@ import sys
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
+CONTENT_TYPE_JSON = "application/json"
+
 # Global storage for response data (with thread lock)
 stored_response: bytes | None = None
 data_lock = threading.RLock()
@@ -58,7 +60,7 @@ class VersionServerHandler(BaseHTTPRequestHandler):
             version_check_count = 0
 
         self.send_response(200)
-        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Type", CONTENT_TYPE_JSON)
         self.end_headers()
         self.wfile.write(f'{{"count": {count}}}'.encode())
 
@@ -100,13 +102,13 @@ class VersionServerHandler(BaseHTTPRequestHandler):
 
         if response is None:
             self.send_response(404)
-            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Type", CONTENT_TYPE_JSON)
             self.end_headers()
             self.wfile.write(b'{"error":"No data available"}')
             return
 
         self.send_response(200)
-        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Type", CONTENT_TYPE_JSON)
         self.end_headers()
         self.wfile.write(response)
 
@@ -132,7 +134,7 @@ class VersionServerHandler(BaseHTTPRequestHandler):
         )
 
         self.send_response(200)
-        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Type", CONTENT_TYPE_JSON)
         self.end_headers()
         response = json.dumps(
             {"status": "success", "message": "Data stored successfully"}

--- a/tests/tests/integration/helpers.py
+++ b/tests/tests/integration/helpers.py
@@ -7,6 +7,7 @@ import json
 import os
 import subprocess
 from subprocess import CompletedProcess
+from typing import Any
 
 import pytest
 
@@ -32,7 +33,8 @@ def first_preset_id_or_skip(exasol_path: str, preset_type: str) -> str:
     if not isinstance(presets_list, list) or len(presets_list) == 0:
         pytest.skip(f"no presets found for type {preset_type!r}")
 
-    preset_id = presets_list[0].get("id")
+    first_preset: dict[str, Any] = next(iter(presets_list), {})
+    preset_id = first_preset.get("id")
     if not isinstance(preset_id, str) or preset_id.strip() == "":
         pytest.skip(f"first preset in type {preset_type!r} has no id")
 

--- a/tests/tests/integration/test_external_presets.py
+++ b/tests/tests/integration/test_external_presets.py
@@ -205,16 +205,15 @@ def test_file_uri_nonexistent_path_returns_error(
     deployment_dir.mkdir()
 
     # When init is invoked with a file:// URI pointing to a path that does not exist
+    args = [
+        exasol_path,
+        "init",
+        "file:///this/path/does/not/exist",
+        "--deployment-dir",
+        str(deployment_dir),
+    ]
     with pytest.raises(CalledProcessError) as exc:
-        run_command(
-            [
-                exasol_path,
-                "init",
-                "file:///this/path/does/not/exist",
-                "--deployment-dir",
-                str(deployment_dir),
-            ]
-        )
+        run_command(args)
 
     # Then it fails with an error that references the missing path
     assert exc.value.returncode != 0
@@ -233,16 +232,15 @@ def test_file_uri_unsupported_file_type_returns_error(
     deployment_dir.mkdir()
 
     # When init is invoked with a file:// URI pointing to that plain file
+    args = [
+        exasol_path,
+        "init",
+        f"file://{plain_file}",
+        "--deployment-dir",
+        str(deployment_dir),
+    ]
     with pytest.raises(CalledProcessError) as exc:
-        run_command(
-            [
-                exasol_path,
-                "init",
-                f"file://{plain_file}",
-                "--deployment-dir",
-                str(deployment_dir),
-            ]
-        )
+        run_command(args)
 
     # Then it fails with an error mentioning the directory/archive requirement
     assert exc.value.returncode != 0
@@ -255,16 +253,15 @@ def test_at_ref_on_non_git_url_returns_error(exasol_path: str, tmp_path: Path) -
     deployment_dir.mkdir()
 
     # When init is invoked with an @ref suffix on a non-git HTTPS URL
+    args = [
+        exasol_path,
+        "init",
+        "https://example.com/preset.tar.gz@v1.0.0",
+        "--deployment-dir",
+        str(deployment_dir),
+    ]
     with pytest.raises(CalledProcessError) as exc:
-        run_command(
-            [
-                exasol_path,
-                "init",
-                "https://example.com/preset.tar.gz@v1.0.0",
-                "--deployment-dir",
-                str(deployment_dir),
-            ]
-        )
+        run_command(args)
 
     # Then it fails with an error about the @ref syntax restriction
     assert exc.value.returncode != 0

--- a/tests/tests/integration/test_init.py
+++ b/tests/tests/integration/test_init.py
@@ -155,16 +155,15 @@ def test_init_fails_on_non_empty_directory(exasol_path: str, tmp_path: Path) -> 
     infra_id = first_infrastructure_preset_id_or_skip(exasol_path)
 
     # When `exasol init` is invoked
+    args = [
+        exasol_path,
+        "init",
+        infra_id,
+        "--deployment-dir",
+        str(deployment_dir),
+    ]
     with pytest.raises(CalledProcessError) as exc:
-        run_command(
-            [
-                exasol_path,
-                "init",
-                infra_id,
-                "--deployment-dir",
-                str(deployment_dir),
-            ]
-        )
+        run_command(args)
 
     # Then the command fails
     assert exc.value.returncode != 0

--- a/tests/tests/integration/test_install.py
+++ b/tests/tests/integration/test_install.py
@@ -171,16 +171,15 @@ def test_install_executes_init_step(exasol_path: str, tmp_path: Path) -> None:
     infra_id = first_infrastructure_preset_id_or_skip(exasol_path)
 
     # When the install command is invoked
+    args = [
+        exasol_path,
+        "install",
+        infra_id,
+        "--deployment-dir",
+        str(deployment_dir),
+    ]
     with pytest.raises(CalledProcessError) as excinfo:
-        run_command(
-            [
-                exasol_path,
-                "install",
-                infra_id,
-                "--deployment-dir",
-                str(deployment_dir),
-            ]
-        )
+        run_command(args)
 
     # Then it fails during initialization (proving init ran)
     assert excinfo.value.returncode != 0
@@ -201,17 +200,16 @@ def test_init_local_rejects_unsupported_platform_before_writing_files(
     deployment_dir.mkdir()
 
     # When init is invoked for the local preset
+    args = [
+        exasol_path,
+        "init",
+        "local",
+        "--deployment-dir",
+        str(deployment_dir),
+        "--no-launcher-version-check",
+    ]
     with pytest.raises(CalledProcessError) as exc:
-        run_command(
-            [
-                exasol_path,
-                "init",
-                "local",
-                "--deployment-dir",
-                str(deployment_dir),
-                "--no-launcher-version-check",
-            ]
-        )
+        run_command(args)
 
     # Then it fails before writing deployment state
     stderr = exc.value.stderr.lower()
@@ -283,19 +281,17 @@ def test_init_local_rejects_memory_below_minimum(
     }
 
     # When init is invoked below the supported minimum memory
+    args = [
+        exasol_path,
+        "init",
+        "local",
+        "--deployment-dir",
+        str(deployment_dir),
+        "--memory-mb",
+        "4095",
+    ]
     with pytest.raises(CalledProcessError) as exc:
-        run_command(
-            [
-                exasol_path,
-                "init",
-                "local",
-                "--deployment-dir",
-                str(deployment_dir),
-                "--memory-mb",
-                "4095",
-            ],
-            env=env,
-        )
+        run_command(args, env=env)
 
     # Then the user sees the minimum-memory validation message
     assert (

--- a/tests/tests/integration/test_presets.py
+++ b/tests/tests/integration/test_presets.py
@@ -22,7 +22,8 @@ def _first_preset_id_or_skip(exasol_path: str, preset_type: str) -> str:
     if not isinstance(presets_list, list) or len(presets_list) == 0:
         pytest.skip(f"no presets found for type {preset_type!r}")
 
-    preset_id = presets_list[0].get("id")
+    first_preset: dict[str, Any] = next(iter(presets_list), {})
+    preset_id = first_preset.get("id")
     if not isinstance(preset_id, str) or preset_id.strip() == "":
         pytest.skip(f"first preset in type {preset_type!r} has no id")
 

--- a/tests/tests/integration/test_presets.py
+++ b/tests/tests/integration/test_presets.py
@@ -122,19 +122,18 @@ def test_presets_export_fails_on_non_empty_dir(
     (target / "somefile.txt").write_text("x")
 
     # When `exasol presets export` is called
+    args = [
+        exasol_path,
+        "presets",
+        "export",
+        preset_id,
+        "--type",
+        "infrastructure",
+        "--to",
+        str(target),
+    ]
     with pytest.raises(CalledProcessError) as exc:
-        run_command(
-            [
-                exasol_path,
-                "presets",
-                "export",
-                preset_id,
-                "--type",
-                "infrastructure",
-                "--to",
-                str(target),
-            ]
-        )
+        run_command(args)
 
     # Then it fails
     assert exc.value.returncode != 0

--- a/tests/tests/integration/test_reconfiguration.py
+++ b/tests/tests/integration/test_reconfiguration.py
@@ -418,18 +418,17 @@ def test_config_set_refuses_running_deployment(
     _set_workflow_state(deployment_dir, {"running": {}})
 
     # When config set is requested
+    args = [
+        exasol_path,
+        "config",
+        "set",
+        "--cluster-size",
+        "3",
+        "--deployment-dir",
+        str(deployment_dir),
+    ]
     with pytest.raises(CalledProcessError) as exc:
-        run_command(
-            [
-                exasol_path,
-                "config",
-                "set",
-                "--cluster-size",
-                "3",
-                "--deployment-dir",
-                str(deployment_dir),
-            ]
-        )
+        run_command(args)
 
     # Then it tells the user to destroy before changing configuration
     stderr = exc.value.stderr.lower()
@@ -478,18 +477,17 @@ def test_config_set_refuses_state_with_possible_resources(
     _set_workflow_state(deployment_dir, workflow_state)
 
     # When config set is requested
+    args = [
+        exasol_path,
+        "config",
+        "set",
+        "--cluster-size",
+        "3",
+        "--deployment-dir",
+        str(deployment_dir),
+    ]
     with pytest.raises(CalledProcessError) as exc:
-        run_command(
-            [
-                exasol_path,
-                "config",
-                "set",
-                "--cluster-size",
-                "3",
-                "--deployment-dir",
-                str(deployment_dir),
-            ]
-        )
+        run_command(args)
 
     # Then it refuses the configuration change with destroy guidance
     stderr = exc.value.stderr.lower()
@@ -579,20 +577,19 @@ def test_install_refuses_same_preset_configuration_change_for_running_deployment
     _set_workflow_state(deployment_dir, {"running": {}})
 
     # When install is rerun with changed same-preset configuration
+    args = [
+        exasol_path,
+        "install",
+        str(infra_dir),
+        str(install_dir),
+        "--cluster-size",
+        "3",
+        "--deployment-dir",
+        str(deployment_dir),
+        "--no-launcher-version-check",
+    ]
     with pytest.raises(CalledProcessError) as exc:
-        run_command(
-            [
-                exasol_path,
-                "install",
-                str(infra_dir),
-                str(install_dir),
-                "--cluster-size",
-                "3",
-                "--deployment-dir",
-                str(deployment_dir),
-                "--no-launcher-version-check",
-            ]
-        )
+        run_command(args)
 
     # Then it refuses the configuration change without destroying or mutating state
     stderr = exc.value.stderr.lower()
@@ -631,17 +628,16 @@ def test_init_refuses_different_preset_without_remove(
     )
 
     # When init is requested with a different preset
+    args = [
+        exasol_path,
+        "init",
+        second_preset,
+        "--deployment-dir",
+        str(deployment_dir),
+        "--no-launcher-version-check",
+    ]
     with pytest.raises(CalledProcessError) as exc:
-        run_command(
-            [
-                exasol_path,
-                "init",
-                second_preset,
-                "--deployment-dir",
-                str(deployment_dir),
-                "--no-launcher-version-check",
-            ]
-        )
+        run_command(args)
 
     # Then it fails before replacing local state
     assert exc.value.returncode != 0
@@ -677,18 +673,17 @@ def test_install_refuses_different_preset_without_removing_local_state(
     old_local.write_text("old")
 
     # When install is requested with a different preset
+    args = [
+        exasol_path,
+        "install",
+        str(infra_dir),
+        str(install_dir),
+        "--deployment-dir",
+        str(deployment_dir),
+        "--no-launcher-version-check",
+    ]
     with pytest.raises(CalledProcessError) as exc:
-        run_command(
-            [
-                exasol_path,
-                "install",
-                str(infra_dir),
-                str(install_dir),
-                "--deployment-dir",
-                str(deployment_dir),
-                "--no-launcher-version-check",
-            ]
-        )
+        run_command(args)
 
     # Then it fails before removing or reconfiguring local state
     assert exc.value.returncode != 0
@@ -790,16 +785,15 @@ def test_remove_refuses_non_deployment_directory(
     local_file.write_text("leftover")
 
     # When the recovery command is run
+    args = [
+        exasol_path,
+        "remove",
+        "--auto-approve",
+        "--deployment-dir",
+        str(deployment_dir),
+    ]
     with pytest.raises(CalledProcessError) as exc:
-        run_command(
-            [
-                exasol_path,
-                "remove",
-                "--auto-approve",
-                "--deployment-dir",
-                str(deployment_dir),
-            ]
-        )
+        run_command(args)
 
     # Then it refuses to remove unrelated local files
     assert exc.value.returncode != 0

--- a/tools/cleanup/pkg/cleanup/orchestration.go
+++ b/tools/cleanup/pkg/cleanup/orchestration.go
@@ -202,7 +202,7 @@ func FilterDeploymentDetailsByTypes(details *DeploymentDetails, typeFilter []Res
 	return &filteredDetails
 }
 
-func ResolvedLocations(explicit []string, defaults []string) []string {
+func ResolvedLocations(explicit, defaults []string) []string {
 	if len(explicit) == 0 {
 		return append([]string(nil), defaults...)
 	}

--- a/tools/cleanup/pkg/cleanup/providers/aws/collect.go
+++ b/tools/cleanup/pkg/cleanup/providers/aws/collect.go
@@ -621,7 +621,7 @@ func CollectDeploymentSummaries(
 }
 
 // preferPtrEarlier returns the earlier non-nil pointer, else existing.
-func preferPtrEarlier(existing *time.Time, candidate *time.Time) *time.Time {
+func preferPtrEarlier(existing, candidate *time.Time) *time.Time {
 	if candidate == nil {
 		return existing
 	}

--- a/tools/cleanup/pkg/cleanup/providers/aws/collect.go
+++ b/tools/cleanup/pkg/cleanup/providers/aws/collect.go
@@ -232,15 +232,8 @@ func CollectDeploymentDetails(
 	for i := range details.Resources {
 		meta := &details.Resources[i]
 		switch meta.Ref.Type {
-		case ResourceIAMRole:
+		case ResourceIAMRole, ResourceIAMInstProf:
 			// Basic presence and created time already recorded; mark state
-			if _, ok := meta.Attr["state"]; !ok {
-				meta.Attr["state"] = "present"
-			}
-			if ct, ok := meta.Attr["createTime"].(time.Time); ok {
-				earliest = preferPtrEarlier(earliest, &ct)
-			}
-		case ResourceIAMInstProf:
 			if _, ok := meta.Attr["state"]; !ok {
 				meta.Attr["state"] = "present"
 			}

--- a/tools/cleanup/pkg/cleanup/providers/exoscale/collect.go
+++ b/tools/cleanup/pkg/cleanup/providers/exoscale/collect.go
@@ -729,7 +729,7 @@ func derefLabels(labels *map[string]string) map[string]string {
 	return *labels
 }
 
-func preferEarlier(existing *time.Time, candidate *time.Time) *time.Time {
+func preferEarlier(existing, candidate *time.Time) *time.Time {
 	if candidate == nil {
 		return existing
 	}

--- a/tools/cleanup/pkg/cleanup/providers/exoscale/handlers.go
+++ b/tools/cleanup/pkg/cleanup/providers/exoscale/handlers.go
@@ -23,6 +23,8 @@ type Handler interface {
 
 var ErrUnsupportedResource = errors.New("unsupported resource type for deletion")
 
+const notFoundErrorSubstring = "not found"
+
 // registry maps resource types to concrete handlers.
 var registry = map[ResourceType]Handler{}
 
@@ -78,7 +80,7 @@ func (h *computeInstanceHandler) Delete(ctx context.Context, ref ResourceRef) er
 	op, err := h.client.DeleteInstance(ctx, uuid)
 	if err != nil {
 		// Treat not found as success for idempotent cleanup
-		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
+		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), notFoundErrorSubstring) {
 			return nil
 		}
 		return fmt.Errorf("failed to delete instance: %w", err)
@@ -158,7 +160,7 @@ func (h *privateNetworkHandler) Delete(ctx context.Context, ref ResourceRef) err
 
 	op, err := h.client.DeletePrivateNetwork(ctx, uuid)
 	if err != nil {
-		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
+		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), notFoundErrorSubstring) {
 			return nil
 		}
 		return fmt.Errorf("failed to delete private network: %w", err)
@@ -186,7 +188,7 @@ func (h *securityGroupHandler) Delete(ctx context.Context, ref ResourceRef) erro
 
 	op, err := h.client.DeleteSecurityGroup(ctx, uuid)
 	if err != nil {
-		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
+		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), notFoundErrorSubstring) {
 			return nil
 		}
 		return fmt.Errorf("failed to delete security group: %w", err)
@@ -210,7 +212,7 @@ func (h *sshKeyHandler) Delete(ctx context.Context, ref ResourceRef) error {
 	// SSH keys use name as ID in v3
 	op, err := h.client.DeleteSSHKey(ctx, ref.ID)
 	if err != nil {
-		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
+		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), notFoundErrorSubstring) {
 			return nil
 		}
 		return fmt.Errorf("failed to delete SSH key: %w", err)
@@ -237,7 +239,7 @@ func (h *iamRoleHandler) Delete(ctx context.Context, ref ResourceRef) error {
 
 	op, err := h.client.DeleteIAMRole(ctx, uuid)
 	if err != nil {
-		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
+		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), notFoundErrorSubstring) {
 			return nil
 		}
 		return fmt.Errorf("failed to delete IAM role: %w", err)


### PR DESCRIPTION
## Description

Fixes the mechanical, low-risk subset of the SonarQube findings surfaced after SPOT-31665
enabled scanning for this repo. Each fix is its own atomic commit.

## Related Issue

[SPOT-31705](https://exasol.atlassian.net/browse/SPOT-31705)

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [x] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [x] `refactor`: Code refactoring
- [x] `chore`: Maintenance tasks

## Changes Made

- Explain blank `embed` imports
- Group consecutive same-type function parameters
- Rename single-method interfaces to follow Go convention
- Inline single-use if-init variables
- Rename local variables to camelCase
- Extract duplicated string literals into constants
- Redirect shell script error messages to stderr
- Add explicit return statements to shell helper functions
- Enforce HTTPS protocol on installer download
- Scope `dependabot-auto-merge` workflow permissions to job level
- Merge identical IAM switch-case branches
- Avoid indexing a possibly-empty preset list (fixes a potential `IndexError`)
- Isolate the raising call in `pytest.raises` blocks
- Declare `container_shell.sh` as POSIX sh
- Mark tests and mocks in SonarQube config

## Testing

- [x] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [ ] Manually tested the changes

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [ ] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format


[SPOT-31705]: https://exasol.atlassian.net/browse/SPOT-31705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ