### PR TITLE
docs: bring README up to date with 2.2 features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Notable user-facing changes to Exasol Personal are documented here.
 
 ### Changed
 
+- Documented named deployments, the `exasol slc` command group, and `exasol diag local` in the README, and made clear which features apply to local versus cloud deployments. Named deployments now have their own README section (they apply to both deployment types, not just cloud), a new section covers UDFs and script language containers, and the Limitations section no longer states that UDFs are unavailable on local deployments.
+
 ### Fixed
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ exasol install local
 
 In a few seconds you'll have a local Exasol instance running. Run `exasol info` at any time to see how to connect, then head to the **Load Sample Data** section to start querying.
 
+To run UDFs locally, install a script language container — see **UDFs and Script Language Containers** below. To run several local databases side by side, see **Deployments and Named Deployments**.
+
 Prefer to run in your own cloud? See the **Deploy to the Cloud** section below.
 
 
@@ -102,9 +104,37 @@ With the launcher installed (see **Install the Launcher** above):
 
    When the deployment process has finished, you will see instructions on how to connect to your Exasol database using a client of your choice. You can also find this information at any time by using `exasol info` in the terminal.
 
-By default, Exasol Personal stores deployment state in `~/.exasol/personal/deployments/default`. If you run a command from an existing deployment directory, Exasol Personal uses that directory instead. Pass `--deployment-dir <path>` to choose a different deployment directory explicitly, or pass `--deployment <name>` (`-d <name>`) to use `~/.exasol/personal/deployments/<name>` — useful for running more than one deployment side by side without picking your own path. `--deployment-dir` and `--deployment` cannot be used together. Deployment names are matched case-sensitively, but may collide on case-insensitive filesystems (the default on macOS and Windows). Use `exasol deployments list` to see every default and named deployment directory, its status, and which one is currently active.
 
-Keep the deployment directory until deployment resources have been destroyed. Deleting the directory does not remove those resources and can make cleanup harder.
+## 🗂️ Deployments and Named Deployments
+
+Each Exasol Personal deployment — local or cloud — keeps its state in a **deployment directory**. This section applies to both deployment types.
+
+By default, Exasol Personal stores deployment state in `~/.exasol/personal/deployments/default`. If you run a command from an existing deployment directory, Exasol Personal uses that directory instead.
+
+To run more than one deployment side by side, give each one a **name** with `--deployment <name>` (`-d <name>`). Named deployments live under `~/.exasol/personal/deployments/<name>`, so you can address them by name from any working directory:
+
+```bash
+exasol install local -d demo             # a local deployment named "demo"
+exasol install aws -d staging            # a cloud deployment named "staging"
+exasol status -d demo                    # check on it from anywhere
+exasol connect -d demo -c "SELECT 1"
+```
+
+Names are matched case-sensitively, but may collide on case-insensitive filesystems (the default on macOS and Windows).
+
+Named deployments are optional — choosing a deployment directory by path still works. Pass `--deployment-dir <path>` to use a directory of your choice. `--deployment-dir` and `--deployment` cannot be used together.
+
+Use `exasol deployments list` to see every default and named deployment directory together with its status, presets, and path:
+
+```bash
+$ exasol deployments list
+default status=running preset=local/ubuntu path=/Users/me/.exasol/personal/deployments/default
+staging status=stopped preset=aws/ubuntu path=/Users/me/.exasol/personal/deployments/staging
+```
+
+The listing covers launcher-managed deployment directories only; deployments selected with an arbitrary `--deployment-dir` path are not included.
+
+Keep a deployment directory until its deployment resources have been destroyed. Deleting the directory does not remove those resources and can make cleanup harder.
 
 An initialized deployment directory is tied to the selected infrastructure and installation presets. Rerun `exasol install <preset>` with the same presets to retry a failed deployment safely, or use `exasol config get`, `exasol config set`, and `exasol config reset` to inspect or change parameters for the existing presets without deleting local state. To switch presets in the same deployment directory, run `exasol destroy --remove` before initializing again, or run `exasol remove` if the deployment resources are already gone.
 
