### PR TITLE
feat: Support Windows VM runner (SPOT-31740)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Notable user-facing changes to Exasol Personal are documented here.
 
 ### Added
 
+- Added initial Windows amd64 support for `exasol install local`. The Windows runner uses Podman/WSL2 and currently does not support host/container shells, SLCs, or scheduled database version checks.
+
 - Added named deployment selection with `--deployment` / `-d`, so users can manage multiple deployments under the default Exasol Personal deployment root without passing full directory paths.
 
   Example: `exasol status --deployment demo` targets the named `demo` deployment. `--deployment` and `--deployment-dir` cannot be used together.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## 🔥 Key Features
 
-- 💻 **Runs Locally in Seconds** — Spin up a full Exasol database on your own Mac with one command (macOS today; Windows & Linux coming soon)
+- 💻 **Runs Locally in Seconds** — Spin up a full Exasol database on your Mac or Windows PC with one command (Linux coming soon)
 - 🤖 **Built for Agentic AI** — Connect AI agents and LLM tools directly through a scriptable CLI
 - 🧠 **Built-in AI Functions** — Leverage native AI/ML capabilities with GPU acceleration, right where your data lives
 - 🏎️ **In-Memory Performance** — Run complex analytics at in-memory speed with Exasol's industry-leading analytics engine
@@ -34,9 +34,9 @@
 
 ## ✅ Prerequisites
 
-**Local deployment (recommended — fastest):** a Mac with at least 8 GB RAM.
+**Local deployment (recommended — fastest):** a Mac with at least 8 GB RAM, or a Windows amd64 PC with Podman and WSL2 available.
 
-> Local deployment is currently **macOS only**. Windows and Linux support is coming soon — until then, use a cloud deployment on those platforms.
+> Local deployment is supported on macOS Apple Silicon and Windows amd64. Linux support is coming soon.
 
 **Cloud deployment:** an account on one of the supported providers, with permission to provision compute instances:
 
@@ -63,9 +63,9 @@ Verify the installation with `exasol version`.
 
 ## 🏎️ Quick Start — Run Exasol Locally
 
-The fastest way to try Exasol: a full database running on your own Mac.
+The fastest way to try Exasol: a full database running on your own Mac or Windows PC.
 
-> **Currently macOS only.** Windows and Linux support is coming soon — to run Exasol on those platforms today, use a cloud deployment (see the **Deploy to the Cloud** section below).
+> Local deployment is supported on macOS Apple Silicon and Windows amd64. Use a cloud deployment on Linux (see the **Deploy to the Cloud** section below).
 
 With the launcher installed (see **Install the Launcher** above), start a local Exasol database:
 ```bash
@@ -161,7 +161,7 @@ exasol start
 ```
 The IP addresses of the nodes will change when you restart Exasol Personal. Check the output of the `start` command to know how to connect to the deployment after a restart.
 
-For local deployments, which currently require macOS with at least 8 GB RAM, the launcher manages a local VM runtime and an internal deployment share inside the deployment directory. If you do not configure local VM memory explicitly, it defaults to about 50% of detected host memory. Configured local VM memory must be at least 4096 MB. The initial local database credentials are `sys` / `exasol`. `exasol shell host` opens the local VM shell, and `exasol shell container` opens a shell inside the local database container.
+For local deployments, the launcher manages the platform-specific local runtime inside the deployment directory. On macOS, it manages a VM and an internal deployment share; on Windows, the runner manages the Podman/WSL2 runtime. If you do not configure local runtime memory explicitly, it defaults to about 50% of detected host memory where available. Configured local runtime memory must be at least 4096 MB. The initial local database credentials are `sys` / `exasol`. Shell access is available on macOS; it is not yet available for Windows local deployments.
 
 ## 🗑️ Remove Exasol Personal
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -27,8 +27,9 @@ tasks:
       - "task --list"
 
   generate:
-    desc: 'Run generation for all packages. TARGET_GOOS/TARGET_GOARCH: also stage a non-host platform''s embedded resources. SKIP_EMBED=true: never fetch real embedded resource data, just write empty placeholders (for lint/test builds that never look at the bytes).'
+    desc: 'Run generation for all packages. RUNNER_PATH overrides the Exasol Local runner with a local executable. TARGET_GOOS/TARGET_GOARCH: also stage a non-host platform''s embedded resources. SKIP_EMBED=true: never fetch real embedded resource data, just write empty placeholders (for lint/test builds that never look at the bytes).'
     vars:
