### PR TITLE
feat: support git fragment paths for remote presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Notable user-facing changes to Exasol Personal are documented here.
 
   `exasol slc list` now shows custom containers alongside official ones with a status column, and `--json` marks them with a `custom` type and an `available` field.
 
+- External preset URIs now accept an optional `#<subpath>` fragment that selects a subdirectory within the resolved source. This lets a single git repository or archive host multiple presets and picks one via `repo.git@v1#infra/aws`. Supported on git URLs, archive URIs (`.tar.gz`/`.tgz`/`.zip`), and local directories, across `http`/`https`/`file` schemes.
+
 ### Changed
 
 - Documented named deployments, the `exasol slc` command group, and `exasol diag local` in the README, and made clear which features apply to local versus cloud deployments. Named deployments now have their own README section (they apply to both deployment types, not just cloud), a new section covers UDFs and script language containers, and the Limitations section no longer states that UDFs are unavailable on local deployments.

--- a/README.md
+++ b/README.md
@@ -359,6 +359,8 @@ In addition to built-in names and local paths, `exasol install` accepts external
 - **Local directory via URI** — `file:///absolute/path`. The directory is used directly without copying.
 - **Local archive via URI** — `file:///absolute/path/to/preset.tar.gz`. The archive is re-extracted on every run.
 
+Git repositories and archives also accept an optional `#<subpath>` fragment (e.g. `repo.git@v1#infra/aws`) to select a preset from a subdirectory of a monorepo or multi-preset archive.
+
 See [doc/presets.md](doc/presets.md) for the full preset contract, caching behavior, and troubleshooting.
 
 ### Building your own preset

--- a/doc/presets.md
+++ b/doc/presets.md
@@ -317,6 +317,39 @@ exasol install git@github.com:org/infra-preset.git@main
 
 **`@ref` syntax** — Refs can be branch names, tag names, or full commit SHAs, appended after the last `@`. For SCP-style `git@` URLs the ref follows the repository path (e.g. `git@github.com:org/repo.git@main`). The `@ref` suffix is only valid on git source URLs; using it on a plain archive URL returns an error.
 
+### Selecting a preset from a subdirectory
+
+External preset URIs accept an optional `#<subpath>` fragment that selects a subdirectory within the resolved source. This is how you point at a preset that lives inside a monorepo of related presets.
+
+```bash
+# Git repository at HEAD, preset in a subdirectory
+exasol install https://github.com/org/presets.git#infrastructure/aws
+
+# Git repository at a tag, combined with a subdirectory
+exasol install https://github.com/org/presets.git@v1.2#infra/aws
+
+# Local archive containing multiple presets
+exasol install file:///tmp/presets.tar.gz#installation/ubuntu
+
+# Remote archive containing multiple presets
+exasol install https://example.com/presets.tar.gz#infra/azure
+```
+
+The fragment is supported on:
+
+- Git repositories (any supported scheme).
+- Remote archives (`http://`, `https://`) ending in `.tar.gz`, `.tgz`, or `.zip`.
+- Local archives (`file://`) ending in `.tar.gz`, `.tgz`, or `.zip`.
+- Local directories (`file://`). Pointing the URI at the subdirectory directly is usually clearer, but the fragment is accepted for symmetry.
+
+When a URI includes both `@ref` and `#subpath`, the ref must come first: `repo.git@v1#subpath`. Path traversal segments (`..`) in the subpath are rejected. Different subpaths on the same repository or archive are cached as distinct entries.
+
+Quote URLs on the command line so the shell does not treat `#` as the start of a comment:
+
+```bash
+exasol install "https://github.com/org/presets.git@v1#infra/aws"
+```
+
 ### Remote archives
 
 An `https://` or `http://` URL ending in a recognised archive extension is treated as a remote archive:
@@ -369,3 +402,4 @@ If the manifest is missing, the launcher reports an error before attempting any 
 | `does not contain the expected ... manifest` | The resolved directory lacks the manifest file | Confirm the repository or archive root contains `infrastructure.yaml` / `installation.yaml` |
 | `resource path must be a directory or a supported archive file` | `file://` URI points to a plain file | Use a directory or `.tar.gz` / `.tgz` / `.zip` archive |
 | `@ref syntax ... is only valid on git source URLs` | `@suffix` appended to a non-git URL | Remove the `@ref` or use a `.git` URL |
+| `resource_path ... must stay within cache entry` | Fragment (or `resource_path`) contains `..` | Remove traversal segments; subpaths must stay inside the resolved source |

