### PR TITLE
fix: Resolve SonarCloud reliability, maintainability, and security-hotspot findings

### DIFF
--- a/.github/actions/tests-deployment/action.yml
+++ b/.github/actions/tests-deployment/action.yml
@@ -27,17 +27,18 @@ runs:
       uses: ./.github/actions/setup-task
     - name: Install uv (system Python path)
       if: ${{ inputs.system-python == 'true' }}
-      shell: bash
-      run: |
-        curl -LsSf https://astral.sh/uv/install.sh | sh
-        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-    - name: Install Python 3.13 and Poetry via uv (system Python path)
+      uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+    - name: Install Python 3.13 (system Python path)
       if: ${{ inputs.system-python == 'true' }}
       shell: bash
       run: |
         uv python install 3.13
-        uv tool install poetry
         echo "$(dirname "$(uv python find 3.13)")" >> "$GITHUB_PATH"
+    - name: Install Poetry (system Python path)
+      if: ${{ inputs.system-python == 'true' }}
+      uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
+      with:
+        version: "2.4.1"
     - name: Install test dependencies (system Python path)
       if: ${{ inputs.system-python == 'true' }}
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,11 @@ jobs:
 
       - name: Determine previous tag for changelog
         id: prev
+        env:
+          TAG: ${{ inputs.tag }}
+          INPUT_PREV: ${{ inputs.previous_tag }}
         run: |
           set -euo pipefail
-          TAG='${{ inputs.tag }}'
-          INPUT_PREV='${{ inputs.previous_tag }}'
           if [ -n "${INPUT_PREV}" ]; then
             PREV="${INPUT_PREV}"
           else

--- a/.github/workflows/tests-deployment.yml
+++ b/.github/workflows/tests-deployment.yml
@@ -109,11 +109,13 @@ jobs:
       - name: Validate Azure location input
         if: ${{ matrix.infra == 'azure' }}
         shell: bash
+        env:
+          SECRET_AZURE_LOCATION: ${{ secrets.AZURE_LOCATION }}
         run: |
           location="${{ vars.AZURE_LOCATION }}"
           source="vars.AZURE_LOCATION"
           if [ -z "${location}" ]; then
-            location="${{ secrets.AZURE_LOCATION }}"
+            location="${SECRET_AZURE_LOCATION}"
             source="secrets.AZURE_LOCATION"
           fi
 
@@ -128,12 +130,15 @@ jobs:
       - name: Setup Exoscale credentials
         if: ${{ matrix.infra == 'exoscale' }}
         shell: bash
+        env:
+          SECRET_EXOSCALE_API_KEY: ${{ secrets.EXOSCALE_API_KEY }}
+          SECRET_EXOSCALE_API_SECRET: ${{ secrets.EXOSCALE_API_SECRET }}
         run: |
-          echo "EXOSCALE_API_KEY=${{ secrets.EXOSCALE_API_KEY }}" >> "$GITHUB_ENV"
-          echo "EXOSCALE_API_SECRET=${{ secrets.EXOSCALE_API_SECRET }}" >> "$GITHUB_ENV"
+          echo "EXOSCALE_API_KEY=${SECRET_EXOSCALE_API_KEY}" >> "$GITHUB_ENV"
+          echo "EXOSCALE_API_SECRET=${SECRET_EXOSCALE_API_SECRET}" >> "$GITHUB_ENV"
           # The Exoscale preset uses an aliased AWS provider for SOS endpoint resources.
-          echo "AWS_ACCESS_KEY_ID=${{ secrets.EXOSCALE_API_KEY }}" >> "$GITHUB_ENV"
-          echo "AWS_SECRET_ACCESS_KEY=${{ secrets.EXOSCALE_API_SECRET }}" >> "$GITHUB_ENV"
+          echo "AWS_ACCESS_KEY_ID=${SECRET_EXOSCALE_API_KEY}" >> "$GITHUB_ENV"
+          echo "AWS_SECRET_ACCESS_KEY=${SECRET_EXOSCALE_API_SECRET}" >> "$GITHUB_ENV"
 
       # Doing a second build here again. In theory, we could
       # upload the build artifact from the ci.yml workflow

--- a/assets/infrastructure/aws/main.tf
+++ b/assets/infrastructure/aws/main.tf
@@ -199,6 +199,23 @@ resource "aws_s3_bucket_policy" "bootstrap_assets" {
             "aws:sourceVpce" = aws_vpc_endpoint.s3_gateway.id
           }
         }
+      },
+      {
+        # Access happens over HTTPS via the VPC endpoint above; this blocks
+        # any other transport.
+        Sid       = "DenyInsecureTransport",
+        Effect    = "Deny",
+        Principal = "*",
+        Action    = "s3:*",
+        Resource = [
+          aws_s3_bucket.bootstrap_assets.arn,
+          "${aws_s3_bucket.bootstrap_assets.arn}/*"
+        ],
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
       }
     ]
   })

--- a/assets/infrastructure/azure/main.tf
+++ b/assets/infrastructure/azure/main.tf
@@ -141,6 +141,10 @@ resource "azurerm_storage_account" "remote_archive" {
     virtual_network_subnet_ids = [azurerm_subnet.subnet.id]
   }
 
+  identity {
+    type = "SystemAssigned"
+  }
+
   tags = local.common_tags
 }
 
@@ -183,6 +187,10 @@ resource "azurerm_storage_account" "bootstrap_assets" {
   # (see `azurerm_storage_account_sas.bootstrap_assets`). The blobs themselves are
   # non-secret bootstrap scripts. The sensitive `remote_archive` account keeps its
   # strict `network_rules` because nothing uploads to it from outside the VNet.
+
+  identity {
+    type = "SystemAssigned"
+  }
 
   tags = local.common_tags
 }
@@ -314,6 +322,10 @@ resource "azurerm_linux_virtual_machine" "nodes" {
     public_key = tls_private_key.ssh_key.public_key_openssh
   }
 
