### PR TITLE
test: fix deployment output routing expectation

### DIFF
--- a/tests/framework/launcher.py
+++ b/tests/framework/launcher.py
@@ -257,10 +257,19 @@ class Launcher:
             )
             return False
 
-        if "Ready for deployment" not in info_result.stdout:
+        if "Deployment State: initialized" not in info_result.stdout:
             logging.error(
-                "Info output does not contain 'No workflow state file was found': %s",
+                "Info stdout does not report initialized state: %s",
                 info_result.stdout,
+            )
+            return False
+
+        if "Ready for deployment" not in info_result.stderr:
+            logging.error(
+                "Info stderr does not contain ready-for-deployment guidance.\n"
+                "stdout: %s\nstderr: %s",
+                info_result.stdout,
+                info_result.stderr,
             )
             return False
 

--- a/tests/tests/integration/test_launcher_framework.py
+++ b/tests/tests/integration/test_launcher_framework.py
@@ -1,0 +1,35 @@
+# Copyright 2026 Exasol AG
+# SPDX-License-Identifier: MIT
+
+"""Tests for the Python launcher test framework."""
+
+from pathlib import Path
+from subprocess import CompletedProcess
+
+from framework.launcher import Launcher
+
+
+class InfoLauncher(Launcher):
+    def __init__(self, stdout: str, stderr: str) -> None:
+        super().__init__("unused")
+        self.stdout = stdout
+        self.stderr = stderr
+
+    def info(self, deployment_dir: str, *args: str) -> CompletedProcess[str]:
+        return CompletedProcess(
+            args=["unused", "info", "--deployment-dir", deployment_dir, *args],
+            returncode=0,
+            stdout=self.stdout,
+            stderr=self.stderr,
+        )
+
+
+def test_has_no_deployment_accepts_info_guidance_on_stderr(tmp_path: Path) -> None:
+    # Given: info reports initialized state on stdout and next-step guidance on stderr.
+    launcher = InfoLauncher(
+        stdout="Exasol Personal Deployment Overview\nDeployment State: initialized\n",
+        stderr="Ready for deployment. Run `exasol deploy` to apply it.\n",
+    )
+
+    # When / Then: the deployment framework accepts the current output contract.
+    assert launcher.has_no_deployment(str(tmp_path))


### PR DESCRIPTION
## Description

Fix the deployment E2E test framework after the CLI output routing changes. `exasol info` now keeps the initialized deployment summary on stdout and writes ready-for-deployment guidance to stderr, but `Launcher.has_no_deployment()` still looked for that guidance on stdout. This made deployment fixtures fail during setup in the manually triggered Deployment Tests workflow.

Failed run investigated: https://github.com/exasol/exasol-personal/actions/runs/30097953204/job/89496613566

## Related Issue

None.

## Type of Change

- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Updated `tests/framework/launcher.py` to validate initialized state on stdout and ready-for-deployment guidance on stderr.
- Added direct coverage for the deployment test framework helper's stdout/stderr expectations.
- Scanned deployment E2E tests for similar stale output-routing assumptions; the remaining stdout assertions cover primary command output such as query tables, active deployment summaries, or SLC operation results.

## Testing

- [ ] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

- `poetry run pytest -vv tests/test_launcher_framework.py`
- `poetry run ruff check tests/test_launcher_framework.py framework/launcher.py tests/deployment tests/integration`
- `poetry run ruff format --check tests/test_launcher_framework.py framework/launcher.py`
- `poetry run pytest -vv --exasol-path=../bin/exasol tests/integration/test_cli.py::test_info_reports_missing_deployment_without_error tests/integration/test_cli.py::test_info_command_init_deployment tests/integration/test_deployment_directory_resolution.py::test_info_reports_uninitialized_resolved_default_dir`
- `poetry run mypy framework/launcher.py tests/test_launcher_framework.py`
- `git diff --check`

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [ ] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [ ] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [x] All targeted tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

This is test-framework-only and does not change CLI runtime behavior. I did not run cloud deployment tests locally because they provision real infrastructure.