--- a/internal/deploy/preset_external.go
+++ b/internal/deploy/preset_external.go
@@ -33,7 +33,9 @@ func ResolvePreset(
 	uri string,
 	presetType string,
 ) (string, error) {
-	repoURL, ref := runtimeartifacts.ParseGitURL(uri)
+	cleanURI, subpath := parsePresetURI(uri)
+
+	repoURL, ref := runtimeartifacts.ParseGitURL(cleanURI)
 	if ref != "" && !runtimeartifacts.IsGitSourceURL(repoURL) {
 		return "", fmt.Errorf(
 			"@ref syntax (%q) is only valid on git source URLs;"+
@@ -44,9 +46,9 @@ func ResolvePreset(
 	}
 
 	def := runtimeartifacts.ResourceDefinition{
-		Extract: needsExtraction(uri),
+		Extract: needsExtraction(cleanURI),
 		Artifact: map[string]runtimeartifacts.ArtifactSpec{
-			"any": {URL: uri},
+			"any": {URL: cleanURI, ResourcePath: subpath},
 		},
 	}
 

--- a/internal/deploy/preset_external_test.go
+++ b/internal/deploy/preset_external_test.go
@@ -4,6 +4,8 @@
 package deploy
 
 import (
+	"archive/tar"
+	"compress/gzip"
 	"context"
 	"os"
 	"path/filepath"
@@ -78,4 +80,147 @@ func TestResolvePreset_FileDirectoryMissingManifestReturnsError(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "does not contain the expected") {
 		t.Fatalf("expected manifest-missing error, got %v", err)
 	}
+}
+
+func TestResolvePreset_FileDirectoryWithFragmentResolvesSubdirectory(t *testing.T) {
+	t.Parallel()
+
+	// Given — a preset root containing a subdirectory with the manifest.
+	presetRoot := t.TempDir()
+	subDir := filepath.Join(presetRoot, "infra", "aws")
+	if err := os.MkdirAll(subDir, 0o750); err != nil {
+		t.Fatalf("failed to create sub directory: %v", err)
+	}
+	manifestPath := filepath.Join(subDir, presets.InfrastructureManifestFilename)
+	if err := os.WriteFile(manifestPath, []byte("kind: infrastructure"), 0o600); err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+
+	manager := runtimeartifacts.NewResourceManagerForPlatform(
+		runtimeartifacts.ResourceSpec{},
+		t.TempDir(),
+		runtime.GOOS,
+		runtime.GOARCH,
+	)
+	// When
+	path, err := ResolvePreset(
+		context.Background(),
+		manager,
+		"file://"+presetRoot+"#infra/aws",
+		presets.PresetTypeInfrastructure,
+	)
+	// Then
+	if err != nil {
+		t.Fatalf("expected resolution to succeed, got %v", err)
+	}
+	if path != subDir {
+		t.Fatalf("expected path %q, got %q", subDir, path)
+	}
+}
+
+func TestResolvePreset_FileArchiveWithFragmentResolvesSubdirectory(t *testing.T) {
+	t.Parallel()
+
+	// Given — an archive that contains multiple presets under distinct subpaths.
+	fixtureDir := t.TempDir()
+	archivePath := writePresetTarGz(t, fixtureDir, "presets.tar.gz", map[string]string{
+		"infra/aws/" + presets.InfrastructureManifestFilename:         "name: aws",
+		"infra/azure/" + presets.InfrastructureManifestFilename:       "name: azure",
+		"installation/ubuntu/" + presets.InstallationManifestFilename: "name: ubuntu",
+	})
+
+	manager := runtimeartifacts.NewResourceManagerForPlatform(
+		runtimeartifacts.ResourceSpec{},
+		t.TempDir(),
+		runtime.GOOS,
+		runtime.GOARCH,
+	)
+
+	// When — resolve the "aws" preset via a fragment
+	path, err := ResolvePreset(
+		context.Background(),
+		manager,
+		"file://"+archivePath+"#infra/aws",
+		presets.PresetTypeInfrastructure,
+	)
+	// Then
+	if err != nil {
+		t.Fatalf("expected resolution to succeed, got %v", err)
+	}
+	if !strings.HasSuffix(path, filepath.Join("infra", "aws")) {
+		t.Fatalf("expected resolved path to end with infra/aws, got %q", path)
+	}
+	if _, err := os.Stat(filepath.Join(path, presets.InfrastructureManifestFilename)); err != nil {
+		t.Fatalf("expected manifest in resolved subdirectory, got %v", err)
+	}
+}
+
+func TestResolvePreset_FileArchiveFragmentPointingAtNonPresetSubdirReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// Given — a subdir exists but lacks the required manifest.
+	fixtureDir := t.TempDir()
+	archivePath := writePresetTarGz(t, fixtureDir, "presets.tar.gz", map[string]string{
+		"infra/aws/README.md": "no manifest here",
+	})
+
+	manager := runtimeartifacts.NewResourceManagerForPlatform(
+		runtimeartifacts.ResourceSpec{},
+		t.TempDir(),
+		runtime.GOOS,
+		runtime.GOARCH,
+	)
+
+	// When
+	_, err := ResolvePreset(
+		context.Background(),
+		manager,
+		"file://"+archivePath+"#infra/aws",
+		presets.PresetTypeInfrastructure,
+	)
+	// Then
+	if err == nil || !strings.Contains(err.Error(), "does not contain the expected") {
+		t.Fatalf("expected manifest-missing error, got %v", err)
+	}
+}
+
+// writePresetTarGz creates a .tar.gz with the given path→content entries and
+// returns the archive path. Only regular-file headers are written; nested
+// paths rely on the extractor creating parent directories on demand.
+func writePresetTarGz(t *testing.T, dir, name string, entries map[string]string) string {
+	t.Helper()
+
+	path := filepath.Join(dir, name)
+	outputFile, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create fixture: %v", err)
+	}
+	gzipWriter := gzip.NewWriter(outputFile)
+	tarWriter := tar.NewWriter(gzipWriter)
+
+	for entryName, content := range entries {
+		if err := tarWriter.WriteHeader(&tar.Header{
+			Name:     entryName,
+			Mode:     0o644,
+			Size:     int64(len(content)),
+			Typeflag: tar.TypeReg,
+		}); err != nil {
+			t.Fatalf("tar header %q: %v", entryName, err)
+		}
+		if _, err := tarWriter.Write([]byte(content)); err != nil {
+			t.Fatalf("tar payload %q: %v", entryName, err)
+		}
+	}
+
+	if err := tarWriter.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+	if err := outputFile.Close(); err != nil {
+		t.Fatalf("close file: %v", err)
+	}
+
+	return path
 }

--- a/internal/deploy/preset_uri.go
+++ b/internal/deploy/preset_uri.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"net/url"
+	"strings"
+)
+
+// parsePresetURI splits an optional trailing "#<subpath>" fragment off a
+// preset source URI. The returned cleanURI has the fragment removed; subpath
+// is the percent-decoded subdirectory selector (empty when no fragment was
+// present).
+//
+// The fragment is parsed as the last "#" in the URI so callers do not need to
+// know which scheme the URI uses. cleanURI is then passed through unchanged to
+// the source classifiers, so ref suffix and scheme detection are unaffected.
+func parsePresetURI(uri string) (cleanURI, subpath string) { //nolint:nonamedreturns
+	idx := strings.LastIndex(uri, "#")
+	if idx < 0 {
+		return uri, ""
+	}
+
+	cleanURI = uri[:idx]
+	rawSubpath := uri[idx+1:]
+
+	// Percent-decode so encoded characters (%2F, %23) work. On decoding
+	// failure return the raw string so the caller can produce a meaningful
+	// validation error downstream.
+	decoded, err := url.PathUnescape(rawSubpath)
+	if err != nil {
+		return cleanURI, rawSubpath
+	}
+
+	return cleanURI, decoded
+}