+  identity {
+    type = "SystemAssigned"
+  }
+
   os_disk {
     name                 = "${local.deployment_id}-${each.key}-os"
     caching              = "ReadWrite"
@@ -341,6 +353,8 @@ resource "azurerm_managed_disk" "data_disks" {
   create_option        = "Empty"
   disk_size_gb         = var.data_volume_size
   tags                 = local.common_tags
+
+  public_network_access_enabled = true
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "data_disks" {

--- a/cmd/exasol/deployment_logging.go
+++ b/cmd/exasol/deployment_logging.go
@@ -24,7 +24,7 @@ const (
 	commandInstall                          = "install"
 )
 
-var deploymentLogCleanup = func() {}
+var deploymentLogCleanup = func() { /* no-op until a log session starts */ }
 
 func requireDeploymentFileLogging(cmd *cobra.Command) {
 	if cmd.Annotations == nil {
@@ -52,7 +52,7 @@ var startDeploymentLogSession = func(
 			"error", err.Error(),
 		)
 
-		return func() {}, nil
+		return func() { /* no-op: logging never started, nothing to clean up */ }, nil
 	}
 
 	file, err := os.OpenFile(
@@ -67,7 +67,7 @@ var startDeploymentLogSession = func(
 			"error", err.Error(),
 		)
 
-		return func() {}, nil
+		return func() { /* no-op: logging never started, nothing to clean up */ }, nil
 	}
 
 	globalDeploymentFileSink.Set(file, slog.LevelDebug)
@@ -88,7 +88,7 @@ var startDeploymentLogSession = func(
 
 func setDeploymentLogCleanup(cleanup func()) {
 	if cleanup == nil {
-		deploymentLogCleanup = func() {}
+		deploymentLogCleanup = func() { /* no-op: cleared, nothing to clean up */ }
 		return
 	}
 
@@ -97,12 +97,12 @@ func setDeploymentLogCleanup(cleanup func()) {
 
 func runDeploymentLogCleanup() {
 	deploymentLogCleanup()
-	deploymentLogCleanup = func() {}
+	deploymentLogCleanup = func() { /* no-op: reset after running so repeated calls are safe */ }
 }
 
 func setupDeploymentLogSession(cmd *cobra.Command, deployment config.DeploymentDir) error {
 	// Default cleanup is always a no-op, so Execute() can always defer cleanup once.
-	setDeploymentLogCleanup(func() {})
+	setDeploymentLogCleanup(func() { /* no-op default */ })
 
 	if !deploymentFileLoggingIsRequired(cmd) {
 		return nil

--- a/cmd/exasol/install.go
+++ b/cmd/exasol/install.go
@@ -39,95 +39,13 @@ func init() {
 	// Install creates (init) and then operates on (deploy) the deployment directory.
 	requireDeploymentFileLogging(installCmd)
 
-	installCmd.Long = strings.TrimRight(installCmd.Long, "\n") +
-		"\n\t" + presetNamesForHelp(presets.PresetTypeInfrastructure,
-		presets.ListEmbeddedInfrastructuresPresets()) +
-		"\n\t" + presetNamesForHelp(presets.PresetTypeInstallation,
-		presets.ListEmbeddedInstallationsPresets())
-
-	if matrix := embeddedPresetCompatibilityMatrix(); matrix != "" {
-		installCmd.Long += "\n\n\t" + strings.ReplaceAll(matrix, "\n", "\n\t")
-	}
+	appendInstallCmdPresetHelp()
 
 	// Run initialization
-	installCmd.PreRunE = func(cmd *cobra.Command, args []string) error {
-		cmd.SilenceUsage = true
-
-		deployment := commonFlags.Deployment()
-		wasInitialized, err := config.HasExasolPersonalStateFile(deployment)
-		if err != nil {
-			return err
-		}
-		infraVars := collectInfrastructureVariableOverrides(cmd)
-		installVars := collectInstallationVariableOverrides(cmd)
-		infraPreset, err := resolvePresetRef(
-			cmd.Context(),
-			args[0],
-			presets.PresetTypeInfrastructure,
-		)
-		if err != nil {
-			return err
-		}
-		installPreset, err := resolveInstallationPresetRef(cmd.Context(), args, 1, infraPreset)
-		if err != nil {
-			return err
-		}
-
-		if wasInitialized {
-			if err := prepareInitializedInstall(
-				cmd,
-				deployment,
-				infraPreset,
-				installPreset,
-				infraVars,
-				installVars,
-			); err != nil {
-				return fmt.Errorf("initialization failed: %w", err)
-			}
-		} else {
-			if err := deploy.InitDeployment(
-				cmd.Context(),
-				infraPreset,
-				installPreset,
-				infraVars,
-				installVars,
-				deployment,
-				!commonFlags.NoLauncherVersionCheck,
-				CurrentLauncherVersion,
-			); err != nil {
-				return fmt.Errorf("initialization failed: %w", err)
-			}
-		}
-
-		if err := setupDeploymentLogSession(cmd, deployment); err != nil {
-			return err
-		}
-		addTerminalNotice(deploy.EulaNoticeText)
-
-		return nil
-	}
+	installCmd.PreRunE = runInstallPreRun
 
 	// Perform deployment after initialization completes.
-	installCmd.PersistentPostRunE = func(cmd *cobra.Command, _ []string) error {
-		deployment := commonFlags.Deployment()
-		if err := deploy.Deploy(
-			cmd.Context(),
-			deployment,
-			commonFlags.DeployVerbose,
-			deploy.DeployOptions{
-				UpdateDependencyLockfile: commonFlags.DeployTofuUpdateLockfile,
-			},
-		); err != nil {
-			return fmt.Errorf("deployment failed: %w", err)
-		}
-
-		err := addConnectionInstructionsTerminalOutput(deployment)
-		if err != nil {
-			return fmt.Errorf("failed to print deployment info: %w", err)
-		}
-
-		return nil
-	}
+	installCmd.PersistentPostRunE = runInstallPersistentPostRun
 
 	// Make "install" runnable without subcommands; no-op RunE prevents usage output.
 	// init runs in PreRunE, deploy runs in PersistentPostRunE
@@ -139,6 +57,128 @@ func init() {
 	registerVerboseFlag(installCmd, commonFlags)
 	registerDeployFlags(installCmd, commonFlags)
 	rootCmd.AddCommand(installCmd)
+}
+
+// appendInstallCmdPresetHelp adds the list of embedded presets and their
+// compatibility matrix to the command's long description.
+func appendInstallCmdPresetHelp() {
+	installCmd.Long = strings.TrimRight(installCmd.Long, "\n") +
+		"\n\t" + presetNamesForHelp(presets.PresetTypeInfrastructure,
+		presets.ListEmbeddedInfrastructuresPresets()) +
+		"\n\t" + presetNamesForHelp(presets.PresetTypeInstallation,
+		presets.ListEmbeddedInstallationsPresets())
+
+	if matrix := embeddedPresetCompatibilityMatrix(); matrix != "" {
+		installCmd.Long += "\n\n\t" + strings.ReplaceAll(matrix, "\n", "\n\t")
+	}
+}
+
+func runInstallPreRun(cmd *cobra.Command, args []string) error {
+	cmd.SilenceUsage = true
+
+	deployment := commonFlags.Deployment()
+	wasInitialized, err := config.HasExasolPersonalStateFile(deployment)
+	if err != nil {
+		return err
+	}
+	infraVars := collectInfrastructureVariableOverrides(cmd)
+	installVars := collectInstallationVariableOverrides(cmd)
+	infraPreset, err := resolvePresetRef(
+		cmd.Context(),
+		args[0],
+		presets.PresetTypeInfrastructure,
+	)
+	if err != nil {
+		return err
+	}
+	installPreset, err := resolveInstallationPresetRef(cmd.Context(), args, 1, infraPreset)
+	if err != nil {
+		return err
+	}
+
+	if err := initializeInstall(
+		cmd,
+		deployment,
+		wasInitialized,
+		infraPreset,
+		installPreset,
+		infraVars,
+		installVars,
+	); err != nil {
+		return err
+	}
+
+	if err := setupDeploymentLogSession(cmd, deployment); err != nil {
+		return err
+	}
+	addTerminalNotice(deploy.EulaNoticeText)
+
+	return nil
+}
+
+// initializeInstall either reconciles an already-initialized deployment with
+// the requested presets, or creates a new deployment from scratch.
+//
+//nolint:revive // wasInitialized reflects on-disk deployment state, not internal control coupling.
+func initializeInstall(
+	cmd *cobra.Command,
+	deployment config.DeploymentDir,
+	wasInitialized bool,
+	infraPreset deploy.PresetRef,
+	installPreset deploy.PresetRef,
+	infraVars map[string]string,
+	installVars map[string]string,
+) error {
+	if wasInitialized {
+		if err := prepareInitializedInstall(
+			cmd,
+			deployment,
+			infraPreset,
+			installPreset,
+			infraVars,
+			installVars,
+		); err != nil {
+			return fmt.Errorf("initialization failed: %w", err)
+		}
+
+		return nil
+	}
+
+	if err := deploy.InitDeployment(
+		cmd.Context(),
+		infraPreset,
+		installPreset,
+		infraVars,
+		installVars,
+		deployment,
+		!commonFlags.NoLauncherVersionCheck,
+		CurrentLauncherVersion,
+	); err != nil {
+		return fmt.Errorf("initialization failed: %w", err)
+	}
+
+	return nil
+}
+
+func runInstallPersistentPostRun(cmd *cobra.Command, _ []string) error {
+	deployment := commonFlags.Deployment()
+	if err := deploy.Deploy(
+		cmd.Context(),
+		deployment,
+		commonFlags.DeployVerbose,
+		deploy.DeployOptions{
+			UpdateDependencyLockfile: commonFlags.DeployTofuUpdateLockfile,
+		},
+	); err != nil {
+		return fmt.Errorf("deployment failed: %w", err)
+	}
+
+	err := addConnectionInstructionsTerminalOutput(deployment)
+	if err != nil {
+		return fmt.Errorf("failed to print deployment info: %w", err)
+	}
+
+	return nil
 }
 
 func prepareInitializedInstall(

--- a/cmd/exasol/presets_list.go
+++ b/cmd/exasol/presets_list.go
@@ -92,41 +92,66 @@ func renderPresetSection(writer io.Writer, header string, presetsList []Preset) 
 
 func renderPresetListText(writer io.Writer, typeFilter string, catalog PresetCatalog) error {
 	filter := normalizePresetTypeFilter(typeFilter)
-	if filter != "" {
-		if _, ok := findPresetTypeHandler(filter); !ok {
-			return fmt.Errorf(
-				"invalid preset type %q (expected one of: %s)",
-				typeFilter,
-				allowedPresetTypes(),
-			)
-		}
+	if err := validateRenderPresetTypeFilter(filter, typeFilter); err != nil {
+		return err
 	}
 
-	wroteAny := false
-	writeSection := func(header string, presetsList []Preset) error {
-		if wroteAny {
-			if _, err := fmt.Fprintln(writer); err != nil {
-				return err
-			}
-		}
-		wroteAny = true
-
-		return renderPresetSection(writer, header, presetsList)
-	}
-
-	for _, h := range presetTypeHandlers {
-		if filter != "" && filter != h.Type {
-			continue
-		}
-		if err := writeSection(h.Header, h.GetFromCatalog(catalog)); err != nil {
-			return err
-		}
+	wroteAny, err := writeFilteredPresetSections(writer, filter, catalog)
+	if err != nil {
+		return err
 	}
 
 	if filter != "" {
 		return nil
 	}
 
+	return writePresetAppendix(writer, wroteAny)
+}
+
+func validateRenderPresetTypeFilter(filter, typeFilter string) error {
+	if filter == "" {
+		return nil
+	}
+	if _, ok := findPresetTypeHandler(filter); !ok {
+		return fmt.Errorf(
+			"invalid preset type %q (expected one of: %s)",
+			typeFilter,
+			allowedPresetTypes(),
+		)
+	}
+
+	return nil
+}
+
+// writeFilteredPresetSections writes one section per preset type handler that
+// matches filter (all of them when filter is empty), separated by blank
+// lines. It reports whether any section was written.
+func writeFilteredPresetSections(
+	writer io.Writer, filter string, catalog PresetCatalog,
+) (bool, error) {
+	wroteAny := false
+
+	for _, handler := range presetTypeHandlers {
+		if filter != "" && filter != handler.Type {
+			continue
+		}
+		if wroteAny {
+			if _, err := fmt.Fprintln(writer); err != nil {
+				return wroteAny, err
+			}
+		}
+		section := handler.GetFromCatalog(catalog)
+		if err := renderPresetSection(writer, handler.Header, section); err != nil {
+			return wroteAny, err
+		}
+		wroteAny = true
+	}
+
+	return wroteAny, nil
+}
+
+//nolint:revive // wroteAny reflects prior output state, not internal control coupling.
+func writePresetAppendix(writer io.Writer, wroteAny bool) error {
 	appendix := embeddedPresetAppendixText()
 	if appendix == "" {
 		return nil

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -184,42 +184,13 @@ func Connect(
 		databaseOptFns = append(databaseOptFns, exasol.WithVersionOutput(writers.stderr))
 	}
 
-	database, err := NewExasolConnection(
-		deployment,
-		connectionInfo,
-		opts.Username,
-		opts.Password,
-		opts.InsecureSkipCertValidation,
-		databaseOptFns...,
-	)
+	database, err := connectToDatabase(ctx, deployment, connectionInfo, opts, databaseOptFns)
 	if err != nil {
 		return err
 	}
-
-	dialCtx, cancel := context.WithTimeout(ctx, connectDialTimeout)
-	defer cancel()
-	if err := database.Connect(dialCtx); err != nil {
-		return err
-	}
-
 	defer database.Close()
 
-	printer := printResultTable
-	switch opts.OutputFormat {
-	case OutputFormatTable:
-		printer = printResultTable
-	case OutputFormatCSV:
-		printer = printResultCSV
-	case OutputFormatJSON:
-		printer = newJSONResultPrinter(opts.JSONFormat)
-	default:
-		printer = printResultTable
-	}
-
-	// The interactive preview cap applies only when an interactive shell is
-	// actually started. --command/--file and non-interactive JSON execution
-	// return everything by default, so they behave as non-interactive
-	// (unlimited) unless --max-rows is set explicitly.
+	printer := selectResultPrinter(opts.OutputFormat, opts.JSONFormat)
 	modeDefault := 0
 	if interactiveShell {
 		modeDefault = interactivePreviewMaxRows
@@ -239,25 +210,7 @@ func Connect(
 	}
 
 	processInput := func(input string) error {
-		// The input string is expected to be trimmed of whitespace
-		if input == "" {
-			return nil
-		}
-
-		queryResult, err := database.Exec(ctx, input, maxRows)
-		if err != nil {
-			return err
-		}
-
-		if err := printer(writers.stdout, queryResult); err != nil {
-			return err
-		}
-
-		if queryResult.Truncated() {
-			return printTruncationFooter(writers.stderr, len(queryResult.Rows()))
-		}
-
-		return nil
+		return execStatement(ctx, database, maxRows, printer, writers, input)
 	}
 
 	if nonInteractive {
@@ -273,6 +226,82 @@ func Connect(
 	return RunShellWithOpts(processInput, ShellOpts{
 		ExecuteOnSemicolon: opts.ExecuteOnSemicolon,
 	})
+}
+
+// connectToDatabase establishes the database connection used for the rest of
+// the session and applies the initial dial timeout, which the underlying
+// driver's Open call does not enforce on its own.
+func connectToDatabase(
+	ctx context.Context,
+	deployment config.DeploymentDir,
+	connectionInfo *config.ConnectionInfo,
+	opts *Opts,
+	databaseOptFns []exasol.OptFn,
+) (generaltypes.Databaser, error) {
+	database, err := NewExasolConnection(
+		deployment,
+		connectionInfo,
+		opts.Username,
+		opts.Password,
+		opts.InsecureSkipCertValidation,
+		databaseOptFns...,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	dialCtx, cancel := context.WithTimeout(ctx, connectDialTimeout)
+	defer cancel()
+	if err := database.Connect(dialCtx); err != nil {
+		return nil, err
+	}
+
+	return database, nil
+}
+
+// selectResultPrinter picks the printer matching the requested output format,
+// defaulting to the table renderer.
+func selectResultPrinter(format OutputFormat, jsonFormat JSONFormat) resultPrinter {
+	switch format {
+	case OutputFormatTable:
+		return printResultTable
+	case OutputFormatCSV:
+		return printResultCSV
+	case OutputFormatJSON:
+		return newJSONResultPrinter(jsonFormat)
+	default:
+		return printResultTable
+	}
+}
+
+// execStatement runs a single trimmed input statement and prints its result,
+// including the truncation footer when the row cap was hit.
+func execStatement(
+	ctx context.Context,
+	database generaltypes.Databaser,
+	maxRows int,
+	printer resultPrinter,
+	writers connectOutputWriters,
+	input string,
+) error {
+	if input == "" {
+		return nil
+	}
+
+	queryResult, err := database.Exec(ctx, input, maxRows)
+	if err != nil {
+		return err
+	}
+
+	if err := printer(writers.stdout, queryResult); err != nil {
+		return err
+	}
+
+	if queryResult.Truncated() {
+		return printTruncationFooter(writers.stderr, len(queryResult.Rows()))
+	}
+
+	return nil
 }
 
 type connectOutputWriters struct {

--- a/internal/deploy/configuration.go
+++ b/internal/deploy/configuration.go
@@ -130,52 +130,84 @@ func ResetDeploymentConfiguration(
 	optionNames []string,
 	resetAll bool,
 ) (DeploymentConfiguration, error) {
-	if !resetAll && len(optionNames) == 0 {
-		return DeploymentConfiguration{}, errors.New("provide option names to reset, or pass --all")
-	}
-	if resetAll && len(optionNames) > 0 {
-		return DeploymentConfiguration{}, errors.New("pass either --all or option names, not both")
+	if err := validateResetSelection(optionNames, resetAll); err != nil {
+		return DeploymentConfiguration{}, err
 	}
 
 	err := withDeploymentExclusiveLock(ctx, deployment,
 		func(deployment config.DeploymentDir) error {
-			exasolState, err := config.ReadExasolPersonalState(deployment)
-			if err != nil {
-				return err
-			}
-			if err := WorkflowStatePermitsConfigure(exasolState); err != nil {
-				return err
-			}
-
-			configuration, err := readDeploymentConfiguration(deployment)
-			if err != nil {
-				return err
-			}
-			if !resetAll {
-				configuration, err = resetSelectedDeploymentConfiguration(
-					configuration,
-					optionNames,
-				)
-				if err != nil {
-					return err
-				}
-			} else {
-				resetAllConfigurationValues(configuration.Infrastructure.Options)
-				resetAllConfigurationValues(configuration.Installation.Options)
-			}
-
-			return writeDeploymentConfiguration(
-				ctx,
-				deployment,
-				exasolState,
-				configuration,
-			)
+			return resetDeploymentConfigurationLocked(ctx, deployment, optionNames, resetAll)
 		})
 	if err != nil {
 		return DeploymentConfiguration{}, err
 	}
 
 	return GetDeploymentConfiguration(ctx, deployment, nil)
+}
+
+// validateResetSelection rejects the two invalid combinations of --all and
+// explicit option names, before any lock is taken.
+//
+//nolint:revive // resetAll mirrors the command-level --all flag.
+func validateResetSelection(optionNames []string, resetAll bool) error {
+	if !resetAll && len(optionNames) == 0 {
+		return errors.New("provide option names to reset, or pass --all")
+	}
+	if resetAll && len(optionNames) > 0 {
+		return errors.New("pass either --all or option names, not both")
+	}
+
+	return nil
+}
+
+func resetDeploymentConfigurationLocked(
+	ctx context.Context,
+	deployment config.DeploymentDir,
+	optionNames []string,
+	resetAll bool,
+) error {
+	exasolState, err := config.ReadExasolPersonalState(deployment)
+	if err != nil {
+		return err
+	}
+	if err := WorkflowStatePermitsConfigure(exasolState); err != nil {
+		return err
+	}
+
+	configuration, err := readDeploymentConfiguration(deployment)
+	if err != nil {
+		return err
+	}
+	configuration, err = applyConfigurationReset(configuration, optionNames, resetAll)
+	if err != nil {
+		return err
+	}
+
+	return writeDeploymentConfiguration(
+		ctx,
+		deployment,
+		exasolState,
+		configuration,
+	)
+}
+
+// applyConfigurationReset resets either the explicitly selected options or,
+// when resetAll is set, every option in the configuration.
+//
+//nolint:revive // resetAll mirrors the command-level --all flag.
+func applyConfigurationReset(
+	configuration DeploymentConfiguration,
+	optionNames []string,
+	resetAll bool,
+) (DeploymentConfiguration, error) {
+	if resetAll {
+		resetAllConfigurationValues(configuration.Infrastructure.Options)
+		resetAllConfigurationValues(configuration.Installation.Options)
+
+		return configuration, nil
+	}
+
+	return resetSelectedDeploymentConfiguration(configuration, optionNames)
 }
 
 func readDeploymentConfiguration(
@@ -496,7 +528,7 @@ func readInstallationConfigurationValues(
 	deployment config.DeploymentDir,
 	manifest *presets.InstallManifest,
 ) ([]DeploymentConfigValue, error) {
-	if manifest == nil || manifest.Variables == nil || len(manifest.Variables.Vars) == 0 {
+	if !manifestHasInstallationVariables(manifest) {
 		return []DeploymentConfigValue{}, nil
 	}
 
@@ -507,49 +539,73 @@ func readInstallationConfigurationValues(
 
 	values := make([]DeploymentConfigValue, 0, len(manifest.Variables.Vars))
 	for name, def := range manifest.Variables.Vars {
-		name = strings.TrimSpace(name)
-		if name == "" || def == nil || isReservedInstallationVariableName(name) {
-			continue
-		}
-		defaultValue, err := def.DefaultScalar()
+		value, included, err := installationConfigValue(name, def, currentValues)
 		if err != nil {
-			return nil, fmt.Errorf("invalid default for installation variable %q: %w", name, err)
+			return nil, err
 		}
-		effectiveType, err := def.EffectiveType()
-		if err != nil {
-			return nil, fmt.Errorf("invalid definition of installation variable %q: %w", name, err)
+		if included {
+			values = append(values, value)
 		}
-		value := defaultValue
-		if current, ok := currentValues[name]; ok {
-			value = current
-		}
-		rawValue, err := scalarToRawString(value)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"invalid current value for installation variable %q: %w",
-				name,
-				err,
-			)
-		}
-		rawDefault, err := scalarToRawString(defaultValue)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"invalid default value for installation variable %q: %w",
-				name,
-				err,
-			)
-		}
-		values = append(values, DeploymentConfigValue{
-			Name:       name,
-			Type:       installationVariableType(effectiveType),
-			Value:      value,
-			Default:    defaultValue,
-			RawValue:   rawValue,
-			RawDefault: rawDefault,
-		})
 	}
 
 	return values, nil
+}
+
+func manifestHasInstallationVariables(manifest *presets.InstallManifest) bool {
+	return manifest != nil && manifest.Variables != nil && len(manifest.Variables.Vars) > 0
+}
+
+// installationConfigValue builds the DeploymentConfigValue for a single
+// installation variable definition. included is false for names that should
+// be skipped entirely (blank, nil definition, or reserved).
+func installationConfigValue(
+	name string,
+	def *presets.VariableDef,
+	currentValues map[string]any,
+) (DeploymentConfigValue, bool, error) {
+	name = strings.TrimSpace(name)
+	if name == "" || def == nil || isReservedInstallationVariableName(name) {
+		return DeploymentConfigValue{}, false, nil
+	}
+
+	defaultValue, err := def.DefaultScalar()
+	if err != nil {
+		return DeploymentConfigValue{}, false, fmt.Errorf(
+			"invalid default for installation variable %q: %w", name, err,
+		)
+	}
+	effectiveType, err := def.EffectiveType()
+	if err != nil {
+		return DeploymentConfigValue{}, false, fmt.Errorf(
+			"invalid definition of installation variable %q: %w", name, err,
+		)
+	}
+
+	currentValue := defaultValue
+	if current, ok := currentValues[name]; ok {
+		currentValue = current
+	}
+	rawValue, err := scalarToRawString(currentValue)
+	if err != nil {
+		return DeploymentConfigValue{}, false, fmt.Errorf(
+			"invalid current value for installation variable %q: %w", name, err,
+		)
+	}
+	rawDefault, err := scalarToRawString(defaultValue)
+	if err != nil {
+		return DeploymentConfigValue{}, false, fmt.Errorf(
+			"invalid default value for installation variable %q: %w", name, err,
+		)
+	}
+
+	return DeploymentConfigValue{
+		Name:       name,
+		Type:       installationVariableType(effectiveType),
+		Value:      currentValue,
+		Default:    defaultValue,
+		RawValue:   rawValue,
+		RawDefault: rawDefault,
+	}, true, nil
 }
 
 func readCurrentInstallationVariables(

--- a/internal/deploy/deploymentControl.go
+++ b/internal/deploy/deploymentControl.go
@@ -343,83 +343,7 @@ func workflowStatePermitsStop(
 func Stop(ctx context.Context, deployment config.DeploymentDir, verbose bool) error {
 	err := withDeploymentExclusiveLock(ctx, deployment,
 		func(deployment config.DeploymentDir) error {
-			exasolState, err := config.ReadExasolPersonalState(deployment)
-			if err != nil {
-				return err
-			}
-
-			if err = reconcileLocalVMState(ctx, exasolState, deployment); err != nil {
-				return err
-			}
-
-			decision, err := workflowStatePermitsStop(exasolState)
-			if err != nil {
-				return util.LoggedError(err, "run `status` for more information")
-			}
-			if !decision.shouldRun {
-				logLifecycleGuidance(decision.guidance)
-
-				return nil
-			}
-
-			slog.Info("stopping deployment. this may take a few minutes")
-
-			// Set the workflowstate to stop in-progress
-			err = exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateOperationInProgress{
-				Operation: config.StopOperation,
-			}, deployment)
-			if err != nil {
-				slog.Error("failed to set workflow state to in-progress", "error", err.Error())
-			}
-
-			// Register signal handler for catching interruptions and set state
-			// in case of interruption
-			unregister, _ := util.RegisterOnceSignalHandler(func() {
-				slog.Warn("Stop Operation interrupted")
-				_ = exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateInterrupted{
-					Error:                      "Stop Operation interrupted via signal",
-					InterruptedDuringOperation: config.StopOperation,
-				}, deployment)
-			})
-
-			// Fallback cleanup
-			defer unregister()
-
-			manifest, err := config.ReadInfrastructureManifest(deployment)
-			if err != nil {
-				return err
-			}
-			backend, err := newDeploymentBackend(deployment, manifest)
-			if err != nil {
-				return err
-			}
-
-			var externalCommandOutput io.Writer
-			if verbose {
-				externalCommandOutput = os.Stderr
-			}
-
-			if err := backend.Stop(
-				ctx,
-				externalCommandOutput,
-				externalCommandOutput,
-			); err != nil {
-				unregister()
-
-				return markOperationInterrupted(exasolState, deployment, config.StopOperation, err)
-			}
-
-			// Stop handling interrupts before committing final stopped state
-			unregister()
-
-			err = exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateStopped{}, deployment)
-			if err != nil {
-				slog.Error("failed to set workflow state", "error", err.Error())
-			}
-
-			slog.Info("database is stopped and no longer accepts connections")
-
-			return nil
+			return stopLocked(ctx, deployment, verbose)
 		})
 	if errors.Is(err, ErrDeploymentDirectoryLocked) {
 		slog.Warn(err.Error())
@@ -427,4 +351,99 @@ func Stop(ctx context.Context, deployment config.DeploymentDir, verbose bool) er
 	}
 
 	return err
+}
+
+func stopLocked(ctx context.Context, deployment config.DeploymentDir, verbose bool) error {
+	exasolState, err := config.ReadExasolPersonalState(deployment)
+	if err != nil {
+		return err
+	}
+
+	if err := reconcileLocalVMState(ctx, exasolState, deployment); err != nil {
+		return err
+	}
+
+	decision, err := workflowStatePermitsStop(exasolState)
+	if err != nil {
+		return util.LoggedError(err, "run `status` for more information")
+	}
+	if !decision.shouldRun {
+		logLifecycleGuidance(decision.guidance)
+
+		return nil
+	}
+
+	slog.Info("stopping deployment. this may take a few minutes")
+
+	// Set the workflowstate to stop in-progress
+	if err := exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateOperationInProgress{
+		Operation: config.StopOperation,
+	}, deployment); err != nil {
+		slog.Error("failed to set workflow state to in-progress", "error", err.Error())
+	}
+
+	return runStopBackend(ctx, exasolState, deployment, verbose)
+}
+
+// runStopBackend registers the interruption signal handler, invokes the
+// backend's stop operation, and commits the final stopped state. It is
+// split out from stopLocked so the signal-handler lifetime (registered
+// right before the backend call, unregistered right after) stays scoped
+// to a single, easy-to-audit block.
+//
+//nolint:revive // verbose mirrors the command-level --verbose flag.
+func runStopBackend(
+	ctx context.Context,
+	exasolState *config.ExasolPersonalState,
+	deployment config.DeploymentDir,
+	verbose bool,
+) error {
+	// Register signal handler for catching interruptions and set state
+	// in case of interruption
+	unregister, _ := util.RegisterOnceSignalHandler(func() {
+		slog.Warn("Stop Operation interrupted")
+		_ = exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateInterrupted{
+			Error:                      "Stop Operation interrupted via signal",
+			InterruptedDuringOperation: config.StopOperation,
+		}, deployment)
+	})
+
+	// Fallback cleanup
+	defer unregister()
+
+	manifest, err := config.ReadInfrastructureManifest(deployment)
+	if err != nil {
+		return err
+	}
+	backend, err := newDeploymentBackend(deployment, manifest)
+	if err != nil {
+		return err
+	}
+
+	var externalCommandOutput io.Writer
+	if verbose {
+		externalCommandOutput = os.Stderr
+	}
+
+	if err := backend.Stop(
+		ctx,
+		externalCommandOutput,
+		externalCommandOutput,
+	); err != nil {
+		unregister()
+
+		return markOperationInterrupted(exasolState, deployment, config.StopOperation, err)
+	}
+
+	// Stop handling interrupts before committing final stopped state
+	unregister()
+
+	err = exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateStopped{}, deployment)
+	if err != nil {
+		slog.Error("failed to set workflow state", "error", err.Error())
+	}
+
+	slog.Info("database is stopped and no longer accepts connections")
+
+	return nil
 }

--- a/internal/deploy/shared.go
+++ b/internal/deploy/shared.go
@@ -133,36 +133,63 @@ func PollWithBackoff(
 			return nil
 		}
 
-		logValues := []any{"elapsed_seconds", elapsed, "next_retry_in_seconds", backoff}
-		if !deadline.IsZero() {
-			remaining := int(time.Until(deadline).Seconds())
-			if remaining < 0 {
-				remaining = 0
-			}
-			logValues = append(logValues, "remaining_seconds", remaining)
-		}
-		slog.Info(params.LogPrefix, logValues...)
+		logPollAttempt(params.LogPrefix, elapsed, backoff, deadline)
 
-		// Sleep with backoff, handle cancellation
-		select {
-		case <-ctx.Done():
-			if lastErr != nil {
-				slog.Info(params.LogPrefix+" timeout/cancelled",
-					"elapsed_seconds", elapsed, "last_error", lastErr.Error())
-
-				return lastErr
-			}
-
-			return ctx.Err()
-		case <-time.After(time.Duration(backoff) * time.Second):
+		waitErr := awaitNextPollAttempt(ctx, backoff, elapsed, lastErr, params.LogPrefix)
+		if waitErr != nil {
+			return waitErr
 		}
 
 		elapsed += backoff
-		if backoff < params.MaxBackoff {
-			backoff *= 2
-			if backoff > params.MaxBackoff {
-				backoff = params.MaxBackoff
-			}
-		}
+		backoff = nextBackoff(backoff, params.MaxBackoff)
 	}
+}
+
+func logPollAttempt(logPrefix string, elapsed, backoff int, deadline time.Time) {
+	logValues := []any{"elapsed_seconds", elapsed, "next_retry_in_seconds", backoff}
+	if !deadline.IsZero() {
+		remaining := int(time.Until(deadline).Seconds())
+		if remaining < 0 {
+			remaining = 0
+		}
+		logValues = append(logValues, "remaining_seconds", remaining)
+	}
+	slog.Info(logPrefix, logValues...)
+}
+
+// awaitNextPollAttempt sleeps for backoff, handling cancellation. It returns
+// nil once the backoff interval elapses (meaning polling should continue),
+// or the error PollWithBackoff should return if ctx is done first.
+func awaitNextPollAttempt(
+	ctx context.Context,
+	backoff, elapsed int,
+	lastErr error,
+	logPrefix string,
+) error {
+	select {
+	case <-ctx.Done():
+		if lastErr != nil {
+			slog.Info(logPrefix+" timeout/cancelled",
+				"elapsed_seconds", elapsed, "last_error", lastErr.Error())
+
+			return lastErr
+		}
+
+		return ctx.Err()
+	case <-time.After(time.Duration(backoff) * time.Second):
+		return nil
+	}
+}
+
+func nextBackoff(backoff, maxBackoff int) int {
+	if backoff >= maxBackoff {
+		return backoff
+	}
+
+	backoff *= 2
+	if backoff > maxBackoff {
+		backoff = maxBackoff
+	}
+
+	return backoff
 }

--- a/internal/deploy/tofu_backend.go
+++ b/internal/deploy/tofu_backend.go
@@ -120,73 +120,88 @@ func (b *tofuBackend) ReadConfiguration() ([]DeploymentConfigValue, error) {
 		return nil, err
 	}
 
-	currentValues := map[string]cty.Value{}
-	tfvarsData, err := os.ReadFile(b.cfg.VarsOutputFile())
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
+	currentValues, err := b.loadCurrentTofuValues()
+	if err != nil {
 		return nil, err
-	}
-	if err == nil {
-		currentValues, err = tofu.ParseVarsValuesFile(tfvarsData, b.cfg.VarsOutputFile())
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	values := make([]DeploymentConfigValue, 0, len(defaults))
 	for name, variable := range defaults {
-		if variable == nil {
+		value, ok, err := tofuConfigValueForVariable(name, variable, currentValues)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
 			continue
 		}
-		if _, reserved := tofuReservedVariableNames[name]; reserved {
-			continue
-		}
-		value := variable.Value
-		if current, ok := currentValues[name]; ok {
-			value = current
-		}
-		scalar, err := ctyScalarToGoValue(value)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"invalid current value for infrastructure variable %q: %w",
-				name,
-				err,
-			)
-		}
-		defaultScalar, err := ctyScalarToGoValue(variable.Value)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"invalid default value for infrastructure variable %q: %w",
-				name,
-				err,
-			)
-		}
-		rawValue, err := ctyScalarToRawString(value)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"invalid current value for infrastructure variable %q: %w",
-				name,
-				err,
-			)
-		}
-		rawDefault, err := ctyScalarToRawString(variable.Value)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"invalid default value for infrastructure variable %q: %w",
-				name,
-				err,
-			)
-		}
-		values = append(values, DeploymentConfigValue{
-			Name:       name,
-			Type:       tofuVariableType(variable.Type),
-			Value:      scalar,
-			Default:    defaultScalar,
-			RawValue:   rawValue,
-			RawDefault: rawDefault,
-		})
+		values = append(values, value)
 	}
 
 	return values, nil
+}
+
+// tofuConfigValueForVariable resolves a single infrastructure variable's
+// current and default config values. The second return value reports whether
+// the variable is user-facing at all (false for nil entries and reserved
+// names, which callers should skip).
+func tofuConfigValueForVariable(
+	name string,
+	variable *tofu.Variable,
+	currentValues map[string]cty.Value,
+) (DeploymentConfigValue, bool, error) {
+	if variable == nil {
+		return DeploymentConfigValue{}, false, nil
+	}
+	if _, reserved := tofuReservedVariableNames[name]; reserved {
+		return DeploymentConfigValue{}, false, nil
+	}
+
+	value := variable.Value
+	if current, ok := currentValues[name]; ok {
+		value = current
+	}
+
+	scalar, err := ctyScalarToGoValue(value)
+	if err != nil {
+		return DeploymentConfigValue{}, false, fmt.Errorf(
+			"invalid current value for infrastructure variable %q: %w",
+			name,
+			err,
+		)
+	}
+	defaultScalar, err := ctyScalarToGoValue(variable.Value)
+	if err != nil {
+		return DeploymentConfigValue{}, false, fmt.Errorf(
+			"invalid default value for infrastructure variable %q: %w",
+			name,
+			err,
+		)
+	}
+	rawValue, err := ctyScalarToRawString(value)
+	if err != nil {
+		return DeploymentConfigValue{}, false, fmt.Errorf(
+			"invalid current value for infrastructure variable %q: %w",
+			name,
+			err,
+		)
+	}
+	rawDefault, err := ctyScalarToRawString(variable.Value)
+	if err != nil {
+		return DeploymentConfigValue{}, false, fmt.Errorf(
+			"invalid default value for infrastructure variable %q: %w",
+			name,
+			err,
+		)
+	}
+
+	return DeploymentConfigValue{
+		Name:       name,
+		Type:       tofuVariableType(variable.Type),
+		Value:      scalar,
+		Default:    defaultScalar,
+		RawValue:   rawValue,
+		RawDefault: rawDefault,
+	}, true, nil
 }
 
 func (b *tofuBackend) ReadDeploymentConfigVariables() (
@@ -504,6 +519,22 @@ func (b *tofuBackend) Destroy(
 
 func (b *tofuBackend) hasTofu() bool {
 	return b.cfg != nil
+}
+
+// loadCurrentTofuValues reads the deployment's applied tfvars file, returning
+// an empty set (rather than an error) when the deployment has not been
+// configured yet.
+func (b *tofuBackend) loadCurrentTofuValues() (map[string]cty.Value, error) {
+	tfvarsData, err := os.ReadFile(b.cfg.VarsOutputFile())
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]cty.Value{}, nil
+		}
+
+		return nil, err
+	}
+
+	return tofu.ParseVarsValuesFile(tfvarsData, b.cfg.VarsOutputFile())
 }
 
 func (b *tofuBackend) loadDefaults() (map[string]*tofu.Variable, error) {

--- a/internal/directorymutex/directorymutex.go
+++ b/internal/directorymutex/directorymutex.go
@@ -222,36 +222,44 @@ func (m *DirectoryMutex) tryAcquire(mode lockMode) (bool, error) {
 
 	switch mode {
 	case modeExclusive:
-		if marker != nil {
-			return false, errWouldBlock
-		}
-
-		return m.createMarker(exclusiveMarkerName)
+		return m.tryAcquireExclusive(marker)
 	case modeShared:
-		if marker == nil {
-			return m.createMarker(sharedMarkerName(1))
-		}
-		if marker.mode == modeExclusive {
-			return false, errWouldBlock
-		}
-		if marker.mode != modeShared {
-			return false, ErrInvalidMarker
-		}
-
-		nextName := sharedMarkerName(marker.count + 1)
-		nextPath := filepath.Join(m.path, nextName)
-		if err := os.Rename(marker.path, nextPath); err != nil {
-			if os.IsNotExist(err) || os.IsExist(err) {
-				return false, errWouldBlock
-			}
-
-			return false, err
-		}
-
-		return true, nil
+		return m.tryAcquireShared(marker)
 	default:
 		return false, fmt.Errorf("unsupported lock mode: %d", mode)
 	}
+}
+
+func (m *DirectoryMutex) tryAcquireExclusive(marker *markerInfo) (bool, error) {
+	if marker != nil {
+		return false, errWouldBlock
+	}
+
+	return m.createMarker(exclusiveMarkerName)
+}
+
+func (m *DirectoryMutex) tryAcquireShared(marker *markerInfo) (bool, error) {
+	if marker == nil {
+		return m.createMarker(sharedMarkerName(1))
+	}
+	if marker.mode == modeExclusive {
+		return false, errWouldBlock
+	}
+	if marker.mode != modeShared {
+		return false, ErrInvalidMarker
+	}
+
+	nextName := sharedMarkerName(marker.count + 1)
+	nextPath := filepath.Join(m.path, nextName)
+	if err := os.Rename(marker.path, nextPath); err != nil {
+		if os.IsNotExist(err) || os.IsExist(err) {
+			return false, errWouldBlock
+		}
+
+		return false, err
+	}
+
+	return true, nil
 }
 
 func (m *DirectoryMutex) tryRelease(mode lockMode) (bool, error) {

--- a/internal/directorymutex/directorymutex.go
+++ b/internal/directorymutex/directorymutex.go
@@ -411,7 +411,7 @@ func withTimeoutIfMissing(
 		return context.WithTimeout(context.Background(), timeout)
 	}
 	if _, hasDeadline := ctx.Deadline(); hasDeadline {
-		return ctx, func() {}
+		return ctx, func() { /* no-op: caller-provided ctx already owns its own cancellation */ }
 	}
 
 	return context.WithTimeout(ctx, timeout)

--- a/internal/runtimeartifacts/cache.go
+++ b/internal/runtimeartifacts/cache.go
@@ -258,36 +258,14 @@ func (c *Cache) Clean(ctx context.Context, opts CleanOptions) (CleanSummary, err
 			return err
 		}
 		if opts.Mode == CleanupModePartialDownloads {
-			plan, planErr := c.planPartialDownloadCleanup()
-			summary = plan.summary(opts.DryRun)
-			if planErr != nil || opts.DryRun {
-				return planErr
-			}
+			summary, err = c.cleanPartialDownloads(opts.DryRun)
 
-			return removePartialDownloads(plan)
-		}
-
-		index, _, err := c.readIndex()
-		if err != nil {
-			// If we can't read the cache index, we treat it as empty so we can
-			// still wipe the cache.
-			index = emptyCacheIndex()
-		}
-		plan, err := c.planCleanup(index, cfg, opts)
-		summary = plan.summary()
-		if err == nil && !opts.DryRun {
-			if opts.Mode == CleanupModeAll {
-				err = c.wipeCacheContents(&index)
-			} else {
-				err = c.removeEntries(&index, plan)
-			}
-		}
-		if err != nil || opts.DryRun {
 			return err
 		}
-		index.LastCleanup = c.clock.Now().UTC()
 
-		return c.writeIndex(index)
+		summary, err = c.cleanIndexedEntries(cfg, opts)
+
+		return err
 	})
 
 	return summary, err
@@ -295,6 +273,41 @@ func (c *Cache) Clean(ctx context.Context, opts CleanOptions) (CleanSummary, err
 
 func (c *Cache) Unlock() error {
 	return c.clearLock()
+}
+
+//nolint:revive // dryRun mirrors the command-level --dry-run flag.
+func (c *Cache) cleanPartialDownloads(dryRun bool) (CleanSummary, error) {
+	plan, err := c.planPartialDownloadCleanup()
+	summary := plan.summary(dryRun)
+	if err != nil || dryRun {
+		return summary, err
+	}
+
+	return summary, removePartialDownloads(plan)
+}
+
+func (c *Cache) cleanIndexedEntries(cfg CacheConfig, opts CleanOptions) (CleanSummary, error) {
+	index, _, err := c.readIndex()
+	if err != nil {
+		// If we can't read the cache index, we treat it as empty so we can
+		// still wipe the cache.
+		index = emptyCacheIndex()
+	}
+	plan, err := c.planCleanup(index, cfg, opts)
+	summary := plan.summary()
+	if err == nil && !opts.DryRun {
+		if opts.Mode == CleanupModeAll {
+			err = c.wipeCacheContents(&index)
+		} else {
+			err = c.removeEntries(&index, plan)
+		}
+	}
+	if err != nil || opts.DryRun {
+		return summary, err
+	}
+	index.LastCleanup = c.clock.Now().UTC()
+
+	return summary, c.writeIndex(index)
 }
 
 func (c *Cache) listEntries(index cacheIndex) []CacheEntryInfo {

--- a/internal/runtimeartifacts/manager.go
+++ b/internal/runtimeartifacts/manager.go
@@ -158,44 +158,12 @@ func (m *Manager) Get(
 		return "", err
 	}
 
-	noChecksum := strings.TrimSpace(artifact.Sha256) == ""
-
 	var resolvedPath string
 	err = m.cache.withExclusiveLock(ctx, func() error {
-		index, _, err := m.cache.readIndex()
-		if err != nil {
-			return err
-		}
+		var lockErr error
+		resolvedPath, lockErr = m.resolveUnderLock(ctx, resourceID, artifact, &entry)
 
-		if noChecksum {
-			slog.Info(
-				"re-fetching resource without checksum, result may not be stable",
-				"id",
-				resourceID,
-				"url",
-				artifact.URL,
-			)
-		} else {
-			cachedPath, err := m.getCacheEntry(&index, artifact, entry)
-			if err != nil {
-				return err
-			}
-			if cachedPath != "" {
-				resolvedPath = cachedPath
-				slog.Info("found resource in cache", "id", resourceID, "path", resolvedPath)
-
-				return nil
-			}
-		}
-
-		resolvedPath, err = m.refresh(ctx, resourceID, artifact, &entry, &index)
-		if err != nil {
-			return err
-		}
-
-		slog.Info("fetched resource", "id", resourceID, "path", resolvedPath)
-
-		return nil
+		return lockErr
 	})
 	if err != nil {
 		return "", err
@@ -212,6 +180,50 @@ func (m *Manager) Request(ctx context.Context, resourceID string) (string, error
 	}
 
 	return m.Get(ctx, def, resourceID)
+}
+
+// resolveUnderLock resolves the cached path for an artifact, refreshing it if
+// necessary. It must run under the cache's exclusive lock since it reads and
+// mutates the shared index.
+func (m *Manager) resolveUnderLock(
+	ctx context.Context,
+	resourceID string,
+	artifact ArtifactSpec,
+	entry *cacheIndexEntry,
+) (string, error) {
+	index, _, err := m.cache.readIndex()
+	if err != nil {
+		return "", err
+	}
+
+	if strings.TrimSpace(artifact.Sha256) == "" {
+		slog.Info(
+			"re-fetching resource without checksum, result may not be stable",
+			"id",
+			resourceID,
+			"url",
+			artifact.URL,
+		)
+	} else {
+		cachedPath, err := m.getCacheEntry(&index, artifact, *entry)
+		if err != nil {
+			return "", err
+		}
+		if cachedPath != "" {
+			slog.Info("found resource in cache", "id", resourceID, "path", cachedPath)
+
+			return cachedPath, nil
+		}
+	}
+
+	resolvedPath, err := m.refresh(ctx, resourceID, artifact, entry, &index)
+	if err != nil {
+		return "", err
+	}
+
+	slog.Info("fetched resource", "id", resourceID, "path", resolvedPath)
+
+	return resolvedPath, nil
 }
 
 func (*Manager) identify(ctx context.Context, artifact ArtifactSpec) string {
@@ -237,39 +249,54 @@ func (m *Manager) fetch(ctx context.Context, artifact ArtifactSpec, entry *cache
 			continue
 		}
 
-		fetchPath := m.cache.absolutePath(entry.ArtifactPath)
+		return m.fetchFromSource(ctx, source, artifact, entry)
+	}
 
-		_ = os.MkdirAll(filepath.Dir(fetchPath), dirPerm)
-		redirectPath, err := source.Fetch(ctx, artifact.URL, fetchPath)
-		if err != nil {
-			return err
-		}
-		if redirectPath != "" {
-			entry.RedirectPath = redirectPath
+	return fmt.Errorf("unsupported resource scheme in %q", artifact.URL)
+}
 
-			return nil
-		}
+func (m *Manager) fetchFromSource(
+	ctx context.Context,
+	source Source,
+	artifact ArtifactSpec,
+	entry *cacheIndexEntry,
+) error {
+	fetchPath := m.cache.absolutePath(entry.ArtifactPath)
 
-		info, err := os.Stat(fetchPath)
-		if err != nil {
-			return err
-		}
-
-		// Only check the checksum for files with a specified sha256.
-		if !info.IsDir() && strings.TrimSpace(artifact.Sha256) != "" {
-			actual, err := sha256OfFile(fetchPath)
-			if err != nil {
-				return err
-			}
-			if actual != artifact.Sha256 {
-				return checksumMismatchError(artifact.Sha256, actual)
-			}
-		}
+	_ = os.MkdirAll(filepath.Dir(fetchPath), dirPerm)
+	redirectPath, err := source.Fetch(ctx, artifact.URL, fetchPath)
+	if err != nil {
+		return err
+	}
+	if redirectPath != "" {
+		entry.RedirectPath = redirectPath
 
 		return nil
 	}
 
-	return fmt.Errorf("unsupported resource scheme in %q", artifact.URL)
+	return verifyFetchedChecksum(fetchPath, artifact.Sha256)
+}
+
+func verifyFetchedChecksum(fetchPath, expectedSha256 string) error {
+	info, err := os.Stat(fetchPath)
+	if err != nil {
+		return err
+	}
+
+	// Only check the checksum for files with a specified sha256.
+	if info.IsDir() || strings.TrimSpace(expectedSha256) == "" {
+		return nil
+	}
+
+	actual, err := sha256OfFile(fetchPath)
+	if err != nil {
+		return err
+	}
+	if actual != expectedSha256 {
+		return checksumMismatchError(expectedSha256, actual)
+	}
+
+	return nil
 }
 
 // resolveEmbedded materializes an embed:true resource from data compiled into

--- a/tests/tests/deployment/test_custom.py
+++ b/tests/tests/deployment/test_custom.py
@@ -112,8 +112,6 @@ def test_custom_deployment_rejects_small_instance_types(
 
     try:
         _deployment, config = request.getfixturevalue("custom_deployment")
-        assert config.instance_type == expected_instance_type
-        pytest.fail(f"Deployment should fail for instance_type={config.instance_type}")
     except (subprocess.CalledProcessError, RuntimeError):
         # Expected failure from Terraform or deployment layer - pass
         logging.info(
@@ -127,6 +125,9 @@ def test_custom_deployment_rejects_small_instance_types(
             expected_instance_type,
         )
         pytest.fail(f"Unexpected exception type: {type(unexpected).__name__}")
+    else:
+        assert config.instance_type == expected_instance_type
+        pytest.fail(f"Deployment should fail for instance_type={config.instance_type}")
 
 
 def test_custom_deployment_success(

--- a/tests/tests/deployment/test_custom.py
+++ b/tests/tests/deployment/test_custom.py
@@ -3,7 +3,6 @@
 
 """Tests using a deployment with custom configuration."""
 
-import logging
 import subprocess
 import textwrap
 from collections.abc import Iterator
@@ -110,24 +109,16 @@ def test_custom_deployment_rejects_small_instance_types(
 
     expected_instance_type = request.getfixturevalue("instance_type")
 
-    try:
+    def deploy_with_undersized_instance_type() -> None:
         _deployment, config = request.getfixturevalue("custom_deployment")
-    except (subprocess.CalledProcessError, RuntimeError):
-        # Expected failure from Terraform or deployment layer - pass
-        logging.info(
-            "Expected deployment failure for instance_type=%s",
-            expected_instance_type,
-        )
-        return
-    except Exception as unexpected:
-        logging.exception(
-            "Unexpected exception occurred for instance_type=%s",
-            expected_instance_type,
-        )
-        pytest.fail(f"Unexpected exception type: {type(unexpected).__name__}")
-    else:
         assert config.instance_type == expected_instance_type
         pytest.fail(f"Deployment should fail for instance_type={config.instance_type}")
+
+    # Deployment is expected to fail (via Terraform or the deployment layer) for
+    # undersized instance types. Any other exception fails the test with its own
+    # traceback; if deployment succeeds instead, `pytest.fail` above fails it too.
+    with pytest.raises((subprocess.CalledProcessError, RuntimeError)):
+        deploy_with_undersized_instance_type()
 
 
 def test_custom_deployment_success(

--- a/tools/cleanup/pkg/cleanup/providers/aws/arn.go
+++ b/tools/cleanup/pkg/cleanup/providers/aws/arn.go
@@ -21,83 +21,114 @@ func classifyARN(arn string) (ResourceType, string) {
 	service := parts[2]
 	resource := parts[5]
 
-	// Split resource on '/' to get type and id; some resources embed type in prefix.
-	segs := strings.Split(resource, "/")
-	if len(segs) < minSegs {
-		// Some ARNs might use ':' separators; try that.
-		alt := strings.Split(resource, ":")
-		if len(alt) >= minSegs {
-			segs = alt
-		}
-	}
-	rtype := segs[0]
-	rid := segs[len(segs)-1]
+	rtype, rid := splitResourceTypeAndID(resource)
 
-	switch service {
-	case "ec2":
-		switch rtype {
-		case "instance":
-			return ResourceEC2Instance, rid
-		case "volume":
-			return ResourceEBSVolume, rid
-		case "vpc-endpoint":
-			return ResourceVPCEndpoint, rid
-		case "internet-gateway":
-			return ResourceInternetGW, rid
-		case "route-table":
-			return ResourceRouteTable, rid
-		case "security-group":
-			return ResourceSecurityGrp, rid
-		case "subnet":
-			return ResourceSubnet, rid
-		case "vpc":
-			return ResourceVPC, rid
-		case "key-pair":
-			// EC2 key pairs: classify for display and cleanup
-			return ResourceEC2KeyPair, rid
-		default:
-			// fallthrough to synthesized type below
-		}
-	case "s3":
-		// S3 bucket ARNs are of the form arn:aws:s3:::bucket-name
-		// For S3, resource part can be like ':::bucket-name' without type segment
-		if strings.HasPrefix(resource, ":::") {
-			return ResourceS3Bucket, strings.TrimPrefix(resource, ":::")
-		}
-		// Some ARN parsers split arn:aws:s3:::bucket-name into parts where
-		// resource == "bucket-name" and region/account are empty.
-		if resource != "" {
-			return ResourceS3Bucket, resource
-		}
-	case "ssm":
-		// parameter ARNs start with parameter/<full path>
-		if rtype == "parameter" {
-			// Return the full parameter name after the "parameter/" prefix
-			// instead of only the last segment
-			full := strings.TrimPrefix(resource, "parameter/")
-			return ResourceSSMParam, full
-		}
-	case "iam":
-		// Classify common IAM resources for better display
-		switch rtype {
-		case "user":
-			return ResourceType("iam-user"), rid
-		case "role":
-			return ResourceIAMRole, rid
-		case "policy":
-			return ResourceType("iam-policy"), rid
-		case "instance-profile":
-			return ResourceIAMInstProf, rid
-		default:
-			// fallthrough
-		}
-	default:
-		// fallthrough to synthesized type below
+	if resType, id, ok := classifyByService(service, rtype, rid, resource); ok {
+		return resType, id
 	}
+
 	// Fallback: synthesize a display type from service and rtype so UI shows something meaningful
 	if rtype != "" {
 		return ResourceType(service + "-" + rtype), rid
 	}
 
 	return ResourceType(service), rid
+}
+
+// splitResourceTypeAndID splits an ARN resource segment on '/' to get type and
+// id; some resources embed the type in a ':'-separated prefix instead.
+func splitResourceTypeAndID(resource string) (string, string) {
+	segs := strings.Split(resource, "/")
+	if len(segs) < minSegs {
+		alt := strings.Split(resource, ":")
+		if len(alt) >= minSegs {
+			segs = alt
+		}
+	}
+
+	return segs[0], segs[len(segs)-1]
+}
+
+// classifyByService dispatches to the per-service classifier and reports
+// whether the service/type combination was recognized.
+func classifyByService(service, rtype, rid, resource string) (ResourceType, string, bool) {
+	switch service {
+	case "ec2":
+		if resType, ok := classifyEC2Resource(rtype); ok {
+			return resType, rid, true
+		}
+	case "s3":
+		return classifyS3Resource(resource)
+	case "ssm":
+		return classifySSMResource(rtype, resource)
+	case "iam":
+		if resType, ok := classifyIAMResource(rtype); ok {
+			return resType, rid, true
+		}
+	}
+
+	return "", "", false
+}
+
+func classifyEC2Resource(rtype string) (ResourceType, bool) {
+	switch rtype {
+	case "instance":
+		return ResourceEC2Instance, true
+	case "volume":
+		return ResourceEBSVolume, true
+	case "vpc-endpoint":
+		return ResourceVPCEndpoint, true
+	case "internet-gateway":
+		return ResourceInternetGW, true
+	case "route-table":
+		return ResourceRouteTable, true
+	case "security-group":
+		return ResourceSecurityGrp, true
+	case "subnet":
+		return ResourceSubnet, true
+	case "vpc":
+		return ResourceVPC, true
+	case "key-pair":
+		return ResourceEC2KeyPair, true
+	default:
+		return "", false
+	}
+}
+
+// classifyS3Resource handles S3 bucket ARNs, which are of the form
+// arn:aws:s3:::bucket-name and may parse with an empty type segment.
+func classifyS3Resource(resource string) (ResourceType, string, bool) {
+	if strings.HasPrefix(resource, ":::") {
+		return ResourceS3Bucket, strings.TrimPrefix(resource, ":::"), true
+	}
+	if resource != "" {
+		return ResourceS3Bucket, resource, true
+	}
+
+	return "", "", false
+}
+
+// classifySSMResource handles parameter ARNs, returning the full parameter
+// name after the "parameter/" prefix rather than only the last segment.
+func classifySSMResource(rtype, resource string) (ResourceType, string, bool) {
+	if rtype != "parameter" {
+		return "", "", false
+	}
+
+	return ResourceSSMParam, strings.TrimPrefix(resource, "parameter/"), true
+}
+
+func classifyIAMResource(rtype string) (ResourceType, bool) {
+	switch rtype {
+	case "user":
+		return ResourceType("iam-user"), true
+	case "role":
+		return ResourceIAMRole, true
+	case "policy":
+		return ResourceType("iam-policy"), true
+	case "instance-profile":
+		return ResourceIAMInstProf, true
+	default:
+		return "", false
+	}
 }

--- a/tools/cleanup/pkg/cleanup/providers/aws/collect.go
+++ b/tools/cleanup/pkg/cleanup/providers/aws/collect.go
@@ -408,20 +408,11 @@ func CollectDeploymentSummaries(
 				return err
 			}
 			for _, mapping := range out.ResourceTagMappingList {
-				// Primary indicator: Project == exasol-personal
-				projectTag := tagValue(mapping.Tags, "Project")
 				deploymentID := tagValue(mapping.Tags, "Deployment")
-				isModern := projectTag == "exasol-personal"
-				// Legacy deployments: no Project tag
-				if !isModern {
-					if !deploymentIDRegex.MatchString(deploymentID) {
-						continue
-					}
-				} else {
-					// Even for modern, ensure deployment tag matches strict format
-					if !deploymentIDRegex.MatchString(deploymentID) {
-						continue
-					}
+				// Applies to both modern and legacy deployments: ensure the
+				// deployment tag matches the strict format.
+				if !deploymentIDRegex.MatchString(deploymentID) {
+					continue
 				}
 
 				ownerTag := tagValue(mapping.Tags, "Owner")

--- a/tools/cleanup/pkg/cleanup/providers/aws/handlers.go
+++ b/tools/cleanup/pkg/cleanup/providers/aws/handlers.go
@@ -335,34 +335,56 @@ func (h *ec2RouteTableHandler) Delete(ctx context.Context, ref ResourceRef) erro
 	if err != nil {
 		return err
 	}
-	for _, rt := range out.RouteTables {
-		// Skip main route table (association main=true)
-		for _, assoc := range rt.Associations {
-			if assoc.Main != nil && *assoc.Main {
-				return errors.New("cannot delete main route table: " + ref.ID)
-			}
-			if assoc.RouteTableAssociationId != nil {
-				_, derr := h.client.DisassociateRouteTable(
-					ctx,
-					&ec2svc.DisassociateRouteTableInput{
-						AssociationId: assoc.RouteTableAssociationId,
-					},
-				)
-				if derr != nil {
-					return derr
-				}
-			}
-		}
+	if err := h.disassociateRouteTables(ctx, ref.ID, out.RouteTables); err != nil {
+		return err
 	}
+
 	_, err = h.client.DeleteRouteTable(
 		ctx,
 		&ec2svc.DeleteRouteTableInput{RouteTableId: aws.String(ref.ID)},
 	)
-	if err != nil {
-		if strings.Contains(err.Error(), "InvalidRouteTableID.NotFound") {
-			return nil
+	if err != nil && strings.Contains(err.Error(), "InvalidRouteTableID.NotFound") {
+		return nil
+	}
+
+	return err
+}
+
+// disassociateRouteTables detaches every subnet/gateway association from the
+// given route tables, refusing to touch the main route table.
+func (h *ec2RouteTableHandler) disassociateRouteTables(
+	ctx context.Context,
+	routeTableID string,
+	tables []ec2types.RouteTable,
+) error {
+	for _, rt := range tables {
+		for _, assoc := range rt.Associations {
+			if err := h.disassociateRouteTableAssociation(ctx, routeTableID, assoc); err != nil {
+				return err
+			}
 		}
 	}
+
+	return nil
+}
+
+func (h *ec2RouteTableHandler) disassociateRouteTableAssociation(
+	ctx context.Context,
+	routeTableID string,
+	assoc ec2types.RouteTableAssociation,
+) error {
+	if assoc.Main != nil && *assoc.Main {
+		return errors.New("cannot delete main route table: " + routeTableID)
+	}
+	if assoc.RouteTableAssociationId == nil {
+		return nil
+	}
+	_, err := h.client.DisassociateRouteTable(
+		ctx,
+		&ec2svc.DisassociateRouteTableInput{
+			AssociationId: assoc.RouteTableAssociationId,
+		},
+	)
 
 	return err
 }

--- a/tools/cleanup/pkg/cleanup/providers/aws/handlers.go
+++ b/tools/cleanup/pkg/cleanup/providers/aws/handlers.go
@@ -224,6 +224,9 @@ func (h *ec2InternetGatewayHandler) Delete(ctx context.Context, ref ResourceRef)
 	return lastErr
 }
 
+// errInvalidVpcEndpointIDNotFound is the AWS error code returned when a VPC endpoint no longer exists.
+const errInvalidVpcEndpointIDNotFound = "InvalidVpcEndpointId.NotFound"
+
 // VPC Endpoint handler: remove route table entries referencing the endpoint, then delete the endpoint.
 type ec2VpcEndpointHandler struct{ client *ec2svc.Client }
 
@@ -237,7 +240,7 @@ func (h *ec2VpcEndpointHandler) Delete(ctx context.Context, ref ResourceRef) err
 	if err != nil {
 		// If not found, treat as success
 		if strings.Contains(err.Error(), "VpcEndpointIdNotFound") ||
-			strings.Contains(err.Error(), "InvalidVpcEndpointId.NotFound") {
+			strings.Contains(err.Error(), errInvalidVpcEndpointIDNotFound) {
 			return nil
 		}
 		return err
@@ -261,7 +264,7 @@ func (h *ec2VpcEndpointHandler) Delete(ctx context.Context, ref ResourceRef) err
 		return nil
 	}
 	// Treat not found as success
-	if strings.Contains(delErr.Error(), "InvalidVpcEndpointId.NotFound") ||
+	if strings.Contains(delErr.Error(), errInvalidVpcEndpointIDNotFound) ||
 		strings.Contains(delErr.Error(), "VpcEndpointIdNotFound") {
 		return nil
 	}
@@ -308,7 +311,7 @@ func (h *ec2VpcEndpointHandler) Delete(ctx context.Context, ref ResourceRef) err
 		VpcEndpointIds: []string{ref.ID},
 	})
 	if retryErr != nil {
-		if strings.Contains(retryErr.Error(), "InvalidVpcEndpointId.NotFound") ||
+		if strings.Contains(retryErr.Error(), errInvalidVpcEndpointIDNotFound) ||
 			strings.Contains(retryErr.Error(), "VpcEndpointIdNotFound") {
 			return nil
 		}

--- a/tools/cleanup/pkg/cleanup/providers/aws/run.go
+++ b/tools/cleanup/pkg/cleanup/providers/aws/run.go
@@ -42,35 +42,62 @@ func PlanActions(details *DeploymentDetails, typeFilter []ResourceType) ([]Actio
 	if details == nil || len(details.Resources) == 0 {
 		return nil, ErrNoResourcesPlanned
 	}
-	filter := map[ResourceType]struct{}{}
-	for _, t := range typeFilter {
-		filter[t] = struct{}{}
-	}
+	filter := buildTypeFilter(typeFilter)
 	plan := BuildPlan()
 	var actions []Action
 	for _, phase := range plan.Phases {
-		for _, resource := range details.Resources {
-			if !containsType(phase.Types, resource.Ref.Type) {
-				continue
-			}
-			if len(filter) > 0 {
-				if _, ok := filter[resource.Ref.Type]; !ok {
-					continue
-				}
-			}
-			act := Action{Ref: resource.Ref, Op: opForResource(resource), Reason: ""}
-			if resource.Protected {
-				act.Op = OpSkip
-				act.Reason = "protected"
-			}
-			actions = append(actions, act)
-		}
+		actions = append(actions, actionsForPhase(phase, details.Resources, filter)...)
 	}
 	if len(actions) == 0 {
 		return nil, ErrNoResourcesPlanned
 	}
 
 	return actions, nil
+}
+
+func buildTypeFilter(typeFilter []ResourceType) map[ResourceType]struct{} {
+	filter := map[ResourceType]struct{}{}
+	for _, t := range typeFilter {
+		filter[t] = struct{}{}
+	}
+
+	return filter
+}
+
+// actionsForPhase builds the actions for resources belonging to a single phase.
+func actionsForPhase(phase Phase, resources []ResourceMeta, filter map[ResourceType]struct{}) []Action {
+	var actions []Action
+	for _, resource := range resources {
+		if !resourceMatchesPhase(resource, phase, filter) {
+			continue
+		}
+		actions = append(actions, buildAction(resource))
+	}
+
+	return actions
+}
+
+func resourceMatchesPhase(resource ResourceMeta, phase Phase, filter map[ResourceType]struct{}) bool {
+	if !containsType(phase.Types, resource.Ref.Type) {
+		return false
+	}
+	if len(filter) > 0 {
+		if _, ok := filter[resource.Ref.Type]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+func buildAction(resource ResourceMeta) Action {
+	act := Action{Ref: resource.Ref, Op: opForResource(resource), Reason: ""}
+	if resource.Protected {
+		act.Op = OpSkip
+		act.Reason = "protected"
+	}
+
+	return act
 }
 
 func containsType(list []ResourceType, t ResourceType) bool {

--- a/tools/cleanup/pkg/cleanup/providers/azure/collect.go
+++ b/tools/cleanup/pkg/cleanup/providers/azure/collect.go
@@ -35,40 +35,60 @@ func CollectDeploymentSummaries(
 			return nil, fmt.Errorf("failed to list Azure resource groups: %w", err)
 		}
 		for _, group := range page.Value {
-			if group == nil || group.Name == nil {
-				continue
-			}
-			if !matchesDeploymentTags(group.Tags, legacy) {
-				continue
-			}
-			rgLocation := valueOrEmpty(group.Location)
-			if !matchesLocation(location, rgLocation) {
-				continue
-			}
-			owner := tagValue(group.Tags, tagOwner)
-			if !ownerMatchesFilter(owner, ownerFilter) {
-				continue
-			}
-
-			resources, err := listResourcesInGroup(ctx, cl, *group.Name)
+			summary, ok, err := summarizeDeploymentGroup(ctx, cl, group, location, ownerFilter, legacy)
 			if err != nil {
 				return nil, err
 			}
-
-			summaries = append(summaries, DeploymentSummary{
-				ID:        tagValue(group.Tags, tagDeployment),
-				Provider:  ProviderName,
-				Region:    rgLocation,
-				Owner:     ownerOrDash(owner),
-				CreatedAt: parseCreatedAt(tagValue(group.Tags, tagCreatedAt)),
-				State:     deriveState(resources),
-				// Count the resource group itself alongside the resources it holds.
-				Resources: len(resources) + 1,
-			})
+			if ok {
+				summaries = append(summaries, summary)
+			}
 		}
 	}
 
 	return summaries, nil
+}
+
+// summarizeDeploymentGroup builds a DeploymentSummary for a resource group,
+// reporting ok=false when the group doesn't match the deployment/location/owner
+// filters and is not part of the result set.
+func summarizeDeploymentGroup(
+	ctx context.Context,
+	cl *clients,
+	group *armresources.ResourceGroup,
+	location string,
+	ownerFilter string,
+	legacy bool,
+) (DeploymentSummary, bool, error) {
+	if group == nil || group.Name == nil {
+		return DeploymentSummary{}, false, nil
+	}
+	if !matchesDeploymentTags(group.Tags, legacy) {
+		return DeploymentSummary{}, false, nil
+	}
+	rgLocation := valueOrEmpty(group.Location)
+	if !matchesLocation(location, rgLocation) {
+		return DeploymentSummary{}, false, nil
+	}
+	owner := tagValue(group.Tags, tagOwner)
+	if !ownerMatchesFilter(owner, ownerFilter) {
+		return DeploymentSummary{}, false, nil
+	}
+
+	resources, err := listResourcesInGroup(ctx, cl, *group.Name)
+	if err != nil {
+		return DeploymentSummary{}, false, err
+	}
+
+	return DeploymentSummary{
+		ID:        tagValue(group.Tags, tagDeployment),
+		Provider:  ProviderName,
+		Region:    rgLocation,
+		Owner:     ownerOrDash(owner),
+		CreatedAt: parseCreatedAt(tagValue(group.Tags, tagCreatedAt)),
+		State:     deriveState(resources),
+		// Count the resource group itself alongside the resources it holds.
+		Resources: len(resources) + 1,
+	}, true, nil
 }
 
 // CollectDeploymentDetails returns the resource group for a deployment together

--- a/tools/cleanup/pkg/cleanup/providers/exoscale/run.go
+++ b/tools/cleanup/pkg/cleanup/providers/exoscale/run.go
@@ -36,41 +36,63 @@ func PlanActions(details *DeploymentDetails, typeFilter []ResourceType) ([]Actio
 	if details == nil || len(details.Resources) == 0 {
 		return nil, ErrNoResourcesPlanned
 	}
-	filter := map[ResourceType]struct{}{}
-	for _, t := range typeFilter {
-		filter[t] = struct{}{}
-	}
+	filter := buildTypeFilter(typeFilter)
 	plan := BuildPlan()
 	var actions []Action
 	for _, phase := range plan.Phases {
-		for _, resource := range details.Resources {
-			name, _ := resource.Attr["name"].(string)
-			state, _ := resource.Attr["state"].(string)
-			if !containsType(phase.Types, resource.Ref.Type) {
-				slog.Debug("PlanActions: skipping resource (type not in phase)", "type", resource.Ref.Type, "name", name, "state", state)
-				continue
-			}
-			if len(filter) > 0 {
-				if _, ok := filter[resource.Ref.Type]; !ok {
-					slog.Debug("PlanActions: skipping resource (type filtered)", "type", resource.Ref.Type, "name", name, "state", state)
-					continue
-				}
-			}
-			act := Action{Ref: resource.Ref, Op: opForResource(resource), Reason: ""}
-			if resource.Protected {
-				act.Op = OpSkip
-				act.Reason = "protected"
-				slog.Debug("PlanActions: skipping resource (protected)", "type", resource.Ref.Type, "name", name, "state", state)
-			}
-			slog.Debug("PlanActions: adding action", "type", resource.Ref.Type, "name", name, "state", state, "op", act.Op)
-			actions = append(actions, act)
-		}
+		actions = append(actions, actionsForPhase(phase, details.Resources, filter)...)
 	}
 	if len(actions) == 0 {
 		return nil, ErrNoResourcesPlanned
 	}
 
 	return actions, nil
+}
+
+func buildTypeFilter(typeFilter []ResourceType) map[ResourceType]struct{} {
+	filter := map[ResourceType]struct{}{}
+	for _, t := range typeFilter {
+		filter[t] = struct{}{}
+	}
+
+	return filter
+}
+
+// actionsForPhase builds the actions for resources belonging to a single phase,
+// logging why any resource was skipped.
+func actionsForPhase(phase Phase, resources []ResourceMeta, filter map[ResourceType]struct{}) []Action {
+	var actions []Action
+	for _, resource := range resources {
+		if act, ok := planActionForResource(phase, resource, filter); ok {
+			actions = append(actions, act)
+		}
+	}
+
+	return actions
+}
+
+func planActionForResource(phase Phase, resource ResourceMeta, filter map[ResourceType]struct{}) (Action, bool) {
+	name, _ := resource.Attr["name"].(string)
+	state, _ := resource.Attr["state"].(string)
+	if !containsType(phase.Types, resource.Ref.Type) {
+		slog.Debug("PlanActions: skipping resource (type not in phase)", "type", resource.Ref.Type, "name", name, "state", state)
+		return Action{}, false
+	}
+	if len(filter) > 0 {
+		if _, ok := filter[resource.Ref.Type]; !ok {
+			slog.Debug("PlanActions: skipping resource (type filtered)", "type", resource.Ref.Type, "name", name, "state", state)
+			return Action{}, false
+		}
+	}
+	act := Action{Ref: resource.Ref, Op: opForResource(resource), Reason: ""}
+	if resource.Protected {
+		act.Op = OpSkip
+		act.Reason = "protected"
+		slog.Debug("PlanActions: skipping resource (protected)", "type", resource.Ref.Type, "name", name, "state", state)
+	}
+	slog.Debug("PlanActions: adding action", "type", resource.Ref.Type, "name", name, "state", state, "op", act.Op)
+
+	return act, true
 }
 
 func containsType(list []ResourceType, t ResourceType) bool {

--- a/tools/cleanup/pkg/cleanup/providers/stackit/run.go
+++ b/tools/cleanup/pkg/cleanup/providers/stackit/run.go
@@ -38,35 +38,62 @@ func PlanActions(details *DeploymentDetails, typeFilter []ResourceType) ([]Actio
 	if details == nil || len(details.Resources) == 0 {
 		return nil, ErrNoResourcesPlanned
 	}
-	filter := map[ResourceType]struct{}{}
-	for _, t := range typeFilter {
-		filter[t] = struct{}{}
-	}
+	filter := buildTypeFilter(typeFilter)
 	plan := BuildPlan()
 	var actions []Action
 	for _, phase := range plan.Phases {
-		for _, resource := range details.Resources {
-			if !containsType(phase.Types, resource.Ref.Type) {
-				continue
-			}
-			if len(filter) > 0 {
-				if _, ok := filter[resource.Ref.Type]; !ok {
-					continue
-				}
-			}
-			act := Action{Ref: resource.Ref, Op: opForResource(resource), Reason: ""}
-			if resource.Protected {
-				act.Op = OpSkip
-				act.Reason = "protected"
-			}
-			actions = append(actions, act)
-		}
+		actions = append(actions, actionsForPhase(phase, details.Resources, filter)...)
 	}
 	if len(actions) == 0 {
 		return nil, ErrNoResourcesPlanned
 	}
 
 	return actions, nil
+}
+
+func buildTypeFilter(typeFilter []ResourceType) map[ResourceType]struct{} {
+	filter := map[ResourceType]struct{}{}
+	for _, t := range typeFilter {
+		filter[t] = struct{}{}
+	}
+
+	return filter
+}
+
+// actionsForPhase builds the actions for resources belonging to a single phase.
+func actionsForPhase(phase Phase, resources []ResourceMeta, filter map[ResourceType]struct{}) []Action {
+	var actions []Action
+	for _, resource := range resources {
+		if !resourceMatchesPhase(resource, phase, filter) {
+			continue
+		}
+		actions = append(actions, buildAction(resource))
+	}
+
+	return actions
+}
+
+func resourceMatchesPhase(resource ResourceMeta, phase Phase, filter map[ResourceType]struct{}) bool {
+	if !containsType(phase.Types, resource.Ref.Type) {
+		return false
+	}
+	if len(filter) > 0 {
+		if _, ok := filter[resource.Ref.Type]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+func buildAction(resource ResourceMeta) Action {
+	act := Action{Ref: resource.Ref, Op: opForResource(resource), Reason: ""}
+	if resource.Protected {
+		act.Op = OpSkip
+		act.Reason = "protected"
+	}
+
+	return act
 }
 
 func containsType(list []ResourceType, t ResourceType) bool {


### PR DESCRIPTION
## Description

Resolves the SonarCloud-flagged reliability, maintainability, and security-hotspot findings for exasol-personal: two direct reliability/maintainability fixes, seven refactors extracting helpers to reduce cyclomatic complexity, one test simplification, and hardening of GitHub Actions workflows and Terraform infrastructure against untrusted-input and supply-chain issues. No deployed behavior changes.

## Related Issue

SPOT-32039

## Type of Change

- [x] `fix`: Bug fix
- [x] `refactor`: Code refactoring
- [x] `test`: Test additions or changes

## Changes Made

- Resolved SonarCloud reliability and maintainability issues flagged in the Go codebase
- Extracted helpers across `install`, `Cache`/`Manager`, `Connect`, configuration/`Stop`/`PollWithBackoff`, cleanup providers, `ReadConfiguration`, and `tryAcquire` to reduce cyclomatic complexity
- Simplified an undersized-instance-type test using `pytest.raises`
- Pinned and verified `uv`/Poetry installer GitHub Actions instead of unpinned third-party actions
- Avoided expanding workflow inputs/secrets directly in `run` blocks to close a script-injection hotspot
- Hardened Terraform AWS/Azure infrastructure configuration without changing deployed behavior

## Testing

- [x] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

`task lint`, `task build`, `go test -race ./...`, and `task tests-integration` all pass on this branch. No new tests were needed — this PR is fixes and refactors of existing, already-covered behavior.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [ ] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

No CHANGELOG entry — these are internal reliability/maintainability/security-hardening changes with no user-visible CLI, deployment, or compatibility impact.