@@ -114,7 +144,7 @@ Runtime tools such as OpenTofu are downloaded on demand and reused from a per-us
 
 To get started quickly, Exasol provides a sample dataset hosted on S3 that you can import using SQL.
 
-You can load it directly by executing this command in your deployment directory (e.g. `~/.exasol/personal/deployments/default` for a default deployment):
+You can load it directly by executing this command in your deployment directory (e.g. `~/.exasol/personal/deployments/default` for a default deployment), or from anywhere by adding `-d <name>` for a named deployment:
 
 ```bash
 exasol connect -f sample.sql
@@ -145,6 +175,29 @@ Exasol infers the table schema directly from the Parquet files, so there's no ne
 | `PRODUCTS` | 1,000,000 | 27.3 MiB |
 | `PRODUCT_REVIEWS` | 1,822,007 | 154.5 MiB |
 
+## 🐍 UDFs and Script Language Containers
+
+User-defined functions (UDFs) run inside a **script language container** (SLC), which provides the language runtime for a script language such as `PYTHON3`, `JAVA`, or `R`.
+
+**Cloud deployments** come with the standard script language containers, so UDFs work out of the box.
+
+**Local deployments** ship without any SLC installed. Install the one you need with `exasol slc`, and UDFs in that language start working:
+
+```bash
+exasol slc list                 # available containers and which are installed
+exasol slc install python3      # enables PYTHON3 / PYTHON312 UDFs
+exasol slc install java         # enables JAVA / JAVA17 UDFs
+exasol slc install r            # enables R / R44 UDFs
+exasol slc update python3       # update an installed container
+exasol slc remove python3
+```
+
+The argument is a language alias as used in `CREATE ... SCRIPT`, matched case-insensitively. `exasol slc list` shows each container's flavor, its aliases, its version, and whether it is installed.
+
+Installing, updating, or removing an SLC restarts the local database so the change takes effect, which drops open connections and aborts running statements. The command asks for confirmation first; pass `--auto-approve` to skip the prompt (required for non-interactive use), or `--no-restart` to record the change and activate it on the next start.
+
+`exasol slc install`, `update`, and `remove` apply to local deployments only.
+
 ## ⏯️ Start and stop Exasol Personal
 
 To save costs, you can temporarily stop Exasol Personal by using the following command:
@@ -162,6 +215,8 @@ exasol start
 The IP addresses of the nodes will change when you restart Exasol Personal. Check the output of the `start` command to know how to connect to the deployment after a restart.
 
 For local deployments, which currently require macOS with at least 8 GB RAM, the launcher manages a local VM runtime and an internal deployment share inside the deployment directory. If you do not configure local VM memory explicitly, it defaults to about 50% of detected host memory. Configured local VM memory must be at least 4096 MB. The initial local database credentials are `sys` / `exasol`. `exasol shell host` opens the local VM shell, and `exasol shell container` opens a shell inside the local database container.
+
+If a local deployment does not behave as expected, `exasol diag local` prints a JSON snapshot of its runtime state — VM status, guest IP, bound host ports, per-port reachability, and database readiness. It is safe to run whether or not the deployment is currently running.
 
 ## 🗑️ Remove Exasol Personal
 
@@ -311,7 +366,7 @@ Where the database runs depends on the deployment type:
 
 Local deployments are intended for development and exploration and do not yet support every feature of a cloud deployment:
 
-- **UDFs** — user-defined functions are not available yet (coming soon).
+- **UDFs** — supported, but no script language container is installed by default. Install one with `exasol slc install <language>` (see **UDFs and Script Language Containers** above); on cloud deployments UDFs work out of the box.
 - **Virtual schemas** — virtual schemas are not available yet (coming soon).
 - **Admin UI** — the Administration UI is not available yet (coming soon).
 - **Multi-node clusters** — a local deployment is a single VM on your machine by design and always runs as a single node.


### PR DESCRIPTION
## Description

The README had not caught up with 2.2. Three features shipped without documentation — named deployments, the `exasol slc` command group, and `exasol diag local` — and the Limitations section still told users that UDFs are unavailable on local deployments, which is no longer true. It was also unclear which of the newer capabilities apply to local deployments, to cloud deployments, or to both.

This PR documents the missing features and makes the local-versus-cloud split explicit wherever it matters.

## Related Issue

None — documentation follow-up to the 2.2 release.

## Type of Change

- [x] `docs`: Documentation update

## Changes Made

- **New section "Deployments and Named Deployments".** Named deployments were only described in a paragraph buried at the end of "Deploy to the Cloud", even though they apply to local deployments too. The section now states up front that it covers both, gives `-d` examples for each (`exasol install local -d demo`, `exasol install aws -d staging`), explains that named deployments live under `~/.exasol/personal/deployments/<name>`, and makes clear that path-based `--deployment-dir` is still supported.
- **Documented `exasol deployments list`** with real output, and corrected a pre-existing inaccuracy: the old text claimed the listing shows "which one is currently active", which it does not. It shows name, status, presets, and path, and covers launcher-managed directories only.
- **New section "UDFs and Script Language Containers".** Leads with the local/cloud difference — cloud deployments come with the standard SLCs; local deployments ship without any — then covers `exasol slc list/install/update/remove`, that the argument is a case-insensitively matched language alias, the database restart with `--auto-approve` / `--no-restart`, and that `install`/`update`/`remove` are local-only.
- **Fixed the Limitations section.** The "UDFs — not available yet (coming soon)" bullet was wrong as of 2.2. It now says UDFs are supported locally once a container is installed, and work out of the box on cloud. Virtual schemas, Admin UI, and single-node are unchanged.
- **Documented `exasol diag local`** as the troubleshooting entry point in the local paragraph of "Start and stop".
- **Cross-references** from Quick Start to the two new sections, so a local-only reader finds them, plus a `-d` hint in "Load Sample Data".
- **CHANGELOG entry** under `Unreleased` → `Changed`.

### Example of the local UDF flow now documented

```bash
exasol slc list                 # available containers and which are installed
exasol slc install python3      # enables PYTHON3 / PYTHON312 UDFs
```

### Example of the named-deployment flow now documented

```bash
exasol install local -d demo    # a local deployment named "demo"
exasol status -d demo           # address it by name from anywhere
exasol deployments list         # see every named deployment and its status
```

## Testing

- [x] Ran `task fmt` and `task lint` — clean (0 issues)
- [ ] Added new tests for new functionality — not applicable, documentation only
- [x] Manually verified every documented claim against the source

### Test Details

Documentation-only change; no code paths are touched. Each behavioral claim was checked against the implementation rather than the changelog:

- `--deployment` / `-d` and `--deployment-dir` are registered together and marked mutually exclusive (`cmd/exasol/commonFlags.go`), and both are present on `install`, `status`, and `connect`.
- `exasol deployments list` output format and the fact that it does not mark an active deployment (`cmd/exasol/deployments.go`).
- SLC aliases (`python3`, `java`, `r`) resolve case-insensitively against the catalog (`assets/resources/slc-catalog.yaml`, `internal/slc/catalog.go`).
- `slc install`/`update`/`remove` are local-only, and the restart-confirmation / `--auto-approve` / `--no-restart` behavior (`internal/deploy/slc.go`, `cmd/exasol/slc.go`).
- `exasol diag local` scope and that it is safe to run when the deployment is down (`cmd/exasol/diagLocal.go`).

Note: `task fmt` and `task lint` were run, but not the full `task all`.

## Checklist

- [x] Code follows the project's coding guidelines
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [ ] Added/updated tests — not applicable
- [x] All tests pass locally — `task fmt` / `task lint` only; no test-affecting changes
- [x] Commit messages follow Conventional Commits format

## Additional Notes

Two deliberate judgment calls worth a reviewer's opinion:

1. **Key Features was left untouched.** Local UDF support is arguably headline-worthy, but the list is already nine bullets, so the local/cloud parity story stays in Limitations instead.
2. **Two pre-existing paragraphs moved sections.** Introducing the "Deployments" heading pulled the paragraphs on preset pinning and the runtime artifact cache out of "Deploy to the Cloud" and into it. Both are generic rather than cloud-specific, so this reads as an improvement — but it is a side effect of the restructure, not an intentional relocation. Easy to move back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