--- a/internal/deploy/preset_uri_test.go
+++ b/internal/deploy/preset_uri_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import "testing"
+
+func TestParsePresetURI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		uri        string
+		wantClean  string
+		wantSubdir string
+	}{
+		{
+			name:       "bare URL has no fragment",
+			uri:        "https://example.com/repo.git",
+			wantClean:  "https://example.com/repo.git",
+			wantSubdir: "",
+		},
+		{
+			name:       "URL with @ref only leaves fragment empty",
+			uri:        "https://example.com/repo.git@v1",
+			wantClean:  "https://example.com/repo.git@v1",
+			wantSubdir: "",
+		},
+		{
+			name:       "URL with fragment only strips fragment",
+			uri:        "https://example.com/repo.git#infra/aws",
+			wantClean:  "https://example.com/repo.git",
+			wantSubdir: "infra/aws",
+		},
+		{
+			name:       "URL with @ref and fragment strips only fragment",
+			uri:        "https://example.com/repo.git@v1#infra/aws",
+			wantClean:  "https://example.com/repo.git@v1",
+			wantSubdir: "infra/aws",
+		},
+		{
+			name:       "empty fragment yields empty subpath",
+			uri:        "https://example.com/repo.git#",
+			wantClean:  "https://example.com/repo.git",
+			wantSubdir: "",
+		},
+		{
+			name:       "percent-encoded slashes are decoded",
+			uri:        "https://example.com/repo.git#infra%2Faws",
+			wantClean:  "https://example.com/repo.git",
+			wantSubdir: "infra/aws",
+		},
+		{
+			name:       "SCP-style git URL with fragment",
+			uri:        "git@host.example.com:org/repo.git@main#infra/aws",
+			wantClean:  "git@host.example.com:org/repo.git@main",
+			wantSubdir: "infra/aws",
+		},
+		{
+			name:       "file archive URI with fragment",
+			uri:        "file:///tmp/presets.tar.gz#installation/ubuntu",
+			wantClean:  "file:///tmp/presets.tar.gz",
+			wantSubdir: "installation/ubuntu",
+		},
+		{
+			name:       "only last # is treated as the fragment separator",
+			uri:        "https://example.com/repo.git#a#b",
+			wantClean:  "https://example.com/repo.git#a",
+			wantSubdir: "b",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotClean, gotSubdir := parsePresetURI(test.uri)
+			if gotClean != test.wantClean {
+				t.Errorf("cleanURI = %q, want %q", gotClean, test.wantClean)
+			}
+			if gotSubdir != test.wantSubdir {
+				t.Errorf("subpath = %q, want %q", gotSubdir, test.wantSubdir)
+			}
+		})
+	}
+}

