### PR TITLE
fix(ci): Only delay Dependabot auto-merge for ungrouped updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -20,37 +20,36 @@ jobs:
     env:
       MERGE_DELAY_DAYS: "7"
     steps:
-      - name: Fetch Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
-        with:
-          github-token: ${{ secrets.DEPENDABOT_ALERTS_TOKEN || github.token }}
-          alert-lookup: ${{ secrets.DEPENDABOT_ALERTS_TOKEN != '' }}
-
-      - name: Check auto-merge policy
+      - name: Classify pull request
         id: policy
         env:
-          ALERT_STATE: ${{ steps.metadata.outputs.alert-state }}
-          PACKAGE_ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
-          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          case "${ALERT_STATE}:${PACKAGE_ECOSYSTEM}:${UPDATE_TYPE}" in
-            OPEN:*)
+          # Every version-update group in dependabot.yml uses "patterns: ['*']",
+          # so a routine update always lands on the group's branch. Anything else
+          # on a gomod/pip dependabot branch is an individual (security) update,
+          # since security updates are never assigned to a group.
+          case "${HEAD_REF}" in
+            dependabot/go_modules/*go-weekly-updates-*|dependabot/pip/*python-weekly-updates-*)
               echo "eligible=true" >> "${GITHUB_OUTPUT}"
-              echo "reason=security update" >> "${GITHUB_OUTPUT}"
+              echo "requires-delay=false" >> "${GITHUB_OUTPUT}"
+              echo "reason=routine grouped update" >> "${GITHUB_OUTPUT}"
               ;;
-            *:gomod:version-update:semver-patch|*:gomod:version-update:semver-minor|*:pip:version-update:semver-patch|*:pip:version-update:semver-minor)
+            dependabot/go_modules/*|dependabot/pip/*)
               echo "eligible=true" >> "${GITHUB_OUTPUT}"
-              echo "reason=${PACKAGE_ECOSYSTEM} ${UPDATE_TYPE}" >> "${GITHUB_OUTPUT}"
+              echo "requires-delay=true" >> "${GITHUB_OUTPUT}"
+              echo "reason=ungrouped update, treated as security" >> "${GITHUB_OUTPUT}"
               ;;
             *)
               echo "eligible=false" >> "${GITHUB_OUTPUT}"
-              echo "reason=${PACKAGE_ECOSYSTEM} ${UPDATE_TYPE}" >> "${GITHUB_OUTPUT}"
+              echo "requires-delay=false" >> "${GITHUB_OUTPUT}"
+              echo "reason=outside the auto-merge lanes" >> "${GITHUB_OUTPUT}"
               ;;
           esac
 
       - name: Check merge delay
         id: delay
+        if: steps.policy.outputs.requires-delay == 'true'
         env:
           PR_CREATED_AT: ${{ github.event.pull_request.created_at }}
           MERGE_DELAY_DAYS: ${{ env.MERGE_DELAY_DAYS }}
@@ -65,7 +64,7 @@ jobs:
           else
             remaining=$((required_age - age))
             echo "passed=false" >> "${GITHUB_OUTPUT}"
-            echo "Dependabot PR is waiting for the ${MERGE_DELAY_DAYS}-day merge delay. Remaining seconds: ${remaining}"
+            echo "Dependabot security PR is waiting for the ${MERGE_DELAY_DAYS}-day merge delay. Remaining seconds: ${remaining}"
           fi
 
       - name: Report manual review requirement
@@ -76,7 +75,7 @@ jobs:
           echo "Dependabot PR requires manual review: ${REASON}"
 
       - name: Report merge delay
-        if: steps.policy.outputs.eligible == 'true' && steps.delay.outputs.passed != 'true'
+        if: steps.policy.outputs.requires-delay == 'true' && steps.delay.outputs.passed != 'true'
         env:
           REASON: ${{ steps.policy.outputs.reason }}
           MERGE_DELAY_DAYS: ${{ env.MERGE_DELAY_DAYS }}
@@ -84,7 +83,7 @@ jobs:
           echo "Dependabot PR is eligible for auto-merge after the ${MERGE_DELAY_DAYS}-day merge delay: ${REASON}"
 
       - name: Approve pull request
-        if: steps.policy.outputs.eligible == 'true' && steps.delay.outputs.passed == 'true'
+        if: steps.policy.outputs.eligible == 'true' && (steps.policy.outputs.requires-delay != 'true' || steps.delay.outputs.passed == 'true')
         env:
           GH_TOKEN: ${{ github.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -96,7 +95,7 @@ jobs:
           fi
 
       - name: Enable auto-merge
-        if: steps.policy.outputs.eligible == 'true' && steps.delay.outputs.passed == 'true'
+        if: steps.policy.outputs.eligible == 'true' && (steps.policy.outputs.requires-delay != 'true' || steps.delay.outputs.passed == 'true')
         env:
           GH_TOKEN: ${{ github.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -134,8 +133,15 @@ jobs:
             head_ref=$(jq -r '.headRefName' <<< "${pr}")
             review_decision=$(jq -r '.reviewDecision' <<< "${pr}")
 
+            # See the "Classify pull request" step in the auto-merge-pr job for
+            # why grouped branches are routine and everything else is treated
+            # as a security update requiring the merge delay.
             case "${head_ref}" in
+              dependabot/go_modules/*go-weekly-updates-*|dependabot/pip/*python-weekly-updates-*)
+                requires_delay=false
+                ;;
               dependabot/go_modules/*|dependabot/pip/*)
+                requires_delay=true
                 ;;
               *)
                 echo "Skipping Dependabot PR #${number}: manual review lane (${head_ref})"
@@ -143,15 +149,17 @@ jobs:
                 ;;
             esac
 
-            created=$(date -d "${created_at}" +%s)
-            now=$(date +%s)
-            required_age=$((MERGE_DELAY_DAYS * 24 * 60 * 60))
-            age=$((now - created))
+            if [[ "${requires_delay}" == "true" ]]; then
+              created=$(date -d "${created_at}" +%s)
+              now=$(date +%s)
+              required_age=$((MERGE_DELAY_DAYS * 24 * 60 * 60))
+              age=$((now - created))
 
-            if [[ "${age}" -lt "${required_age}" ]]; then
-              remaining=$((required_age - age))
-              echo "Skipping Dependabot PR #${number}: waiting for ${MERGE_DELAY_DAYS}-day merge delay. Remaining seconds: ${remaining}"
-              continue
+              if [[ "${age}" -lt "${required_age}" ]]; then
+                remaining=$((required_age - age))
+                echo "Skipping Dependabot PR #${number}: waiting for ${MERGE_DELAY_DAYS}-day merge delay. Remaining seconds: ${remaining}"
+                continue
+              fi
             fi
 
             if [[ "${review_decision}" != "APPROVED" ]]; then

--- a/doc/ci.md
+++ b/doc/ci.md
@@ -21,12 +21,11 @@ All CI jobs declare explicit minimal permissions.
 ### Dependabot Auto-Merge (`dependabot-auto-merge.yml`)
 
 Runs for Dependabot pull requests and enables auto-merge for Go and Python patch and minor version updates after required branch protection checks pass.
-Eligible pull requests wait 7 days after PR creation before the workflow approves them and enables auto-merge.
-Security update pull requests are still opened immediately because Dependabot cooldown does not delay security updates, but they use the same 7-day merge delay unless maintainers merge them manually.
-Security updates outside the normal Go and Python patch/minor policy require the optional `DEPENDABOT_ALERTS_TOKEN` secret so the workflow can identify the linked Dependabot alert during pull request-triggered runs.
-GitHub Actions updates and major version updates that are not identified as security updates remain manual review items.
+Eligibility is derived from the pull request's branch name: Go and Python updates that land on their ecosystem's grouped update branch (see `groups` in [`dependabot.yml`](../.github/dependabot.yml)) are routine and are approved immediately, since Dependabot cooldown already delayed their creation.
+Any Go or Python Dependabot branch that falls outside its group is treated as a security update — Dependabot never assigns security updates to a group — and waits 7 days after PR creation before the workflow approves it and enables auto-merge, since Dependabot cooldown does not delay security updates.
+GitHub Actions updates remain manual review items regardless of grouping.
 Repository auto-merge must be enabled for this workflow to queue eligible pull requests.
-The workflow uses `pull_request_target` only for trusted Dependabot metadata and GitHub pull request operations; it does not check out or execute pull request code.
+The workflow uses `pull_request_target` only for pull request metadata (branch name, creation time, review status) and GitHub pull request operations; it does not check out or execute pull request code, and does not depend on Dependabot's commit-message metadata.
 Scheduled rechecks run every 6 hours to pick up eligible open Dependabot PRs after the merge delay has elapsed.
 
 Dependabot version updates use built-in cooldown periods before PR creation:
@@ -35,7 +34,7 @@ Dependabot version updates use built-in cooldown periods before PR creation:
 - Go and Python patch updates wait 2 days.
 - Go and Python minor updates wait 7 days.
 
-The merge delay is separate from Dependabot cooldown: cooldown delays routine PR creation, while the workflow delay defers approval and auto-merge after the PR exists.
+The merge delay is separate from Dependabot cooldown: cooldown delays routine PR creation, while the workflow delay defers approval and auto-merge for ungrouped (security) PRs after they exist.
 Auto-merge does not itself rebase Dependabot PRs; branch protection and Dependabot's own update behavior determine whether stale branches are refreshed before merging.
 
 ### Release Pipeline (`release.yml`)

--- a/doc/repository_security_spec.md
+++ b/doc/repository_security_spec.md
@@ -20,7 +20,7 @@ General guidance is in [CI Security Best Practices](ci_security_best_practices.m
 - PR jobs are non-privileged and must not use secrets or OIDC cloud credentials.
 - PR jobs use explicit minimal permissions (`contents: read`).
 - `pull_request_target` is not used for contributor code execution.
-- [`dependabot-auto-merge.yml`](../.github/workflows/dependabot-auto-merge.yml) may use `pull_request_target` only for Dependabot-authored pull requests, only without checking out or executing pull request code, and only to inspect Dependabot metadata, approve eligible pull requests, and enable auto-merge.
+- [`dependabot-auto-merge.yml`](../.github/workflows/dependabot-auto-merge.yml) may use `pull_request_target` only for Dependabot-authored pull requests, only without checking out or executing pull request code, and only to inspect pull request metadata (branch name, creation time, review status), approve eligible pull requests, and enable auto-merge.
 
 ### Trusted Privileged Lane
 
@@ -39,7 +39,7 @@ General guidance is in [CI Security Best Practices](ci_security_best_practices.m
 - Mutable installer patterns in privileged paths are not allowed.
 - GitHub Actions dependencies are maintained through Dependabot.
 - Dependabot version updates use built-in cooldown before pull request creation so routine updates have an ecosystem observation period; Dependabot security updates are not delayed by cooldown.
-- Dependabot auto-merge is limited to eligible Go and Python patch/minor updates plus identified security updates after a 7-day merge delay and required branch protection checks pass. GitHub Actions updates and non-security major updates require manual review.
+- Dependabot auto-merge approves and enables auto-merge immediately for Go and Python patch/minor updates once they reach their ecosystem's grouped update branch (cooldown already delayed their creation). Any Go/Python update outside that group is treated as a security update and waits an additional 7-day merge delay, since Dependabot cooldown does not delay security updates; required branch protection checks still gate the actual merge. GitHub Actions updates always require manual review.
 - Repository auto-merge may be enabled to let the Dependabot workflow queue eligible pull requests behind branch protection checks.
 
 ### Workflow Change Governance
@@ -98,7 +98,6 @@ This ensures workflow and release-control changes cannot merge without maintaine
 
 - Prefer OIDC short-lived credentials over long-lived cloud secrets.
 - Move high-risk credentials behind protected environments only.
-- If `DEPENDABOT_ALERTS_TOKEN` is configured for security-update detection, use a least-privilege GitHub App or personal access token with read access to Dependabot alerts only.
 - Audit and reduce repository/org secret inventory on a regular cadence.
 
 This keeps privileged automation aligned with least-privilege and limits blast radius if workflow code changes.


### PR DESCRIPTION
## Description

The `auto-merge-pr` job in `dependabot-auto-merge.yml` failed for grouped Dependabot PRs (e.g. #228) because `dependabot/fetch-metadata` could not parse the commit message: with 168 updates bundled into one group, the commit message's YAML metadata trailer got truncated at GitHub's 65536-byte commit-message limit before its closing `...` marker, so the action returned "PR does not contain metadata, nothing to do" and the whole job failed before ever reaching the merge-delay/approval steps.

Separately, the workflow's 7-day merge delay was applied uniformly to every eligible PR, including security updates — but Dependabot's own cooldown mechanism already delays routine version updates before their PR is even opened (cooldown does not apply to security updates), so the extra workflow-level delay was redundant for routine updates and only actually needed for security fixes.

## Related Issue

Related to #228 (the failing run this PR fixes)

## Type of Change

- [x] `fix`: Bug fix

## Changes Made

- Replaced the `dependabot/fetch-metadata` step and its commit-message parsing with a branch-name classification step: PRs on their ecosystem's grouped update branch (`dependabot.yml`'s `groups`, e.g. `go-weekly-updates`) are routine and merge without an extra delay; any other Go/Python Dependabot branch is treated as a security update (Dependabot never assigns security updates to a group) and still waits the 7-day merge delay.
- Applied the same classification to the `scheduled-recheck` job's loop.
- This removes the dependency on commit-message parsing entirely, so the 65536-byte truncation on large grouped PRs can no longer break the workflow, and drops the never-configured `DEPENDABOT_ALERTS_TOKEN` secret this repo never actually had set up (so security-update detection had silently never worked).
- Updated `doc/ci.md` and `doc/repository_security_spec.md`, which still described the old token-based mechanism and the old uniform 7-day delay.

## Testing

- [x] Manually tested the changes

### Test Details

- Verified the branch-classification logic locally (pure bash, no side effects) against real branch names pulled from this repo (including the pip ecosystem's `/tests` directory nesting) and synthetic edge cases; caught and fixed two bugs this way before pushing (a missed `/tests` path segment, generalized afterward into a directory-agnostic glob).
- `pull_request_target` always runs the workflow file from `main`, so the `auto-merge-pr` job's new logic can't be exercised live before merge — confirmed this constraint and relied on the local logic test instead.
- Checked all 5 currently-open Dependabot PRs against the new classification and against the repo's actual open Dependabot alerts (there are currently zero) to sanity-check the "ungrouped ⇒ security" heuristic; confirmed the known false-positive case (PRs with pre-release version strings excluded from grouping get an unneeded one-time 7-day wait) is acceptable since it fails safe.
- `python3 -c "import yaml; yaml.safe_load(...)"` to confirm the workflow YAML parses.

No changelog entry — this only changes internal CI automation behavior, not anything user-facing.

## Checklist

- [x] Code follows the project's coding guidelines
- [x] Updated documentation (if applicable)
- [ ] Updated `CHANGELOG.md` for user-facing changes — not applicable, this is CI-internal only
- [x] Commit messages follow Conventional Commits format