### PR TITLE
Fix release-prep CLI output formatting

### DIFF
--- a/cmd/exasol/terminal_notice.go
+++ b/cmd/exasol/terminal_notice.go
@@ -70,18 +70,22 @@ type terminalConfig struct {
 }
 
 func writeTerminalMessages(cfg terminalConfig) {
+	hasPrecedingMessages := len(terminalNotices) > 0 || len(terminalOutputs) > 0
 	for _, message := range terminalNotices {
 		_, _ = fmt.Fprintln(cfg.stderr, message)
 	}
 	terminalNotices = nil
+	for _, message := range terminalOutputs {
+		_, _ = fmt.Fprintln(cfg.stdout, message)
+	}
+	terminalOutputs = nil
 	if cfg.showCallsToAction {
+		if len(terminalCallsToAction) > 0 && hasPrecedingMessages {
+			_, _ = fmt.Fprintln(cfg.stderr)
+		}
 		for _, message := range terminalCallsToAction {
 			_, _ = fmt.Fprintln(cfg.stderr, message)
 		}
 	}
 	terminalCallsToAction = nil
-	for _, message := range terminalOutputs {
-		_, _ = fmt.Fprintln(cfg.stdout, message)
-	}
-	terminalOutputs = nil
 }

--- a/cmd/exasol/terminal_notice_test.go
+++ b/cmd/exasol/terminal_notice_test.go
@@ -87,8 +87,34 @@ func TestTerminalMessagesShowCallsToActionWhenVisible(t *testing.T) {
 	if stdout.String() != "" {
 		t.Fatalf("unexpected stdout: %q", stdout.String())
 	}
-	if stderr.String() != "directory notice\nrun `exasol deploy`\n" {
+	if stderr.String() != "directory notice\n\nrun `exasol deploy`\n" {
 		t.Fatalf("unexpected stderr: %q", stderr.String())
+	}
+}
+
+// TestTerminalMessagesPrintCallsToActionLastInCombinedTerminalOutput must not
+// run in parallel: it mutates the package-level terminal message queues.
+//
+//nolint:paralleltest // mutates shared package globals; must run serially
+func TestTerminalMessagesPrintCallsToActionLastInCombinedTerminalOutput(t *testing.T) {
+	resetTerminalMessages()
+	defer resetTerminalMessages()
+
+	// Given: all output kinds are queued.
+	addTerminalNotice("directory notice")
+	addTerminalCallToAction("run `exasol deploy`")
+	addTerminalOutput("deployment overview")
+
+	// When: stdout and stderr are rendered to the same terminal.
+	terminal := bytes.Buffer{}
+	writeTerminalMessages(terminalConfig{
+		stdout: &terminal, stderr: &terminal, showCallsToAction: true,
+	})
+
+	// Then: the call to action is visually separated and printed last.
+	expected := "directory notice\ndeployment overview\n\nrun `exasol deploy`\n"
+	if terminal.String() != expected {
+		t.Fatalf("unexpected terminal output: %q", terminal.String())
 	}
 }
 

--- a/cmd/exasol/usage_template.go
+++ b/cmd/exasol/usage_template.go
@@ -244,8 +244,8 @@ func otherLocalFlags(cmd *cobra.Command) []*pflag.Flag {
 
 // nolint: revive, lll
 const customUsageTemplate = `Usage:
-{{ if .HasAvailableSubCommands}}  {{.CommandPath}} [command] [flags]{{ else }}  {{.UseLine}}
-{{ end }}
+	{{if .HasAvailableSubCommands}}{{.CommandPath}} [command] [flags]{{else}}{{.UseLine}}{{end}}
+
 {{ if .HasAvailableSubCommands }}
 
 {{- $cmd := . }}

--- a/tests/tests/integration/test_cli.py
+++ b/tests/tests/integration/test_cli.py
@@ -49,6 +49,27 @@ def test_help_output_never_has_more_than_one_blank_line(exasol_path: str) -> Non
     assert "\n\n\n" not in leaf_help
 
 
+def test_help_usage_section_is_indented_and_separated(exasol_path: str) -> None:
+    # Given representative help outputs for root, parent, and leaf commands
+    commands = [
+        ([exasol_path, "--help"], "exasol [command] [flags]"),
+        ([exasol_path, "presets", "--help"], "exasol presets [command] [flags]"),
+        ([exasol_path, "status", "--help"], "exasol status [flags]"),
+        ([exasol_path, "presets", "list", "--help"], "exasol presets list [flags]"),
+    ]
+
+    for command, usage_line in commands:
+        # When help output is rendered
+        output = run_command(command).stdout
+        lines = output.splitlines()
+        usage_index = lines.index("Usage:")
+
+        # Then the Usage section has the same shape as other indented sections
+        assert lines[usage_index + 1] == f"\t{usage_line}"
+        assert lines[usage_index + 2] == ""
+        assert lines[usage_index + 3] != ""
+
+
 def test_version(exasol_path: str) -> None:
     # Given the current version of the program based on the the latest git version tag
     git_describe_command_result = run_command(


### PR DESCRIPTION
## Description

Fixes two release-prep CLI output regressions:

- Call-to-action guidance now prints after primary command output, so next-step guidance appears at the end of terminal output.
- Help `Usage:` sections now use the same indentation style as other help sections and always include a blank line before the next section.

## Related Issue

No related issue.

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Flush terminal output in notice, primary output, CTA order and visually separate visible CTAs.
- Update the custom Cobra usage template to render `Usage:` consistently.
- Add regression coverage for CTA terminal ordering and real CLI help usage-section layout.

## Testing

- [ ] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

- `go test ./cmd/exasol`
- Built `/tmp/exasol-help-check` from the branch.
- Sampled `--help`, `status --help`, `presets --help`, and `presets list --help` output.
- `poetry run pytest --exasol-path=/tmp/exasol-help-check tests/integration/test_cli.py::test_help_flag tests/integration/test_cli.py::test_help_output_never_has_more_than_one_blank_line tests/integration/test_cli.py::test_help_usage_section_is_indented_and_separated`

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [ ] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [ ] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [x] All targeted tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

This fixes regressions found during release preparation that were not in a published version, so no changelog entry was added.