### PR TITLE
docs: document version-check behavior and opt-out flags in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,19 @@ Local deployments are intended for development and exploration and do not yet su
 
 Cloud deployments support all of the above.
 
+## 🔎 Version Check
+
+Exasol Personal periodically checks for newer versions so it can let you know when an update is available. The launcher checks for a newer `exasol` binary, and cloud deployments additionally check for a newer database version. These checks send a small amount of information (such as the current version, operating system, and architecture) to Exasol.
+
+Both checks are opt-out. Pass the flags to `exasol install` to disable them:
+
+```bash
+exasol install <preset> --no-launcher-version-check   # disable the launcher update check
+exasol install <preset> --no-db-version-check         # disable the database version check (cloud deployments)
+```
+
+For details on what data is collected and how it is used, see the [Exasol Privacy Policy](https://www.exasol.com/privacy-policy/).
+
 ## ⚖️ Licensing
 
 The Exasol Launcher source code in this repository is open-source software licensed under the [MIT License](./LICENSE). You are free to use, modify, and distribute it. Contributions are made under the same terms.


### PR DESCRIPTION
## Description

Documents the launcher's version-check behavior in the README, since it wasn't previously explained anywhere user-facing. Briefly covers what the two checks do, how to opt out of each, and links to the Exasol privacy policy for details on the data collected.

## Related Issue

None

## Type of Change

- [x] `docs`: Documentation update

## Changes Made

- Added a new "Version Check" section to `README.md` (before **Licensing**) explaining the launcher update check and the cloud-only database version check.
- Documented the existing opt-out flags `--no-launcher-version-check` and `--no-db-version-check`.
- Linked to the [Exasol Privacy Policy](https://www.exasol.com/privacy-policy/) for details on data collected.

## Testing

- [ ] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

Docs-only change; reviewed the rendered Markdown for accuracy against the existing flag implementations (`cmd/exasol/commonFlags.go`, `assets/installation/ubuntu/installation.yaml`).

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [ ] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [ ] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

No `CHANGELOG.md` entry: this documents two flags that already exist and already ship (`--no-launcher-version-check`, `--no-db-version-check`) — no CLI behavior changed. Happy to add a `Changed` entry if you'd prefer it be called out there too.