### PR TITLE
fix: Show full deployment status in `exasol deployments list`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,9 @@ Notable user-facing changes to Exasol Personal are documented here.
 
   Example: `exasol status --deployment demo` targets the named `demo` deployment. `--deployment` and `--deployment-dir` cannot be used together.
 
-- Added `exasol deployments list` to show default and named deployment directories, their status, and which deployment is currently active.
+- Added `exasol deployments list` to show default and named deployment directories and their deployment status (`not_initialized`, `initialized`, `operation_in_progress`, `interrupted`, `deployment_failed`, `stopped`, or `running`), the same status vocabulary as `exasol status`.
 
-  The list helps users distinguish the default deployment from named deployments and spot missing or inactive deployment directories.
+  The list helps users distinguish the default deployment from named deployments and see at a glance which ones are deployed and running.
 
 - Added the `exasol slc` command group (`install`, `list`, `update`, `remove`) to manage official script language containers (SLCs) in local deployments. Local deployments ship without any SLC, so UDFs in a given language only run once its container is installed.
 

--- a/cmd/exasol/deployments.go
+++ b/cmd/exasol/deployments.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -28,22 +29,17 @@ named deployment directory selected via --deployment/-d. This does not include
 deployment directories selected via an arbitrary --deployment-dir path.
 `, deploymentsRootDisplayPath())
 
-const (
-	deploymentStatusInitialized    = "initialized"
-	deploymentStatusNotInitialized = "not_initialized"
-)
-
 // deploymentListEntry describes one launcher-managed deployment directory for
-// `exasol deployments list`. Note: unlike `exasol status`, Status here is only
-// ever "initialized" or "not_initialized" — see registerDeploymentsCommands
-// doc comment for why this intentionally does not run full deploy.Status.
+// `exasol deployments list`. Status uses the same lifecycle vocabulary as
+// `exasol status` (deploy.StatusNotInitialized, deploy.StatusRunning, etc.),
+// computed via the lock-free, connection-check-free deploy.GetStatus — see
+// deploymentListEntryFor.
 type deploymentListEntry struct {
 	Name           string `json:"name"`
 	Path           string `json:"path"`
 	Status         string `json:"status"`
 	Infrastructure string `json:"infrastructure,omitempty"`
 	Installation   string `json:"installation,omitempty"`
-	Active         bool   `json:"active"`
 }
 
 var deploymentsCmd = &cobra.Command{
@@ -62,7 +58,7 @@ var deploymentsListCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cmd.SilenceUsage = true
-		entries, err := listDeploymentDirectories()
+		entries, err := listDeploymentDirectories(cmd.Context())
 		if err != nil {
 			return err
 		}
@@ -82,7 +78,7 @@ var deploymentsListCmd = &cobra.Command{
 // PersistentPreRunE never resolves a deployment directory (and never emits
 // the resolved-directory notice) for this command; see
 // registerDeploymentsCommands.
-func listDeploymentDirectories() ([]deploymentListEntry, error) {
+func listDeploymentDirectories(ctx context.Context) ([]deploymentListEntry, error) {
 	root, err := config.DeploymentsRootPath()
 	if err != nil {
 		return nil, err
@@ -97,11 +93,6 @@ func listDeploymentDirectories() ([]deploymentListEntry, error) {
 		return nil, fmt.Errorf("read deployments directory %q: %w", root, err)
 	}
 
-	activePath, err := activeDeploymentDirPath()
-	if err != nil {
-		return nil, err
-	}
-
 	entries := make([]deploymentListEntry, 0, len(dirEntries))
 	for _, dirEntry := range dirEntries {
 		if !dirEntry.IsDir() {
@@ -109,7 +100,7 @@ func listDeploymentDirectories() ([]deploymentListEntry, error) {
 		}
 
 		path := filepath.Join(root, dirEntry.Name())
-		entries = append(entries, deploymentListEntryFor(dirEntry.Name(), path, activePath))
+		entries = append(entries, deploymentListEntryFor(ctx, dirEntry.Name(), path))
 	}
 
 	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
@@ -121,25 +112,27 @@ func listDeploymentDirectories() ([]deploymentListEntry, error) {
 // entry is reported as not_initialized rather than aborting the whole
 // listing. A permission error on the deployments root itself, by contrast,
 // is surfaced by listDeploymentDirectories as a command failure.
-func deploymentListEntryFor(name, path, activePath string) deploymentListEntry {
+func deploymentListEntryFor(ctx context.Context, name, path string) deploymentListEntry {
 	entry := deploymentListEntry{
 		Name:   name,
 		Path:   path,
-		Status: deploymentStatusNotInitialized,
-		Active: path == activePath,
+		Status: deploy.StatusNotInitialized,
 	}
 
-	// Reuses the same recognition check as current-working-directory
-	// detection elsewhere in the CLI (modern state file, deployment version
-	// marker, legacy .workflowState.json), so this listing never disagrees
-	// with the rest of the CLI about whether a directory is a real
-	// deployment.
-	recognized, err := isRecognizedDeploymentDir(path)
-	if err != nil || !recognized {
+	// deploy.GetStatus with checkConnection=false reads only the persisted
+	// workflow state — no per-directory lock, no DB/VM probe — so it is cheap
+	// enough to call once per listed directory. It already treats a missing
+	// or unreadable state file as StatusNotInitialized, which is exactly the
+	// tolerant fallback this function wants for a malformed entry.
+	status, err := deploy.GetStatus(ctx, config.NewDeploymentDir(path), false)
+	if err != nil || status == nil {
 		return entry
 	}
 
-	entry.Status = deploymentStatusInitialized
+	entry.Status = status.Status
+	if entry.Status == deploy.StatusNotInitialized {
+		return entry
+	}
 
 	identity, err := deploy.ResolveDeploymentPresetIdentity(config.NewDeploymentDir(path))
 	if err != nil {
@@ -150,21 +143,6 @@ func deploymentListEntryFor(name, path, activePath string) deploymentListEntry {
 	entry.Installation = identity.Installation
 
 	return entry
-}
-
-// activeDeploymentDirPath reports what resolution would select right now with
-// no --deployment-dir or --deployment/-d flag, from the current working
-// directory. It calls the shared pure precedence function directly rather than
-// resolveDeploymentDirForCommand, which also emits the resolved-directory
-// visibility notice — inappropriate here since deploymentsListCmd has its own
-// dedicated output.
-func activeDeploymentDirPath() (string, error) {
-	deployment, _, err := resolveDeploymentDirFromValues(deploymentDirFlagValues{})
-	if err != nil {
-		return "", err
-	}
-
-	return deployment.Root(), nil
 }
 
 func renderDeploymentsListText(writer io.Writer, entries []deploymentListEntry) error {
@@ -184,18 +162,13 @@ func renderDeploymentsListText(writer io.Writer, entries []deploymentListEntry) 
 }
 
 func deploymentListEntryText(entry deploymentListEntry) string {
-	marker := " "
-	if entry.Active {
-		marker = "*"
-	}
-
 	preset := ""
 	if entry.Infrastructure != "" || entry.Installation != "" {
 		preset = fmt.Sprintf(" preset=%s/%s", entry.Infrastructure, entry.Installation)
 	}
 
 	return fmt.Sprintf(
-		"%s %s status=%s%s path=%s", marker, entry.Name, entry.Status, preset, entry.Path,
+		"%s status=%s%s path=%s", entry.Name, entry.Status, preset, entry.Path,
 	)
 }
 

--- a/cmd/exasol/deployments_test.go
+++ b/cmd/exasol/deployments_test.go
@@ -4,11 +4,13 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/deploy"
 )
 
 //nolint:paralleltest // t.Chdir and t.Setenv change process state.
@@ -17,7 +19,7 @@ func TestListDeploymentDirectories_EmptyWhenRootMissing(t *testing.T) {
 	setTestHome(t, home)
 	t.Chdir(t.TempDir())
 
-	entries, err := listDeploymentDirectories()
+	entries, err := listDeploymentDirectories(context.Background())
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -36,7 +38,7 @@ func TestListDeploymentDirectories_SortsAlphabeticallyAndIgnoresNonDirectories(t
 	mkdirTest(t, filepath.Join(deploymentsRoot, "prod-aws"))
 	writeTestMarker(t, filepath.Join(deploymentsRoot, "not-a-directory"))
 
-	entries, err := listDeploymentDirectories()
+	entries, err := listDeploymentDirectories(context.Background())
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
@@ -56,17 +58,17 @@ func TestListDeploymentDirectories_ReportsNotInitializedForUnrecognizedDirectory
 	deploymentsRoot := filepath.Join(config.LauncherDirPath(home), "deployments")
 	mkdirTest(t, filepath.Join(deploymentsRoot, "empty"))
 
-	entries, err := listDeploymentDirectories()
+	entries, err := listDeploymentDirectories(context.Background())
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
-	if len(entries) != 1 || entries[0].Status != deploymentStatusNotInitialized {
+	if len(entries) != 1 || entries[0].Status != deploy.StatusNotInitialized {
 		t.Fatalf("expected a single not_initialized entry, got: %#v", entries)
 	}
 }
 
 //nolint:paralleltest // t.Chdir and t.Setenv change process state.
-func TestListDeploymentDirectories_ReportsInitializedForLegacyMarkerOnlyDirectory(t *testing.T) {
+func TestListDeploymentDirectories_ReportsNotInitializedForLegacyMarkerOnlyDirectory(t *testing.T) {
 	home := t.TempDir()
 	setTestHome(t, home)
 	t.Chdir(t.TempDir())
@@ -75,66 +77,62 @@ func TestListDeploymentDirectories_ReportsInitializedForLegacyMarkerOnlyDirector
 	mkdirTest(t, legacyDir)
 	writeTestMarker(t, filepath.Join(legacyDir, legacyWorkflowStateMarker))
 
-	entries, err := listDeploymentDirectories()
+	// A directory recognized only via the legacy .workflowState.json marker
+	// (no modern state file) has no lifecycle state for deploy.GetStatus to
+	// read, so it is reported as not_initialized.
+	entries, err := listDeploymentDirectories(context.Background())
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
-	if len(entries) != 1 || entries[0].Status != deploymentStatusInitialized {
-		t.Fatalf("expected a single initialized entry, got: %#v", entries)
+	if len(entries) != 1 || entries[0].Status != deploy.StatusNotInitialized {
+		t.Fatalf("expected a single not_initialized entry, got: %#v", entries)
 	}
 }
 
 //nolint:paralleltest // t.Chdir and t.Setenv change process state.
-func TestListDeploymentDirectories_MarksActiveEntryFromCwd(t *testing.T) {
+func TestListDeploymentDirectories_ReportsUnparseableStateFileAsNotInitialized(t *testing.T) {
 	home := t.TempDir()
 	setTestHome(t, home)
+	t.Chdir(t.TempDir())
 	deploymentsRoot := filepath.Join(config.LauncherDirPath(home), "deployments")
-	activeDir := filepath.Join(deploymentsRoot, "staging")
-	mkdirTest(t, activeDir)
-	writeTestMarker(t, filepath.Join(activeDir, config.ExasolPersonalStateFileName))
-	mkdirTest(t, filepath.Join(deploymentsRoot, "prod-aws"))
-	t.Chdir(activeDir)
+	corruptDir := filepath.Join(deploymentsRoot, "corrupt")
+	mkdirTest(t, corruptDir)
+	writeTestMarker(t, filepath.Join(corruptDir, config.ExasolPersonalStateFileName))
 
-	entries, err := listDeploymentDirectories()
+	entries, err := listDeploymentDirectories(context.Background())
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
-
-	activeCount := 0
-	for _, entry := range entries {
-		if !entry.Active {
-			continue
-		}
-
-		activeCount++
-		if entry.Name != "staging" {
-			t.Fatalf("expected staging to be active, got: %q", entry.Name)
-		}
+	if len(entries) != 1 || entries[0].Status != deploy.StatusNotInitialized {
+		t.Fatalf("expected a single not_initialized entry, got: %#v", entries)
 	}
-	if activeCount != 1 {
-		t.Fatalf("expected exactly one active entry, got: %d", activeCount)
+	if entries[0].Infrastructure != "" || entries[0].Installation != "" {
+		t.Fatalf("expected no preset identity, got: %#v", entries[0])
 	}
 }
 
 //nolint:paralleltest // t.Chdir and t.Setenv change process state.
-func TestListDeploymentDirectories_NoEntryActiveWhenActiveDirOutsideListedTree(t *testing.T) {
+func TestListDeploymentDirectories_ReportsRunningStatusAndPresetIdentity(t *testing.T) {
 	home := t.TempDir()
 	setTestHome(t, home)
+	t.Chdir(t.TempDir())
 	deploymentsRoot := filepath.Join(config.LauncherDirPath(home), "deployments")
-	mkdirTest(t, filepath.Join(deploymentsRoot, "staging"))
-	outsideDir := t.TempDir()
-	writeTestMarker(t, filepath.Join(outsideDir, config.ExasolPersonalStateFileName))
-	t.Chdir(outsideDir)
+	runningDir := filepath.Join(deploymentsRoot, "running")
+	mkdirTest(t, runningDir)
+	writeRunningStateWithPresetIdentity(t, runningDir, "name:aws", "name:standard")
 
-	entries, err := listDeploymentDirectories()
+	entries, err := listDeploymentDirectories(context.Background())
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
 	}
-
-	for _, entry := range entries {
-		if entry.Active {
-			t.Fatalf("expected no entry to be active, got: %#v", entry)
-		}
+	if len(entries) != 1 {
+		t.Fatalf("expected a single entry, got: %#v", entries)
+	}
+	if entries[0].Status != deploy.StatusRunning {
+		t.Fatalf("expected status %q, got %#v", deploy.StatusRunning, entries[0])
+	}
+	if entries[0].Infrastructure != "aws" || entries[0].Installation != "standard" {
+		t.Fatalf("expected preset identity to be displayed, got: %#v", entries[0])
 	}
 }
 
@@ -154,5 +152,24 @@ func mkdirTest(t *testing.T, path string) {
 
 	if err := os.MkdirAll(path, 0o700); err != nil {
 		t.Fatalf("failed to create directory: %v", err)
+	}
+}
+
+func writeRunningStateWithPresetIdentity(
+	t *testing.T,
+	deploymentPath string,
+	infrastructureIdentity string,
+	installationIdentity string,
+) {
+	t.Helper()
+
+	deployment := config.NewDeploymentDir(deploymentPath)
+	state := &config.ExasolPersonalState{
+		InfrastructurePresetIdentity: infrastructureIdentity,
+		InstallationPresetIdentity:   installationIdentity,
+	}
+	err := state.SetWorkflowStateAndWrite(&config.WorkflowStateRunning{}, deployment)
+	if err != nil {
+		t.Fatalf("failed to write running state: %v", err)
 	}
 }

--- a/openspec/changes/archive/2026-08-03-enrich-deployment-list-status/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-03-enrich-deployment-list-status/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-03

--- a/openspec/changes/archive/2026-08-03-enrich-deployment-list-status/design.md
+++ b/openspec/changes/archive/2026-08-03-enrich-deployment-list-status/design.md
@@ -1,0 +1,59 @@
+## Context
+
+`exasol deployments list` (added in `openspec/changes/archive/2026-07-14-add-named-deployment-directories`) currently determines each entry's `status` via `isRecognizedDeploymentDir` (`cmd/exasol/deployment_dir_resolution.go`) — a marker-file existence check (modern state file, deployment version marker, or legacy `.workflowState.json`) — collapsed to just `initialized`/`not_initialized`. That change's design doc justified this shallowness by contrasting it with `exasol status`'s `deploy.Status()`, which acquires a per-directory lock and probes the database/local VM; running that across every directory in a listing would be slow and could contend with an operation already running against one of them.
+
+That justification describes the locked, connection-checking path only. `internal/deploy/status.go` also exposes `GetStatus(ctx, deployment, checkConnection)`, and the codebase already calls it with `checkConnection=false` and no lock in two places — `internal/deploy/info.go` (under an already-held lock) and `internal/deploy/shared.go`'s `newBlockedStateError` (with no lock at all, per its comment: "these guards have no context; a background read is side-effect free"). That call reads only the persisted workflow-state JSON and returns one of seven real lifecycle states (`not_initialized`, `initialized`, `operation_in_progress`, `interrupted`, `deployment_failed`, `stopped`, `running`) at the same cost class as the marker-file check `deployments list` already performs once per directory.
+
+SPOT-31887 reports that `status` and `active` never reflect real deployment state. Investigation (see the change proposal) confirmed both fields work exactly as originally specified — the gap is in what the original spec promised, not a defect in the implementation. This design closes that gap for `status` using the cheap primitive above, and removes `active` outright per product decision (it answered a different, less useful question — CWD-selection precedence — that doesn't belong in a command listing every directory at once).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Report each listed deployment directory's real lifecycle status, using the same vocabulary and cost profile (no lock, no DB/VM probe) as the existing `checkConnection=false` `GetStatus` call sites.
+- Keep the listing's existing failure-tolerance: one directory's bad state never fails the whole command.
+- Remove the `active` field and its CWD-selection computation from `deployments list` entirely.
+- Broaden preset-identity display to any status other than `not_initialized`.
+
+**Non-Goals:**
+- Changing `exasol status`, `deploy.Status()`, or `deploy.GetStatus` themselves — reused as-is.
+- Preserving the dedicated legacy-marker-recognition guarantee as its own spec scenario. If simplifying the recognition path drops that specific guarantee, that's accepted; `deploy.GetStatus`'s own notion of "initialized" (a readable modern state file) becomes the sole source of truth.
+- Detecting or reporting *why* a state file is unreadable (a distinct "broken" status). Corrupt/unreadable state is folded into `not_initialized`, matching today's existing tolerance for any per-entry error.
+- Live connection/VM probing (`checkConnection=true`) for the listing. `running` means "the persisted workflow state says running," not "the database was just probed and is ready" (that distinction, `database_ready`/`database_connection_failed`, only exists when `checkConnection=true` and is out of scope here).
+
+## Decisions
+
+### Replace the recognition-then-binary-status computation with `deploy.GetStatus(ctx, deployment, false)`
+
+`deploymentListEntryFor` currently calls `isRecognizedDeploymentDir(path)` to decide `initialized` vs. `not_initialized`, then separately calls `deploy.ResolveDeploymentPresetIdentity` when recognized. It will instead call `deploy.GetStatus(ctx, config.NewDeploymentDir(path), false)` directly and use its returned `Status` value as the entry's status. `GetStatus` already treats a missing or unparseable state file as `not_initialized` (via `errors.Is(err, config.ErrMissingConfigFile)` in `GetStatus` itself, and any other read/parse error propagating up — `deploymentListEntryFor` already tolerates per-entry errors by degrading to `not_initialized`, so no new error-handling path is needed).
+
+This means `isRecognizedDeploymentDir` is no longer called from `deployments list`. It keeps its existing callers (current-working-directory recognition in `resolveDeploymentDirFromValues`) — those are unaffected; this change only stops reusing it for the listing's status determination.
+
+Alternatives considered:
+- Keep `isRecognizedDeploymentDir` as a pre-check and only call `GetStatus` when recognized (to explicitly preserve today's legacy-marker guarantee, falling back to `initialized` when `GetStatus` would otherwise say `not_initialized`). Rejected per explicit product decision: the legacy-marker case does not need special preservation, and the extra branch would exist solely to protect a guarantee that is no longer required. A single `GetStatus` call is simpler and has one source of truth for "is this initialized."
+
+### Broaden preset-identity display to `status != not_initialized`
+
+`deploymentListEntryFor` resolves `deploy.ResolveDeploymentPresetIdentity` only when the entry's status was the literal string `initialized`. With the full lifecycle vocabulary, that check becomes `entry.Status != deploymentStatusNotInitialized` — a `running`, `stopped`, `interrupted`, `operation_in_progress`, or `deployment_failed` deployment still has a persisted (or derivable) preset identity and should keep showing it, exactly as an `initialized` one does today.
+
+### Remove `active` and its computation outright, no replacement field
+
+`deploymentListEntry.Active`, `activeDeploymentDirPath()`, and the call to it from `listDeploymentDirectories` are deleted. `deploymentListEntryFor` no longer takes an `activePath` parameter. The text renderer (`deploymentListEntryText`) drops the `*`/` ` marker column — each line becomes `<name> status=<status>[ preset=<infra>/<install>] path=<path>`, one field shorter than today.
+
+`resolveDeploymentDirFromValues` and the CWD-selection precedence it implements are untouched — they remain in use by every other command's directory resolution. Only `deployments list`'s use of it (solely to compute the now-removed `active` field) goes away.
+
+Alternatives considered:
+- Rename `active` to something less ambiguous (e.g. `selected`) instead of removing it. Rejected per explicit product decision: the CWD-selection concept was judged not useful in a command whose purpose is to enumerate every deployment directory, not to answer "which one would a bare command hit."
+
+### No new "broken" status value for unreadable state
+
+A state file that exists but fails to parse is reported as `not_initialized`, identical to a missing state file. This matches the pre-existing tolerance already documented on `deploymentListEntryFor` ("never fails on its own... reported as not_initialized rather than aborting the whole listing") and avoids introducing a status value with no equivalent in `exasol status`'s own vocabulary.
+
+## Risks / Trade-offs
+
+- [A deployment directory whose runtime crashed outside the CLI (e.g. a killed container) keeps showing `running` until a command that does check the connection/VM runs] → Accepted; this is the same staleness already accepted by `GetStatus(ctx, deployment, false)`'s two existing call sites (`info`, blocked-state guidance). `exasol status` remains the authority for a live, verified check.
+- [Dropping `isRecognizedDeploymentDir` in favor of `GetStatus`'s own recognition means a directory recognized only via the legacy `.workflowState.json` marker or the deployment-version marker file — but with no modern state file — now reports `not_initialized` instead of today's `initialized`] → Accepted per explicit product decision; no migration path is provided for this edge case.
+- [Removing `active` is a breaking change to the (unreleased) `deployments list` JSON shape] → Low risk: `exasol deployments list` has not shipped in a stable release (still under `## Unreleased` in `CHANGELOG.md`), so there are no external consumers depending on the current shape yet.
+
+## Migration Plan
+
+Not applicable as a runtime migration — this only changes CLI output shape before the feature's first stable release. `CHANGELOG.md`'s existing `Unreleased` entry for `exasol deployments list` is edited in place to describe the corrected behavior rather than appended to.

