### PR TITLE
feat(ci): include integration test coverage in SonarQube analysis

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -7,4 +7,4 @@ runs:
       uses: ./.github/actions/setup-go
     - name: Build
       shell: bash
-      run: task build
+      run: task build COVERAGE=true

--- a/.github/actions/tests-integration/action.yml
+++ b/.github/actions/tests-integration/action.yml
@@ -5,6 +5,13 @@ runs:
   steps:
     - name: Setup Python and Task
       uses: ./.github/actions/setup-python
+    - name: Setup Go
+      uses: ./.github/actions/setup-go
     - name: Run Integration Tests
       shell: bash
-      run: task tests-integration
+      run: task tests-integration COVERAGE=true
+    - name: Upload integration coverage report
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: coverage-integration-${{ runner.os }}
+        path: coverage-integration.out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-unit
-          path: coverage.out
+          path: coverage-unit.out
 
   tests-integration:
     runs-on: ${{ matrix.os }}
@@ -105,7 +105,9 @@ jobs:
 
   sonarqube:
     runs-on: ubuntu-latest
-    needs: tests-unit
+    needs:
+      - tests-unit
+      - tests-integration
     # Fork PRs and Dependabot PRs never receive repo secrets under the pull_request trigger,
     # so SONAR_TOKEN wouldn't be available anyway; skip them explicitly rather than run a scan that fails.
     if: >-
@@ -118,10 +120,20 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Download coverage report
+      - name: Download unit coverage report
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: coverage-unit
+      - name: Download Linux integration coverage report
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: coverage-integration-Linux
+          path: coverage-integration-linux
+      - name: Download Windows integration coverage report
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: coverage-integration-Windows
+          path: coverage-integration-windows
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,11 @@ tfstate*
 .terraform-providers/
 .terraform/
 __pycache__
-coverage.out
+coverage-unit.out
+coverage-integration.out
+covdata-integration/
+coverage-integration-linux/
+coverage-integration-windows/
 
 # Credentials and secrets
 *.pem

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -59,7 +59,7 @@ tasks:
   # variable messes with path separators and results in incompatible
   # with Windows path.
   build:
-    desc: Build the binary
+    desc: 'Build the binary. COVERAGE=true enables coverage instrumentation.'
     # {{env "GOOS/GOARCH"}}: passes the ambient cross-compile target (if any)
     # through to generate's TARGET_GOOS/TARGET_GOARCH, so its embedded
     # resources are staged for that target rather than just the host.
@@ -70,12 +70,14 @@ tasks:
           TARGET_GOARCH: '{{env "GOARCH"}}'
     vars:
       DEBUG_BUILD: '{{default "false" .DEBUG_BUILD}}'
+      COVERAGE: '{{default "false" .COVERAGE}}'
     env:
       CGO_ENABLED: "0"
     cmds:
       - |
         version=$(git describe --tags --abbrev=0) # First character is "v".
         go build -o {{.BUILD_DIR_NAME}}/{{.BINARY_NAME}} \
+          {{if eq .COVERAGE "true"}}-cover -covermode=atomic {{end}}\
           {{if eq .DEBUG_BUILD "true"}}-gcflags="all=-N -l"{{else}}-trimpath \
           -gcflags=all=-l{{end}} \
           -ldflags "{{if ne .DEBUG_BUILD "true"}}-s -w {{end}}-X main.CurrentLauncherVersion=${version:1}" {{.MAIN_PATH_REL}}
@@ -143,8 +145,8 @@ tasks:
       TEST: '{{default "" .TEST}}'
       COVERAGE: '{{default "false" .COVERAGE}}'
     cmds:
-      - go test -v -race{{if eq .COVERAGE "true"}} -coverprofile=coverage.out -covermode=atomic{{end}}{{if .TEST}} -run "{{.TEST}}"{{end}} ./...
-      - '{{if eq .COVERAGE "true"}}go tool cover -func=coverage.out{{end}}'
+      - go test -v -race{{if eq .COVERAGE "true"}} -coverprofile=coverage-unit.out -covermode=atomic{{end}}{{if .TEST}} -run "{{.TEST}}"{{end}} ./...
+      - '{{if eq .COVERAGE "true"}}go tool cover -func=coverage-unit.out{{end}}'
 
   tests-unit-find:
     desc: Find Go unit test names by wildcard on Linux (`task tests-unit-find TEST=*Ready*`)
@@ -157,11 +159,18 @@ tasks:
         go test -json ./... | jq -r 'select(.Action=="run") | .Test'
 
   tests-integration:
-    desc: Run integration tests
+    desc: 'Run integration tests. COVERAGE=true collects Go coverage from the exasol binary.'
     deps: [tests-setup]
     dir: '{{.TESTS_DIR}}'
+    vars:
+      COVERAGE: '{{default "false" .COVERAGE}}'
+      GOCOVERDIR_PATH: '{{.ROOT_PATH}}{{.SEP}}covdata-integration'
+    env:
+      GOCOVERDIR: '{{if eq .COVERAGE "true"}}{{.GOCOVERDIR_PATH}}{{end}}'
     cmds:
+      - '{{if eq .COVERAGE "true"}}rm -rf {{.GOCOVERDIR_PATH}} && mkdir -p {{.GOCOVERDIR_PATH}}{{end}}'
       - poetry run pytest -vv --exasol-path={{.BUILD_DIR}}{{.SEP}}{{.BINARY_NAME}} {{.TESTS_DIR}}{{.SEP}}tests{{.SEP}}integration
+      - '{{if eq .COVERAGE "true"}}go tool covdata textfmt -i={{.GOCOVERDIR_PATH}} -o={{.ROOT_PATH}}{{.SEP}}coverage-integration.out{{end}}'
 
   tests-deployment:
     desc: Run deployment tests (`e.g. task tests-deployment INFRA=aws TEST=test_standard_deployment.py::test_license_session_limit`)
@@ -304,7 +313,11 @@ tasks:
     desc: Clean build artifacts
     cmds:
       - rm -rf {{.BUILD_DIR}}
-      - rm -f coverage.out
+      - rm -f coverage-unit.out
+      - rm -f coverage-integration.out
+      - rm -rf covdata-integration
+      - rm -rf coverage-integration-linux
+      - rm -rf coverage-integration-windows
 
   fmt-golang:
     desc: Format Go code

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,5 +4,5 @@ sonar.sources=.
 sonar.exclusions=**/*_test.go,**/*_mocks.go,tests/**/*.py
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go,**/*_mocks.go,tests/**/*.py
-sonar.go.coverage.reportPaths=./coverage.out
-sonar.coverage.exclusions=**/*_test.go,tests/**/*.py,tools/cleanup/**
+sonar.go.coverage.reportPaths=./coverage-unit.out,./coverage-integration-linux/coverage-integration.out,./coverage-integration-windows/coverage-integration.out
+sonar.coverage.exclusions=**/*_test.go,tests/**/*.py,tools/**,**/typesfakes/**


### PR DESCRIPTION
## Description

The SonarQube CI scan only ever read `coverage.out`, which is produced solely by Go unit tests. `task tests-integration` drives the already-built `exasol` binary as a subprocess from Python pytest, so any code paths only exercised by integration tests were invisible to SonarQube's coverage metric.

This PR instruments the CI-built `exasol` binary with Go's native binary coverage support (`-cover`), collects the raw counters written by the instrumented binary during the integration test run (`GOCOVERDIR`), converts them to a coverage profile (`go tool covdata textfmt`), and feeds that profile into the SonarQube scan alongside the unit test profile. Coverage is collected on both the Ubuntu and Windows integration test legs, since Go coverage profiles reference source by import path (not filesystem path), so both merge cleanly into the same scan.

It also widens `sonar.coverage.exclusions` to exclude `tools/**` and `**/typesfakes/**` from the coverage metric: these are dev tooling and generated test-double code that were never going to be meaningfully covered and were dragging the reported percentage down artificially.

## Related Issue

None.

## Type of Change

- [x] `feat`: New feature

## Changes Made

- `Taskfile.yml`: `build` and `tests-integration` gain a `COVERAGE=true` var; `tests-integration` sets `GOCOVERDIR` and converts the raw counters to `coverage-integration.out`. Unit test output renamed `coverage.out` → `coverage-unit.out` for symmetry. `clean` removes all coverage artifacts.
- `.github/actions/build/action.yml` / `.github/actions/tests-integration/action.yml`: always build/test with coverage instrumentation (a no-op wherever `GOCOVERDIR` isn't set, so harmless for other callers like `merge.yml`/`tests-deployment.yml`); upload the integration coverage file per OS (`coverage-integration-Linux` / `coverage-integration-Windows`) to avoid an artifact name collision across the matrix.
- `.github/workflows/ci.yml`: `sonarqube` job now also depends on `tests-integration` and downloads both OS-specific integration coverage artifacts.
- `sonar-project.properties`: `sonar.go.coverage.reportPaths` lists the unit profile plus both integration profiles. `sonar.coverage.exclusions` widened from `tools/cleanup/**` to all of `tools/**`, plus `**/typesfakes/**` (generated counterfeiter fakes), so build tooling and generated mocks no longer count against the coverage metric.
- `.gitignore`: ignores the new local/CI coverage artifacts.

## Testing

- [x] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

Ran `task build COVERAGE=true` followed by `task tests-integration COVERAGE=true` locally: all 81 integration tests passed, and the resulting `coverage-integration.out` reported real, non-trivial statement coverage distinct from the unit test profile — confirming the instrumented binary actually captures integration-exercised code paths. Also reran `task tests-unit COVERAGE=true` to confirm the `coverage-unit.out` rename didn't break anything.

Merged the unit + integration profiles locally to sanity-check the combined number the scan will report: **66.5% → 69.7%** after the exclusion change, with the previously 0%-covered `fake_*.go`/`tools/**` files no longer diluting the metric.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable) — n/a, CI-only change, no user-facing behavior changed
- [ ] Updated `CHANGELOG.md` for user-facing changes — n/a, this doesn't affect CLI/deployment behavior
- [ ] Added/updated tests — n/a, this change itself is test-infrastructure/CI plumbing
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format