+      RUNNER_PATH: '{{default "" .RUNNER_PATH}}'
       TARGET_GOOS: '{{default "" .TARGET_GOOS}}'
       TARGET_GOARCH: '{{default "" .TARGET_GOARCH}}'
       SKIP_EMBED: '{{default "" .SKIP_EMBED}}'
@@ -39,7 +40,7 @@ tasks:
       # the resourceembedder's own settings instead, without that side effect.
       - >-
         unset GOOS GOARCH;
-        TARGET_GOOS="{{.TARGET_GOOS}}" TARGET_GOARCH="{{.TARGET_GOARCH}}" SKIP_EMBED="{{.SKIP_EMBED}}"
+        RUNNER_PATH="{{.RUNNER_PATH}}" TARGET_GOOS="{{.TARGET_GOOS}}" TARGET_GOARCH="{{.TARGET_GOARCH}}" SKIP_EMBED="{{.SKIP_EMBED}}"
         go generate ./...
 
   tofu-lock-update:
@@ -82,6 +83,11 @@ tasks:
 
   build-windows:
     desc: Cross-compile the Windows binary (defaults to GOARCH=amd64)
+    deps:
+      - task: generate
+        vars:
+          TARGET_GOOS: windows
+          TARGET_GOARCH: '{{default "amd64" .GOARCH}}'
     vars:
       DEBUG_BUILD: '{{default "false" .DEBUG_BUILD}}'
       TARGET_GOARCH: '{{default "amd64" .GOARCH}}'

--- a/assets/infrastructure/local/infrastructure.yaml
+++ b/assets/infrastructure/local/infrastructure.yaml
@@ -1,5 +1,5 @@
-name: Exasol Local on macOS
-description: Exasol Local deployment using the macOS Apple Silicon VM runner.
+name: Exasol Local
+description: Exasol Local deployment using the platform-specific local runner.
 backend: local
 
 local:

--- a/doc/development.md
+++ b/doc/development.md
@@ -116,6 +116,13 @@ Resources marked `embed: true` in `assets/resources/resources.yaml` (currently j
 
 To iterate locally on the embedded resource without waiting on the real network artifact, edit its `url` in `resources.yaml` to a local path (`file://` or a bare path) instead of the real URL, then re-run the generator and rebuild:
 
+For a one-off local Exasol Local runner executable, use `RUNNER_PATH` instead. It overrides the runner only for that generation and does not modify the manifest:
+
+```bash
+task generate TARGET_GOOS=windows TARGET_GOARCH=amd64 RUNNER_PATH="$PWD/launcher.exe"
+task build-windows
+```
+
 ```yaml
 exasol-local-runner:
   extract: true

--- a/internal/deploy/diag_local.go
+++ b/internal/deploy/diag_local.go
@@ -90,7 +90,10 @@ func diagnoseLocalUnsafe(
 	diagnostics.Warning = unexpectedRunningVMWarning(deployment)
 
 	if state, err := localRuntime.ReadState(); err == nil {
-		diagnostics.Ports = map[string]int{"ssh": state.SSHPort, "db": state.DBPort}
+		diagnostics.Ports = map[string]int{"db": state.DBPort}
+		if localruntime.SupportsSSH() {
+			diagnostics.Ports["ssh"] = state.SSHPort
+		}
 		if state.UIPort != 0 {
 			diagnostics.Ports["ui"] = state.UIPort
 		}

--- a/internal/deploy/diag_local_test.go
+++ b/internal/deploy/diag_local_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/exasol/exasol-personal/internal/config"
@@ -15,6 +16,9 @@ import (
 
 func TestDiagnoseLocalUnsafe_UnsupportedPlatform(t *testing.T) {
 	t.Parallel()
+	if isSupportedLocalPlatform(runtime.GOOS, runtime.GOARCH) {
+		t.Skip("current platform supports local deployments")
+	}
 
 	// Deliberately does not set localAllowUnsupportedEnv, unlike the
 	// "supported platform" tests below (which cannot run in parallel with

--- a/internal/deploy/local_backend.go
+++ b/internal/deploy/local_backend.go
@@ -23,8 +23,10 @@ import (
 )
 
 const (
-	localSupportedOS           = "darwin"
-	localSupportedArch         = "arm64"
+	localSupportedMacOS       = "darwin"
+	localSupportedMacArch     = "arm64"
+	localSupportedWindowsOS   = "windows"
+	localSupportedWindowsArch = "amd64"
 	localAllowUnsupportedEnv   = "EXASOL_LOCAL_ALLOW_UNSUPPORTED_PLATFORM"
 	hostMemoryDefaultDivisor   = 2
 	localDefaultCPUCount       = 2
@@ -47,7 +49,7 @@ const (
 )
 
 var errUnsupportedLocalPlatform = errors.New(
-	"local deployments are only supported on macOS Apple Silicon",
+	"local deployments are only supported on macOS Apple Silicon or Windows amd64",
 )
 
 func newLocalBackend(
@@ -218,11 +220,16 @@ func validateLocalPlatform(goos, goarch, allowUnsupported string) error {
 	if allowUnsupported != "" {
 		return nil
 	}
-	if goos == localSupportedOS && goarch == localSupportedArch {
+	if isSupportedLocalPlatform(goos, goarch) {
 		return nil
 	}
 
 	return fmt.Errorf("%w (current platform: %s/%s)", errUnsupportedLocalPlatform, goos, goarch)
+}
+
+func isSupportedLocalPlatform(goos, goarch string) bool {
+	return (goos == localSupportedMacOS && goarch == localSupportedMacArch) ||
+		(goos == localSupportedWindowsOS && goarch == localSupportedWindowsArch)
 }
 
 func canonicalLocalConfigName(name string) string {
@@ -321,6 +328,9 @@ func (b *localBackend) OpenHostShell(
 	ctx context.Context,
 	_ string,
 ) error {
+	if !localruntime.SupportsSSH() {
+		return errors.New("host shell is not supported by the Windows local runner")
+	}
 	sshRemote, err := localSSHRemoteUnsafe(b.deployment)
 	if err != nil {
 		return err
@@ -334,6 +344,9 @@ func (b *localBackend) OpenHostShell(
 }
 
 func (b *localBackend) OpenCOSShell(ctx context.Context) error {
+	if !localruntime.SupportsSSH() {
+		return errors.New("container shell is not supported by the Windows local runner")
+	}
 	sshRemote, err := localSSHRemoteUnsafe(b.deployment)
 	if err != nil {
 		return err

--- a/internal/deploy/local_backend_test.go
+++ b/internal/deploy/local_backend_test.go
@@ -50,6 +50,17 @@ func TestValidateLocalPlatform_AcceptsMacOSAppleSilicon(t *testing.T) {
 	}
 }
 
+func TestValidateLocalPlatform_AcceptsWindowsAMD64(t *testing.T) {
+	t.Parallel()
+
+	// Given / When
+	err := validateLocalPlatform("windows", "amd64", "")
+	// Then
+	if err != nil {
+		t.Fatalf("expected platform to be accepted, got %v", err)
+	}
+}
+
 func TestValidateLocalPlatform_RejectsUnsupportedPlatform(t *testing.T) {
 	t.Parallel()
 
@@ -70,6 +81,21 @@ func TestValidateLocalPlatform_AllowsUnsupportedPlatformForTests(t *testing.T) {
 	// Then
 	if err != nil {
 		t.Fatalf("expected override to accept platform, got %v", err)
+	}
+}
+
+func TestLocalShellsAreRejectedWhenRunnerHasNoSSH(t *testing.T) {
+	t.Parallel()
+	if localruntime.SupportsSSH() {
+		t.Skip("the macOS local runner supports SSH shells")
+	}
+
+	backend := &localBackend{}
+	if err := backend.OpenHostShell(context.Background(), ""); err == nil {
+		t.Fatal("expected host shell to be rejected without SSH support")
+	}
+	if err := backend.OpenCOSShell(context.Background()); err == nil {
+		t.Fatal("expected container shell to be rejected without SSH support")
 	}
 }
 

--- a/internal/deploy/local_runtime.go
+++ b/internal/deploy/local_runtime.go
@@ -49,16 +49,18 @@ func startPreparedLocalRuntime(
 
 	localConfig := toLocalRuntimeConfig(runtimeConfig)
 	startArgs := []string{"start"}
-	versionCheckArgs, err := localRunnerVersionCheckArgs(runtime.Deployment())
-	if err != nil {
-		return err
+	if localruntime.SupportsSSH() {
+		versionCheckArgs, err := localRunnerVersionCheckArgs(runtime.Deployment())
+		if err != nil {
+			return err
+		}
+		startArgs = append(startArgs, versionCheckArgs...)
+		slcArgs, err := localRunnerSlcArgs(runtime.Deployment())
+		if err != nil {
+			return err
+		}
+		startArgs = append(startArgs, slcArgs...)
 	}
-	startArgs = append(startArgs, versionCheckArgs...)
-	slcArgs, err := localRunnerSlcArgs(runtime.Deployment())
-	if err != nil {
-		return err
-	}
-	startArgs = append(startArgs, slcArgs...)
 	if localConfig.Ports != "" {
 		startArgs = append(startArgs, "--ports", localConfig.Ports)
 	}
@@ -244,15 +246,6 @@ func writeLocalDeploymentArtifacts(
 		}
 	}
 
-	sshPort := strconv.Itoa(state.SSHPort)
-	sshCommand := fmt.Sprintf(
-		"ssh -i %s %s@%s -p %s",
-		state.PrivateKeyRelativePath,
-		localSSHUser,
-		localDeploymentPublicHost,
-		sshPort,
-	)
-
 	info := &config.DeploymentInfo{
 		Backend:         localDeploymentBackend,
 		DeploymentId:    deploymentID,
@@ -267,10 +260,19 @@ func writeLocalDeploymentArtifacts(
 			DBPort:                     state.DBPort,
 			Username:                   localDBUser,
 			InsecureSkipCertValidation: true,
-			SSHCommand:                 sshCommand,
-			SSHPort:                    sshPort,
-			ShellSupported:             true,
 		},
+	}
+	if localruntime.SupportsSSH() {
+		sshPort := strconv.Itoa(state.SSHPort)
+		info.Connection.SSHCommand = fmt.Sprintf(
+			"ssh -i %s %s@%s -p %s",
+			state.PrivateKeyRelativePath,
+			localSSHUser,
+			localDeploymentPublicHost,
+			sshPort,
+		)
+		info.Connection.SSHPort = sshPort
+		info.Connection.ShellSupported = true
 	}
 	if err := config.WriteDeploymentInfo(deployment.Root(), info); err != nil {
 		return err

--- a/internal/deploy/preset_validation_test.go
+++ b/internal/deploy/preset_validation_test.go
@@ -88,7 +88,7 @@ install: []
 }
 
 func TestInitDeployment_RejectsUnsupportedLocalPlatformBeforeMutation(t *testing.T) {
-	if runtime.GOOS == localSupportedOS && runtime.GOARCH == localSupportedArch {
+	if isSupportedLocalPlatform(runtime.GOOS, runtime.GOARCH) {
 		t.Skip("current platform supports local deployments")
 	}
 	t.Setenv(localAllowUnsupportedEnv, "")

--- a/internal/localruntime/runtime.go
+++ b/internal/localruntime/runtime.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	goRuntime "runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -30,12 +31,13 @@ import (
 )
 
 const (
-	DirName            = "local"
-	runtimeDirName     = "runtime"
-	vmDirName          = "vm"
-	vmStateFileName    = "vm-state.json"
-	vmPIDFileName      = "vm.pid"
-	PrivateKeyFileName = "node_access.pem"
+	DirName             = "local"
+	runtimeDirName      = "runtime"
+	vmDirName           = "vm"
+	initializedFileName = "runner-initialized"
+	vmStateFileName     = "vm-state.json"
+	vmPIDFileName       = "vm.pid"
+	PrivateKeyFileName  = "node_access.pem"
 	// runnerVersionMarkerFileName records the semver of the runner this
 	// deployment was last prepared/started with. It's a launcher-owned file,
 	// distinct from vm-state.json, whose schema is dictated by the runner's
@@ -49,7 +51,7 @@ const (
 	markerFileMode              = 0o600
 	executableFileMode          = 0o700
 	maxTCPPort                  = 65535
-	// Internal escape hatch for development with runners that predate version reporting.
+	// Internal escape hatch for development with embedded runners that predate version reporting.
 	forceRunnerReconciliationEnv = "EXASOL_LOCAL_FORCE_RUNNER_RECONCILIATION"
 	// Internal escape hatch for tests: exasol-local-runner is embed-only, so
 	// non-macOS test hosts have no way to resolve a runner through the
@@ -81,6 +83,7 @@ type Paths struct {
 	StatePath               string
 	PrivateKeyPath          string
 	RunnerVersionMarkerPath string
+	InitializedPath         string
 }
 
 func NewPaths(deployment config.DeploymentDir) Paths {
@@ -94,6 +97,7 @@ func NewPaths(deployment config.DeploymentDir) Paths {
 		StatePath:               filepath.Join(workDir, vmStateFileName),
 		PrivateKeyPath:          filepath.Join(root, PrivateKeyFileName),
 		RunnerVersionMarkerPath: filepath.Join(workDir, runnerVersionMarkerFileName),
+		InitializedPath:         filepath.Join(workDir, initializedFileName),
 	}
 }
 
@@ -157,11 +161,13 @@ func (runtime *Runtime) Prepare(ctx context.Context, out, outErr io.Writer) erro
 	if err != nil {
 		return err
 	}
-	if err := runtime.reconcileRunnerVersion(ctx, runnerPath); err != nil {
-		return err
-	}
-	if err := runtime.ensureSSHKey(); err != nil {
-		return err
+	if runnerSupportsSSH() {
+		if err := runtime.reconcileRunnerVersion(ctx, runnerPath); err != nil {
+			return err
+		}
+		if err := runtime.ensureSSHKey(); err != nil {
+			return err
+		}
 	}
 
 	return runtime.initializeVMIfNeeded(ctx, runnerPath, out, outErr)
@@ -280,7 +286,11 @@ func (runtime *Runtime) Destroy(ctx context.Context, out, outErr io.Writer) erro
 // stop; a runner that fails to resolve or stop is treated the same way,
 // since Destroy's job is cleanup, not reporting a runner-invocation failure.
 func (runtime *Runtime) stopBeforeDestroy(ctx context.Context, out, outErr io.Writer) error {
-	if _, err := os.Stat(runtime.paths.VMDir); err != nil {
+	initializedPath := runtime.paths.VMDir
+	if !runnerSupportsSSH() {
+		initializedPath = runtime.paths.InitializedPath
+	}
+	if _, err := os.Stat(initializedPath); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
@@ -313,30 +323,65 @@ func (runtime *Runtime) resolveRunnerPath(ctx context.Context) (string, error) {
 	return runtime.manager.Request(ctx, exasolLocalRunnerResourceID)
 }
 
+func runnerSupportsSSH() bool {
+	return goRuntime.GOOS == "darwin" && goRuntime.GOARCH == "arm64"
+}
+
+func supportsRunnerDaemonPID() bool {
+	return runnerSupportsSSH()
+}
+
+// SupportsSSH reports whether the current local runner exposes SSH access to a guest VM.
+func SupportsSSH() bool {
+	return runnerSupportsSSH()
+}
+
 func (runtime *Runtime) initializeVMIfNeeded(
 	ctx context.Context,
 	runnerPath string,
 	out, outErr io.Writer,
 ) error {
-	if _, err := os.Stat(runtime.paths.VMDir); err == nil {
+	initializedPath := runtime.paths.VMDir
+	if !runnerSupportsSSH() {
+		initializedPath = runtime.paths.InitializedPath
+	}
+	if _, err := os.Stat(initializedPath); err == nil {
 		return nil
 	} else if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("failed to inspect local VM directory: %w", err)
 	}
 
-	return runtime.runnerCommand(
-		ctx,
-		runnerPath,
-		[]string{"init", "--ssh-key", runtime.paths.PrivateKeyPath},
-		out,
-		outErr,
-	)
+	args := []string{"init"}
+	if runnerSupportsSSH() {
+		args = append(args, "--ssh-key", runtime.paths.PrivateKeyPath)
+	}
+
+	if err := runtime.runnerCommand(ctx, runnerPath, args, out, outErr); err != nil {
+		return err
+	}
+	if runnerSupportsSSH() {
+		return nil
+	}
+
+	if err := os.WriteFile(
+		runtime.paths.InitializedPath,
+		[]byte("initialized\n"),
+		privateFileMode,
+	); err != nil {
+		return fmt.Errorf("failed to record local runner initialization: %w", err)
+	}
+
+	return nil
 }
 
 func (runtime *Runtime) toState(state *runnerState) (*State, error) {
-	keyFile, err := runtime.paths.PrivateKeyRelativePath(runtime.deployment)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve local SSH key path: %w", err)
+	keyFile := ""
+	if runnerSupportsSSH() {
+		var err error
+		keyFile, err = runtime.paths.PrivateKeyRelativePath(runtime.deployment)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve local SSH key path: %w", err)
+		}
 	}
 
 	return &State{
@@ -490,6 +535,7 @@ func (runtime *Runtime) runRunnerCommand(
 
 	cmd := exec.CommandContext(ctx, runnerPath, args...)
 	cmd.Dir = runtime.paths.WorkDir
+	cmd.Stdin = os.Stdin
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = util.CombineWriters(&stdout, out)
@@ -508,6 +554,9 @@ func (runtime *Runtime) runRunnerCommand(
 }
 
 func (runtime *Runtime) waitForDaemonExit(ctx context.Context) error {
+	if !supportsRunnerDaemonPID() {
+		return nil
+	}
 	pid, err := runtime.readDaemonPID()
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -646,8 +695,10 @@ func validateRunnerState(state *runnerState) error {
 	if state == nil {
 		return errors.New("local VM state is missing")
 	}
-	if err := validatePort("ssh", state.Ports.SSH); err != nil {
-		return err
+	if runnerSupportsSSH() {
+		if err := validatePort("ssh", state.Ports.SSH); err != nil {
+			return err
+		}
 	}
 	if err := validatePort("database", state.Ports.DB); err != nil {
 		return err

--- a/internal/runtimeartifacts/manager.go
+++ b/internal/runtimeartifacts/manager.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 )
 
@@ -144,7 +145,13 @@ func (m *Manager) Get(
 ) (string, error) {
 	artifact, err := def.Resolve(m.platform.GOOS, m.platform.GOARCH)
 	if err != nil {
-		return "", err
+		if !def.Embed {
+			return "", err
+		}
+		if _, registered := lookupEmbedded(resourceID); !registered {
+			return "", err
+		}
+		artifact = embeddedArtifact(resourceID, def)
 	}
 
 	// If the source can identify its content before fetching, use that identity
@@ -202,6 +209,33 @@ func (m *Manager) Get(
 	}
 
 	return resolvedPath, nil
+}
+
+// embeddedArtifact provides cache metadata for a resource that was embedded
+// during a local build even though the checked-in manifest has no artifact for
+// this target yet. The registered bytes remain the source of truth; the URL
+// and digest only give the cache a stable, per-content identity.
+func embeddedArtifact(resourceID string, def ResourceDefinition) ArtifactSpec {
+	data, _ := lookupEmbedded(resourceID)
+	sum := sha256.Sum256(data)
+	artifact := ArtifactSpec{
+		URL:    "embedded://" + resourceID + "/resource.zip",
+		Sha256: hex.EncodeToString(sum[:]),
+	}
+	keys := make([]string, 0, len(def.Artifact))
+	for key := range def.Artifact {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		candidate := def.Artifact[key]
+		artifact.DownloadPath = candidate.DownloadPath
+		artifact.ResourcePath = candidate.ResourcePath
+
+		break
+	}
+
+	return artifact
 }
 
 // Request looks up a definition from the static spec by ID and resolves it.

--- a/internal/runtimeartifacts/manager_test.go
+++ b/internal/runtimeartifacts/manager_test.go
@@ -406,6 +406,55 @@ func TestManager_RequestResolvesEmbeddedResourceWithoutNetwork(t *testing.T) {
 	}
 }
 
+//nolint:paralleltest // embeddedResources is shared; concurrent Register calls aren't safe.
+func TestManager_RequestResolvesEmbeddedResourceWithoutDeclaredPlatformArtifact(t *testing.T) {
+	// Given
+	const resourceID = "embedded-undeclared-platform-test"
+	const runnerContent = "runner"
+	cacheDir := t.TempDir()
+	fixtureDir := t.TempDir()
+	archivePath := writeZipFixture(
+		t,
+		fixtureDir,
+		"artifact.zip",
+		map[string]string{"launcher": runnerContent},
+	)
+	archiveData, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatalf("failed to read artifact fixture: %v", err)
+	}
+	Register(resourceID, archiveData)
+	t.Cleanup(func() { delete(embeddedResources, resourceID) })
+	spec := ResourceSpec{
+		resourceID: {
+			Extract: true,
+			Embed:   true,
+			Artifact: map[string]ArtifactSpec{
+				"darwin/arm64": {
+					URL:          "https://example.com/artifact.zip",
+					Sha256:       "deadbeef",
+					ResourcePath: "launcher",
+				},
+			},
+		},
+	}
+	manager := NewResourceManagerForPlatform(spec, cacheDir, "windows", "amd64")
+
+	// When
+	path, err := manager.Request(context.Background(), resourceID)
+	// Then
+	if err != nil {
+		t.Fatalf("expected embedded resource to resolve, got %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("expected resolved path to be readable, got %v", err)
+	}
+	if string(data) != runnerContent {
+		t.Fatalf("expected runner content, got %q", string(data))
+	}
+}
+
 func TestManager_RequestFailsWhenEmbeddedResourceNotRegistered(t *testing.T) {
 	t.Parallel()
 

--- a/tools/resourceembedder/main.go
+++ b/tools/resourceembedder/main.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"archive/zip"
 	"bytes"
 	"context"
 	_ "embed" // required by go:embed on resourceFileTemplateSource below
@@ -35,10 +36,11 @@ import (
 )
 
 const (
-	dirPerm             = 0o700
-	filePerm            = 0o600
-	generatedDirRelPath = "assets/resources/generated"
-	generatedPkg        = "generated"
+	dirPerm               = 0o700
+	filePerm              = 0o600
+	generatedDirRelPath   = "assets/resources/generated"
+	generatedPkg          = "generated"
+	localRunnerResourceID = "exasol-local-runner"
 )
 
 //go:embed resource_file.go.tmpl
@@ -63,9 +65,10 @@ func repoRoot() (string, error) {
 }
 
 type config struct {
-	goos      string
-	goarch    string
-	skipEmbed bool
+	goos       string
+	goarch     string
+	skipEmbed  bool
+	runnerPath string
 }
 
 func main() {
@@ -104,10 +107,11 @@ func run(ctx context.Context, args []string) error {
 			cfg.goos,
 			cfg.goarch,
 		),
-		outputDir: outputDir,
-		goos:      cfg.goos,
-		goarch:    cfg.goarch,
-		skipEmbed: cfg.skipEmbed,
+		outputDir:  outputDir,
+		goos:       cfg.goos,
+		goarch:     cfg.goarch,
+		skipEmbed:  cfg.skipEmbed,
+		runnerPath: cfg.runnerPath,
 	}
 
 	return g.generatePlatform(ctx, spec)
@@ -128,6 +132,7 @@ func parseFlags(args []string) (config, error) {
 		cfg.goarch = goarch
 	}
 	cfg.skipEmbed = strings.TrimSpace(os.Getenv("SKIP_EMBED")) == "true"
+	cfg.runnerPath = strings.TrimSpace(os.Getenv("RUNNER_PATH"))
 	flags.StringVar(&cfg.goos, "goos", cfg.goos, "Target GOOS")
 	flags.StringVar(&cfg.goarch, "goarch", cfg.goarch, "Target GOARCH")
 	flags.BoolVar(
@@ -136,6 +141,7 @@ func parseFlags(args []string) (config, error) {
 		cfg.skipEmbed,
 		"Never fetch real artifact data; always write an empty placeholder (for lint/test builds that never look at the embedded bytes)",
 	)
+	flags.StringVar(&cfg.runnerPath, "runner-path", cfg.runnerPath, "Local Exasol Local runner executable to embed")
 	if err := flags.Parse(args); err != nil {
 		return config{}, err
 	}
@@ -161,11 +167,12 @@ type platformFileData struct {
 }
 
 type generator struct {
-	manager   *runtimeartifacts.Manager
-	outputDir string
-	goos      string
-	goarch    string
-	skipEmbed bool
+	manager    *runtimeartifacts.Manager
+	outputDir  string
+	goos       string
+	goarch     string
+	skipEmbed  bool
+	runnerPath string
 }
 
 // generatePlatform combines every embed: true resource in spec that declares
@@ -212,6 +219,9 @@ func (g *generator) resolveResourceEmbed(
 		// not: skip it unconditionally and just satisfy the build constraint.
 		return nil, nil
 	}
+	if resourceID == localRunnerResourceID && g.runnerPath != "" {
+		return g.embedLocalRunnerOverride(resourceID, def)
+	}
 
 	if _, err := def.Resolve(g.goos, g.goarch); err != nil {
 		return nil, nil
@@ -237,6 +247,61 @@ func (g *generator) resolveResourceEmbed(
 		return nil, err
 	}
 
+	return g.writeEmbeddedData(resourceID, data)
+}
+
+func (g *generator) embedLocalRunnerOverride(
+	resourceID string,
+	def runtimeartifacts.ResourceDefinition,
+) (*resourceEmbed, error) {
+	runnerData, err := os.ReadFile(g.runnerPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read RUNNER_PATH %s: %w", g.runnerPath, err)
+	}
+
+	archiveData, err := zipRunnerData(runnerData, embeddedResourcePath(def))
+	if err != nil {
+		return nil, err
+	}
+
+	return g.writeEmbeddedData(resourceID, archiveData)
+}
+
+func embeddedResourcePath(def runtimeartifacts.ResourceDefinition) string {
+	keys := make([]string, 0, len(def.Artifact))
+	for key := range def.Artifact {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if path := def.Artifact[key].ResourcePath; path != "" {
+			return path
+		}
+	}
+
+	return "launcher"
+}
+
+func zipRunnerData(runnerData []byte, resourcePath string) ([]byte, error) {
+	var archive bytes.Buffer
+	writer := zip.NewWriter(&archive)
+	header := &zip.FileHeader{Name: resourcePath, Method: zip.Deflate}
+	header.SetMode(0o700)
+	entry, err := writer.CreateHeader(header)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create local runner archive entry: %w", err)
+	}
+	if _, err := entry.Write(runnerData); err != nil {
+		return nil, fmt.Errorf("failed to write local runner archive entry: %w", err)
+	}
+	if err := writer.Close(); err != nil {
+		return nil, fmt.Errorf("failed to finish local runner archive: %w", err)
+	}
+
+	return archive.Bytes(), nil
+}
+
+func (g *generator) writeEmbeddedData(resourceID string, data []byte) (*resourceEmbed, error) {
 	if err := os.MkdirAll(g.outputDir, dirPerm); err != nil {
 		return nil, err
 	}

--- a/tools/resourceembedder/main_test.go
+++ b/tools/resourceembedder/main_test.go
@@ -4,9 +4,12 @@
 package main
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -16,6 +19,62 @@ import (
 
 	"github.com/exasol/exasol-personal/internal/runtimeartifacts"
 )
+
+func TestGeneratePlatform_EmbedsRunnerPathForUndeclaredPlatform(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	runnerPath := filepath.Join(t.TempDir(), "launcher.exe")
+	if err := os.WriteFile(runnerPath, []byte("windows runner"), 0o700); err != nil {
+		t.Fatalf("failed to write runner fixture: %v", err)
+	}
+	def := runtimeartifacts.ResourceDefinition{
+		Extract: true,
+		Embed:   true,
+		Artifact: map[string]runtimeartifacts.ArtifactSpec{
+			"darwin/arm64": {URL: "https://example.com/launcher.zip", Sha256: "deadbeef", ResourcePath: "launcher"},
+		},
+	}
+	spec := runtimeartifacts.ResourceSpec{"exasol-local-runner": def}
+	outputDir := t.TempDir()
+	g := &generator{
+		outputDir:  outputDir,
+		goos:       "windows",
+		goarch:     "amd64",
+		runnerPath: runnerPath,
+	}
+
+	// When
+	err := g.generatePlatform(context.Background(), spec)
+
+	// Then
+	if err != nil {
+		t.Fatalf("expected local runner override to be embedded, got %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(outputDir, "exasol_local_runner_windows_amd64.bin"))
+	if err != nil {
+		t.Fatalf("expected embedded runner archive, got %v", err)
+	}
+	archive, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("expected embedded runner to be a zip archive, got %v", err)
+	}
+	if len(archive.File) != 1 || archive.File[0].Name != "launcher" {
+		t.Fatalf("expected archive to contain launcher, got %+v", archive.File)
+	}
+	reader, err := archive.File[0].Open()
+	if err != nil {
+		t.Fatalf("expected archive entry to open, got %v", err)
+	}
+	defer reader.Close()
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("expected archive entry to be readable, got %v", err)
+	}
+	if string(content) != "windows runner" {
+		t.Fatalf("expected runner data, got %q", content)
+	}
+}
 
 func newFixtureServer(t *testing.T, name string, data []byte) *httptest.Server {
 	t.Helper()


### PR DESCRIPTION
## Description

Adds the initial Windows amd64 local-runner integration backed by the Windows VM runner prototype.

## Related Issue

SPOT-31740

## Type of Change

- [x] `feat`: New feature

## Changes Made

- Support Windows amd64 as a local deployment platform.
- Disable unsupported Windows runner capabilities: host/container shells, SSH configuration, SLC flags, and version-check flags.
- Restore `RUNNER_PATH` so a local Windows runner executable can be embedded for prototype builds.
- Document Windows prerequisites and the local-runner build workflow.

## Testing

- [x] Added new tests for embedded runner overrides and runtime resolution without a declared Windows artifact.
- [x] Manually tested the generated Windows runner build.

### Test Details

- `go test ./tools/resourceembedder -run TestGeneratePlatform_EmbedsRunnerPathForUndeclaredPlatform`
- `go test ./internal/runtimeartifacts -run TestManager_RequestResolvesEmbeddedResourceWithoutDeclaredPlatformArtifact`
- `go test ./internal/localruntime`
- `task build-windows`

`task fmt` reports zero lint issues, but the installed golangci-lint crashes in its Go analysis phase (exit 7). The broader runtime/deploy tests have pre-existing macOS temporary-path assertion failures caused by `/var` resolving to `/private/var`.

## Checklist

- [x] Code follows the project coding guidelines.
- [x] Updated documentation.
- [x] Updated CHANGELOG.md.
- [x] Added or updated tests.
- [x] Commit message follows Conventional Commits.
- [ ] Full local suite passes; see Test Details.

## Additional Notes

The runner is supplied through `RUNNER_PATH` for this prototype until a published Windows runner artifact and checksum are available.