### PR TITLE
fix: document CLI output contract and align SLC commands

### DIFF
--- a/cmd/exasol/slc.go
+++ b/cmd/exasol/slc.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"text/tabwriter"
 
@@ -43,6 +42,8 @@ const slcNoRestartFlagName = "no-restart"
 
 const slcCmdShortDesc = "Manage script language containers (SLCs)"
 
+const slcNoneAvailableText = "No script language containers are available for this platform."
+
 const slcCmdLongDesc = slcCmdShortDesc + `
 
 Script language containers provide the language runtimes used by UDFs.
@@ -75,7 +76,7 @@ var slcInstallCmd = &cobra.Command{
 			slcConfirmFunc(cmd, slcInstallOpts.AutoApprove, fmt.Sprintf("Installing %q", alias)),
 		)
 		if errors.Is(err, deploy.ErrSLCOperationCancelled) {
-			safePrint(slcOperationAbortedMessage)
+			addTerminalNotice(slcOperationAbortedMessage)
 
 			return nil
 		}
@@ -83,8 +84,12 @@ var slcInstallCmd = &cobra.Command{
 			return err
 		}
 
+		if commonFlags.OutputJson {
+			return renderSLCCommandJSON(result)
+		}
+
 		if result.AlreadyInstalled {
-			safePrint(fmt.Sprintf(
+			addTerminalOutput(fmt.Sprintf(
 				"%s is already installed and up to date (version %s, aliases: %s). Nothing to do.",
 				result.Entry.Flavor,
 				result.Entry.Version,
@@ -116,7 +121,7 @@ var slcUpdateCmd = &cobra.Command{
 			slcConfirmFunc(cmd, slcUpdateOpts.AutoApprove, fmt.Sprintf("Updating %q", alias)),
 		)
 		if errors.Is(err, deploy.ErrSLCOperationCancelled) {
-			safePrint(slcOperationAbortedMessage)
+			addTerminalNotice(slcOperationAbortedMessage)
 
 			return nil
 		}
@@ -124,17 +129,21 @@ var slcUpdateCmd = &cobra.Command{
 			return err
 		}
 
+		if commonFlags.OutputJson {
+			return renderSLCCommandJSON(result)
+		}
+
 		if !result.Found {
-			safePrint(fmt.Sprintf(
-				"No SLC matching %q is installed, so there is nothing to update.\n"+
-					"Run `exasol slc install %s` to install it.",
-				alias, alias,
+			addTerminalOutput(fmt.Sprintf(
+				"No SLC matching %q is installed, so there is nothing to update.",
+				alias,
 			))
+			addTerminalNotice(fmt.Sprintf("Run `exasol slc install %s` to install it.", alias))
 
 			return nil
 		}
 		if result.Unchanged {
-			safePrint(fmt.Sprintf(
+			addTerminalOutput(fmt.Sprintf(
 				"%s is already up to date (version %s). Nothing to do.",
 				result.Entry.Flavor,
 				result.Entry.Version,
@@ -165,7 +174,7 @@ var slcRemoveCmd = &cobra.Command{
 			slcConfirmFunc(cmd, slcRemoveOpts.AutoApprove, fmt.Sprintf("Removing %q", alias)),
 		)
 		if errors.Is(err, deploy.ErrSLCOperationCancelled) {
-			safePrint(slcOperationAbortedMessage)
+			addTerminalNotice(slcOperationAbortedMessage)
 
 			return nil
 		}
@@ -173,8 +182,12 @@ var slcRemoveCmd = &cobra.Command{
 			return err
 		}
 
+		if commonFlags.OutputJson {
+			return renderSLCCommandJSON(result)
+		}
+
 		if !result.Found {
-			safePrint(fmt.Sprintf(
+			addTerminalOutput(fmt.Sprintf(
 				"No SLC matching %q is installed, so there is nothing to remove.",
 				alias,
 			))
@@ -208,13 +221,13 @@ func slcConfirmFunc(cmd *cobra.Command, autoApprove bool, action string) deploy.
 		}
 
 		_, _ = fmt.Fprintf(
-			cmd.OutOrStdout(),
+			cmd.ErrOrStderr(),
 			"%s will restart the database. Open connections will be dropped and running "+
 				"statements aborted.\nContinue? [y/N]: ",
 			action,
 		)
 
-		line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+		line, err := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
 		if err != nil && !errors.Is(err, io.EOF) {
 			return false, err
 		}
@@ -235,7 +248,7 @@ var slcListCmd = &cobra.Command{
 		}
 
 		if commonFlags.OutputJson {
-			return renderSLCListJSON(cmd.OutOrStdout(), statuses)
+			return queueSLCListJSON(statuses)
 		}
 
 		renderSLCListText(statuses)
@@ -244,37 +257,42 @@ var slcListCmd = &cobra.Command{
 	},
 }
 
-type slcListJSONItem struct {
-	Language  string   `json:"language"`
-	Flavor    string   `json:"flavor"`
-	Version   string   `json:"version"`
-	Aliases   []string `json:"aliases"`
-	Installed bool     `json:"installed"`
+func renderSLCListJSON(writer io.Writer, statuses []deploy.SLCStatus) error {
+	content, err := formatSLCListJSON(statuses)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(writer, content)
+
+	return err
 }
 
-func renderSLCListJSON(writer io.Writer, statuses []deploy.SLCStatus) error {
-	items := make([]slcListJSONItem, 0, len(statuses))
-	for _, status := range statuses {
-		items = append(items, slcListJSONItem{
-			Language:  status.Language,
-			Flavor:    status.Flavor,
-			Version:   status.Version,
-			Aliases:   status.Aliases,
-			Installed: status.Installed,
-		})
+func queueSLCListJSON(statuses []deploy.SLCStatus) error {
+	content, err := formatSLCListJSON(statuses)
+	if err != nil {
+		return err
+	}
+	addTerminalOutput(content)
+
+	return nil
+}
+
+func formatSLCListJSON(statuses []deploy.SLCStatus) (string, error) {
+	content, err := json.MarshalIndent(statuses, "", "  ")
+	if err != nil {
+		return "", err
 	}
 
-	encoder := json.NewEncoder(writer)
-	encoder.SetIndent("", "  ")
-
-	return encoder.Encode(items)
+	return string(content), nil
 }
 
 func renderSLCListText(statuses []deploy.SLCStatus) {
-	if len(statuses) == 0 {
-		safePrint("No script language containers are available for this platform.")
+	addTerminalOutput(formatSLCListText(statuses))
+}
 
-		return
+func formatSLCListText(statuses []deploy.SLCStatus) string {
+	if len(statuses) == 0 {
+		return slcNoneAvailableText
 	}
 
 	var builder strings.Builder
@@ -297,7 +315,7 @@ func renderSLCListText(statuses []deploy.SLCStatus) {
 	}
 	_ = writer.Flush()
 
-	safePrint(strings.TrimRight(builder.String(), "\n"))
+	return strings.TrimRight(builder.String(), "\n")
 }
 
 func printSLCInstallResult(result *deploy.SLCInstallResult) {
@@ -313,6 +331,7 @@ func printSLCInstallResult(result *deploy.SLCInstallResult) {
 	)
 
 	switch result.Outcome {
+	case deploy.SLCApplyNone:
 	case deploy.SLCApplyRestarted:
 		message += " Database restarted; the language is ready to use."
 	case deploy.SLCApplyStarted:
@@ -322,7 +341,7 @@ func printSLCInstallResult(result *deploy.SLCInstallResult) {
 	default:
 	}
 
-	safePrint(message)
+	addTerminalOutput(message)
 }
 
 func printSLCUpdateResult(result *deploy.SLCUpdateResult) {
@@ -332,6 +351,7 @@ func printSLCUpdateResult(result *deploy.SLCUpdateResult) {
 	}
 
 	switch result.Outcome {
+	case deploy.SLCApplyNone:
 	case deploy.SLCApplyRestarted:
 		message += " Database restarted; the new version is ready to use."
 	case deploy.SLCApplyStarted:
@@ -341,13 +361,14 @@ func printSLCUpdateResult(result *deploy.SLCUpdateResult) {
 	default:
 	}
 
-	safePrint(message)
+	addTerminalOutput(message)
 }
 
 func printSLCRemoveResult(result *deploy.SLCRemoveResult) {
 	message := fmt.Sprintf("Removed %s.", result.Entry.Flavor)
 
 	switch result.Outcome {
+	case deploy.SLCApplyNone:
 	case deploy.SLCApplyRestarted:
 		message += " Database restarted; the language is no longer available."
 	case deploy.SLCApplyStarted:
@@ -357,7 +378,17 @@ func printSLCRemoveResult(result *deploy.SLCRemoveResult) {
 	default:
 	}
 
-	safePrint(message)
+	addTerminalOutput(message)
+}
+
+func renderSLCCommandJSON(value any) error {
+	content, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		return err
+	}
+	addTerminalOutput(string(content))
+
+	return nil
 }
 
 // nolint: gochecknoinits
@@ -365,6 +396,7 @@ func init() {
 	requireDefaultDeploymentCompatibility(slcInstallCmd)
 	requireInitializedDeploymentDir(slcInstallCmd)
 	registerDeploymentDirFlag(slcInstallCmd, commonFlags)
+	registerOutputFlags(slcInstallCmd, commonFlags)
 	registerVerboseFlag(slcInstallCmd, commonFlags)
 	slcInstallCmd.Flags().BoolVar(&slcInstallOpts.AutoApprove, slcAutoApproveFlagName, false,
 		slcAutoApproveFlagDesc)
@@ -374,6 +406,7 @@ func init() {
 	requireDefaultDeploymentCompatibility(slcUpdateCmd)
 	requireInitializedDeploymentDir(slcUpdateCmd)
 	registerDeploymentDirFlag(slcUpdateCmd, commonFlags)
+	registerOutputFlags(slcUpdateCmd, commonFlags)
 	registerVerboseFlag(slcUpdateCmd, commonFlags)
 	slcUpdateCmd.Flags().BoolVar(&slcUpdateOpts.AutoApprove, slcAutoApproveFlagName, false,
 		slcAutoApproveFlagDesc)
@@ -383,6 +416,7 @@ func init() {
 	requireDefaultDeploymentCompatibility(slcRemoveCmd)
 	requireInitializedDeploymentDir(slcRemoveCmd)
 	registerDeploymentDirFlag(slcRemoveCmd, commonFlags)
+	registerOutputFlags(slcRemoveCmd, commonFlags)
 	registerVerboseFlag(slcRemoveCmd, commonFlags)
 	slcRemoveCmd.Flags().BoolVar(&slcRemoveOpts.AutoApprove, slcAutoApproveFlagName, false,
 		slcAutoApproveFlagDesc)

--- a/cmd/exasol/slc_test.go
+++ b/cmd/exasol/slc_test.go
@@ -5,28 +5,48 @@ package main
 
 import (
 	"bytes"
-	"io"
-	"os"
+	"encoding/json"
 	"strings"
 	"testing"
 
+	"github.com/exasol/exasol-personal/internal/config"
 	"github.com/exasol/exasol-personal/internal/deploy"
+	"github.com/spf13/pflag"
 )
 
 // On an unsupported architecture `slc list` degrades gracefully: SLCStatuses returns an
 // empty set (no error), which the renderers must present as the "none available" message
 // and an empty JSON array — never an error or a non-zero exit.
 
-//nolint:paralleltest // swaps the process-wide os.Stdout to capture safePrint output.
 func TestRenderSLCListTextNoneAvailable(t *testing.T) {
-	output := captureStdout(t, func() {
-		renderSLCListText([]deploy.SLCStatus{})
-	})
+	t.Parallel()
+
+	output := formatSLCListText([]deploy.SLCStatus{})
 
 	if strings.TrimSpace(
 		output,
 	) != "No script language containers are available for this platform." {
 		t.Fatalf("unexpected text output: %q", output)
+	}
+}
+
+//nolint:paralleltest // mutates shared terminal message queues
+func TestRenderSLCListTextQueuesPrimaryOutput(t *testing.T) {
+	resetTerminalMessages()
+	defer resetTerminalMessages()
+
+	renderSLCListText([]deploy.SLCStatus{})
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	writeTerminalMessages(&stdout, &stderr)
+
+	if strings.TrimSpace(stdout.String()) !=
+		"No script language containers are available for this platform." {
+		t.Fatalf("unexpected stdout: %q", stdout.String())
+	}
+	if stderr.String() != "" {
+		t.Fatalf("unexpected stderr: %q", stderr.String())
 	}
 }
 
@@ -43,25 +63,69 @@ func TestRenderSLCListJSONEmptyIsArray(t *testing.T) {
 	}
 }
 
-// captureStdout runs emit with os.Stdout redirected to a pipe and returns what it wrote.
-func captureStdout(t *testing.T, emit func()) string {
-	t.Helper()
+//nolint:paralleltest // mutates shared terminal message queues
+func TestRenderSLCCommandJSONQueuesParseablePrimaryOutput(t *testing.T) {
+	resetTerminalMessages()
+	defer resetTerminalMessages()
 
-	reader, writer, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("failed to create pipe: %v", err)
+	result := &deploy.SLCInstallResult{
+		Operation: deploy.SLCOperationInstall,
+		Entry: config.InstalledSLC{
+			Language: "python",
+			Flavor:   "python-3.12",
+			Version:  "3.12",
+			Image:    "docker.io/exasol/script-language-container:python-3.12",
+			Target:   "/exa/slc/python-3.12",
+			Aliases:  []string{"PYTHON3", "PYTHON312"},
+		},
+		Changed: true,
+		Outcome: deploy.SLCApplyDeferred,
 	}
-	original := os.Stdout
-	os.Stdout = writer
-	t.Cleanup(func() { os.Stdout = original })
 
-	emit()
-	_ = writer.Close()
-
-	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, reader); err != nil {
-		t.Fatalf("failed to read captured output: %v", err)
+	if err := renderSLCCommandJSON(result); err != nil {
+		t.Fatalf("failed to render JSON: %v", err)
 	}
 
-	return buf.String()
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+	writeTerminalMessages(&stdout, &stderr)
+
+	if stderr.String() != "" {
+		t.Fatalf("unexpected stderr: %q", stderr.String())
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &decoded); err != nil {
+		t.Fatalf("stdout is not parseable JSON: %v\n%s", err, stdout.String())
+	}
+	if decoded["operation"] != "install" {
+		t.Fatalf("unexpected operation: %v", decoded["operation"])
+	}
+	if decoded["outcome"] != "deferred" {
+		t.Fatalf("unexpected outcome: %v", decoded["outcome"])
+	}
+}
+
+func TestSLCApplyOutcomeStringReportsNoOp(t *testing.T) {
+	t.Parallel()
+
+	if got := deploy.SLCApplyNone.String(); got != "none" {
+		t.Fatalf("expected no-op outcome, got %q", got)
+	}
+}
+
+//nolint:paralleltest // reads package-global Cobra commands
+func TestSLCMutationCommandsRegisterJSONFlag(t *testing.T) {
+	for _, cmd := range []struct {
+		name string
+		cmd  interface{ Flag(name string) *pflag.Flag }
+	}{
+		{name: "install", cmd: slcInstallCmd},
+		{name: "update", cmd: slcUpdateCmd},
+		{name: "remove", cmd: slcRemoveCmd},
+	} {
+		if cmd.cmd.Flag("json") == nil {
+			t.Fatalf("expected slc %s to register --json", cmd.name)
+		}
+	}
 }

--- a/doc/best_practices.md
+++ b/doc/best_practices.md
@@ -25,18 +25,19 @@ For more detailed information, consider these resources:
 - [Reddit Discussion on init() Best Practices](https://www.reddit.com/r/golang/comments/prtpqy/best_practices_regarding_init_function_and_small/)
 - [StackOverflow: Is it bad to use init() functions?](https://stackoverflow.com/questions/56039154/is-it-really-bad-to-use-init-functions-in-go)
 
-## Only print to the terminal in `cmd` packages
+## Keep CLI output in the command layer
 
-**Rule:** Do not use `fmt.Printf`, `fmt.Println`, or other functions that print directly to the terminal inside packages outside of your `cmd` layer.
+**Rule:** Command implementations own terminal presentation. Library packages return data and errors; they do not print user-facing output directly.
 
 ### Explanation
 
-The Go standard library’s `fmt` package provides functions like `Print`, `Println`, and `Printf` that write formatted output to standard output (`os.Stdout`) by default. These are useful in CLI entry points, but they hard-code a specific output destination (the terminal).
+Terminal output is part of the CLI contract, not part of the deployment, configuration, or runtime libraries. Keeping it in the command layer preserves a clean separation between core logic and presentation, makes library code reusable outside a terminal, and keeps command output testable.
 
-When code in lower-level packages prints directly to the terminal, it couples those packages to a particular execution context. Code that prints to stdout cannot be easily reused in environments where terminal output is inappropriate, such as servers, tests, background jobs, libraries, or GUI applications.
+The command layer should build text and JSON output from the same returned domain objects. Library packages should accept and return objects, not pre-rendered CLI representations whose only purpose is to be printed. Text output may intentionally be shorter or more human-oriented, but JSON output must be complete enough for automation and agent workflows.
 
-By restricting direct terminal output to the `cmd` package (or other designated boundary layers), you preserve separation between **core logic** and **presentation**. Other packages should return values or accept an `io.Writer` for output instead of printing directly. This makes logic testable (you can capture or mock output) and reusable in contexts beyond a terminal. A common idiom in Go is to use `fmt.Fprintf(w, ...)` with an `io.Writer` parameter when output must be produced programmatically, rather than writing straight to stdout. :contentReference[oaicite:1]{index=1}
+Use stdout only for primary command output. When `--json` is selected, stdout must contain only valid JSON for successful command output so callers can parse it directly without filtering. Human guidance, progress notes, current-directory notices, prompts, and call-to-action messages belong on stderr.
 
+Expected errors are not successful command output. Unsupported features, invalid platform/backend combinations, validation failures, and other expected failures should be returned through the command error path so they are written to stderr and never mixed into stdout.
 
-
+Route queued terminal output through the command helpers: use `addTerminalOutput` for primary stdout output and `addTerminalNotice` for stderr notices. This preserves ordering and keeps JSON stdout parseable when root-level notices are added.
 

--- a/internal/deploy/slc.go
+++ b/internal/deploy/slc.go
@@ -26,8 +26,6 @@ var ErrSLCNotSupported = errors.New(
 // ErrSLCOperationCancelled is returned when the user declines the database-restart prompt.
 var ErrSLCOperationCancelled = errors.New("operation cancelled")
 
-const slcOperationInProgressSuffix = " script language container (this may take a few minutes)"
-
 // ErrDeploymentNotPresent is returned when an SLC change operation (install/update/remove)
 // is attempted on a deployment that has only been initialized, never deployed. SLC
 // management operates on a deployed database, so there is nothing to change — and, crucially,
@@ -76,12 +74,22 @@ func confirmOrCancel(confirm ConfirmFunc) error {
 	return nil
 }
 
-// SLCApplyOutcome describes how an install/remove was applied to the running state.
+// SLCApplyOutcome describes how an install, update, or remove was applied to the running state.
 type SLCApplyOutcome int
 
+const slcApplyOutcomeUnknown = "unknown"
+
 const (
+	SLCOperationInstall = "install"
+	SLCOperationUpdate  = "update"
+	SLCOperationRemove  = "remove"
+)
+
+const (
+	// SLCApplyNone means no apply action was needed.
+	SLCApplyNone SLCApplyOutcome = iota
 	// SLCApplyRestarted means the running database was stopped and started again.
-	SLCApplyRestarted SLCApplyOutcome = iota
+	SLCApplyRestarted
 	// SLCApplyStarted means a stopped database was started to apply the change.
 	SLCApplyStarted
 	// SLCApplyDeferred means the change was persisted but the (stopped) database was not
@@ -89,38 +97,63 @@ const (
 	SLCApplyDeferred
 )
 
+func (outcome SLCApplyOutcome) String() string {
+	switch outcome {
+	case SLCApplyNone:
+		return "none"
+	case SLCApplyRestarted:
+		return "restarted"
+	case SLCApplyStarted:
+		return "started"
+	case SLCApplyDeferred:
+		return "deferred"
+	default:
+		return slcApplyOutcomeUnknown
+	}
+}
+
+func (outcome SLCApplyOutcome) MarshalText() ([]byte, error) {
+	return []byte(outcome.String()), nil
+}
+
 // SLCInstallResult reports the outcome of an install.
 type SLCInstallResult struct {
-	Entry            config.InstalledSLC
-	AlreadyInstalled bool
-	Replaced         bool
-	Outcome          SLCApplyOutcome
+	Operation        string              `json:"operation"`
+	Entry            config.InstalledSLC `json:"entry"`
+	AlreadyInstalled bool                `json:"alreadyInstalled"`
+	Replaced         bool                `json:"replaced"`
+	Changed          bool                `json:"changed"`
+	Outcome          SLCApplyOutcome     `json:"outcome"`
 }
 
 // SLCRemoveResult reports the outcome of a remove.
 type SLCRemoveResult struct {
-	Found   bool
-	Entry   config.InstalledSLC
-	Outcome SLCApplyOutcome
+	Operation string               `json:"operation"`
+	Found     bool                 `json:"found"`
+	Changed   bool                 `json:"changed"`
+	Entry     *config.InstalledSLC `json:"entry,omitempty"`
+	Outcome   SLCApplyOutcome      `json:"outcome"`
 }
 
 // SLCUpdateResult reports the outcome of an update.
 type SLCUpdateResult struct {
-	Found       bool
-	Unchanged   bool
-	FromFlavor  string
-	FromVersion string
-	Entry       config.InstalledSLC
-	Outcome     SLCApplyOutcome
+	Operation   string               `json:"operation"`
+	Found       bool                 `json:"found"`
+	Unchanged   bool                 `json:"unchanged"`
+	Changed     bool                 `json:"changed"`
+	FromFlavor  string               `json:"fromFlavor,omitempty"`
+	FromVersion string               `json:"fromVersion,omitempty"`
+	Entry       *config.InstalledSLC `json:"entry,omitempty"`
+	Outcome     SLCApplyOutcome      `json:"outcome"`
 }
 
 // SLCStatus describes one catalog SLC and whether it is installed in this deployment.
 type SLCStatus struct {
-	Language  string
-	Flavor    string
-	Version   string
-	Aliases   []string
-	Installed bool
+	Language  string   `json:"language"`
+	Flavor    string   `json:"flavor"`
+	Version   string   `json:"version"`
+	Aliases   []string `json:"aliases"`
+	Installed bool     `json:"installed"`
 }
 
 // InstallSLC resolves an alias against the official SLC catalog, records the SLC in
@@ -160,7 +193,12 @@ func InstallSLC(
 
 	// An identical already-installed image is a no-op: no state change, no restart.
 	if idx := findInstalledByImage(state.InstalledSLCs, entry.Image); idx >= 0 {
-		return &SLCInstallResult{Entry: state.InstalledSLCs[idx], AlreadyInstalled: true}, nil
+		return &SLCInstallResult{
+			Operation:        SLCOperationInstall,
+			Entry:            state.InstalledSLCs[idx],
+			AlreadyInstalled: true,
+			Outcome:          SLCApplyNone,
+		}, nil
 	}
 
 	replaces, err := slc.CheckInstallable(installedEntries(state), entry)
@@ -184,22 +222,30 @@ func InstallSLC(
 
 	if !restart {
 		slog.Info(
-			alias+" script language container recorded; it will activate on the next start",
+			"script language container install recorded",
+			"alias", alias,
 			"flavor", entry.Flavor,
+			"version", entry.Version,
+			"replaced", replaces,
+			"activation", "next_start",
 		)
 
 		return &SLCInstallResult{
-			Entry:    toInstalledSLC(entry),
-			Replaced: replaces,
-			Outcome:  SLCApplyDeferred,
+			Operation: SLCOperationInstall,
+			Entry:     toInstalledSLC(entry),
+			Replaced:  replaces,
+			Changed:   true,
+			Outcome:   SLCApplyDeferred,
 		}, nil
 	}
 
 	slog.Info(
-		"installing "+alias+slcOperationInProgressSuffix,
+		"installing script language container",
+		"alias", alias,
 		"flavor", entry.Flavor,
+		"version", entry.Version,
+		"may_take_minutes", true,
 	)
-
 	outcome, err := applySLCChange(ctx, deployment, verbose, true)
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -208,12 +254,20 @@ func InstallSLC(
 		)
 	}
 
-	slog.Info(alias + " script language container is installed")
+	slog.Info(
+		"script language container installed",
+		"alias", alias,
+		"flavor", entry.Flavor,
+		"version", entry.Version,
+		"outcome", outcome.String(),
+	)
 
 	return &SLCInstallResult{
-		Entry:    toInstalledSLC(entry),
-		Replaced: replaces,
-		Outcome:  outcome,
+		Operation: SLCOperationInstall,
+		Entry:     toInstalledSLC(entry),
+		Replaced:  replaces,
+		Changed:   true,
+		Outcome:   outcome,
 	}, nil
 }
 
@@ -243,7 +297,7 @@ func RemoveSLC(
 
 	index := findInstalledSLC(state.InstalledSLCs, alias)
 	if index < 0 {
-		return &SLCRemoveResult{Found: false}, nil
+		return &SLCRemoveResult{Operation: SLCOperationRemove, Found: false}, nil
 	}
 
 	// Confirm before disrupting a running database (only when a restart will happen).
@@ -264,35 +318,51 @@ func RemoveSLC(
 
 	if !restart {
 		slog.Info(
-			alias+" script language container recorded for removal; it applies on the next start",
+			"script language container removal recorded",
+			"alias", alias,
 			"flavor", removed.Flavor,
+			"version", removed.Version,
+			"activation", "next_start",
 		)
 
-		return &SLCRemoveResult{Found: true, Entry: removed, Outcome: SLCApplyDeferred}, nil
+		return &SLCRemoveResult{
+			Operation: SLCOperationRemove,
+			Found:     true,
+			Changed:   true,
+			Entry:     &removed,
+			Outcome:   SLCApplyDeferred,
+		}, nil
 	}
 
 	if isLocalDeploymentRunning(ctx, deployment) {
 		slog.Info(
-			"removing "+alias+slcOperationInProgressSuffix,
+			"removing script language container",
+			"alias", alias,
 			"flavor", removed.Flavor,
+			"version", removed.Version,
+			"may_take_minutes", true,
 		)
 	}
-
 	outcome, err := applySLCChange(ctx, deployment, verbose, false)
 	if err != nil {
 		return nil, err
 	}
 
-	if outcome == SLCApplyDeferred {
-		slog.Info(
-			alias+" script language container removed; it will no longer load on the next start",
-			"flavor", removed.Flavor,
-		)
-	} else {
-		slog.Info(alias + " script language container is removed")
-	}
+	slog.Info(
+		"script language container removed",
+		"alias", alias,
+		"flavor", removed.Flavor,
+		"version", removed.Version,
+		"outcome", outcome.String(),
+	)
 
-	return &SLCRemoveResult{Found: true, Entry: removed, Outcome: outcome}, nil
+	return &SLCRemoveResult{
+		Operation: SLCOperationRemove,
+		Found:     true,
+		Changed:   true,
+		Entry:     &removed,
+		Outcome:   outcome,
+	}, nil
 }
 
 // UpdateSLC re-resolves an installed SLC against the catalog and, if the resolved image
@@ -330,14 +400,20 @@ func UpdateSLC(
 
 	index := findInstalledSLC(state.InstalledSLCs, alias)
 	if index < 0 {
-		return &SLCUpdateResult{Found: false}, nil
+		return &SLCUpdateResult{Operation: SLCOperationUpdate, Found: false}, nil
 	}
 	installed := state.InstalledSLCs[index]
 
 	// Shared no-op test with install: an unchanged (content-addressed) image is nothing to
 	// update.
 	if findInstalledByImage(state.InstalledSLCs, entry.Image) >= 0 {
-		return &SLCUpdateResult{Found: true, Unchanged: true, Entry: installed}, nil
+		return &SLCUpdateResult{
+			Operation: SLCOperationUpdate,
+			Found:     true,
+			Unchanged: true,
+			Entry:     &installed,
+			Outcome:   SLCApplyNone,
+		}, nil
 	}
 
 	// An update can move to a new flavor (e.g. the unversioned alias shifting from
@@ -357,21 +433,29 @@ func UpdateSLC(
 	}
 
 	result := &SLCUpdateResult{
+		Operation:   SLCOperationUpdate,
 		Found:       true,
+		Changed:     true,
 		FromFlavor:  installed.Flavor,
 		FromVersion: installed.Version,
-		Entry:       toInstalledSLC(entry),
 	}
+	resultEntry := toInstalledSLC(entry)
+	result.Entry = &resultEntry
 
-	state.InstalledSLCs = upsertInstalledSLC(remaining, toInstalledSLC(entry))
+	state.InstalledSLCs = upsertInstalledSLC(remaining, resultEntry)
 	if err := config.WriteExasolPersonalState(state, deployment); err != nil {
 		return nil, err
 	}
 
 	if !restart {
 		slog.Info(
-			alias+" script language container update recorded; it will apply on the next start",
+			"script language container update recorded",
+			"alias", alias,
+			"from_flavor", installed.Flavor,
+			"from_version", installed.Version,
 			"flavor", entry.Flavor,
+			"version", entry.Version,
+			"activation", "next_start",
 		)
 		result.Outcome = SLCApplyDeferred
 
@@ -379,8 +463,13 @@ func UpdateSLC(
 	}
 
 	slog.Info(
-		"updating "+alias+slcOperationInProgressSuffix,
+		"updating script language container",
+		"alias", alias,
+		"from_flavor", installed.Flavor,
+		"from_version", installed.Version,
 		"flavor", entry.Flavor,
+		"version", entry.Version,
+		"may_take_minutes", true,
 	)
 	outcome, err := applySLCChange(ctx, deployment, verbose, true)
 	if err != nil {
@@ -391,8 +480,17 @@ func UpdateSLC(
 			err,
 		)
 	}
-	slog.Info(alias + " script language container is updated")
 	result.Outcome = outcome
+
+	slog.Info(
+		"script language container updated",
+		"alias", alias,
+		"from_flavor", installed.Flavor,
+		"from_version", installed.Version,
+		"flavor", entry.Flavor,
+		"version", entry.Version,
+		"outcome", outcome.String(),
+	)
 
 	return result, nil
 }


### PR DESCRIPTION
## Description

Documents the Exasol Personal CLI output contract and applies it to the SLC commands introduced for SPOT-30976.

The contract separates successful command output from terminal guidance: stdout carries the selected text or JSON representation, stderr carries prompts, notices, call-to-action guidance, and expected command errors. Library code still owns diagnostic logging through `slog`; the CLI logging setup decides where those records are routed.

## Related Issue

Fixes https://exasol.atlassian.net/browse/SPOT-30976

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [x] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Documented the stdout/stderr/JSON ownership rules in `doc/best_practices.md`.
- Added JSON output support for `exasol slc install`, `exasol slc update`, and `exasol slc remove`.
- Routed SLC command result output through the terminal output queue helpers.
- Moved restart prompts and terminal notices off stdout.
- Made SLC list and mutation result objects JSON-ready in the deploy layer so the command layer can render those same objects directly.
- Removed redundant command-layer SLC JSON DTOs.
- Restored structured SLC operation logging in the deploy layer with stable messages and attributes.
- Added an explicit no-op SLC apply outcome so JSON output and logs do not imply a restart when no apply action happened.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

### Test Details

- `env GOCACHE=/tmp/go-build-cache GOLANGCI_LINT_CACHE=/tmp/golangci-lint-cache task fmt`
- `env GOCACHE=/tmp/go-build-cache go test ./cmd/exasol ./internal/deploy ./internal/slc`

The stacked follow-up branch was also validated with `task all` after rebasing onto this PR.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [ ] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

This PR intentionally distinguishes terminal output from logging. The deploy-layer SLC code logs useful operation progress and outcomes with `slog`, while the command layer controls human-readable and JSON command output.
