### PR TITLE
fix(ci): Skip SonarQube scan for Dependabot pull requests too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,9 +106,12 @@ jobs:
   sonarqube:
     runs-on: ubuntu-latest
     needs: tests-unit
-    # Fork PRs never receive repo secrets under the pull_request trigger, so SONAR_TOKEN
-    # wouldn't be available anyway; skip them explicitly rather than run a scan that fails.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    # Fork PRs and Dependabot PRs never receive repo secrets under the pull_request trigger,
+    # so SONAR_TOKEN wouldn't be available anyway; skip them explicitly rather than run a scan that fails.
+    if: >-
+      github.event_name == 'push' ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login != 'dependabot[bot]')
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Description

The `sonarqube` job in `ci.yml` failed for Dependabot PR #214 (`SonarQube Scan` step, exit code 3: `Not authorized or project not found. Please check the 'SONAR_TOKEN' environment variable...`).

The job's guard only checked that the PR isn't from a fork (`head.repo.full_name == github.repository`), on the reasoning that fork PRs never receive repo secrets under the `pull_request` trigger. That's true, but incomplete: Dependabot PRs also live in the same repo (so the fork check passes), yet GitHub withholds repository secrets from `pull_request` runs authored by Dependabot as well, for the same reason it withholds them from forks — to stop an untrusted dependency bump from exfiltrating secrets. So `SONAR_TOKEN` was empty, and the scan attempted to authenticate anyway and got rejected by SonarQube.

## Related Issue

Related to the failing run on #214 (no tracked issue)

## Type of Change

- [x] `fix`: Bug fix

## Changes Made

- Extended the `sonarqube` job's `if:` guard to also skip PRs authored by `dependabot[bot]`, matching the same-repo-but-no-secrets restriction GitHub applies to them.
- Checked the rest of `ci.yml` for any other jobs/steps relying on `secrets.*` under this same guard pattern — `SONAR_TOKEN` was the only one.

## Testing

- [x] Manually tested the changes

### Test Details

- `python3 -c "import yaml; yaml.safe_load(...)"` to confirm the workflow YAML parses.
- Confirmed via `grep` that no other job in `ci.yml` uses `secrets.*` under the same fork-only guard, so this was the only gap.

No changelog entry — this only changes internal CI automation behavior, not anything user-facing.

## Checklist

- [x] Code follows the project's coding guidelines
- [ ] Updated documentation (if applicable) — not applicable, no doc described this guard's scope
- [ ] Updated `CHANGELOG.md` for user-facing changes — not applicable, this is CI-internal only
- [x] Commit messages follow Conventional Commits format