### PR TITLE
Prepare Exasol Personal 2.2 release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Notable user-facing changes to Exasol Personal are documented here.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Breaking Changes
+
+- None.
+
+## 2.2.0 - 2026-07-24
+
+### Added
+
 - Added named deployment selection with `--deployment` / `-d`, so users can manage multiple deployments under the default Exasol Personal deployment root without passing full directory paths.
 
   Example: `exasol status --deployment demo` targets the named `demo` deployment. `--deployment` and `--deployment-dir` cannot be used together.

--- a/assets/resources/resources.yaml
+++ b/assets/resources/resources.yaml
@@ -26,6 +26,6 @@ exasol-local-runner:
   embed: true
   artifact:
     darwin/arm64:
-      url: https://github.com/exasol/exasol-local-vm/releases/download/v1.0.0/mac-runner-aarch64.zip
-      sha256: 5d3470c2ab68873aeb0c2e83a28e047e4d4ccd8bb81948ea7442e812b6920c1c
+      url: https://github.com/exasol/exasol-local-vm/releases/download/v1.1.0-rc3/mac-launcher-aarch64.zip
+      sha256: 123fd1668fd031eed1b136daaa3a475835f2f2b64f482c0f5c7896f4b65047ec
       resource_path: launcher


### PR DESCRIPTION
## Description

Prepare the Exasol Personal 2.2 release candidate by pinning the embedded local VM runtime to the published `exasol-local-vm v1.1.0-rc3` release and finalizing the in-repo changelog for `2.2.0`.

## Related Issue

SPOT-31774

## Type of Change

- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [x] `chore`: Maintenance tasks

## Changes Made

- Updated the embedded `exasol-local-runner` resource to download `mac-launcher-aarch64.zip` from `exasol-local-vm v1.1.0-rc3`.
- Updated the embedded resource SHA256 to the checksum published with the `v1.1.0-rc3` release.
- Moved current `Unreleased` changelog entries into `2.2.0 - 2026-07-24` and left an empty `Unreleased` scaffold.

## Testing

- [x] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

- `task generate TARGET_GOOS=darwin TARGET_GOARCH=arm64`
- `task all`

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [ ] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [ ] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

Deployment E2E validation is still part of the release-candidate task and is not covered by this PR.