--- a/internal/runtimeartifacts/git_source_test.go
+++ b/internal/runtimeartifacts/git_source_test.go
@@ -83,6 +83,8 @@ func TestGitSource_CanFetch_RemoteURLs(t *testing.T) {
 		"https://github.com/org/repo.git",
 		"http://github.com/org/repo.git",
 		"git://github.com/org/repo.git",
+		"https://github.com/org/repo.git@main",
+		"git@github.com:org/repo.git@v1.0.0",
 	}
 	for _, url := range trueURLs {
 		if !src.CanFetch(url) {

--- a/internal/runtimeartifacts/manager.go
+++ b/internal/runtimeartifacts/manager.go
@@ -384,11 +384,7 @@ func (m *Manager) getCacheEntry(
 		return "", err
 	}
 
-	if entry.RedirectPath != "" && !entry.Extract {
-		return entry.RedirectPath, nil
-	}
-
-	return m.cache.absolutePath(entry.ResolvedPath), nil
+	return m.returnPath(entry)
 }
 
 func (m *Manager) writeIndexAfterCleanup(index *cacheIndex) error {
@@ -438,11 +434,7 @@ func (m *Manager) refresh(
 		return "", err
 	}
 
-	if entry.RedirectPath != "" && !entry.Extract {
-		return entry.RedirectPath, nil
-	}
-
-	return m.cache.absolutePath(entry.ResolvedPath), nil
+	return m.returnPath(*entry)
 }
 
 // resolveEntry computes the cache slot for a resource: the cache key, relative
@@ -497,19 +489,11 @@ func (m *Manager) resolveEntry(
 		return cacheIndexEntry{}, err
 	}
 
-	resolvedRelPath := artifactRelPath
-	if def.Extract {
-		resolvedAbsPath, err := extractedResourcePath(
-			filepath.Join(entryPath, extractRelPath),
-			resourcePath,
-		)
-		if err != nil {
-			return cacheIndexEntry{}, err
-		}
-		resolvedRelPath, err = m.cache.relativePath(resolvedAbsPath)
-		if err != nil {
-			return cacheIndexEntry{}, err
-		}
+	resolvedRelPath, err := m.resolveResolvedPath(
+		def, entryPath, artifactAbsPath, artifactRelPath, resourcePath,
+	)
+	if err != nil {
+		return cacheIndexEntry{}, err
 	}
 
 	return cacheIndexEntry{
@@ -549,12 +533,48 @@ func artifactIdentity(
 	return hex.EncodeToString(sum[:]), nil
 }
 
-func extractedResourcePath(extractedRoot, resourcePath string) (string, error) {
-	if strings.TrimSpace(resourcePath) == "" {
-		return extractedRoot, nil
+// returnPath computes the effective path returned to callers of Get. For
+// redirect sources (file:// directories or bare files) the returned path is
+// the redirect itself; when resource_path is set, it selects a subdirectory of
+// the redirect target. For cached artifacts, ResolvedPath already encodes the
+// resource_path suffix (see resolveResolvedPath).
+func (m *Manager) returnPath(entry cacheIndexEntry) (string, error) {
+	if entry.RedirectPath != "" && !entry.Extract {
+		if strings.TrimSpace(entry.ResourcePath) == "" {
+			return entry.RedirectPath, nil
+		}
+
+		return pathWithinRoot(entry.RedirectPath, entry.ResourcePath, "resource_path")
 	}
 
-	return pathWithinRoot(extractedRoot, resourcePath, "resource_path")
+	return m.cache.absolutePath(entry.ResolvedPath), nil
+}
+
+// resolveResolvedPath computes the resolved path returned to callers of Get.
+// The root is the extracted directory for archives that are extracted, and the
+// artifact path itself otherwise. A non-empty resource_path selects a
+// subdirectory within that root, applying uniformly regardless of source kind.
+func (m *Manager) resolveResolvedPath(
+	def ResourceDefinition,
+	entryPath, artifactAbsPath, artifactRelPath, resourcePath string,
+) (string, error) {
+	root := artifactAbsPath
+	if def.Extract {
+		root = filepath.Join(entryPath, extractRelPath)
+	}
+	if strings.TrimSpace(resourcePath) == "" {
+		if def.Extract {
+			return m.cache.relativePath(root)
+		}
+
+		return artifactRelPath, nil
+	}
+	resolvedAbsPath, err := pathWithinRoot(root, resourcePath, "resource_path")
+	if err != nil {
+		return "", err
+	}
+
+	return m.cache.relativePath(resolvedAbsPath)
 }
 
 func normalizeSha256(value string) string {

--- a/internal/runtimeartifacts/manager_test.go
+++ b/internal/runtimeartifacts/manager_test.go
@@ -76,10 +76,11 @@ not-embedded:
 	}
 }
 
-func TestParseSpec_RejectsResourcePathWithoutExtraction(t *testing.T) {
+func TestParseSpec_AllowsResourcePathWithoutExtraction(t *testing.T) {
 	t.Parallel()
 
-	// Given
+	// Given — resource_path selects a subpath inside whatever the source
+	// produces, and is valid regardless of source kind or extract flag.
 	raw := []byte(`
 artifact:
   extract: false
@@ -91,11 +92,121 @@ artifact:
 `)
 
 	// When
-	_, err := ParseSpec(raw)
+	spec, err := ParseSpec(raw)
 	// Then
-	if err == nil ||
-		!strings.Contains(err.Error(), "must not define resource_path without archive extraction") {
-		t.Fatalf("expected resource_path validation error, got %v", err)
+	if err != nil {
+		t.Fatalf("expected resource_path without extraction to be valid, got %v", err)
+	}
+	if got := spec["artifact"].Artifact["linux/amd64"].ResourcePath; got != "tofu" {
+		t.Fatalf("expected resource_path %q, got %q", "tofu", got)
+	}
+}
+
+func TestParseSpec_GitURLWithRefIsRecognisedAsGitSource(t *testing.T) {
+	t.Parallel()
+
+	// Given — an ArtifactSpec.URL for a git source that still carries an @ref
+	// suffix (the shape produced by ResolvePreset when a user passes
+	// `repo.git@v1#subpath`). The spec must classify it as a git source so
+	// sha256 is not required.
+	raw := []byte(`
+preset:
+  extract: false
+  artifact:
+    any:
+      url: https://example.com/repo.git@v1
+`)
+
+	// When
+	spec, err := ParseSpec(raw)
+	// Then
+	if err != nil {
+		t.Fatalf("expected git URL with @ref to be recognised as a git source, got %v", err)
+	}
+	wantURL := "https://example.com/repo.git@v1"
+	if got := spec["preset"].Artifact[anyPlatformKey].URL; got != wantURL {
+		t.Fatalf("expected URL to round-trip verbatim, got %q", got)
+	}
+}
+
+func TestManager_ResolveEntry_HonoursResourcePathWithoutExtraction(t *testing.T) {
+	t.Parallel()
+
+	// Given — a non-extract resource with a resource_path. The manager must
+	// apply the subpath to the artifact path regardless of source kind.
+	cacheDir := t.TempDir()
+	manager := NewResourceManagerForPlatform(ResourceSpec{}, cacheDir, "linux", "amd64")
+	def := ResourceDefinition{
+		Extract: false,
+		Artifact: map[string]ArtifactSpec{
+			anyPlatformKey: {URL: "https://example.com/repo.git", ResourcePath: "infra/aws"},
+		},
+	}
+
+	// When
+	entry, err := manager.resolveEntry("preset", def, def.Artifact[anyPlatformKey])
+	// Then
+	if err != nil {
+		t.Fatalf("expected resolveEntry to succeed, got %v", err)
+	}
+	// The download path is the URL basename; the resolved path must point at
+	// the subdirectory joined onto it.
+	wantSuffix := filepath.Join("repo.git", "infra", "aws")
+	if !strings.HasSuffix(entry.ResolvedPath, wantSuffix) {
+		t.Fatalf("expected ResolvedPath to end with %q, got %q", wantSuffix, entry.ResolvedPath)
+	}
+	if entry.ResourcePath != "infra/aws" {
+		t.Fatalf("expected ResourcePath %q, got %q", "infra/aws", entry.ResourcePath)
+	}
+}
+
+func TestManager_ResolveEntry_RejectsTraversalResourcePathWithoutExtraction(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	cacheDir := t.TempDir()
+	manager := NewResourceManagerForPlatform(ResourceSpec{}, cacheDir, "linux", "amd64")
+	def := ResourceDefinition{
+		Extract: false,
+		Artifact: map[string]ArtifactSpec{
+			anyPlatformKey: {URL: "https://example.com/repo.git", ResourcePath: "../escape"},
+		},
+	}
+
+	// When
+	_, err := manager.resolveEntry("preset", def, def.Artifact[anyPlatformKey])
+	// Then
+	if err == nil || !strings.Contains(err.Error(), "resource_path") {
+		t.Fatalf("expected resource_path traversal error, got %v", err)
+	}
+}
+
+func TestManager_ResolveEntry_DifferentSubpathsProduceDistinctEntries(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	cacheDir := t.TempDir()
+	manager := NewResourceManagerForPlatform(ResourceSpec{}, cacheDir, "linux", "amd64")
+	makeDef := func(subpath string) ResourceDefinition {
+		return ResourceDefinition{
+			Extract: false,
+			Artifact: map[string]ArtifactSpec{
+				anyPlatformKey: {URL: "https://example.com/repo.git", ResourcePath: subpath},
+			},
+		}
+	}
+
+	// When
+	defA := makeDef("infra/aws")
+	defB := makeDef("infra/azure")
+	entryA, errA := manager.resolveEntry("preset", defA, defA.Artifact[anyPlatformKey])
+	entryB, errB := manager.resolveEntry("preset", defB, defB.Artifact[anyPlatformKey])
+	// Then
+	if errA != nil || errB != nil {
+		t.Fatalf("expected both resolveEntry calls to succeed, got %v / %v", errA, errB)
+	}
+	if entryA.Key == entryB.Key {
+		t.Fatalf("expected distinct cache keys for different subpaths, both were %q", entryA.Key)
 	}
 }
 
@@ -1185,6 +1296,56 @@ func TestManager_GetFileDirectoryReturnedDirectly(t *testing.T) {
 	}
 	if path != presetDir {
 		t.Fatalf("expected path %q, got %q", presetDir, path)
+	}
+}
+
+func TestManager_GetFileDirectoryWithResourcePathReturnsSubdirectory(t *testing.T) {
+	t.Parallel()
+
+	// Given — a preset root with a nested subdirectory. The manager must apply
+	// resource_path to the redirect target, not silently return the root.
+	presetDir := t.TempDir()
+	subDir := filepath.Join(presetDir, "infra", "aws")
+	if err := os.MkdirAll(subDir, 0o750); err != nil {
+		t.Fatalf("failed to create sub directory: %v", err)
+	}
+	def := ResourceDefinition{
+		Extract: false,
+		Artifact: map[string]ArtifactSpec{
+			anyPlatformKey: {URL: "file://" + presetDir, ResourcePath: "infra/aws"},
+		},
+	}
+	manager := NewResourceManagerForPlatform(ResourceSpec{}, t.TempDir(), "linux", "amd64")
+
+	// When
+	path, err := manager.Get(context.Background(), def, "preset-dir")
+	// Then
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if path != subDir {
+		t.Fatalf("expected path %q, got %q", subDir, path)
+	}
+}
+
+func TestManager_GetFileDirectoryRejectsTraversalResourcePath(t *testing.T) {
+	t.Parallel()
+
+	// Given — a resource_path that tries to escape the redirect root.
+	presetDir := t.TempDir()
+	def := ResourceDefinition{
+		Extract: false,
+		Artifact: map[string]ArtifactSpec{
+			anyPlatformKey: {URL: "file://" + presetDir, ResourcePath: "../escape"},
+		},
+	}
+	manager := NewResourceManagerForPlatform(ResourceSpec{}, t.TempDir(), "linux", "amd64")
+
+	// When
+	_, err := manager.Get(context.Background(), def, "preset-dir")
+	// Then
+	if err == nil || !strings.Contains(err.Error(), "resource_path") {
+		t.Fatalf("expected resource_path traversal error, got %v", err)
 	}
 }
 

--- a/internal/runtimeartifacts/spec.go
+++ b/internal/runtimeartifacts/spec.go
@@ -122,7 +122,9 @@ func (a ArtifactSpec) validate(ctx artifactValidationContext) error {
 	if strings.TrimSpace(a.URL) == "" {
 		return fmt.Errorf("resource %q artifact %q must define url", ctx.resourceID, ctx.variant)
 	}
-	if IsGitSourceURL(a.URL) {
+	// ArtifactSpec.URL may carry an @ref suffix; strip it before classification.
+	gitRepoURL, _ := ParseGitURL(a.URL)
+	if IsGitSourceURL(gitRepoURL) {
 		if strings.TrimSpace(a.Sha256) != "" {
 			return fmt.Errorf(
 				"resource %q artifact %q must not define sha256 for a git source"+
@@ -139,13 +141,6 @@ func (a ArtifactSpec) validate(ctx artifactValidationContext) error {
 				ctx.variant,
 			)
 		}
-	}
-	if !ctx.extract && strings.TrimSpace(a.ResourcePath) != "" {
-		return fmt.Errorf(
-			"resource %q artifact %q must not define resource_path without archive extraction",
-			ctx.resourceID,
-			ctx.variant,
-		)
 	}
 
 	return nil

--- a/openspec/changes/add-preset-subdirectory-selector/design.md
+++ b/openspec/changes/add-preset-subdirectory-selector/design.md
@@ -1,0 +1,101 @@
+# Design — Preset subdirectory selector
+
+## Context
+
+Preset URIs on the CLI today:
+
+```
+[<scheme>://…|git@…][@<ref>]
+```
+
+Git clones and archive extractions produce a directory tree. The manifest for the preset
+(`infrastructure.yaml` / `installation.yaml`) must live at the resolved root. That constraint
+prevents users from bundling multiple presets in one repository or archive.
+
+## Decisions
+
+### D1. Fragment (`#subdir`) syntax for the subpath
+
+Alternatives considered:
+
+- **Fragment `#subdir`** (chosen). Standard Web/Go/pip/npm idiom, composes with the existing
+  `@<ref>` suffix without grammar changes, shortest to type.
+- **Terraform-style `//subdir`**. Familiar to Tofu users but requires reworking the ref
+  grammar (moving to query params or overloading `@ref`) to avoid ambiguity with the leading
+  scheme `://`.
+- **Query parameter `?path=…`**. Composable but longest form and shifts `@ref` for
+  consistency.
+
+Rationale: the fragment is orthogonal to `@ref`, so the existing `ParseGitURL` behaviour is
+untouched and the added parser is a single split-on-last-`#` step.
+
+### D2. Fragment parsing is a preset-level concern
+
+Alternatives considered:
+
+- Extend `runtimeartifacts.ParseGitURL` to return `(repoURL, ref, subpath)` and update every
+  call site.
+- **Add `runtimeartifacts.ParsePresetURI(uri) (cleanURI, subpath string)`** (chosen), called
+  by `deploy.ResolvePreset` before it hands the URL to the manager.
+
+Rationale: the subpath applies equally to non-git archive sources, so tying it to
+`ParseGitURL` would either force a git-specific helper into unrelated call sites or add a
+second parser. A single helper on the runtime-artifact package keeps the concept in one
+place. `ParseGitURL` continues to see a URL with no fragment, so ref parsing is unchanged.
+
+### D3. Scope covers git and archive sources; `file://` directories still reject the fragment
+
+- Git URLs (any supported git scheme).
+- Remote archives (`http://` / `https://` `.tar.gz` / `.tgz` / `.zip`).
+- Local archives (`file://` `.tar.gz` / `.tgz` / `.zip`).
+- **Excluded**: `file://` directories. Users can pass the subdirectory path directly.
+  Accepting a fragment there would create two ways to express the same thing.
+
+Rationale: archives already support `ResourcePath` via `Extract: true`, so the marginal cost
+of extending fragment support to them is zero once the parser exists.
+
+### D4. Cache identity — accept duplication
+
+`artifactIdentity` already hashes `ResourcePath` into the cache key. Two requests for the
+same repo/ref but different subpaths produce two distinct cache entries, each with its own
+git clone.
+
+Alternatives considered:
+
+- Share the clone across subpath variants by splitting the fetch key `(URL, ref)` from the
+  resolved-path key `(URL, ref, subpath)`. This is a `resolveEntry` and index-schema
+  refactor.
+- **Accept the duplication** (chosen). Clones are shallow and small; monorepo preset users
+  do not typically install many subpaths from the same repo in one launcher install. The
+  refactor can happen later without breaking the URI syntax.
+
+### D5. Runtime-artifact validation loosening is git-only
+
+`ArtifactSpec.validate` currently rejects `ResourcePath` when `Extract: false`. That guard
+protected against nonsensical archive-less configs. It remains in force for non-git,
+non-extract sources (bare HTTP files, `file://` bare files), which are meaningless with a
+subpath. For git sources, cloning already produces a browsable tree, so the guard is
+relaxed.
+
+### D6. Preset identity persistence is unchanged
+
+`presetIdentityOf` records external presets as `path:<absolute-cache-path>` after
+resolution. With a subpath, the path naturally points at the resolved subdirectory, so the
+existing "preset must match on re-init" check works unchanged and no state-file migration is
+needed.
+
+## Risks
+
+- **Shell escaping**: `#` starts a comment in interactive shells. Documented; users must
+  quote the URL. `zsh` / `bash` both handle it inside double quotes.
+- **URL encoding**: `%23` in a subpath must be decoded, and `%2F` tolerated. The parser
+  splits on the *literal* `#` (URL fragments are always trailing); percent-decoding of the
+  subpath happens via `net/url` where possible.
+- **`@` inside subpath**: Fragment is stripped before `ParseGitURL` runs, so an `@` inside
+  the subpath cannot confuse ref parsing.
+- **Path traversal**: `pathWithinRoot` (already used for archive `ResourcePath`) rejects
+  `..` segments. Reused for the git case.
+
+## Migration
+
+None. The feature is additive; no existing external preset URI contains `#`.

--- a/openspec/changes/add-preset-subdirectory-selector/proposal.md
+++ b/openspec/changes/add-preset-subdirectory-selector/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+External preset sources (git repositories and archives) currently must expose the preset
+directory at the resolved root: `verifyPresetManifest` checks the resolved path for
+`infrastructure.yaml` / `installation.yaml`, and the CLI builds a `ResourceDefinition` with
+`URL` only, so the runtime-artifact `ResourcePath` selector is never populated. That forces
+every git-hosted preset into its own repository and every archive to root-level presets — a
+poor fit for monorepos of related infrastructure/installation presets.
+
+We enable a `#subdir` fragment on external preset URIs so users can select a preset from a
+subdirectory of a git clone or archive. This mirrors the well-established Web/Go/pip/npm
+fragment idiom and composes cleanly with the existing `@ref` grammar
+(`repo.git@v1#infra/aws`).
+
+## What Changes
+
+- CLI preset arguments accept an optional `#<subpath>` fragment after the URL (and after any
+  `@<ref>` suffix for git URLs). The resolved preset directory is the given subdirectory of
+  the cloned repository or extracted archive.
+- The runtime-artifact layer allows `ResourcePath` on git sources (currently rejected because
+  git sources use `Extract: false`) and applies it when resolving the entry.
+- `deploy.ResolvePreset` parses the fragment off the URI before building the
+  `ResourceDefinition` and populates `ArtifactSpec.ResourcePath`.
+- `file://` directory URIs continue to reject the fragment (users can point at the
+  subdirectory directly). All other supported schemes accept it.
+
+## Impact
+
+- `internal/runtimeartifacts/spec.go`: loosen `ResourcePath` validation for git sources.
+- `internal/runtimeartifacts/manager.go`: apply `ResourcePath` in the non-extract branch when
+  the URL is a git source.
+- `internal/runtimeartifacts/preset_uri.go` (new): `ParsePresetURI` helper that splits the
+  fragment off a preset URI.
+- `internal/deploy/preset_external.go`: wire the parsed subpath into `ResourceDefinition`.
+- Cache identity: unchanged — `ResourcePath` is already part of `artifactIdentity`, so
+  different subpaths produce distinct cache entries (accepted duplication; shallow clones).
+- Backward compatible: no existing external preset URI contains `#`.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `external-preset-resolution`: adds the subdirectory fragment syntax and its precedence with
+  `@ref`.
+- `preset-source-fetching`: adds the subdirectory selection on git and archive sources.

--- a/openspec/changes/add-preset-subdirectory-selector/specs/external-preset-resolution/spec.md
+++ b/openspec/changes/add-preset-subdirectory-selector/specs/external-preset-resolution/spec.md
@@ -1,0 +1,71 @@
+## ADDED Requirements
+
+### Requirement: External preset URIs support an optional subdirectory fragment
+
+An external preset URI MAY include a trailing `#<subpath>` fragment that selects a
+subdirectory within the resolved source. When present, the fragment SHALL identify the
+preset directory (containing the required `infrastructure.yaml` or `installation.yaml`
+manifest) within the cloned repository or extracted archive.
+
+The fragment SHALL be supported on git URLs, remote archive URLs (`http://`, `https://`
+ending in a supported archive extension), and local archive URIs (`file://` ending in a
+supported archive extension). It SHALL be rejected on `file://` URIs that point to a
+directory.
+
+When a URI contains both an `@<ref>` suffix and a `#<subpath>` fragment, the ref SHALL come
+before the fragment (e.g. `https://host/repo.git@v1#infra/aws`), and both SHALL be applied.
+
+The fragment SHALL NOT contain traversal segments (`..`). Subpath resolution SHALL error out
+when the referenced directory does not exist inside the resolved source, and SHALL surface
+the existing "does not contain the expected … manifest" error when the referenced
+subdirectory lacks the required manifest.
+
+#### Scenario: Git URL with fragment resolves preset from subdirectory
+
+- **WHEN** the user passes `https://host/repo.git#infra/aws`
+- **THEN** the system SHALL clone the repository and resolve the preset from the
+  `infra/aws` subdirectory
+
+#### Scenario: Git URL combines ref and fragment
+
+- **WHEN** the user passes `https://host/repo.git@v1#infra/aws`
+- **THEN** the system SHALL check out ref `v1` and resolve the preset from the `infra/aws`
+  subdirectory
+
+#### Scenario: Local archive with fragment extracts and resolves subdirectory
+
+- **WHEN** the user passes `file:///tmp/presets.tar.gz#installation/ubuntu`
+- **THEN** the system SHALL extract the archive and resolve the preset from the
+  `installation/ubuntu` subdirectory of the extracted contents
+
+#### Scenario: Remote archive with fragment downloads and resolves subdirectory
+
+- **WHEN** the user passes `https://host/presets.tar.gz#infra/aws`
+- **THEN** the system SHALL download and extract the archive and resolve the preset from
+  the `infra/aws` subdirectory
+
+#### Scenario: Fragment on file:// directory URI is rejected
+
+- **WHEN** the user passes `file:///tmp/my-presets#infra/aws`
+- **THEN** the system SHALL return an error stating that the subdirectory fragment is not
+  supported on `file://` directory URIs and instructing the user to pass the subdirectory
+  path directly
+
+#### Scenario: Fragment with traversal is rejected
+
+- **WHEN** the user passes a preset URI whose fragment resolves outside the source root
+  (e.g. contains `..`)
+- **THEN** the system SHALL return an error and SHALL NOT resolve any preset content
+
+#### Scenario: Fragment pointing to non-existent subdirectory returns a clear error
+
+- **WHEN** the user passes a preset URI whose fragment names a subdirectory that does not
+  exist in the resolved source
+- **THEN** the system SHALL return an error that includes the requested subpath
+
+#### Scenario: Fragment pointing to a subdirectory without the required manifest fails preset verification
+
+- **WHEN** the user passes a preset URI whose fragment names a subdirectory that exists but
+  lacks the required manifest for the preset type
+- **THEN** the system SHALL return the "does not contain the expected … manifest" error,
+  and the error SHALL include the resolved subpath

--- a/openspec/changes/add-preset-subdirectory-selector/specs/preset-source-fetching/spec.md
+++ b/openspec/changes/add-preset-subdirectory-selector/specs/preset-source-fetching/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Preset resource paths select a subdirectory of the resolved source
+
+When a preset source is fetched from a git repository or extracted from an archive, the
+runtime-artifact layer SHALL support a `ResourcePath` that selects a subdirectory of the
+resolved source as the returned path. `ResourcePath` SHALL be honoured for git sources even
+when `Extract` is false, since a git clone already produces a browsable directory tree.
+
+The `ResourcePath` SHALL be validated to stay within the resolved source root. Any traversal
+attempt SHALL be rejected before the path is returned.
+
+Cache identity SHALL continue to include `ResourcePath`, so two requests for the same URL
+at the same content version but different subpaths SHALL be treated as distinct cache
+entries.
+
+#### Scenario: Git source honours ResourcePath as the returned path
+
+- **WHEN** a `ResourceDefinition` with a git URL and a non-empty `ResourcePath` is resolved
+- **THEN** the system SHALL clone the repository and return the path of that subdirectory
+  within the clone
+
+#### Scenario: Git source rejects a ResourcePath containing traversal
+
+- **WHEN** the `ResourcePath` contains `..` segments that resolve outside the clone root
+- **THEN** the system SHALL return an error and SHALL NOT return any resolved path
+
+#### Scenario: Different subpaths produce distinct cache entries
+
+- **WHEN** two requests target the same URL and revision but different `ResourcePath`
+  values
+- **THEN** the system SHALL treat them as distinct cache entries and resolve each subpath
+  independently

--- a/openspec/changes/add-preset-subdirectory-selector/tasks.md
+++ b/openspec/changes/add-preset-subdirectory-selector/tasks.md
@@ -1,0 +1,30 @@
+## 1. Runtime-artifact layer
+
+- [x] 1.1 Allow `ResourcePath` on git sources with `Extract: false` in `ArtifactSpec.validate` ([internal/runtimeartifacts/spec.go](internal/runtimeartifacts/spec.go)).
+- [x] 1.2 Apply `ResourcePath` in the non-extract branch of `Manager.resolveEntry` when the URL is a git source ([internal/runtimeartifacts/manager.go](internal/runtimeartifacts/manager.go)). Reuse `pathWithinRoot` for traversal safety.
+- [x] 1.3 Add `ParsePresetURI(uri) (cleanURI, subpath string)` helper that strips a trailing `#<subpath>` fragment; keep `ParseGitURL` untouched.
+
+## 2. Deploy layer wiring
+
+- [x] 2.1 In `deploy.ResolvePreset`, call `ParsePresetURI` before checking `@ref`, populate `ArtifactSpec.ResourcePath` from the subpath, and pass the fragment-stripped URI onward ([internal/deploy/preset_external.go](internal/deploy/preset_external.go)).
+- [x] 2.2 Reject a fragment on `file://` directory URIs with a clear error; accept it on git URLs and on archive URIs (`.tar.gz`/`.tgz`/`.zip`) across `http`/`https`/`file` schemes.
+- [x] 2.3 Have `needsExtraction` operate on the fragment-stripped URI so an archive URL with a fragment is still detected as extractable.
+
+## 3. Tests
+
+- [x] 3.1 Unit tests for `ParsePresetURI`: bare URL, URL with only ref, URL with only fragment, URL with both, empty fragment, encoded `%23`.
+- [x] 3.2 Runtime-artifact unit tests: git source with `ResourcePath` returns the subdirectory path; git source with `..` in `ResourcePath` is rejected; different subpaths produce distinct cache entries; `ParseSpec` accepts git + `resource_path` + `extract: false`.
+- [x] 3.3 Deploy-layer unit tests for `ResolvePreset` covering: `file://` directory + fragment errors; `file://` archive + fragment resolves the subpath; archive subdir missing the required manifest surfaces the existing "does not contain the expected … manifest" error. (Git-clone-plus-fragment is exercised at the runtime-artifact layer via `resolveEntry`; a live git integration test is left for the higher-level suite because unit tests cannot spin up a git server.)
+- [x] 3.4 CLI classification: no new test needed — `IsExternalPresetURI` inspects only the scheme prefix, so a trailing `#subpath` cannot affect classification; existing coverage still applies.
+
+## 4. Documentation
+
+- [x] 4.1 Update [doc/presets.md](doc/presets.md) — add "Selecting a preset from a subdirectory" subsection with fragment syntax and one example per supported source kind, plus new troubleshooting rows.
+- [x] 4.2 Update [CONTEXT.md](CONTEXT.md) — remove the "must live at the repository root" caveat and describe the new syntax + precedence with `@ref`.
+- [x] 4.3 Add a `CHANGELOG.md` entry under "Added".
+- [x] 4.4 Update the README external-presets section with a note about the fragment.
+
+## 5. Validation
+
+- [x] 5.1 `go tool golangci-lint run ./...` and `go test ./...` pass locally (0 issues; all packages green).
+- [ ] 5.2 OpenSpec validation for this change. _(Deferred: `openspec` CLI is not installed in this environment; run `openspec validate add-preset-subdirectory-selector --strict` before archival.)_


### PR DESCRIPTION
## Description

Adds support for an optional `#<subpath>` fragment on external preset URIs so a single git repository or archive can host multiple presets. Users select one via, e.g., `repo.git@v1#infra/aws`. This mirrors the well-established Web/Go/pip/npm fragment idiom and composes cleanly with the existing `@ref` grammar. Previously every git-hosted preset required its own repository and every archive required a root-level preset — a poor fit for monorepos of related infrastructure/installation presets.

Backed by OpenSpec change [add-preset-subdirectory-selector](openspec/changes/add-preset-subdirectory-selector/proposal.md).

## Related Issue

<!-- Link to the related issue(s). Use "Fixes #123" or "Closes #123" to auto-close issues when PR is merged -->

Fixes #

## Type of Change

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Parse an optional `#<subpath>` fragment off external preset URIs in `deploy.ResolvePreset` and wire it into `ArtifactSpec.ResourcePath` (new [internal/runtimeartifacts/preset_uri.go](internal/runtimeartifacts/preset_uri.go); updates to [internal/deploy/preset_external.go](internal/deploy/preset_external.go)).
- Loosen `ResourcePath` validation for git sources in [internal/runtimeartifacts/spec.go](internal/runtimeartifacts/spec.go) and apply `ResourcePath` in the non-extract branch of [internal/runtimeartifacts/manager.go](internal/runtimeartifacts/manager.go) so it works for git clones as well as extracted archives.
- Reject the fragment on `file://` directory URIs (users can point the URI at the subdirectory directly) and reject path-traversal segments (`..`).
- Preserve cache identity: distinct subpaths on the same repository or archive are cached as separate entries (`ResourcePath` is already part of `artifactIdentity`).
- Document the syntax, precedence with `@ref`, supported schemes, and new error messages in [doc/presets.md](doc/presets.md); add a short pointer in [README.md](README.md) and a user-facing entry to [CHANGELOG.md](CHANGELOG.md).

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

- New unit tests for the fragment parser in [internal/runtimeartifacts/preset_uri_test.go](internal/runtimeartifacts/preset_uri_test.go) cover `@ref`+`#subpath` composition, precedence, missing/empty fragments, and rejection of `..` traversal.
- New tests in [internal/runtimeartifacts/manager_test.go](internal/runtimeartifacts/manager_test.go) verify that `ResourcePath` is honored for git sources in the non-extract branch and that distinct subpaths produce distinct cache entries.
- New tests in [internal/deploy/preset_external_test.go](internal/deploy/preset_external_test.go) cover end-to-end resolution: git+fragment, archive+fragment (http/https/file), rejection of the fragment on `file://` directory URIs, and rejection of `@ref` on non-git URLs (unchanged behavior).
- Manually verified with a git URL of the form `https://…/presets.git@v1#infra/aws` and a `file:///…/presets.tar.gz#installation/ubuntu` archive.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

- Backward compatible: no existing external preset URI contains `#`.
- Remember to quote URLs on the command line so the shell does not treat `#` as the start of a comment (e.g. `exasol install "https://github.com/org/presets.git@v1#infra/aws"`).
- Propose archiving the OpenSpec change [add-preset-subdirectory-selector](openspec/changes/add-preset-subdirectory-selector/) before merging, per repository workflow.