--- a/openspec/changes/archive/2026-08-03-enrich-deployment-list-status/proposal.md
+++ b/openspec/changes/archive/2026-08-03-enrich-deployment-list-status/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+SPOT-31887 reports that `exasol deployments list -j` always shows `status: "initialized"` and `active: false` regardless of whether a deployment has actually been deployed, is running, or has stopped. Investigation confirmed the implementation matches the spec exactly — both fields were deliberately scoped narrowly when the command was introduced: `status` only distinguishes "has an init marker" from not, to avoid the cost of `deploy.Status()`'s per-directory lock and DB probe, and `active` means "would be selected with no flags from the current working directory," not "is running." That scoping doesn't meet a reasonable user's expectation of what a deployment listing should show, and a cheaper primitive already exists in this codebase (`deploy.GetStatus(ctx, deployment, false)`, used lock-free and probe-free elsewhere) that closes the gap without reintroducing the original performance concern.
+
+## What Changes
+
+- `exasol deployments list` reports each deployment directory's real lifecycle status (`not_initialized`, `initialized`, `operation_in_progress`, `interrupted`, `deployment_failed`, `stopped`, `running` — the same vocabulary `exasol status` uses) instead of only `initialized`/`not_initialized`, computed via the existing lock-free, no-DB-probe `deploy.GetStatus(ctx, deployment, false)` read per directory.
+- Preset identity is now shown for any listed directory whose status is not `not_initialized` (previously gated on the literal value `initialized`), so `running`/`stopped`/etc. entries keep showing their infrastructure and installation preset.
+- **BREAKING**: The `active` field (and its text-output `*` marker) is removed entirely. It indicated CWD-based directory-selection precedence, which was judged unintuitive and not useful in a command that lists every deployment directory at once. `exasol status` and other per-deployment commands are unaffected — this only removes the field from `deployments list` output.
+- A deployment directory whose state file is present but unreadable/corrupt is still reported as `not_initialized`, matching today's existing tolerant behavior (one bad directory degrades gracefully rather than failing the whole listing).
+- The dedicated legacy-marker recognition guarantee is folded into the general status determination rather than kept as a separate spec scenario; no behavior is promised beyond what `deploy.GetStatus` itself determines.
+
+## Capabilities
+
+### Modified Capabilities
+- `deployment-directory-listing`: replaces the "report initialization status" requirement with a "report deployment status" requirement covering the full lifecycle vocabulary; removes the "indicate the currently active deployment directory" requirement and its scenarios; updates the JSON-output scenario to drop the active field; broadens the preset-identity condition from `status == initialized` to `status != not_initialized`.
+
+## Impact
+
+- `cmd/exasol/deployments.go`: `deploymentListEntry` struct (drop `Active`), `deploymentListEntryFor` (call `deploy.GetStatus` instead of the binary `isRecognizedDeploymentDir` check; broaden the preset-identity condition), `listDeploymentDirectories` (drop `activeDeploymentDirPath` call), `activeDeploymentDirPath` (removed), `renderDeploymentsListText`/`deploymentListEntryText` (drop the active marker column).
+- `CHANGELOG.md`: edit the existing `Unreleased` entry for `exasol deployments list` in place (it hasn't shipped yet) rather than adding a new entry.
+- `tests/tests/integration/test_deployments_list.py`: remove the active-marker test, update status assertions to the new lifecycle values, extend preset-identity assertions to non-`initialized` statuses.
+- No change to `exasol status`, `deploy.GetStatus`, or the CWD-selection resolver (`resolveDeploymentDirFromValues`) — reused as-is, not modified.

--- a/openspec/changes/archive/2026-08-03-enrich-deployment-list-status/specs/deployment-directory-listing/spec.md
+++ b/openspec/changes/archive/2026-08-03-enrich-deployment-list-status/specs/deployment-directory-listing/spec.md
@@ -1,37 +1,24 @@
-# deployment-directory-listing Specification
+## REMOVED Requirements
 
-## Purpose
-Define how `exasol deployments list` enumerates known deployment directories and reports their deployment status and preset identity, so users can discover and manage multiple named deployment directories.
-## Requirements
-### Requirement: CLI SHALL list known deployment directories
-`exasol deployments list` SHALL enumerate the deployment directories under `~/.exasol/personal/deployments/`, including the default deployment directory and every named deployment directory.
+### Requirement: Listing SHALL report initialization status and preset identity
+**Reason**: Superseded by a requirement to report the full deployment lifecycle status instead of a binary initialized/not_initialized check. See the ADDED "Listing SHALL report deployment status and preset identity" requirement below.
+**Migration**: Consumers parsing `status` must accept the full lifecycle vocabulary (`not_initialized`, `initialized`, `operation_in_progress`, `interrupted`, `deployment_failed`, `stopped`, `running`) instead of assuming only `initialized`/`not_initialized`. Consumers that only checked `status == "not_initialized"` need no change; any value other than `not_initialized` still indicates preset identity is present.
 
-#### Scenario: Listing shows the default deployment directory
-- **WHEN** a user runs `exasol deployments list`
-- **AND** `~/.exasol/personal/deployments/default` exists
-- **THEN** the output includes an entry for `default` with its resolved path
+### Requirement: Listing SHALL indicate the currently active deployment directory
+**Reason**: The `active` field indicated CWD-based directory-selection precedence (which directory a flagless command would target), not deployment lifecycle state. This was judged unintuitive and not useful in a command whose purpose is to list every deployment directory at once.
+**Migration**: No replacement field is added. A user who needs to know which directory a flagless command would currently target should run that command directly (e.g. `exasol status`), which reports the resolved deployment directory.
 
-#### Scenario: Listing shows named deployment directories
-- **WHEN** a user runs `exasol deployments list`
-- **AND** one or more named deployment directories exist under `~/.exasol/personal/deployments/`
-- **THEN** the output includes one entry per named deployment directory, with its name and resolved path
+## MODIFIED Requirements
 
-#### Scenario: Listing is empty when no deployment directories exist
-- **WHEN** a user runs `exasol deployments list`
-- **AND** `~/.exasol/personal/deployments/` does not exist or contains no deployment directories
-- **THEN** the command succeeds
-- **AND** the output indicates that no deployment directories exist
+### Requirement: Listing SHALL support JSON output
+`exasol deployments list` SHALL support a `--json` flag that emits the same information as structured JSON instead of human-readable text.
 
-#### Scenario: Non-directory entries are ignored
-- **WHEN** a user runs `exasol deployments list`
-- **AND** `~/.exasol/personal/deployments/` contains a non-directory entry (a file or symlink)
-- **THEN** the output does not include an entry for it
-- **AND** the command does not fail because of it
+#### Scenario: JSON output includes all listed fields
+- **WHEN** a user runs `exasol deployments list --json`
+- **THEN** stdout is valid JSON
+- **AND** each entry includes name, path, status, and preset identity when the status is not `not_initialized`
 
-#### Scenario: Listing is sorted alphabetically by name
-- **WHEN** a user runs `exasol deployments list`
-- **AND** more than one deployment directory exists under `~/.exasol/personal/deployments/`
-- **THEN** the entries appear in alphabetical order by name, regardless of filesystem iteration order
+## ADDED Requirements
 
 ### Requirement: Listing SHALL report deployment status and preset identity
 For each listed deployment directory, `exasol deployments list` SHALL report its deployment lifecycle status using the same status vocabulary as `exasol status` (`not_initialized`, `initialized`, `operation_in_progress`, `interrupted`, `deployment_failed`, `stopped`, `running`), and when that status is not `not_initialized`, its infrastructure and installation preset identity.
@@ -71,11 +58,3 @@ For each listed deployment directory, `exasol deployments list` SHALL report its
 - **AND** a listed deployment directory's status is not `not_initialized` but its preset identity is not yet persisted in its state file
 - **THEN** that entry reports a derived preset identity
 - **AND** the deployment directory's state file is not modified as a result of running `exasol deployments list`
-
-### Requirement: Listing SHALL support JSON output
-`exasol deployments list` SHALL support a `--json` flag that emits the same information as structured JSON instead of human-readable text.
-
-#### Scenario: JSON output includes all listed fields
-- **WHEN** a user runs `exasol deployments list --json`
-- **THEN** stdout is valid JSON
-- **AND** each entry includes name, path, status, and preset identity when the status is not `not_initialized`

--- a/openspec/changes/archive/2026-08-03-enrich-deployment-list-status/tasks.md
+++ b/openspec/changes/archive/2026-08-03-enrich-deployment-list-status/tasks.md
@@ -1,0 +1,32 @@
+## 1. Implementation: `cmd/exasol/deployments.go`
+
+- [x] 1.1 Remove `Active` from `deploymentListEntry` and drop the `json:"active"` tag.
+- [x] 1.2 Rewrite `deploymentListEntryFor` to drop the `activePath` parameter and the `isRecognizedDeploymentDir` call; call `deploy.GetStatus(ctx, config.NewDeploymentDir(path), false)` and use its `Status` value as `entry.Status` (fall back to `deploymentStatusNotInitialized` on any error, matching the function's existing per-entry error tolerance).
+- [x] 1.3 Broaden the preset-identity condition in `deploymentListEntryFor` from `entry.Status == deploymentStatusInitialized` to `entry.Status != deploymentStatusNotInitialized`.
+- [x] 1.4 Thread a `context.Context` from `deploymentsListCmd`'s `RunE` (via `cmd.Context()`) through `listDeploymentDirectories` and `deploymentListEntryFor` for the new `deploy.GetStatus` call.
+- [x] 1.5 Remove `activeDeploymentDirPath` and its call site in `listDeploymentDirectories`.
+- [x] 1.6 Update `deploymentListEntryText` and `renderDeploymentsListText` to drop the `*`/` ` active marker column from the human-readable output.
+- [x] 1.7 Update the doc comments on `deploymentListEntry`, `deploymentListEntryFor`, and `listDeploymentDirectories` that describe today's initialized/not_initialized-only behavior and the active-marker computation.
+
+## 2. Go unit tests: `cmd/exasol/deployments_test.go`
+
+- [x] 2.1 Update `TestListDeploymentDirectories_ReportsInitializedForLegacyMarkerOnlyDirectory` to expect `deploymentStatusNotInitialized` (a legacy-marker-only directory with no modern state file is no longer recognized as initialized), or remove it if a rename better reflects the new expectation.
+- [x] 2.2 Remove `TestListDeploymentDirectories_MarksActiveEntryFromCwd` and `TestListDeploymentDirectories_NoEntryActiveWhenActiveDirOutsideListedTree` (the `Active` field no longer exists).
+- [x] 2.3 Add unit test(s) covering at least one non-`initialized` lifecycle status (e.g. a directory whose state file encodes `WorkflowStateRunning` or `WorkflowStateStopped`) reporting that status and still showing preset identity.
+- [x] 2.4 Add a unit test covering a directory whose state file exists but is unparseable, asserting it reports `not_initialized` and does not fail the listing.
+
+## 3. Integration tests: `tests/tests/integration/test_deployments_list.py`
+
+- [x] 3.1 Remove `test_deployments_list_marks_active_entry_from_current_directory`.
+- [x] 3.2 Extend `test_deployments_list_reports_named_deployments` (or add a new test) to deploy a named deployment (e.g. via `exasol deploy` on the existing `staging` fixture, if the test environment supports a real/fake deploy) and assert `status == "running"` (or the appropriate reachable state) with `infrastructure`/`installation` still present.
+- [x] 3.3 Confirm no remaining test asserts on an `active` key in the JSON output.
+
+## 4. Documentation
+
+- [x] 4.1 Edit the existing `## Unreleased` entry in `CHANGELOG.md` for `exasol deployments list` in place, replacing "their status, and which deployment is currently active" with wording describing the real lifecycle status (no `active` field).
+
+## 5. Validation
+
+- [x] 5.1 Run `task fmt` and `task lint`.
+- [x] 5.2 Run the full test suite (`task all` or repo-equivalent) and confirm all `deployments list` unit and integration tests pass.
+- [x] 5.3 Manually verify `exasol deployments list --json` and the text output against a deployed-and-running local deployment to confirm `status` reflects reality and no `active` key/marker remains.

--- a/tests/tests/integration/test_deployments_list.py
+++ b/tests/tests/integration/test_deployments_list.py
@@ -86,10 +86,21 @@ def test_deployments_list_reports_named_deployments(
     assert "infrastructure" not in empty_named
 
 
-def test_deployments_list_marks_active_entry_from_current_directory(
+def _set_workflow_state(
+    deployment_dir: Path, workflow_state: dict[str, object]
+) -> None:
+    launcher_state_path = deployment_dir / ".exasolLauncherState.json"
+    state = json.loads(launcher_state_path.read_text())
+    state["currentWorkflowState"] = workflow_state
+    launcher_state_path.write_text(json.dumps(state))
+
+
+def test_deployments_list_reports_running_status_for_deployed_deployment(
     exasol_path: str, tmp_path: Path
 ) -> None:
-    # Given a named deployment
+    # Given a named deployment that has been initialized and is now running
+    # (simulated by writing the running workflow state directly, the same
+    # approach test_reconfiguration.py uses to avoid a real deploy)
     home = tmp_path / "home"
     home.mkdir()
     infra_id = first_infrastructure_preset_id_or_skip(exasol_path)
@@ -106,21 +117,24 @@ def test_deployments_list_marks_active_entry_from_current_directory(
         ],
         env=_env_with_home(home),
     )
+    _set_workflow_state(named_dir, {"running": {}})
 
-    # When deployments list is invoked from inside that deployment directory
+    # When deployments list is invoked with --json
     result = subprocess.run(
         [launcher, "deployments", "list", "--json"],
-        cwd=named_dir,
         env=_env_with_home(home),
         capture_output=True,
         text=True,
         check=True,
     )
 
-    # Then only that entry is marked active
+    # Then the entry reports status "running" and keeps its preset identity
     entries = json.loads(result.stdout)
-    active_entries = [entry["name"] for entry in entries if entry["active"]]
-    assert active_entries == ["staging"]
+    staging = next(entry for entry in entries if entry["name"] == "staging")
+    assert staging["status"] == "running"
+    assert staging["infrastructure"]
+    assert staging["installation"]
+    assert "active" not in staging
 
 
 def test_deployments_list_does_not_accept_deployment_dir_or_deployment(


### PR DESCRIPTION
## Description

`exasol deployments list -j` reported `status` as only ever `initialized`/`not_initialized` and always reported `active: false`/an unhelpful CWD-selection flag, regardless of whether a deployment had actually been deployed or was running. Investigation confirmed this matched the original spec exactly (a deliberate scoping decision to avoid `exasol status`'s per-directory lock and DB probe) — but that scope didn't meet a reasonable expectation of what a deployment listing should show.

This PR reports each deployment directory's real lifecycle status (the same vocabulary `exasol status` uses: `not_initialized`, `initialized`, `operation_in_progress`, `interrupted`, `deployment_failed`, `stopped`, `running`) using the existing lock-free, no-DB-probe `deploy.GetStatus(ctx, deployment, false)` read — already used elsewhere in the codebase for exactly this kind of cheap, read-only status check — instead of the previous binary marker check. It also removes the `active` field entirely, since it only ever indicated CWD-based directory-selection precedence (not deployment state) and was judged unintuitive in a command that lists every deployment directory at once.

Full design rationale is in `openspec/changes/archive/2026-08-03-enrich-deployment-list-status/design.md`.

## Related Issue

Jira: [SPOT-31887](https://exasol.atlassian.net/browse/SPOT-31887) — Deployment list returns incorrect status and active values for deployments

## Type of Change

- [x] `fix`: Bug fix
- [ ] `feat`: New feature
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- `exasol deployments list` now reports full deployment lifecycle status per directory instead of only `initialized`/`not_initialized`.
- Preset identity is now shown for any status other than `not_initialized` (previously gated on the literal value `initialized`), so `running`/`stopped`/etc. entries keep showing their preset.
- **BREAKING** (pre-release, not yet in a stable release): removed the `active` field and its `*` text-output marker entirely; no replacement field.
- A deployment directory whose state file is unreadable/corrupt is still reported as `not_initialized`, matching the existing tolerant per-entry error handling.
- Updated `CHANGELOG.md`, Go unit tests, and Python integration tests accordingly.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

- Go unit tests: updated legacy-marker expectation, removed the two active-marker tests, added tests for a `running` status with preserved preset identity and for a corrupt/unparseable state file falling back to `not_initialized`.
- Python integration tests: removed the active-marker test, added `test_deployments_list_reports_running_status_for_deployed_deployment` (simulates a running deployment by writing workflow state directly, matching the existing pattern in `test_reconfiguration.py`, so no real deploy is needed).
- Manually verified against a real local deployment:

  ```
  $ exasol deployments list --json
  [
    {
      "name": "empty-named",
      "path": ".../deployments/empty-named",
      "status": "not_initialized"
    },
    {
      "name": "staging",
      "path": ".../deployments/staging",
      "status": "running",
      "infrastructure": "aws",
      "installation": "ubuntu"
    }
  ]
  ```

## Checklist

- [x] Code follows the project's coding guidelines
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow Conventional Commits format

## Additional Notes

This change was developed via an OpenSpec change proposal; see `openspec/changes/archive/2026-08-03-enrich-deployment-list-status/` for the full proposal, design rationale, and updated spec delta for the `deployment-directory-listing` capability.

[SPOT-31887]: https://exasol.atlassian.net/browse/SPOT-31887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