### PR TITLE
fix: stop script-DDL detection at a statement separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Notable user-facing changes to Exasol Personal are documented here.
 
 ### Fixed
 
+- Fixed `exasol connect` mis-parsing a script definition that follows another `CREATE` statement in the same input. A leading statement such as `CREATE SCHEMA s;` was joined with the statements after it and sent as one, failing with `syntax error ... expecting END_OF_INPUT_`.
+
+  Example: a file containing `CREATE SCHEMA IF NOT EXISTS s;`, `OPEN SCHEMA s;` and a `CREATE ... SCRIPT ... /` definition now runs all three statements instead of failing on line 2.
+
 ### Breaking Changes
 
 - None.

--- a/internal/connect/shell.go
+++ b/internal/connect/shell.go
@@ -226,7 +226,7 @@ func nextToken(sql string, from int) (string, int) {
 }
 
 func isTokenSeparator(sql string, pos int) bool {
-	return isSpaceByte(sql[pos]) || sql[pos] == '(' ||
+	return isSpaceByte(sql[pos]) || sql[pos] == '(' || sql[pos] == ';' ||
 		strings.HasPrefix(sql[pos:], "--") || strings.HasPrefix(sql[pos:], "/*")
 }
 

--- a/internal/connect/shell_test.go
+++ b/internal/connect/shell_test.go
@@ -366,6 +366,9 @@ func TestLooksLikeScriptDDL(t *testing.T) {
 		"CREATE TABLE t -- function\nAS SELECT 1",
 		"CREATE CONNECTION c TO 'a script b'",
 		"CREATE USER u IDENTIFIED BY 'my function pw'",
+		"CREATE SCHEMA s; CREATE PYTHON3 SCALAR SCRIPT foo AS",
+		// A ';' inside a literal must not end the token scan early either.
+		"CREATE CONNECTION c TO 'a;b'; CREATE PYTHON3 SCALAR SCRIPT foo AS",
 	}
 	for _, sql := range notScripts {
 		require.Falsef(t, looksLikeScriptDDL(sql), "expected not script DDL: %q", sql)
@@ -423,6 +426,63 @@ func TestSplitStatementsScriptDelimiter(t *testing.T) {
 			"SELECT add1(41) FROM dual;\n"
 		statements, _ := splitStatements(sql)
 		require.Len(t, statements, 3)
+	})
+
+	t.Run("create statement before a script splits correctly", func(t *testing.T) {
+		t.Parallel()
+
+		// Given
+		sql := "CREATE SCHEMA IF NOT EXISTS s;\n" +
+			"OPEN SCHEMA s;\n" +
+			"CREATE PYTHON3 SCALAR SCRIPT hello() RETURNS INT AS\n" +
+			"def run(c):\n return 1\n/\n" +
+			"SELECT hello();\n"
+
+		// When
+		statements, _ := splitStatements(sql)
+
+		// Then
+		require.Equal(t, []string{
+			"CREATE SCHEMA IF NOT EXISTS s",
+			"OPEN SCHEMA s",
+			"CREATE PYTHON3 SCALAR SCRIPT hello() RETURNS INT AS\ndef run(c):\n return 1",
+			"SELECT hello()",
+		}, statements)
+	})
+
+	t.Run("a quoted semicolon before a script does not confuse the split", func(t *testing.T) {
+		t.Parallel()
+
+		// Given
+		sql := "CREATE CONNECTION c TO 'host;port';\n" +
+			"CREATE PYTHON3 SCALAR SCRIPT hello() RETURNS INT AS\n" +
+			"def run(c):\n return 1\n/\n"
+
+		// When
+		statements, _ := splitStatements(sql)
+
+		// Then
+		require.Equal(t, []string{
+			"CREATE CONNECTION c TO 'host;port'",
+			"CREATE PYTHON3 SCALAR SCRIPT hello() RETURNS INT AS\ndef run(c):\n return 1",
+		}, statements)
+	})
+
+	t.Run("create statement before a java script keeps the body intact", func(t *testing.T) {
+		t.Parallel()
+
+		// Given
+		sql := "CREATE SCHEMA s;\n" +
+			"CREATE JAVA SCALAR SCRIPT m(x DOUBLE) RETURNS DOUBLE AS\n" +
+			"class M { double run() { return x * 2.0; } }\n/\n"
+
+		// When
+		statements, _ := splitStatements(sql)
+
+		// Then
+		require.Len(t, statements, 2)
+		require.Equal(t, "CREATE SCHEMA s", statements[0])
+		require.Contains(t, statements[1], "return x * 2.0;")
 	})
 
 	t.Run("script without slash is buffered, not split on body semicolons", func(t *testing.T) {


### PR DESCRIPTION
## Description

This PR fixes `exasol connect` sending multiple statements to the database as one when a script definition follows another `CREATE` statement in the same input.

## Related Issue

[SPOT-30976](https://exasol.atlassian.net/browse/SPOT-30976)

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Treat `;` as a token separator in `isTokenSeparator`, so script-DDL detection stops at the end of the current statement
- Added tests for a `CREATE` statement and `;` inside a quoted literal preceding a Python and a Java script definition

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

Verified the fix with a regression test covering CREATE SCHEMA IF NOT EXISTS, OPEN SCHEMA, and CREATE ... SCRIPT ... / in a single SQL file. Confirmed all statements execute successfully. Mutation-tested the new coverage by removing the sql[pos] == ';' condition, causing both TestLooksLikeScriptDDL and TestSplitStatementsScriptDelimiter to fail, verifying the tests exercise the fix.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [x] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format


[SPOT-30976]: https://exasol.atlassian.net/browse/SPOT-30976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