### PR TITLE
test: Improve test coverage across under-covered packages

### DIFF
--- a/cmd/exasol/absdirvar_test.go
+++ b/cmd/exasol/absdirvar_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewAbsDirValue_EmptyDefaultLeavesTargetEmpty(t *testing.T) {
+	t.Parallel()
+
+	var target string
+	NewAbsDirValue(&target, "")
+
+	if target != "" {
+		t.Fatalf("expected an empty target for an empty default, got %q", target)
+	}
+}
+
+func TestNewAbsDirValue_ResolvesRelativeDefaultToAbsolute(t *testing.T) {
+	t.Parallel()
+
+	var target string
+	NewAbsDirValue(&target, ".")
+
+	if !filepath.IsAbs(target) {
+		t.Fatalf("expected an absolute path, got %q", target)
+	}
+}
+
+func TestAbsDirValue_StringReturnsTargetOrEmptyWhenNil(t *testing.T) {
+	t.Parallel()
+
+	value := &AbsDirValue{}
+	if got := value.String(); got != "" {
+		t.Fatalf("expected an empty string for a nil target, got %q", got)
+	}
+
+	target := "/some/path"
+	value = &AbsDirValue{target: &target}
+	if got := value.String(); got != "/some/path" {
+		t.Fatalf("expected the target value, got %q", got)
+	}
+}
+
+func TestAbsDirValue_TypeIsFilePath(t *testing.T) {
+	t.Parallel()
+
+	if got := (&AbsDirValue{}).Type(); got != "file-path" {
+		t.Fatalf("expected 'file-path', got %q", got)
+	}
+}
+
+func TestAbsDirValue_SetResolvesToAbsolutePath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	var target string
+	value := &AbsDirValue{target: &target}
+
+	if err := value.Set(dir); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if target != filepath.Clean(dir) {
+		t.Fatalf("expected the cleaned absolute path, got %q", target)
+	}
+}
+
+func TestAbsDirValue_SetAcceptsNonExistentPath(t *testing.T) {
+	t.Parallel()
+
+	var target string
+	value := &AbsDirValue{target: &target}
+	notYetCreated := filepath.Join(t.TempDir(), "not-yet-created")
+
+	if err := value.Set(notYetCreated); err != nil {
+		t.Fatalf("expected a not-yet-existing path to be accepted, got %v", err)
+	}
+}
+
+func TestAbsDirValue_SetRejectsExistingFile(t *testing.T) {
+	t.Parallel()
+
+	filePath := filepath.Join(t.TempDir(), "a-file")
+	if err := os.WriteFile(filePath, []byte("x"), 0o600); err != nil {
+		t.Fatalf("failed to write file fixture: %v", err)
+	}
+
+	var target string
+	value := &AbsDirValue{target: &target}
+
+	if err := value.Set(filePath); err == nil {
+		t.Fatal("expected an error when the path is an existing regular file")
+	}
+}

--- a/cmd/exasol/cache_test.go
+++ b/cmd/exasol/cache_test.go
@@ -164,6 +164,41 @@ func TestCacheCleanRejectsMultipleCleanupSelectors(t *testing.T) {
 	}
 }
 
+//nolint:paralleltest // modifies global clean option state.
+func TestSelectedCacheCleanupMode(t *testing.T) {
+	oldOpts := cacheCleanOpts
+	t.Cleanup(func() {
+		cacheCleanOpts = oldOpts
+	})
+
+	cacheCleanOpts = struct {
+		Invalid          bool
+		All              bool
+		PartialDownloads bool
+		DryRun           bool
+	}{Invalid: true}
+	if got := selectedCacheCleanupMode(); got != runtimeartifacts.CleanupModeInvalid {
+		t.Fatalf("expected CleanupModeInvalid, got %v", got)
+	}
+
+	cacheCleanOpts.Invalid = false
+	cacheCleanOpts.All = true
+	if got := selectedCacheCleanupMode(); got != runtimeartifacts.CleanupModeAll {
+		t.Fatalf("expected CleanupModeAll, got %v", got)
+	}
+
+	cacheCleanOpts.All = false
+	cacheCleanOpts.PartialDownloads = true
+	if got := selectedCacheCleanupMode(); got != runtimeartifacts.CleanupModePartialDownloads {
+		t.Fatalf("expected CleanupModePartialDownloads, got %v", got)
+	}
+
+	cacheCleanOpts.PartialDownloads = false
+	if got := selectedCacheCleanupMode(); got != runtimeartifacts.CleanupModeStale {
+		t.Fatalf("expected the default CleanupModeStale, got %v", got)
+	}
+}
+
 func TestCacheUnlockHelpWarnsAboutActiveLauncherProcesses(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/exasol/config_test.go
+++ b/cmd/exasol/config_test.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/json"
 	"reflect"
 	"strings"
 	"testing"
@@ -12,6 +13,34 @@ import (
 	"github.com/exasol/exasol-personal/internal/deploy"
 	"github.com/spf13/cobra"
 )
+
+func TestFormatConfigurationScalar(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		value any
+		want  string
+	}{
+		"string":      {value: "hello", want: "hello"},
+		"bool":        {value: true, want: "true"},
+		"int":         {value: 42, want: "42"},
+		"int64":       {value: int64(42), want: "42"},
+		"float64":     {value: 3.5, want: "3.5"},
+		"json.Number": {value: json.Number("7"), want: "7"},
+		"nil":         {value: nil, want: ""},
+		"unsupported": {value: []string{"x"}, want: "[x]"},
+	}
+	for name, testCase := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := formatConfigurationScalar(testCase.value); got != testCase.want {
+				t.Errorf("formatConfigurationScalar(%v) = %q, want %q",
+					testCase.value, got, testCase.want)
+			}
+		})
+	}
+}
 
 func TestConfigCommandsDeclareDeploymentPreRunRequirements(t *testing.T) {
 	t.Parallel()

--- a/cmd/exasol/deployment_logging_test.go
+++ b/cmd/exasol/deployment_logging_test.go
@@ -14,6 +14,32 @@ import (
 	"github.com/spf13/cobra"
 )
 
+//nolint:paralleltest // modifies the global deploymentLogCleanup hook.
+func TestSetDeploymentLogCleanup_NilInstallsNoopCleanup(t *testing.T) {
+	original := deploymentLogCleanup
+	t.Cleanup(func() { deploymentLogCleanup = original })
+
+	setDeploymentLogCleanup(nil)
+
+	// A no-op cleanup must be safe to call without side effects.
+	deploymentLogCleanup()
+}
+
+//nolint:paralleltest // modifies the global deploymentLogCleanup hook.
+func TestSetDeploymentLogCleanup_InstallsGivenCleanup(t *testing.T) {
+	original := deploymentLogCleanup
+	t.Cleanup(func() { deploymentLogCleanup = original })
+
+	called := false
+	setDeploymentLogCleanup(func() { called = true })
+
+	deploymentLogCleanup()
+
+	if !called {
+		t.Fatal("expected the installed cleanup function to run")
+	}
+}
+
 func TestRequireDeploymentFileLogging(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/exasol/deployments_test.go
+++ b/cmd/exasol/deployments_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/exasol/exasol-personal/internal/config"
@@ -133,6 +134,70 @@ func TestListDeploymentDirectories_ReportsRunningStatusAndPresetIdentity(t *test
 	}
 	if entries[0].Infrastructure != "aws" || entries[0].Installation != "standard" {
 		t.Fatalf("expected preset identity to be displayed, got: %#v", entries[0])
+	}
+}
+
+func TestDeploymentListEntryText_IncludesPresetWhenPresent(t *testing.T) {
+	t.Parallel()
+
+	entry := deploymentListEntry{
+		Name:           "prod",
+		Path:           "/deployments/prod",
+		Status:         deploy.StatusRunning,
+		Infrastructure: "aws",
+		Installation:   "standard",
+	}
+
+	got := deploymentListEntryText(entry)
+	want := "prod status=running preset=aws/standard path=/deployments/prod"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestDeploymentListEntryText_OmitsPresetWhenAbsent(t *testing.T) {
+	t.Parallel()
+
+	entry := deploymentListEntry{
+		Name:   "empty",
+		Path:   "/deployments/empty",
+		Status: deploy.StatusNotInitialized,
+	}
+
+	got := deploymentListEntryText(entry)
+	want := "empty status=not_initialized path=/deployments/empty"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestRenderDeploymentsListText_ReportsNoDeploymentsWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	var out strings.Builder
+	if err := renderDeploymentsListText(&out, nil); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if out.String() != "No deployment directories found.\n" {
+		t.Fatalf("expected the empty-state message, got %q", out.String())
+	}
+}
+
+func TestRenderDeploymentsListText_RendersOneLinePerEntry(t *testing.T) {
+	t.Parallel()
+
+	entries := []deploymentListEntry{
+		{Name: "a", Path: "/a", Status: deploy.StatusRunning},
+		{Name: "b", Path: "/b", Status: deploy.StatusStopped},
+	}
+
+	var out strings.Builder
+	if err := renderDeploymentsListText(&out, entries); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	want := "a status=running path=/a\nb status=stopped path=/b\n"
+	if out.String() != want {
+		t.Fatalf("expected %q, got %q", want, out.String())
 	}
 }
 

--- a/cmd/exasol/log_routing_test.go
+++ b/cmd/exasol/log_routing_test.go
@@ -61,6 +61,48 @@ func TestRoutingHandler_DoesNotLeakDebugToTerminal(t *testing.T) {
 	}
 }
 
+func TestRoutingHandler_WithAttrsDelegatesToTerminalHandler(t *testing.T) {
+	t.Parallel()
+
+	terminal := &testTerminalHandler{minLevel: slog.LevelInfo}
+	sink := &deploymentFileSink{}
+	handler := newRoutingHandler(terminal, sink)
+
+	got := handler.WithAttrs([]slog.Attr{slog.String("key", "value")})
+
+	routing, ok := got.(*routingHandler)
+	if !ok {
+		t.Fatalf("expected a *routingHandler, got %T", got)
+	}
+	if routing.terminalHandler != terminal {
+		t.Fatal("expected WithAttrs to delegate to the terminal handler and keep the same sink")
+	}
+	if routing.fileSink != sink {
+		t.Fatal("expected the file sink to be carried over unchanged")
+	}
+}
+
+func TestRoutingHandler_WithGroupDelegatesToTerminalHandler(t *testing.T) {
+	t.Parallel()
+
+	terminal := &testTerminalHandler{minLevel: slog.LevelInfo}
+	sink := &deploymentFileSink{}
+	handler := newRoutingHandler(terminal, sink)
+
+	got := handler.WithGroup("group")
+
+	routing, ok := got.(*routingHandler)
+	if !ok {
+		t.Fatalf("expected a *routingHandler, got %T", got)
+	}
+	if routing.terminalHandler != terminal {
+		t.Fatal("expected WithGroup to delegate to the terminal handler and keep the same sink")
+	}
+	if routing.fileSink != sink {
+		t.Fatal("expected the file sink to be carried over unchanged")
+	}
+}
+
 func TestRoutingHandler_DebugRecordWritesToFileSink(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/exasol/presets_list_test.go
+++ b/cmd/exasol/presets_list_test.go
@@ -6,10 +6,46 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/exasol/exasol-personal/internal/presets"
 )
+
+func TestValidateRenderPresetTypeFilter_EmptyFilterIsValid(t *testing.T) {
+	t.Parallel()
+
+	if err := validateRenderPresetTypeFilter("", ""); err != nil {
+		t.Fatalf("expected no error for an empty filter, got %v", err)
+	}
+}
+
+func TestValidateRenderPresetTypeFilter_KnownTypeIsValid(t *testing.T) {
+	t.Parallel()
+
+	err := validateRenderPresetTypeFilter(
+		presets.PresetTypeInfrastructure, presets.PresetTypeInfrastructure,
+	)
+	if err != nil {
+		t.Fatalf("expected no error for a known preset type, got %v", err)
+	}
+}
+
+func TestValidateRenderPresetTypeFilter_UnknownTypeListsAllowedTypes(t *testing.T) {
+	t.Parallel()
+
+	err := validateRenderPresetTypeFilter("bogus", "bogus")
+	if err == nil {
+		t.Fatal("expected an error for an unknown preset type")
+	}
+	if !strings.Contains(err.Error(), "bogus") {
+		t.Fatalf("expected the invalid type to be echoed back, got %v", err)
+	}
+	if !strings.Contains(err.Error(), presets.PresetTypeInfrastructure) ||
+		!strings.Contains(err.Error(), presets.PresetTypeInstallation) {
+		t.Fatalf("expected the allowed types to be listed, got %v", err)
+	}
+}
 
 func TestFilterPresetCatalog_All(t *testing.T) {
 	t.Parallel()

--- a/cmd/exasol/slc_test.go
+++ b/cmd/exasol/slc_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/exasol/exasol-personal/internal/config"
 	"github.com/exasol/exasol-personal/internal/deploy"
+	"github.com/exasol/exasol-personal/internal/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -81,6 +82,63 @@ func hasSubcommand(parent *cobra.Command, name string) bool {
 	return false
 }
 
+func TestSLCConfirmFunc_AutoApproveReturnsNilConfirmFunc(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{Use: "slc"}
+	if slcConfirmFunc(cmd, true, "install") != nil {
+		t.Fatal("expected --auto-approve to bypass confirmation entirely")
+	}
+}
+
+func TestSLCConfirmFunc_NonInteractiveStdinRefusesWithGuidance(t *testing.T) {
+	t.Parallel()
+
+	if util.IsInteractiveStdin() {
+		t.Skip("this process's stdin is a terminal; the non-interactive path isn't reachable here")
+	}
+
+	cmd := &cobra.Command{Use: "slc"}
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+
+	fn := slcConfirmFunc(cmd, false, "install")
+	if fn == nil {
+		t.Fatal("expected a non-nil confirm func when --auto-approve is not set")
+	}
+
+	confirmed, err := fn()
+	if confirmed {
+		t.Fatal("expected non-interactive stdin to never auto-confirm")
+	}
+	if err == nil || !strings.Contains(err.Error(), "--auto-approve") {
+		t.Fatalf("expected guidance to use --auto-approve, got %v", err)
+	}
+}
+
+//nolint:paralleltest // mutates shared terminal message queues
+func TestQueueSLCListJSON_QueuesFormattedJSON(t *testing.T) {
+	resetTerminalMessages()
+	defer resetTerminalMessages()
+
+	statuses := []deploy.SLCStatus{{Flavor: "python-3.12"}}
+	var customs []deploy.CustomSLCStatus
+	if err := queueSLCListJSON(statuses, customs); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	writeTerminalMessages(terminalConfig{stdout: &stdout, stderr: &stderr, showCallsToAction: true})
+
+	want, err := formatSLCListJSON(statuses, customs)
+	if err != nil {
+		t.Fatalf("failed to compute expected JSON: %v", err)
+	}
+	if strings.TrimSpace(stdout.String()) != want {
+		t.Fatalf("expected queued JSON output %q, got %q", want, stdout.String())
+	}
+}
+
 func TestRenderSLCListTextNoneAvailable(t *testing.T) {
 	t.Parallel()
 
@@ -116,6 +174,46 @@ func TestRenderSLCListTextQueuesPrimaryOutput(t *testing.T) {
 	}
 	if stderr.String() != "" {
 		t.Fatalf("unexpected stderr: %q", stderr.String())
+	}
+}
+
+func TestFormatSLCListTextRendersFlavorAliasVersionAndInstalledColumns(t *testing.T) {
+	t.Parallel()
+
+	output := formatSLCListText([]deploy.SLCStatus{
+		{
+			Flavor:    "python-3.12",
+			Aliases:   []string{"PYTHON3", "PYTHON312"},
+			Version:   "11.2.0",
+			Installed: true,
+		},
+		{
+			Flavor:    "java-17",
+			Aliases:   []string{"JAVA", "JAVA17"},
+			Version:   "11.2.0",
+			Installed: false,
+		},
+	}, nil)
+
+	if !strings.Contains(output, "FLAVOR") || !strings.Contains(output, "INSTALLED") {
+		t.Fatalf("expected a header row, got %q", output)
+	}
+	if !strings.Contains(output, "python-3.12") || !strings.Contains(output, "PYTHON3, PYTHON312") {
+		t.Fatalf("expected installed python row, got %q", output)
+	}
+	if !strings.Contains(output, "java-17") {
+		t.Fatalf("expected java row, got %q", output)
+	}
+
+	lines := strings.Split(output, "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected a header plus one line per SLC, got %d lines: %q", len(lines), output)
+	}
+	if !strings.HasSuffix(strings.TrimRight(lines[1], " \t"), "yes") {
+		t.Fatalf("expected installed python row to end in yes, got %q", lines[1])
+	}
+	if !strings.HasSuffix(strings.TrimRight(lines[2], " \t"), "no") {
+		t.Fatalf("expected non-installed java row to end in no, got %q", lines[2])
 	}
 }
 
@@ -210,6 +308,141 @@ func TestRenderSLCCommandJSONQueuesParseablePrimaryOutput(t *testing.T) {
 	}
 	if decoded["outcome"] != "deferred" {
 		t.Fatalf("unexpected outcome: %v", decoded["outcome"])
+	}
+}
+
+//nolint:paralleltest // mutates shared terminal message queues
+func TestPrintSLCInstallResultDescribesOutcomeAndReplacement(t *testing.T) {
+	cases := map[string]struct {
+		result   *deploy.SLCInstallResult
+		wantText []string
+	}{
+		"fresh install, deferred activation": {
+			result: &deploy.SLCInstallResult{
+				Entry:   config.InstalledSLC{Flavor: "python-3.12", Aliases: []string{"PYTHON3"}},
+				Outcome: deploy.SLCApplyDeferred,
+			},
+			wantText: []string{"Installed python-3.12", "next start"},
+		},
+		"replacing an existing flavor, database restarted": {
+			result: &deploy.SLCInstallResult{
+				Entry:    config.InstalledSLC{Flavor: "python-3.12", Aliases: []string{"PYTHON3"}},
+				Replaced: true,
+				Outcome:  deploy.SLCApplyRestarted,
+			},
+			wantText: []string{"Updated python-3.12", "restarted"},
+		},
+		"database started to apply the change": {
+			result: &deploy.SLCInstallResult{
+				Entry:   config.InstalledSLC{Flavor: "python-3.12", Aliases: []string{"PYTHON3"}},
+				Outcome: deploy.SLCApplyStarted,
+			},
+			wantText: []string{"Installed python-3.12", "started"},
+		},
+	}
+
+	for name, testCase := range cases {
+		//nolint:paralleltest // mutates shared terminal message queues
+		t.Run(name, func(t *testing.T) {
+			resetTerminalMessages()
+			defer resetTerminalMessages()
+
+			printSLCInstallResult(testCase.result)
+
+			stdout := bytes.Buffer{}
+			writeTerminalMessages(terminalConfig{stdout: &stdout, showCallsToAction: true})
+			for _, want := range testCase.wantText {
+				if !strings.Contains(stdout.String(), want) {
+					t.Fatalf("expected output to contain %q, got %q", want, stdout.String())
+				}
+			}
+		})
+	}
+}
+
+//nolint:paralleltest // mutates shared terminal message queues
+func TestPrintSLCUpdateResultDescribesFlavorChangeAndOutcome(t *testing.T) {
+	resetTerminalMessages()
+	defer resetTerminalMessages()
+
+	printSLCUpdateResult(&deploy.SLCUpdateResult{
+		Entry:       &config.InstalledSLC{Flavor: "python-3.13"},
+		FromFlavor:  "python-3.12",
+		FromVersion: "11.1.0",
+		Outcome:     deploy.SLCApplyRestarted,
+	})
+
+	stdout := bytes.Buffer{}
+	writeTerminalMessages(terminalConfig{stdout: &stdout, showCallsToAction: true})
+
+	if !strings.Contains(stdout.String(), "Updated python-3.12 to python-3.13") {
+		t.Fatalf("expected flavor transition in output, got %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "restarted") {
+		t.Fatalf("expected restart outcome in output, got %q", stdout.String())
+	}
+}
+
+//nolint:paralleltest // mutates shared terminal message queues
+func TestPrintSLCUpdateResultDescribesStoppedDatabaseStarted(t *testing.T) {
+	resetTerminalMessages()
+	defer resetTerminalMessages()
+
+	printSLCUpdateResult(&deploy.SLCUpdateResult{
+		Entry:   &config.InstalledSLC{Flavor: "python-3.12"},
+		Outcome: deploy.SLCApplyStarted,
+	})
+
+	stdout := bytes.Buffer{}
+	writeTerminalMessages(terminalConfig{stdout: &stdout, showCallsToAction: true})
+
+	if !strings.Contains(stdout.String(), "Updated python-3.12") {
+		t.Fatalf("expected update message, got %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "started") {
+		t.Fatalf("expected started outcome in output, got %q", stdout.String())
+	}
+}
+
+//nolint:paralleltest // mutates shared terminal message queues
+func TestPrintSLCRemoveResultDescribesOutcome(t *testing.T) {
+	resetTerminalMessages()
+	defer resetTerminalMessages()
+
+	printSLCRemoveResult(&deploy.SLCRemoveResult{
+		Entry:   &config.InstalledSLC{Flavor: "python-3.12"},
+		Outcome: deploy.SLCApplyDeferred,
+	})
+
+	stdout := bytes.Buffer{}
+	writeTerminalMessages(terminalConfig{stdout: &stdout, showCallsToAction: true})
+
+	if !strings.Contains(stdout.String(), "Removed python-3.12") {
+		t.Fatalf("expected removal message, got %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "next start") {
+		t.Fatalf("expected deferred-activation wording, got %q", stdout.String())
+	}
+}
+
+//nolint:paralleltest // mutates shared terminal message queues
+func TestPrintSLCRemoveResultDescribesDatabaseRestarted(t *testing.T) {
+	resetTerminalMessages()
+	defer resetTerminalMessages()
+
+	printSLCRemoveResult(&deploy.SLCRemoveResult{
+		Entry:   &config.InstalledSLC{Flavor: "python-3.12"},
+		Outcome: deploy.SLCApplyRestarted,
+	})
+
+	stdout := bytes.Buffer{}
+	writeTerminalMessages(terminalConfig{stdout: &stdout, showCallsToAction: true})
+
+	if !strings.Contains(stdout.String(), "Removed python-3.12") {
+		t.Fatalf("expected removal message, got %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "restarted") {
+		t.Fatalf("expected restarted wording, got %q", stdout.String())
 	}
 }
 

--- a/cmd/exasol/usage_template_test.go
+++ b/cmd/exasol/usage_template_test.go
@@ -47,3 +47,41 @@ func TestInfrastructureVariableFlagsTitle_FallsBackWhenLabelUnknown(t *testing.T
 		t.Fatalf("did not expect usage to contain preset label header, got:\n%s", usage)
 	}
 }
+
+// nolint: paralleltest
+func TestInstallationVariableFlagsTitle_IncludesPresetLabel(t *testing.T) {
+	// Do not run in parallel: this test temporarily modifies global installFlagToVarName.
+	oldMap := installFlagToVarName
+	installFlagToVarName = map[string]string{"dummy-install": "dummy_install"}
+	t.Cleanup(func() { installFlagToVarName = oldMap })
+
+	cmd := &cobra.Command{Use: "init"}
+	cmd.Flags().String("dummy-install", "", "dummy install")
+	cmd.Annotations = map[string]string{installPresetLabelAnnotationKey: "ubuntu"}
+	cmd.SetUsageTemplate(customUsageTemplate)
+
+	usage := cmd.UsageString()
+	if !strings.Contains(usage, "Installation variable flags of preset `ubuntu`:") {
+		t.Fatalf("expected usage to contain preset label header, got:\n%s", usage)
+	}
+}
+
+// nolint: paralleltest
+func TestInstallationVariableFlagsTitle_FallsBackWhenLabelUnknown(t *testing.T) {
+	// Do not run in parallel: this test temporarily modifies global installFlagToVarName.
+	oldMap := installFlagToVarName
+	installFlagToVarName = map[string]string{"dummy-install": "dummy_install"}
+	t.Cleanup(func() { installFlagToVarName = oldMap })
+
+	cmd := &cobra.Command{Use: "init"}
+	cmd.Flags().String("dummy-install", "", "dummy install")
+	cmd.SetUsageTemplate(customUsageTemplate)
+
+	usage := cmd.UsageString()
+	if !strings.Contains(usage, "Installation variable flags:") {
+		t.Fatalf("expected usage to contain fallback install flags header, got:\n%s", usage)
+	}
+	if strings.Contains(usage, "Installation variable flags of preset") {
+		t.Fatalf("did not expect usage to contain preset label header, got:\n%s", usage)
+	}
+}

--- a/cmd/exasol/util_test.go
+++ b/cmd/exasol/util_test.go
@@ -4,10 +4,108 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	"github.com/exasol/exasol-personal/internal/deploy"
 )
+
+func TestConfirmYes(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]bool{
+		"y":       true,
+		"Y":       true,
+		"yes":     true,
+		"YES":     true,
+		"  yes  ": true,
+		"n":       false,
+		"no":      false,
+		"":        false,
+		"maybe":   false,
+	}
+	for input, want := range cases {
+		if got := confirmYes(input); got != want {
+			t.Errorf("confirmYes(%q) = %v, want %v", input, got, want)
+		}
+	}
+}
+
+// nolint: paralleltest // temporarily replaces the package-level os.Stdin.
+func TestAskForUserConfirmation_ReadsAnswerFromStdin(t *testing.T) {
+	restore := replaceStdinWithPipeContent(t, "yes\n")
+	defer restore()
+
+	if !askForUserConfirmation("") {
+		t.Fatal("expected a 'yes' answer to confirm")
+	}
+}
+
+// nolint: paralleltest // temporarily replaces the package-level os.Stdin.
+func TestAskForUserConfirmation_RejectsNegativeAnswer(t *testing.T) {
+	restore := replaceStdinWithPipeContent(t, "no\n")
+	defer restore()
+
+	if askForUserConfirmation("") {
+		t.Fatal("expected a 'no' answer to not confirm")
+	}
+}
+
+// nolint: paralleltest // temporarily replaces the package-level os.Stdin.
+func TestAskForUserConfirmation_UsesCustomValidator(t *testing.T) {
+	restore := replaceStdinWithPipeContent(t, "confirmed\n")
+	defer restore()
+
+	always := func(string) bool { return true }
+	never := func(string) bool { return false }
+
+	if !askForUserConfirmation("", always) {
+		t.Fatal("expected the custom validator to be used")
+	}
+
+	restore2 := replaceStdinWithPipeContent(t, "confirmed\n")
+	defer restore2()
+
+	if askForUserConfirmation("", never) {
+		t.Fatal("expected the custom validator to reject the answer")
+	}
+}
+
+// nolint: paralleltest // temporarily replaces the package-level os.Stdin.
+func TestAskForUserConfirmation_ReturnsFalseOnReadError(t *testing.T) {
+	restore := replaceStdinWithPipeContent(t, "")
+	defer restore()
+
+	if askForUserConfirmation("") {
+		t.Fatal("expected EOF on stdin to be treated as no confirmation")
+	}
+}
+
+// replaceStdinWithPipeContent temporarily replaces os.Stdin with a pipe
+// preloaded with content, so askForUserConfirmation's real bufio.Reader over
+// os.Stdin can be exercised deterministically without a real terminal.
+func replaceStdinWithPipeContent(t *testing.T, content string) func() {
+	t.Helper()
+
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stdin pipe: %v", err)
+	}
+	if _, err := writer.WriteString(content); err != nil {
+		t.Fatalf("failed to write pipe content: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("failed to close pipe writer: %v", err)
+	}
+
+	original := os.Stdin
+	os.Stdin = reader
+
+	return func() {
+		os.Stdin = original
+		_ = reader.Close()
+	}
+}
 
 func TestLooksLikePathPresetArg(t *testing.T) {
 	t.Parallel()

--- a/internal/compatibility/enforce_test.go
+++ b/internal/compatibility/enforce_test.go
@@ -1,0 +1,176 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploymentcompatibility
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+)
+
+func newUninitializedDeployment(t *testing.T) config.DeploymentDir {
+	t.Helper()
+
+	return config.NewDeploymentDir(t.TempDir())
+}
+
+func newInitializedDeployment(t *testing.T, deploymentVersion string) config.DeploymentDir {
+	t.Helper()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	state := &config.ExasolPersonalState{DeploymentVersion: "0.0.0"}
+	if err := config.WriteExasolPersonalState(state, deployment); err != nil {
+		t.Fatalf("failed to write launcher state: %v", err)
+	}
+	if deploymentVersion != "" {
+		if err := config.WriteDeploymentVersionMarker(deployment, deploymentVersion); err != nil {
+			t.Fatalf("failed to write version marker: %v", err)
+		}
+	}
+
+	return deployment
+}
+
+func TestEnforce_UninitializedDeploymentIsAllowedWhenNotRequired(t *testing.T) {
+	t.Parallel()
+
+	deployment := newUninitializedDeployment(t)
+
+	err := EnforceDeploymentDirectoryCompatibility(
+		deployment, "1.0.0", Requirement{CommandName: "init"}, DeploymentDirMayBeUninitialized,
+	)
+	if err != nil {
+		t.Fatalf("expected no error for an uninitialized dir when not required, got %v", err)
+	}
+}
+
+func TestEnforce_UninitializedDeploymentIsRejectedWhenRequired(t *testing.T) {
+	t.Parallel()
+
+	deployment := newUninitializedDeployment(t)
+
+	err := EnforceDeploymentDirectoryCompatibility(
+		deployment, "1.0.0", Requirement{CommandName: "status"}, DeploymentDirMustBeInitialized,
+	)
+
+	if err == nil || !strings.Contains(err.Error(), "not initialized") {
+		t.Fatalf("expected a 'not initialized' error, got %v", err)
+	}
+}
+
+func TestEnforce_LegacyDeploymentLayoutIsAlwaysRejected(t *testing.T) {
+	t.Parallel()
+
+	deployment := newUninitializedDeployment(t)
+	legacyPath := deployment.Resolve(legacyWorkflowStateFileName)
+	if err := os.WriteFile(legacyPath, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("failed to write legacy workflow state file: %v", err)
+	}
+
+	err := EnforceDeploymentDirectoryCompatibility(
+		deployment, "1.0.0", Requirement{CommandName: "status"}, DeploymentDirMayBeUninitialized,
+	)
+
+	if err == nil || !strings.Contains(err.Error(), "older version") {
+		t.Fatalf("expected a legacy-layout error, got %v", err)
+	}
+}
+
+func TestEnforce_InitializedDeploymentMissingVersionMarkerIsRejected(t *testing.T) {
+	t.Parallel()
+
+	deployment := newInitializedDeployment(t, "")
+
+	err := EnforceDeploymentDirectoryCompatibility(
+		deployment, "1.0.0", Requirement{CommandName: "status"}, DeploymentDirMustBeInitialized,
+	)
+
+	if err == nil || !strings.Contains(err.Error(), "missing deployment") {
+		t.Fatalf("expected a missing-version-marker error, got %v", err)
+	}
+}
+
+func TestEnforce_InitializedDeploymentWithEmptyVersionMarkerIsRejected(t *testing.T) {
+	t.Parallel()
+
+	deployment := newInitializedDeployment(t, "")
+	markerPath := deployment.DeploymentVersionMarkerPath()
+	if err := os.WriteFile(markerPath, []byte("  "), 0o600); err != nil {
+		t.Fatalf("failed to write empty version marker: %v", err)
+	}
+
+	err := EnforceDeploymentDirectoryCompatibility(
+		deployment, "1.0.0", Requirement{CommandName: "status"}, DeploymentDirMustBeInitialized,
+	)
+
+	if err == nil || !strings.Contains(err.Error(), "is empty") {
+		t.Fatalf("expected an empty-version-marker error, got %v", err)
+	}
+}
+
+func TestEnforce_CompatibleVersionsAreAllowed(t *testing.T) {
+	t.Parallel()
+
+	deployment := newInitializedDeployment(t, "1.2.0")
+
+	err := EnforceDeploymentDirectoryCompatibility(
+		deployment,
+		"2.0.0",
+		Requirement{CommandName: "status", MinSupportedDeploymentVersion: "1.0.0"},
+		DeploymentDirMustBeInitialized,
+	)
+	if err != nil {
+		t.Fatalf("expected compatible versions to be allowed, got %v", err)
+	}
+}
+
+func TestEnforce_IncompatibleVersionsReturnIncompatibleError(t *testing.T) {
+	t.Parallel()
+
+	deployment := newInitializedDeployment(t, "1.0.0")
+
+	err := EnforceDeploymentDirectoryCompatibility(
+		deployment,
+		"2.0.0",
+		Requirement{CommandName: "deploy", MinSupportedDeploymentVersion: "1.5.0"},
+		DeploymentDirMustBeInitialized,
+	)
+
+	var inc *IncompatibleError
+	if !errors.As(err, &inc) {
+		t.Fatalf("expected an IncompatibleError, got %T: %v", err, err)
+	}
+}
+
+func TestEnforce_InvalidDeploymentVersionMarkerReturnsInvalidVersionError(t *testing.T) {
+	t.Parallel()
+
+	deployment := newInitializedDeployment(t, "not-a-version")
+
+	err := EnforceDeploymentDirectoryCompatibility(
+		deployment,
+		"2.0.0",
+		Requirement{CommandName: "deploy", MinSupportedDeploymentVersion: "1.0.0"},
+		DeploymentDirMustBeInitialized,
+	)
+
+	var inv *InvalidVersionError
+	if !errors.As(err, &inv) {
+		t.Fatalf("expected an InvalidVersionError, got %T: %v", err, err)
+	}
+}
+
+func TestIncompatibleErrorDefaultReasonMessage(t *testing.T) {
+	t.Parallel()
+
+	err := &IncompatibleError{CommandName: "deploy", RequiredAction: "manual_fix"}
+
+	if !strings.Contains(err.Error(), "manual_fix") {
+		t.Fatalf("expected the default-case message to mention the required action, got %q",
+			err.Error())
+	}
+}

--- a/internal/config/connection_info_test.go
+++ b/internal/config/connection_info_test.go
@@ -29,6 +29,40 @@ lKXb6y8Al2UTdJ3ED+yONdAc7OHg4e3vwJ8R
 	testCertSHA256Fingerprint = "CDEC9FB892603FDC23D7CFCC86A533434B5E16E69E7744E057506F2006BD732E"
 )
 
+func TestParseConnectionPort(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]int{
+		"8563":       8563,
+		"  8563  ":   8563,
+		"":           0,
+		"   ":        0,
+		"not-a-port": 0,
+	}
+	for input, want := range cases {
+		if got := parseConnectionPort(input); got != want {
+			t.Errorf("parseConnectionPort(%q) = %d, want %d", input, got, want)
+		}
+	}
+}
+
+func TestFirstNonEmpty(t *testing.T) {
+	t.Parallel()
+
+	if got := firstNonEmpty("", "  ", "b", "c"); got != "b" {
+		t.Fatalf("expected the first non-blank value, got %q", got)
+	}
+	if got := firstNonEmpty("first", "second"); got != "first" {
+		t.Fatalf("expected the first value to win, got %q", got)
+	}
+	if got := firstNonEmpty("", "  ", ""); got != "" {
+		t.Fatalf("expected an empty string when all values are blank, got %q", got)
+	}
+	if got := firstNonEmpty(); got != "" {
+		t.Fatalf("expected an empty string for no arguments, got %q", got)
+	}
+}
+
 func TestResolveConnectionInfo_UsesNormalizedDeploymentConnection(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/deployment_dir_test.go
+++ b/internal/config/deployment_dir_test.go
@@ -4,9 +4,11 @@
 package config
 
 import (
+	"path"
 	"path/filepath"
 	"testing"
 
+	"github.com/exasol/exasol-personal/internal/presets"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,6 +34,49 @@ func TestDeploymentDir_LayoutPaths(t *testing.T) {
 		filepath.Join(root, ConnectionInstruction),
 		deployment.ConnectionInstructionsPath(),
 	)
+}
+
+func TestDeploymentDir_ArtifactPaths(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	deployment := NewDeploymentDir(root)
+
+	require.Equal(t, filepath.Join(root, nodeDetailsFileName), deployment.NodeDetailsPath())
+	require.Equal(
+		t,
+		filepath.Join(root, DeploymentVersionMarkerFileName),
+		deployment.DeploymentVersionMarkerPath(),
+	)
+	require.Equal(t, filepath.Join(root, secretsFileName), deployment.SecretsPath())
+	require.Equal(
+		t,
+		filepath.Join(deployment.InfrastructureDir(), presets.InfrastructureManifestFilename),
+		deployment.InfrastructureManifestPath(),
+	)
+	require.Equal(
+		t,
+		filepath.Join(deployment.InstallationDir(), presets.InstallationManifestFilename),
+		deployment.InstallManifestPath(),
+	)
+	require.Equal(t, "..", deployment.RelativeInfrastructureArtifactDir())
+	require.Equal(
+		t,
+		path.Join("..", InstallationFilesDirectory),
+		deployment.RelativeInstallationPresetDir(),
+	)
+}
+
+func TestDeploymentsRootPath_IsParentOfDefaultDeploymentDir(t *testing.T) {
+	t.Parallel()
+
+	rootsPath, err := DeploymentsRootPath()
+	require.NoError(t, err)
+
+	defaultPath, err := DefaultDeploymentDirPath()
+	require.NoError(t, err)
+
+	require.Equal(t, rootsPath, filepath.Dir(defaultPath))
 }
 
 func TestNamedDeploymentDirPath_SameParentAsDefault(t *testing.T) {

--- a/internal/config/deployment_version_marker_test.go
+++ b/internal/config/deployment_version_marker_test.go
@@ -1,0 +1,36 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadDeploymentVersionMarker_MissingFileReturnsFalseWithoutError(t *testing.T) {
+	t.Parallel()
+
+	deployment := NewDeploymentDir(t.TempDir())
+
+	version, exists, err := ReadDeploymentVersionMarker(deployment)
+
+	require.NoError(t, err)
+	require.False(t, exists)
+	require.Empty(t, version)
+}
+
+func TestWriteThenReadDeploymentVersionMarker_RoundTripsTrimmed(t *testing.T) {
+	t.Parallel()
+
+	deployment := NewDeploymentDir(t.TempDir())
+
+	require.NoError(t, WriteDeploymentVersionMarker(deployment, "  1.2.3  \n"))
+
+	version, exists, err := ReadDeploymentVersionMarker(deployment)
+
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.Equal(t, "1.2.3", version)
+}

--- a/internal/config/exasol_launcher_state_test.go
+++ b/internal/config/exasol_launcher_state_test.go
@@ -226,3 +226,48 @@ func TestWorkflowState(t *testing.T) {
 		}
 	})
 }
+
+func TestHasExasolPersonalStateFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing state file", func(t *testing.T) {
+		t.Parallel()
+
+		deployment := NewDeploymentDir(t.TempDir())
+
+		has, err := HasExasolPersonalStateFile(deployment)
+		expectNoErr(t, err)
+		if has {
+			t.Fatal("expected no state file to be reported as absent")
+		}
+	})
+
+	t.Run("existing state file", func(t *testing.T) {
+		t.Parallel()
+
+		deployment := NewDeploymentDir(t.TempDir())
+		exasolState := &ExasolPersonalState{DeploymentVersion: "0.0.0"}
+		expectNoErr(t, WriteExasolPersonalState(exasolState, deployment))
+
+		has, err := HasExasolPersonalStateFile(deployment)
+		expectNoErr(t, err)
+		if !has {
+			t.Fatal("expected an existing state file to be reported as present")
+		}
+	})
+
+	t.Run("path is a directory, not a file", func(t *testing.T) {
+		t.Parallel()
+
+		deployment := NewDeploymentDir(t.TempDir())
+		if err := os.MkdirAll(deployment.ExasolPersonalStatePath(), 0o750); err != nil {
+			t.Fatalf("failed to create directory at state path: %v", err)
+		}
+
+		has, err := HasExasolPersonalStateFile(deployment)
+		expectNoErr(t, err)
+		if has {
+			t.Fatal("expected a directory at the state path to be reported as absent")
+		}
+	})
+}

--- a/internal/config/manifests_test.go
+++ b/internal/config/manifests_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadInfrastructureManifest_MissingFileReturnsWrappedError(t *testing.T) {
+	t.Parallel()
+
+	deployment := NewDeploymentDir(t.TempDir())
+
+	_, err := ReadInfrastructureManifest(deployment)
+
+	require.ErrorIs(t, err, ErrMissingInfrastructureManifest)
+}
+
+func TestReadInfrastructureManifest_ParsesBackendAndName(t *testing.T) {
+	t.Parallel()
+
+	deployment := NewDeploymentDir(t.TempDir())
+	require.NoError(t, os.MkdirAll(deployment.InfrastructureDir(), 0o750))
+	manifestYAML := "name: Test\ndescription: test infra\nbackend: local\n"
+	require.NoError(t, os.WriteFile(
+		deployment.InfrastructureManifestPath(),
+		[]byte(manifestYAML),
+		0o600,
+	))
+
+	manifest, err := ReadInfrastructureManifest(deployment)
+
+	require.NoError(t, err)
+	require.Equal(t, "Test", manifest.Name)
+	require.Equal(t, "local", manifest.Backend)
+}
+
+func TestReadInstallManifest_MissingFileReturnsWrappedError(t *testing.T) {
+	t.Parallel()
+
+	deployment := NewDeploymentDir(t.TempDir())
+
+	_, err := ReadInstallManifest(deployment)
+
+	require.ErrorIs(t, err, ErrMissingInstallManifest)
+}
+
+func TestReadInstallManifest_ParsesName(t *testing.T) {
+	t.Parallel()
+
+	deployment := NewDeploymentDir(t.TempDir())
+	require.NoError(t, os.MkdirAll(deployment.InstallationDir(), 0o750))
+	manifestYAML := "name: Test Install\ndescription: test install\n"
+	require.NoError(t, os.WriteFile(
+		deployment.InstallManifestPath(),
+		[]byte(manifestYAML),
+		0o600,
+	))
+
+	manifest, err := ReadInstallManifest(deployment)
+
+	require.NoError(t, err)
+	require.Equal(t, "Test Install", manifest.Name)
+}

--- a/internal/config/node_details_test.go
+++ b/internal/config/node_details_test.go
@@ -285,3 +285,26 @@ func TestGetDeploymentHostPort_Error_WhenPortOutOfRange(t *testing.T) {
 	_, _, err := nodeDetails.GetDeploymentHostPort()
 	require.Error(t, err)
 }
+
+func TestGetDeploymentInfoFilePath_MissingFile(t *testing.T) {
+	t.Parallel()
+
+	_, exists, err := GetDeploymentInfoFilePath(t.TempDir())
+
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
+func TestGetDeploymentInfoFilePath_ExistingFile(t *testing.T) {
+	t.Parallel()
+
+	deploymentDir := t.TempDir()
+	expectedPath := filepath.Join(deploymentDir, nodeDetailsFileName)
+	require.NoError(t, os.WriteFile(expectedPath, []byte(`{"deploymentId":"dep-1"}`), 0o600))
+
+	path, exists, err := GetDeploymentInfoFilePath(deploymentDir)
+
+	require.NoError(t, err)
+	require.True(t, exists)
+	require.Equal(t, expectedPath, path)
+}

--- a/internal/config/secrets_test.go
+++ b/internal/config/secrets_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecretsFilePath_MissingFileReturnsError(t *testing.T) {
+	t.Parallel()
+
+	deployment := NewDeploymentDir(t.TempDir())
+
+	_, err := SecretsFilePath(deployment)
+
+	require.ErrorContains(t, err, "secrets file not found")
+}
+
+func TestReadSecrets_MissingFileReturnsError(t *testing.T) {
+	t.Parallel()
+
+	deployment := NewDeploymentDir(t.TempDir())
+
+	_, err := ReadSecrets(deployment)
+
+	require.ErrorContains(t, err, "secrets file not found")
+}
+
+func TestWriteThenReadSecrets_RoundTrips(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	deployment := NewDeploymentDir(root)
+
+	require.NoError(t, WriteSecrets(root, &Secrets{
+		DbPassword:      "db-secret",
+		AdminUiPassword: "admin-secret",
+	}))
+
+	secrets, err := ReadSecrets(deployment)
+
+	require.NoError(t, err)
+	require.Equal(t, "db-secret", secrets.DbPassword)
+	require.Equal(t, "admin-secret", secrets.AdminUiPassword)
+}
+
+func TestWriteSecrets_NilDefaultsToEmptySecrets(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	deployment := NewDeploymentDir(root)
+
+	require.NoError(t, WriteSecrets(root, nil))
+
+	secrets, err := ReadSecrets(deployment)
+
+	require.NoError(t, err)
+	require.Empty(t, secrets.DbPassword)
+}

--- a/internal/config/tasks_test.go
+++ b/internal/config/tasks_test.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestTaskUnmarshalYAML_AcceptsExactlyOneTaskType(t *testing.T) {
+	t.Parallel()
+
+	var remoteExecTask Task
+	require.NoError(t, yaml.Unmarshal([]byte(`
+remoteExec:
+  description: run something
+  filename: script.sh
+`), &remoteExecTask))
+	require.NotNil(t, remoteExecTask.RemoteExec)
+	require.Nil(t, remoteExecTask.LocalCommand)
+
+	var localCommandTask Task
+	require.NoError(t, yaml.Unmarshal([]byte(`
+localCommand:
+  description: run something locally
+  command: ["echo", "hi"]
+`), &localCommandTask))
+	require.NotNil(t, localCommandTask.LocalCommand)
+	require.Nil(t, localCommandTask.RemoteExec)
+}
+
+func TestTaskUnmarshalYAML_RejectsNoTaskType(t *testing.T) {
+	t.Parallel()
+
+	var task Task
+
+	err := yaml.Unmarshal([]byte(`description: nothing set`), &task)
+
+	require.ErrorIs(t, err, ErrNoTaskTypeSet)
+}
+
+func TestTaskUnmarshalYAML_RejectsMultipleTaskTypes(t *testing.T) {
+	t.Parallel()
+
+	var task Task
+
+	err := yaml.Unmarshal([]byte(`
+remoteExec:
+  description: run something
+  filename: script.sh
+localCommand:
+  description: run something locally
+  command: ["echo", "hi"]
+`), &task)
+
+	require.ErrorIs(t, err, ErrMultipleTaskTypesSet)
+}

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	generaltypes "github.com/exasol/exasol-personal/internal/connect/types"
@@ -99,6 +100,159 @@ func (s stubQueryResult) RowsAffected() int64 {
 
 func (s stubQueryResult) Truncated() bool {
 	return s.truncated
+}
+
+func TestPrintExitHint_WritesShellExitInstructions(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	if err := printExitHint(&out); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if out.String() != "Type \"exit\" to exit the shell\n" {
+		t.Fatalf("unexpected output: %q", out.String())
+	}
+}
+
+func TestConnectWriters_DefaultsNilStreamsToDiscard(t *testing.T) {
+	t.Parallel()
+
+	writers := connectWriters(&Opts{})
+	if writers.stdout != io.Discard || writers.stderr != io.Discard {
+		t.Fatalf("expected nil streams to default to io.Discard, got %+v", writers)
+	}
+}
+
+func TestConnectWriters_PreservesProvidedStreams(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	writers := connectWriters(&Opts{Stdout: &stdout, Stderr: &stderr})
+	if writers.stdout != &stdout || writers.stderr != &stderr {
+		t.Fatalf("expected the provided streams to be preserved, got %+v", writers)
+	}
+}
+
+func TestSelectResultPrinter_PicksPrinterByFormat(t *testing.T) {
+	t.Parallel()
+
+	result := stubQueryResult{columnNames: []string{"ID"}, rows: [][]string{{"1"}}}
+
+	var csvOut bytes.Buffer
+	if err := selectResultPrinter(OutputFormatCSV, JSONFormatPretty)(&csvOut, result); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if csvOut.String() != "ID\n1\n" {
+		t.Fatalf("expected CSV output for OutputFormatCSV, got %q", csvOut.String())
+	}
+
+	var tableOut bytes.Buffer
+	err := selectResultPrinter(OutputFormatTable, JSONFormatPretty)(&tableOut, result)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !strings.Contains(tableOut.String(), "ID") {
+		t.Fatalf("expected a table rendering for OutputFormatTable, got %q", tableOut.String())
+	}
+
+	var defaultOut bytes.Buffer
+	err = selectResultPrinter(OutputFormat("bogus"), JSONFormatPretty)(&defaultOut, result)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !strings.Contains(defaultOut.String(), "ID") {
+		t.Fatalf("expected an unknown format to fall back to the table renderer, got %q",
+			defaultOut.String())
+	}
+}
+
+func TestExecStatement_BlankInputIsNoop(t *testing.T) {
+	t.Parallel()
+
+	database := &stubDatabase{}
+	writers := connectOutputWriters{stdout: io.Discard, stderr: io.Discard}
+
+	err := execStatement(context.Background(), database, 0, printResultCSV, writers, "")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(database.queries) != 0 {
+		t.Fatalf("expected no query to be executed for blank input, got %v", database.queries)
+	}
+}
+
+func TestExecStatement_RunsQueryAndPrintsResult(t *testing.T) {
+	t.Parallel()
+
+	database := &stubDatabase{results: []stubExecResult{
+		{result: stubQueryResult{columnNames: []string{"ID"}, rows: [][]string{{"1"}}}},
+	}}
+	var stdout bytes.Buffer
+	writers := connectOutputWriters{stdout: &stdout, stderr: io.Discard}
+
+	err := execStatement(context.Background(), database, 10, printResultCSV, writers, "SELECT 1")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if stdout.String() != "ID\n1\n" {
+		t.Fatalf("expected the CSV result to be printed, got %q", stdout.String())
+	}
+	if len(database.queries) != 1 || database.queries[0] != "SELECT 1" ||
+		database.maxRows[0] != 10 {
+		t.Fatalf("expected the statement to be executed with the given max rows, got %+v", database)
+	}
+}
+
+func TestExecStatement_PrintsTruncationFooterWhenTruncated(t *testing.T) {
+	t.Parallel()
+
+	database := &stubDatabase{results: []stubExecResult{
+		{result: stubQueryResult{
+			columnNames: []string{"ID"},
+			rows:        [][]string{{"1"}},
+			truncated:   true,
+		}},
+	}}
+	var stdout, stderr bytes.Buffer
+	writers := connectOutputWriters{stdout: &stdout, stderr: &stderr}
+
+	err := execStatement(context.Background(), database, 1, printResultCSV, writers, "SELECT 1")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !strings.Contains(stderr.String(), "truncated") {
+		t.Fatalf("expected a truncation footer on stderr, got %q", stderr.String())
+	}
+}
+
+func TestExecStatement_PropagatesExecError(t *testing.T) {
+	t.Parallel()
+
+	execErr := errors.New("boom")
+	database := &stubDatabase{results: []stubExecResult{{err: execErr}}}
+	writers := connectOutputWriters{stdout: io.Discard, stderr: io.Discard}
+
+	err := execStatement(context.Background(), database, 0, printResultCSV, writers, "SELECT 1")
+	if !errors.Is(err, execErr) {
+		t.Fatalf("expected the exec error to propagate, got %v", err)
+	}
+}
+
+func TestRenderedJSONSQLError_ErrorAndUnwrap(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("underlying failure")
+	wrapped := renderedJSONSQLError{cause: cause}
+
+	if wrapped.Error() != cause.Error() {
+		t.Fatalf("expected Error() to mirror the cause, got %q", wrapped.Error())
+	}
+	if !errors.Is(wrapped, cause) {
+		t.Fatal("expected Unwrap to expose the underlying cause")
+	}
+	if !wrapped.SuppressCLIError() {
+		t.Fatal("expected SuppressCLIError to always be true")
+	}
 }
 
 func TestPrintResultJSON(t *testing.T) {
@@ -364,6 +518,19 @@ func TestResolveNonInteractiveSQL(t *testing.T) {
 		require.False(t, nonInteractive)
 		require.Empty(t, sql)
 	})
+}
+
+func TestResolveNonInteractiveSQL_CommandBypassesRealStdin(t *testing.T) {
+	t.Parallel()
+
+	// opts.Command short-circuits before resolveNonInteractiveSQL ever reads
+	// os.Stdin or calls util.IsInteractiveStdin, so this is deterministic
+	// regardless of this process's actual stdin.
+	sql, nonInteractive, err := resolveNonInteractiveSQL(&Opts{Command: "SELECT 1"})
+
+	require.NoError(t, err)
+	require.True(t, nonInteractive)
+	require.Equal(t, "SELECT 1", sql)
 }
 
 type stubDatabase struct {

--- a/internal/connect/driver_logger_test.go
+++ b/internal/connect/driver_logger_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package connect
+
+import (
+	"bytes"
+	"errors"
+	"log"
+	"testing"
+
+	"github.com/exasol/exasol-driver-go/pkg/logger"
+)
+
+// nolint: paralleltest // these tests serialize access to the driver's shared ErrorLogger global.
+func TestWithSilencedDriverErrors_SuppressesOutputDuringCallback(t *testing.T) {
+	var buffer bytes.Buffer
+	original := log.New(&buffer, "prefix: ", 0)
+	restore := setDriverErrorLoggerForTest(t, original)
+	defer restore()
+
+	err := WithSilencedDriverErrors(func() error {
+		logger.ErrorLogger.Print("should not appear")
+		logger.ErrorLogger.Printf("should also not appear %s", "arg")
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if buffer.Len() != 0 {
+		t.Fatalf("expected driver errors to be suppressed, got %q", buffer.String())
+	}
+}
+
+// nolint: paralleltest // these tests serialize access to the driver's shared ErrorLogger global.
+func TestWithSilencedDriverErrors_RestoresOriginalLoggerAfterCallback(t *testing.T) {
+	var buffer bytes.Buffer
+	original := log.New(&buffer, "prefix: ", 0)
+	restore := setDriverErrorLoggerForTest(t, original)
+	defer restore()
+
+	if err := WithSilencedDriverErrors(func() error { return nil }); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	logger.ErrorLogger.Print("visible again")
+	if buffer.String() != "prefix: visible again\n" {
+		t.Fatalf("expected the original logger to be restored, got %q", buffer.String())
+	}
+}
+
+// nolint: paralleltest // these tests serialize access to the driver's shared ErrorLogger global.
+func TestWithSilencedDriverErrors_RestoresOriginalLoggerEvenOnCallbackError(t *testing.T) {
+	var buffer bytes.Buffer
+	original := log.New(&buffer, "prefix: ", 0)
+	restore := setDriverErrorLoggerForTest(t, original)
+	defer restore()
+
+	callbackErr := errors.New("callback failed")
+	err := WithSilencedDriverErrors(func() error { return callbackErr })
+	if !errors.Is(err, callbackErr) {
+		t.Fatalf("expected the callback error to propagate, got %v", err)
+	}
+
+	logger.ErrorLogger.Print("visible again")
+	if buffer.String() != "prefix: visible again\n" {
+		t.Fatalf("expected the original logger to be restored, got %q", buffer.String())
+	}
+}
+
+// nolint: paralleltest // these tests serialize access to the driver's shared ErrorLogger global.
+func TestWithDriverErrorLogger_UsesGivenLoggerDuringCallback(t *testing.T) {
+	var buffer bytes.Buffer
+	temp := log.New(&buffer, "temp: ", 0)
+	restore := setDriverErrorLoggerForTest(t, log.New(&bytes.Buffer{}, "unused: ", 0))
+	defer restore()
+
+	err := withDriverErrorLogger(temp, func() error {
+		logger.ErrorLogger.Print("hello")
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if buffer.String() != "temp: hello\n" {
+		t.Fatalf("expected the temporary logger to receive the message, got %q", buffer.String())
+	}
+}
+
+// setDriverErrorLoggerForTest installs logger as the driver's ErrorLogger and
+// returns a function that restores whatever was active before. The driver
+// exposes ErrorLogger as a bare package variable with no test seam, so tests
+// touching it must serialize instead of running in parallel with each other.
+func setDriverErrorLoggerForTest(t *testing.T, temp logger.Logger) func() {
+	t.Helper()
+
+	previous := logger.ErrorLogger
+	if err := logger.SetLogger(temp); err != nil {
+		t.Fatalf("failed to set driver error logger: %v", err)
+	}
+
+	return func() {
+		_ = logger.SetLogger(previous)
+	}
+}

--- a/internal/connect/readline/buffered_test.go
+++ b/internal/connect/readline/buffered_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package readline
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+const firstLine = "select 1;"
+
+func TestBufferedReadlineStripsTrailingNewlineAndCarriageReturn(t *testing.T) {
+	t.Parallel()
+
+	reader := NewBuffered(strings.NewReader("select 1;\r\nselect 2;\n"))
+
+	first, err := reader.Readline()
+	if err != nil {
+		t.Fatalf("expected first line to read, got %v", err)
+	}
+	if first != firstLine {
+		t.Fatalf("expected CRLF trimmed, got %q", first)
+	}
+
+	second, err := reader.Readline()
+	if err != nil {
+		t.Fatalf("expected second line to read, got %v", err)
+	}
+	if second != "select 2;" {
+		t.Fatalf("expected LF trimmed, got %q", second)
+	}
+
+	if _, err := reader.Readline(); !errors.Is(err, io.EOF) {
+		t.Fatalf("expected io.EOF after the last line, got %v", err)
+	}
+}
+
+func TestBufferedReadlineReturnsFinalLineWithoutTrailingNewline(t *testing.T) {
+	t.Parallel()
+
+	// A script's last line commonly has no trailing newline; the reader must
+	// still return it once (with EOF only on the following call) rather than
+	// silently dropping it.
+	reader := NewBuffered(strings.NewReader("select 1;\nselect 2"))
+
+	first, err := reader.Readline()
+	if err != nil {
+		t.Fatalf("expected first line to read, got %v", err)
+	}
+	if first != firstLine {
+		t.Fatalf("unexpected first line: %q", first)
+	}
+
+	second, err := reader.Readline()
+	if err != nil {
+		t.Fatalf("expected the unterminated final line to be returned, got error %v", err)
+	}
+	if second != "select 2" {
+		t.Fatalf("expected final line without trailing newline, got %q", second)
+	}
+
+	if _, err := reader.Readline(); !errors.Is(err, io.EOF) {
+		t.Fatalf("expected io.EOF once the final line is consumed, got %v", err)
+	}
+}
+
+func TestBufferedReadlineOnEmptyInputReturnsEOFImmediately(t *testing.T) {
+	t.Parallel()
+
+	reader := NewBuffered(strings.NewReader(""))
+
+	if _, err := reader.Readline(); !errors.Is(err, io.EOF) {
+		t.Fatalf("expected io.EOF on empty input, got %v", err)
+	}
+}
+
+func TestBufferedCloseIsANoop(t *testing.T) {
+	t.Parallel()
+
+	reader := NewBuffered(strings.NewReader("select 1;\n"))
+
+	if err := reader.Close(); err != nil {
+		t.Fatalf("expected Close to succeed, got %v", err)
+	}
+
+	// Close must not affect subsequent reads: the underlying bufio.Reader
+	// owns no closable resource of its own.
+	line, err := reader.Readline()
+	if err != nil || line != firstLine {
+		t.Fatalf("expected reads to still work after Close, got %q, %v", line, err)
+	}
+}

--- a/internal/connect/shell_test.go
+++ b/internal/connect/shell_test.go
@@ -6,6 +6,8 @@ package connect
 import (
 	"errors"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -51,6 +53,26 @@ func (mp *mockInputsProcessor) failOnInput(input string, err error) {
 }
 
 // nolint: revive
+func TestGetHistoryFilePath_ResolvesUnderUserCacheDir(t *testing.T) {
+	t.Parallel()
+
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		t.Skipf("no user cache dir available in this environment: %v", err)
+	}
+
+	path, err := getHistoryFilePath()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if filepath.Dir(path) != cacheDir {
+		t.Fatalf("expected the history file to live under %q, got %q", cacheDir, path)
+	}
+	if filepath.Base(path) != "exasol_history" {
+		t.Fatalf("expected the history file name to be exasol_history, got %q", filepath.Base(path))
+	}
+}
+
 func TestRunShell(t *testing.T) {
 	t.Parallel()
 
@@ -122,7 +144,11 @@ func TestRunShell(t *testing.T) {
 				t.Helper()
 
 				require.ErrorIs(t, err, errTest)
-				require.Equal(t, []string{"OPEN SCHEMA dummy  \nSELECT * FROM Dual"}, mocks.inputsProcessor.inputs)
+				require.Equal(
+					t,
+					[]string{"OPEN SCHEMA dummy  \nSELECT * FROM Dual"},
+					mocks.inputsProcessor.inputs,
+				)
 			},
 		},
 		{

--- a/internal/connect/tablewriter/tablewriter_test.go
+++ b/internal/connect/tablewriter/tablewriter_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package tablewriter
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestTableWriter_RendersHeaderAndRows(t *testing.T) {
+	t.Parallel()
+
+	var buffer bytes.Buffer
+	table := New(&buffer)
+
+	table.SetHeader([]string{"ID", "NAME"})
+	if err := table.SetRows([][]string{{"1", "Alice"}, {"2", "Bob"}}); err != nil {
+		t.Fatalf("expected no error setting rows, got %v", err)
+	}
+	if err := table.Render(); err != nil {
+		t.Fatalf("expected no error rendering, got %v", err)
+	}
+
+	output := buffer.String()
+	for _, want := range []string{"ID", "NAME", "1", "Alice", "2", "Bob"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected rendered output to contain %q, got:\n%s", want, output)
+		}
+	}
+}
+
+func TestTableWriter_RendersEmptyTableWithoutError(t *testing.T) {
+	t.Parallel()
+
+	var buffer bytes.Buffer
+	table := New(&buffer)
+
+	table.SetHeader([]string{"ID"})
+	if err := table.Render(); err != nil {
+		t.Fatalf("expected no error rendering an empty table, got %v", err)
+	}
+	if !strings.Contains(buffer.String(), "ID") {
+		t.Fatalf("expected the header to still be rendered, got:\n%s", buffer.String())
+	}
+}

--- a/internal/connect/types/statement_test.go
+++ b/internal/connect/types/statement_test.go
@@ -41,6 +41,31 @@ func TestClassifyStatement(t *testing.T) {
 		{name: "set", sql: "SET AUTOCOMMIT ON", expected: StatementTypeSet},
 		{name: "unknown", sql: "CALL something()", expected: StatementTypeUnknown},
 		{name: "empty", sql: "   ", expected: StatementTypeUnknown},
+		{name: "explain", sql: "EXPLAIN SELECT 1", expected: StatementTypeExplain},
+		{name: "insert", sql: "INSERT INTO t VALUES (1)", expected: StatementTypeInsert},
+		{name: "delete", sql: "DELETE FROM t", expected: StatementTypeDelete},
+		{name: "import", sql: "IMPORT INTO t FROM CSV", expected: StatementTypeImport},
+		{name: "export", sql: "EXPORT t INTO CSV", expected: StatementTypeExport},
+		{name: "create", sql: "CREATE TABLE t (id INT)", expected: StatementTypeCreate},
+		{name: "alter", sql: "ALTER TABLE t ADD COLUMN x INT", expected: StatementTypeAlter},
+		{name: "drop", sql: "DROP TABLE t", expected: StatementTypeDrop},
+		{name: "truncate", sql: "TRUNCATE TABLE t", expected: StatementTypeTruncate},
+		{name: "commit", sql: "COMMIT", expected: StatementTypeCommit},
+		{name: "rollback", sql: "ROLLBACK", expected: StatementTypeRollback},
+		{name: "grant", sql: "GRANT SELECT ON t TO u", expected: StatementTypeGrant},
+		{name: "revoke", sql: "REVOKE SELECT ON t FROM u", expected: StatementTypeRevoke},
+		{
+			name:     "open without schema keyword is unknown",
+			sql:      "OPEN CURSOR foo",
+			expected: StatementTypeUnknown,
+		},
+		{
+			name:     "close without schema keyword is unknown",
+			sql:      "CLOSE CURSOR foo",
+			expected: StatementTypeUnknown,
+		},
+		{name: "open alone is unknown", sql: "OPEN", expected: StatementTypeUnknown},
+		{name: "close alone is unknown", sql: "CLOSE", expected: StatementTypeUnknown},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -55,9 +80,24 @@ func TestStatementTypeUsesExecPath(t *testing.T) {
 
 	require.False(t, StatementTypeSelect.UsesExecPath())
 	require.False(t, StatementTypeWith.UsesExecPath())
+	require.False(t, StatementTypeExplain.UsesExecPath())
+	require.True(t, StatementTypeInsert.UsesExecPath())
 	require.True(t, StatementTypeUpdate.UsesExecPath())
+	require.True(t, StatementTypeDelete.UsesExecPath())
+	require.True(t, StatementTypeMerge.UsesExecPath())
+	require.True(t, StatementTypeImport.UsesExecPath())
+	require.True(t, StatementTypeExport.UsesExecPath())
+	require.True(t, StatementTypeCreate.UsesExecPath())
+	require.True(t, StatementTypeAlter.UsesExecPath())
+	require.True(t, StatementTypeDrop.UsesExecPath())
+	require.True(t, StatementTypeTruncate.UsesExecPath())
 	require.True(t, StatementTypeOpenSchema.UsesExecPath())
 	require.True(t, StatementTypeCloseSchema.UsesExecPath())
-	require.True(t, StatementTypeMerge.UsesExecPath())
+	require.True(t, StatementTypeSet.UsesExecPath())
+	require.True(t, StatementTypeCommit.UsesExecPath())
+	require.True(t, StatementTypeRollback.UsesExecPath())
+	require.True(t, StatementTypeGrant.UsesExecPath())
+	require.True(t, StatementTypeRevoke.UsesExecPath())
 	require.False(t, StatementTypeUnknown.UsesExecPath())
+	require.False(t, StatementType("NOT_A_REAL_TYPE").UsesExecPath())
 }

--- a/internal/deploy/backend_selection_test.go
+++ b/internal/deploy/backend_selection_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"os"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/presets"
+)
+
+func newTofuTestDeployment(t *testing.T) config.DeploymentDir {
+	t.Helper()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := os.MkdirAll(deployment.InfrastructureDir(), 0o700); err != nil {
+		t.Fatalf("create infrastructure dir failed: %v", err)
+	}
+	writeTestFile(t, deployment.InfrastructureManifestPath(), `
+name: Test Tofu Infrastructure
+description: test infrastructure
+backend: tofu
+tofu: {}
+`)
+
+	return deployment
+}
+
+// resolveBackendKind and newDeploymentBackend (given a manifest) are already
+// covered in backend_test.go; the tests below add newDeploymentBackendForDeployment
+// (reading the manifest from disk) and readInfrastructurePresetConfigVariables,
+// which were not covered anywhere.
+
+func TestNewDeploymentBackendForDeployment_ResolvesLocalBackend(t *testing.T) {
+	t.Parallel()
+
+	deployment := newLocalTestDeployment(t)
+
+	backend, err := newDeploymentBackendForDeployment(deployment)
+	if err != nil {
+		t.Fatalf("expected a local backend to resolve, got %v", err)
+	}
+	if backend == nil {
+		t.Fatal("expected a non-nil backend")
+	}
+}
+
+func TestNewDeploymentBackendForDeployment_ResolvesTofuBackend(t *testing.T) {
+	t.Parallel()
+
+	deployment := newTofuTestDeployment(t)
+
+	backend, err := newDeploymentBackendForDeployment(deployment)
+	if err != nil {
+		t.Fatalf("expected a tofu backend to resolve, got %v", err)
+	}
+	if backend == nil {
+		t.Fatal("expected a non-nil backend")
+	}
+}
+
+func TestNewDeploymentBackendForDeployment_MissingManifestReturnsError(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+
+	_, err := newDeploymentBackendForDeployment(deployment)
+	if err == nil {
+		t.Fatal("expected an error when the infrastructure manifest is missing")
+	}
+}
+
+func TestReadInfrastructurePresetConfigVariables_TofuWithoutTofuConfigIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	manifest := &presets.InfrastructureManifest{Backend: "tofu"}
+
+	variables, err := readInfrastructurePresetConfigVariables(PresetRef{Name: "aws"}, manifest)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(variables) != 0 {
+		t.Fatalf("expected an empty variable set, got %+v", variables)
+	}
+}
+
+func TestReadInfrastructurePresetConfigVariables_LocalBackendUsesLocalDefinitions(t *testing.T) {
+	t.Parallel()
+
+	manifest := &presets.InfrastructureManifest{
+		Backend: "local",
+		Local:   &presets.InfrastructureLocal{},
+	}
+
+	variables, err := readInfrastructurePresetConfigVariables(PresetRef{Name: "local"}, manifest)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(variables) == 0 {
+		t.Fatal("expected local backend to declare configurable variables")
+	}
+}

--- a/internal/deploy/config_variables_test.go
+++ b/internal/deploy/config_variables_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+)
+
+func TestResolveInfrastructureConfigVariables_NameBasedEmbeddedPreset(t *testing.T) {
+	t.Parallel()
+
+	resolution, err := ResolveInfrastructureConfigVariables(PresetRef{Name: "local"})
+	if err != nil {
+		t.Fatalf("expected the embedded 'local' preset to resolve, got %v", err)
+	}
+	if resolution.PresetLabel != "local" {
+		t.Fatalf("expected the preset label to be 'local', got %q", resolution.PresetLabel)
+	}
+	if len(resolution.Variables) == 0 {
+		t.Fatal("expected the local preset to declare configurable variables")
+	}
+}
+
+func TestResolveInfrastructureConfigVariables_UnknownPresetReturnsErrorWithLabel(t *testing.T) {
+	t.Parallel()
+
+	resolution, err := ResolveInfrastructureConfigVariables(PresetRef{Name: "does-not-exist"})
+	if err == nil {
+		t.Fatal("expected an error for an unknown preset")
+	}
+	if resolution.PresetLabel != "does-not-exist" {
+		t.Fatalf(
+			"expected the preset label to still be set on error, got %q",
+			resolution.PresetLabel,
+		)
+	}
+}
+
+func TestResolveInfrastructureConfigVariables_PathBasedPreset(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeTestFile(t, dir+"/infrastructure.yaml", `
+name: Test Infrastructure
+description: test infrastructure
+backend: local
+`)
+
+	resolution, err := ResolveInfrastructureConfigVariables(PresetRef{Path: dir})
+	if err != nil {
+		t.Fatalf("expected the path-based preset to resolve, got %v", err)
+	}
+	if resolution.PresetLabel != dir {
+		t.Fatalf("expected the preset label to be the path, got %q", resolution.PresetLabel)
+	}
+}
+
+func TestResolveInfrastructureConfigVariablesFromDeployment_ResolvesLocalBackend(t *testing.T) {
+	t.Parallel()
+
+	deployment := newLocalTestDeployment(t)
+
+	resolution, err := ResolveInfrastructureConfigVariablesFromDeployment(deployment)
+	if err != nil {
+		t.Fatalf("expected the local deployment to resolve, got %v", err)
+	}
+	if resolution.PresetLabel == "" {
+		t.Fatal("expected a non-empty preset label")
+	}
+	if len(resolution.Variables) == 0 {
+		t.Fatal("expected the local backend to declare configurable variables")
+	}
+}
+
+func TestResolveInfrastructureConfigVariablesFromDeployment_MissingManifestReturnsError(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+
+	_, err := ResolveInfrastructureConfigVariablesFromDeployment(deployment)
+	if err == nil {
+		t.Fatal("expected an error when the infrastructure manifest is missing")
+	}
+}

--- a/internal/deploy/configuration_test.go
+++ b/internal/deploy/configuration_test.go
@@ -1,0 +1,366 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/presets"
+)
+
+const testRegionDefault = "us-east-1"
+
+func TestDeploymentConfigValueDisplayNameHyphenatesUnderscores(t *testing.T) {
+	t.Parallel()
+
+	value := DeploymentConfigValue{Name: "instance_count"}
+
+	if got := value.DisplayName(); got != "instance-count" {
+		t.Fatalf("expected 'instance-count', got %q", got)
+	}
+}
+
+func TestNormalizeConfigOptionName(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"instance-count": "instance_count",
+		"instance_count": "instance_count",
+		"  region  ":     "region",
+	}
+	for input, want := range cases {
+		if got := normalizeConfigOptionName(input); got != want {
+			t.Errorf("normalizeConfigOptionName(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestFilterDeploymentConfiguration_SelectsMatchingOptionsRegardlessOfHyphenation(t *testing.T) {
+	t.Parallel()
+
+	configuration := newDeploymentConfigurationFromRaw(
+		map[string]string{"instance_count": "3", "region": "eu-central-1"},
+		map[string]string{"admin_password": "secret"},
+	)
+
+	filtered, err := filterDeploymentConfiguration(configuration, []string{"instance-count"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(filtered.Infrastructure.Options) != 1 ||
+		filtered.Infrastructure.Options[0].Name != "instance_count" {
+		t.Fatalf(
+			"expected only instance_count to be selected, got %+v",
+			filtered.Infrastructure.Options,
+		)
+	}
+	if len(filtered.Installation.Options) != 0 {
+		t.Fatalf(
+			"expected no installation options selected, got %+v",
+			filtered.Installation.Options,
+		)
+	}
+}
+
+func TestFilterDeploymentConfiguration_NoNamesReturnsEverything(t *testing.T) {
+	t.Parallel()
+
+	configuration := newDeploymentConfigurationFromRaw(
+		map[string]string{"region": "eu-central-1"},
+		nil,
+	)
+
+	filtered, err := filterDeploymentConfiguration(configuration, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(filtered.Infrastructure.Options) != 1 {
+		t.Fatalf("expected the full configuration to be returned unfiltered, got %+v", filtered)
+	}
+}
+
+func TestFilterDeploymentConfiguration_UnknownOptionReturnsError(t *testing.T) {
+	t.Parallel()
+
+	configuration := newDeploymentConfigurationFromRaw(
+		map[string]string{"region": "eu-central-1"},
+		nil,
+	)
+
+	_, err := filterDeploymentConfiguration(configuration, []string{"does-not-exist"})
+	if err == nil {
+		t.Fatal("expected an error for an unknown configuration option")
+	}
+}
+
+func TestResetSelectedDeploymentConfiguration_ResetsOnlySelectedOptions(t *testing.T) {
+	t.Parallel()
+
+	configuration := DeploymentConfiguration{
+		Infrastructure: DeploymentConfigurationSection{
+			Options: []DeploymentConfigValue{
+				{
+					Name:       "region",
+					RawValue:   "eu-west-1",
+					RawDefault: testRegionDefault,
+					Default:    testRegionDefault,
+				},
+				{Name: "instance_count", RawValue: "5", RawDefault: "2", Default: 2},
+			},
+		},
+	}
+
+	reset, err := resetSelectedDeploymentConfiguration(configuration, []string{"region"})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if reset.Infrastructure.Options[0].RawValue != testRegionDefault {
+		t.Fatalf(
+			"expected region to be reset to its default, got %+v",
+			reset.Infrastructure.Options[0],
+		)
+	}
+	if reset.Infrastructure.Options[1].RawValue != "5" {
+		t.Fatalf(
+			"expected instance_count to be untouched, got %+v",
+			reset.Infrastructure.Options[1],
+		)
+	}
+}
+
+func TestResetSelectedDeploymentConfiguration_UnknownOptionReturnsError(t *testing.T) {
+	t.Parallel()
+
+	configuration := DeploymentConfiguration{
+		Infrastructure: DeploymentConfigurationSection{
+			Options: []DeploymentConfigValue{{Name: "region"}},
+		},
+	}
+
+	_, err := resetSelectedDeploymentConfiguration(configuration, []string{"does-not-exist"})
+	if err == nil {
+		t.Fatal("expected an error for an unknown configuration option")
+	}
+}
+
+func TestResetAllConfigurationValues_ResetsEveryOption(t *testing.T) {
+	t.Parallel()
+
+	values := []DeploymentConfigValue{
+		{
+			Name:       "region",
+			RawValue:   "eu-west-1",
+			RawDefault: testRegionDefault,
+			Default:    testRegionDefault,
+		},
+		{Name: "instance_count", RawValue: "5", RawDefault: "2", Default: 2},
+	}
+
+	resetAllConfigurationValues(values)
+
+	if values[0].RawValue != testRegionDefault || values[1].RawValue != "2" {
+		t.Fatalf("expected all values to reset to their defaults, got %+v", values)
+	}
+}
+
+func TestConfigValuesRawMap_SkipsBlankNames(t *testing.T) {
+	t.Parallel()
+
+	values := []DeploymentConfigValue{
+		{Name: "region", RawValue: "eu-west-1"},
+		{Name: "  ", RawValue: "ignored"},
+	}
+
+	result := configValuesRawMap(values)
+
+	if len(result) != 1 || result["region"] != "eu-west-1" {
+		t.Fatalf("expected only 'region' to be included, got %+v", result)
+	}
+}
+
+func TestScalarToRawString(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		value   any
+		want    string
+		wantErr bool
+	}{
+		"string":         {value: "hello", want: "hello"},
+		"bool":           {value: true, want: "true"},
+		"int":            {value: 42, want: "42"},
+		"int64":          {value: int64(42), want: "42"},
+		"float64":        {value: 3.5, want: "3.5"},
+		"json.Number":    {value: json.Number("7"), want: "7"},
+		"unsupported":    {value: []string{"x"}, wantErr: true},
+		"struct is nope": {value: struct{}{}, wantErr: true},
+	}
+
+	for name, testCase := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := scalarToRawString(testCase.value)
+
+			if testCase.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if got != testCase.want {
+				t.Fatalf("expected %q, got %q", testCase.want, got)
+			}
+		})
+	}
+}
+
+func newInitializedRealDeployment(t *testing.T) config.DeploymentDir {
+	t.Helper()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := InitDeployment(
+		context.Background(),
+		PresetRef{Name: presets.DefaultInfrastructure},
+		PresetRef{Name: presets.DefaultInstallation},
+		map[string]string{},
+		map[string]string{},
+		deployment,
+		false,
+		"0.0.0",
+	); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	return deployment
+}
+
+func findClusterSizeConfigValue(
+	configuration DeploymentConfiguration,
+) (DeploymentConfigValue, bool) {
+	for _, value := range configuration.Infrastructure.Options {
+		if value.Name == "cluster_size" {
+			return value, true
+		}
+	}
+
+	return DeploymentConfigValue{}, false
+}
+
+func TestResetDeploymentConfiguration_RejectsMissingSelector(t *testing.T) {
+	t.Parallel()
+
+	deployment := newInitializedRealDeployment(t)
+
+	_, err := ResetDeploymentConfiguration(context.Background(), deployment, nil, false)
+	if err == nil {
+		t.Fatal("expected an error when neither option names nor --all is given")
+	}
+}
+
+func TestResetDeploymentConfiguration_RejectsBothAllAndOptionNames(t *testing.T) {
+	t.Parallel()
+
+	deployment := newInitializedRealDeployment(t)
+
+	_, err := ResetDeploymentConfiguration(
+		context.Background(), deployment, []string{"cluster_size"}, true,
+	)
+	if err == nil {
+		t.Fatal("expected an error when both --all and option names are given")
+	}
+}
+
+func TestResetDeploymentConfiguration_ResetSelectedOptionRestoresItsDefault(t *testing.T) {
+	t.Parallel()
+
+	deployment := newInitializedRealDeployment(t)
+
+	before, err := GetDeploymentConfiguration(context.Background(), deployment, nil)
+	if err != nil {
+		t.Fatalf("failed to read initial configuration: %v", err)
+	}
+	clusterSize, found := findClusterSizeConfigValue(before)
+	if !found {
+		t.Fatal("expected the aws preset to declare a cluster_size variable")
+	}
+	defaultRawValue := clusterSize.RawDefault
+
+	overrideValue := "5"
+	if defaultRawValue == overrideValue {
+		overrideValue = "6"
+	}
+	if _, err := SetDeploymentConfiguration(
+		context.Background(),
+		map[string]string{"cluster_size": overrideValue},
+		nil,
+		deployment,
+	); err != nil {
+		t.Fatalf("failed to override cluster_size: %v", err)
+	}
+
+	after, err := ResetDeploymentConfiguration(
+		context.Background(), deployment, []string{"cluster_size"}, false,
+	)
+	if err != nil {
+		t.Fatalf("failed to reset cluster_size: %v", err)
+	}
+
+	reset, found := findClusterSizeConfigValue(after)
+	if !found {
+		t.Fatal("expected cluster_size to still be present after reset")
+	}
+	if reset.RawValue != defaultRawValue {
+		t.Fatalf("expected cluster_size to be reset to %q, got %q", defaultRawValue, reset.RawValue)
+	}
+}
+
+func TestResetDeploymentConfiguration_ResetAllRestoresEveryDefault(t *testing.T) {
+	t.Parallel()
+
+	deployment := newInitializedRealDeployment(t)
+
+	before, err := GetDeploymentConfiguration(context.Background(), deployment, nil)
+	if err != nil {
+		t.Fatalf("failed to read initial configuration: %v", err)
+	}
+	clusterSize, found := findClusterSizeConfigValue(before)
+	if !found {
+		t.Fatal("expected the aws preset to declare a cluster_size variable")
+	}
+	defaultRawValue := clusterSize.RawDefault
+
+	overrideValue := "5"
+	if defaultRawValue == overrideValue {
+		overrideValue = "6"
+	}
+	if _, err := SetDeploymentConfiguration(
+		context.Background(),
+		map[string]string{"cluster_size": overrideValue},
+		nil,
+		deployment,
+	); err != nil {
+		t.Fatalf("failed to override cluster_size: %v", err)
+	}
+
+	after, err := ResetDeploymentConfiguration(context.Background(), deployment, nil, true)
+	if err != nil {
+		t.Fatalf("failed to reset all configuration: %v", err)
+	}
+
+	reset, found := findClusterSizeConfigValue(after)
+	if !found {
+		t.Fatal("expected cluster_size to still be present after reset")
+	}
+	if reset.RawValue != defaultRawValue {
+		t.Fatalf("expected cluster_size to be reset to %q, got %q", defaultRawValue, reset.RawValue)
+	}
+}

--- a/internal/deploy/connect_test.go
+++ b/internal/deploy/connect_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/connect"
+	"github.com/exasol/exasol-personal/internal/presets"
+)
+
+func TestConnect_BlockedStateReturnsErrorWithoutResolvingConnectionInfo(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := InitDeployment(
+		context.Background(),
+		PresetRef{Name: presets.DefaultInfrastructure},
+		PresetRef{Name: presets.DefaultInstallation},
+		map[string]string{},
+		map[string]string{},
+		deployment,
+		false,
+		"0.0.0",
+	); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	err := Connect(context.Background(), &connect.Opts{}, deployment)
+	if !errors.Is(err, ErrUnexpectedDeploymentStatus) {
+		t.Fatalf("expected ErrUnexpectedDeploymentStatus, got %v", err)
+	}
+}
+
+func TestConnect_MissingStateReturnsError(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+
+	if err := Connect(context.Background(), &connect.Opts{}, deployment); err == nil {
+		t.Fatal("expected an error when no launcher state has been persisted")
+	}
+}

--- a/internal/deploy/connection_instructions_test.go
+++ b/internal/deploy/connection_instructions_test.go
@@ -5,6 +5,7 @@ package deploy
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
 
@@ -62,6 +63,41 @@ func TestGetConnectionInstructionsTextNotInitializedHandlesMissingDirectory(t *t
 	}
 	assertContains(t, content, "Deployment directory: "+deployment.Root())
 	assertContains(t, content, "Deployment State: not_initialized")
+}
+
+func TestWriteConnectionInstructionsFile_WritesContentToDeploymentRoot(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	deployment := config.NewDeploymentDir(t.TempDir())
+
+	// When
+	err := writeConnectionInstructionsFile(deployment, "hello instructions")
+	// Then
+	if err != nil {
+		t.Fatalf("expected write to succeed, got %v", err)
+	}
+	content, readErr := os.ReadFile(deployment.ConnectionInstructionsPath())
+	if readErr != nil {
+		t.Fatalf("failed to read written instructions file: %v", readErr)
+	}
+	if string(content) != "hello instructions" {
+		t.Fatalf("expected written content to match, got %q", content)
+	}
+}
+
+func TestWriteConnectionInstructionsFile_MissingDirectoryReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	deployment := config.NewDeploymentDir(t.TempDir() + "/missing")
+
+	// When
+	err := writeConnectionInstructionsFile(deployment, "hello instructions")
+	// Then
+	if err == nil {
+		t.Fatal("expected an error when the deployment directory does not exist")
+	}
 }
 
 func initDeploymentForInfoTest(t *testing.T, deployment config.DeploymentDir) {

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -4,11 +4,13 @@
 package deploy
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
 
 	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/presets"
 )
 
 func TestAppendDeployFailureHint_AddsLauncherLogPath(t *testing.T) {
@@ -71,5 +73,92 @@ func TestAppendDeployFailureHintNilInput(t *testing.T) {
 
 	if err := appendDeployFailureHint(config.NewDeploymentDir(t.TempDir()), nil); err != nil {
 		t.Fatalf("expected nil, got: %v", err)
+	}
+}
+
+func TestDeployFailureResourceHint_LocalBackendMentionsLocalVM(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	deployment := newLocalTestDeployment(t)
+
+	// Then
+	if hint := deployFailureResourceHint(deployment); hint != localDeployFailureResourceHint {
+		t.Fatalf("expected the local-backend hint, got %q", hint)
+	}
+}
+
+func TestDeployFailureResourceHint_MissingManifestFallsBackToCloudHint(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	deployment := config.NewDeploymentDir(t.TempDir())
+
+	// Then
+	if hint := deployFailureResourceHint(deployment); hint != cloudDeployFailureResourceHint {
+		t.Fatalf("expected the cloud fallback hint, got %q", hint)
+	}
+}
+
+func TestWorkflowStatePermitsDeploy_ReturnsErrorWhenWorkflowStateUnreadable(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	exasolState := &config.ExasolPersonalState{}
+
+	// When
+	err := WorkflowStatePermitsDeploy(exasolState, config.NewDeploymentDir(t.TempDir()))
+	// Then
+	if err == nil {
+		t.Fatal("expected an error when no workflow state is set")
+	}
+}
+
+func TestDeploy_BlockedStateReturnsErrorWithoutInvokingBackend(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := InitDeployment(
+		context.Background(),
+		PresetRef{Name: presets.DefaultInfrastructure},
+		PresetRef{Name: presets.DefaultInstallation},
+		map[string]string{},
+		map[string]string{},
+		deployment,
+		false,
+		"0.0.0",
+	); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+	exasolState, err := config.ReadExasolPersonalState(deployment)
+	if err != nil {
+		t.Fatalf("read state failed: %v", err)
+	}
+	if err := exasolState.SetWorkflowStateAndWrite(
+		&config.WorkflowStateStopped{}, deployment,
+	); err != nil {
+		t.Fatalf("write workflow state failed: %v", err)
+	}
+
+	// When
+	err = Deploy(context.Background(), deployment, false, DeployOptions{})
+	// Then
+	if !errors.Is(err, ErrUnexpectedDeploymentStatus) {
+		t.Fatalf("expected ErrUnexpectedDeploymentStatus, got %v", err)
+	}
+}
+
+func TestDeploy_MissingStateReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	deployment := config.NewDeploymentDir(t.TempDir())
+
+	// When
+	err := Deploy(context.Background(), deployment, false, DeployOptions{})
+	// Then
+	if err == nil {
+		t.Fatal("expected an error when no launcher state has been persisted")
 	}
 }

--- a/internal/deploy/deploymentControl_test.go
+++ b/internal/deploy/deploymentControl_test.go
@@ -5,10 +5,14 @@ package deploy
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/directorymutex"
+	"github.com/exasol/exasol-personal/internal/presets"
 )
 
 func TestWorkflowStatePermitsStart_RequiresStartForStoppedDeployment(t *testing.T) {
@@ -193,6 +197,417 @@ func TestWorkflowStatePermitsStop_GuidesForAlreadyStoppedDeployment(t *testing.T
 	}
 	if !strings.Contains(decision.guidance, "already stopped") {
 		t.Fatalf("expected already-stopped guidance, got %q", decision.guidance)
+	}
+}
+
+func TestWorkflowStatePermitsStart_ReturnsErrorWhenWorkflowStateUnreadable(t *testing.T) {
+	t.Parallel()
+
+	// Given: launcher state with no workflow state set at all.
+	exasolState := &config.ExasolPersonalState{}
+
+	// When: start permission is checked.
+	_, err := workflowStatePermitsStart(
+		context.Background(),
+		exasolState,
+		config.NewDeploymentDir(t.TempDir()),
+	)
+	// Then: the unreadable workflow state surfaces as an error.
+	if err == nil {
+		t.Fatal("expected an error when no workflow state is set")
+	}
+}
+
+func TestWorkflowStatePermitsStart_GuidesForDeploymentFailed(t *testing.T) {
+	t.Parallel()
+
+	// Given: a deployment whose workflow state is failed.
+	exasolState := &config.ExasolPersonalState{}
+	if err := exasolState.SetWorkflowState(&config.WorkflowStateDeploymentFailed{}); err != nil {
+		t.Fatalf("set workflow state failed: %v", err)
+	}
+
+	// When: start permission is checked.
+	decision, err := workflowStatePermitsStart(
+		context.Background(), exasolState, config.NewDeploymentDir(t.TempDir()),
+	)
+	// Then: the caller gets guidance instead of retrying the backend.
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if decision.shouldRun {
+		t.Fatal("expected a failed deployment to skip backend start")
+	}
+	if !strings.Contains(decision.guidance, "failed state") {
+		t.Fatalf("expected failed-state guidance, got %q", decision.guidance)
+	}
+}
+
+func TestWorkflowStatePermitsStart_ResumesForOperationInProgressStart(t *testing.T) {
+	t.Parallel()
+
+	// Given: an operation already in progress is a start.
+	exasolState := &config.ExasolPersonalState{}
+	if err := exasolState.SetWorkflowState(&config.WorkflowStateOperationInProgress{
+		Operation: config.StartOperation,
+	}); err != nil {
+		t.Fatalf("set workflow state failed: %v", err)
+	}
+
+	// When: start permission is checked.
+	decision, err := workflowStatePermitsStart(
+		context.Background(), exasolState, config.NewDeploymentDir(t.TempDir()),
+	)
+	// Then: the caller resumes the in-progress start.
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if !decision.shouldRun {
+		t.Fatal("expected an in-progress start to resume")
+	}
+}
+
+func TestWorkflowStatePermitsStart_SkipsForOperationInProgressOtherOperation(t *testing.T) {
+	t.Parallel()
+
+	// Given: an operation already in progress is not a start.
+	exasolState := &config.ExasolPersonalState{}
+	if err := exasolState.SetWorkflowState(&config.WorkflowStateOperationInProgress{
+		Operation: config.DestroyOperation,
+	}); err != nil {
+		t.Fatalf("set workflow state failed: %v", err)
+	}
+
+	// When: start permission is checked.
+	decision, err := workflowStatePermitsStart(
+		context.Background(), exasolState, config.NewDeploymentDir(t.TempDir()),
+	)
+	// Then: the caller skips start and gets recovery guidance.
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if decision.shouldRun {
+		t.Fatal("expected a different in-progress operation to skip start")
+	}
+	if !strings.Contains(decision.guidance, "exasol status") {
+		t.Fatalf("expected recovery guidance, got %q", decision.guidance)
+	}
+}
+
+func TestWorkflowStatePermitsStart_ResumesForInterruptedStartOrStop(t *testing.T) {
+	t.Parallel()
+
+	for _, operation := range []string{config.StartOperation, config.StopOperation} {
+		// Given: a workflow interrupted during a start or stop.
+		exasolState := &config.ExasolPersonalState{}
+		if err := exasolState.SetWorkflowState(&config.WorkflowStateInterrupted{
+			InterruptedDuringOperation: operation,
+		}); err != nil {
+			t.Fatalf("set workflow state failed: %v", err)
+		}
+
+		// When: start permission is checked.
+		decision, err := workflowStatePermitsStart(
+			context.Background(), exasolState, config.NewDeploymentDir(t.TempDir()),
+		)
+		// Then: the caller resumes via start.
+		if err != nil {
+			t.Fatalf("expected no error for interrupted %q, got: %v", operation, err)
+		}
+		if !decision.shouldRun {
+			t.Fatalf("expected an interrupted %q to resume via start", operation)
+		}
+	}
+}
+
+func TestWorkflowStatePermitsStart_SkipsForInterruptedOtherOperation(t *testing.T) {
+	t.Parallel()
+
+	// Given: a workflow interrupted during an unrelated operation (destroy).
+	exasolState := &config.ExasolPersonalState{}
+	if err := exasolState.SetWorkflowState(&config.WorkflowStateInterrupted{
+		InterruptedDuringOperation: config.DestroyOperation,
+	}); err != nil {
+		t.Fatalf("set workflow state failed: %v", err)
+	}
+
+	// When: start permission is checked.
+	decision, err := workflowStatePermitsStart(
+		context.Background(), exasolState, config.NewDeploymentDir(t.TempDir()),
+	)
+	// Then: the caller skips start and gets recovery guidance.
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if decision.shouldRun {
+		t.Fatal("expected an interrupted destroy to skip start")
+	}
+	if !strings.Contains(decision.guidance, "exasol status") {
+		t.Fatalf("expected recovery guidance, got %q", decision.guidance)
+	}
+}
+
+func TestWorkflowStatePermitsStop_ReturnsErrorWhenWorkflowStateUnreadable(t *testing.T) {
+	t.Parallel()
+
+	// Given: launcher state with no workflow state set at all.
+	exasolState := &config.ExasolPersonalState{}
+
+	// Then: stop permission is checked and the unreadable workflow state surfaces as an error.
+	if _, err := workflowStatePermitsStop(exasolState); err == nil {
+		t.Fatal("expected an error when no workflow state is set")
+	}
+}
+
+func TestWorkflowStatePermitsStop_GuidesForDeploymentFailed(t *testing.T) {
+	t.Parallel()
+
+	// Given: a deployment whose workflow state is failed.
+	exasolState := &config.ExasolPersonalState{}
+	if err := exasolState.SetWorkflowState(&config.WorkflowStateDeploymentFailed{}); err != nil {
+		t.Fatalf("set workflow state failed: %v", err)
+	}
+
+	// When: stop permission is checked.
+	decision, err := workflowStatePermitsStop(exasolState)
+	// Then: the caller gets guidance instead of retrying the backend.
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if decision.shouldRun {
+		t.Fatal("expected a failed deployment to skip backend stop")
+	}
+	if !strings.Contains(decision.guidance, "failed state") {
+		t.Fatalf("expected failed-state guidance, got %q", decision.guidance)
+	}
+}
+
+func TestWorkflowStatePermitsStop_ResumesForOperationInProgressStop(t *testing.T) {
+	t.Parallel()
+
+	// Given: an operation already in progress is a stop.
+	exasolState := &config.ExasolPersonalState{}
+	if err := exasolState.SetWorkflowState(&config.WorkflowStateOperationInProgress{
+		Operation: config.StopOperation,
+	}); err != nil {
+		t.Fatalf("set workflow state failed: %v", err)
+	}
+
+	// When: stop permission is checked.
+	decision, err := workflowStatePermitsStop(exasolState)
+	// Then: the caller resumes the in-progress stop.
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if !decision.shouldRun {
+		t.Fatal("expected an in-progress stop to resume")
+	}
+}
+
+func TestWorkflowStatePermitsStop_SkipsForOperationInProgressOtherOperation(t *testing.T) {
+	t.Parallel()
+
+	// Given: an operation already in progress is not a stop.
+	exasolState := &config.ExasolPersonalState{}
+	if err := exasolState.SetWorkflowState(&config.WorkflowStateOperationInProgress{
+		Operation: config.DestroyOperation,
+	}); err != nil {
+		t.Fatalf("set workflow state failed: %v", err)
+	}
+
+	// When: stop permission is checked.
+	decision, err := workflowStatePermitsStop(exasolState)
+	// Then: the caller skips stop and gets recovery guidance.
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if decision.shouldRun {
+		t.Fatal("expected a different in-progress operation to skip stop")
+	}
+	if !strings.Contains(decision.guidance, "exasol status") {
+		t.Fatalf("expected recovery guidance, got %q", decision.guidance)
+	}
+}
+
+func TestWorkflowStatePermitsStop_ResumesForInterruptedStartStopOrDestroy(t *testing.T) {
+	t.Parallel()
+
+	for _, operation := range []string{
+		config.StartOperation, config.StopOperation, config.DestroyOperation,
+	} {
+		// Given: a workflow interrupted during a start, stop, or destroy.
+		exasolState := &config.ExasolPersonalState{}
+		if err := exasolState.SetWorkflowState(&config.WorkflowStateInterrupted{
+			InterruptedDuringOperation: operation,
+		}); err != nil {
+			t.Fatalf("set workflow state failed: %v", err)
+		}
+
+		// When: stop permission is checked.
+		decision, err := workflowStatePermitsStop(exasolState)
+		// Then: the caller resumes via stop.
+		if err != nil {
+			t.Fatalf("expected no error for interrupted %q, got: %v", operation, err)
+		}
+		if !decision.shouldRun {
+			t.Fatalf("expected an interrupted %q to resume via stop", operation)
+		}
+	}
+}
+
+func TestWorkflowStatePermitsStop_SkipsForInterruptedOtherOperation(t *testing.T) {
+	t.Parallel()
+
+	// Given: a workflow interrupted during an unrelated operation (install).
+	exasolState := &config.ExasolPersonalState{}
+	if err := exasolState.SetWorkflowState(&config.WorkflowStateInterrupted{
+		InterruptedDuringOperation: "install",
+	}); err != nil {
+		t.Fatalf("set workflow state failed: %v", err)
+	}
+
+	// When: stop permission is checked.
+	decision, err := workflowStatePermitsStop(exasolState)
+	// Then: the caller skips stop and gets recovery guidance.
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if decision.shouldRun {
+		t.Fatal("expected an interrupted install to skip stop")
+	}
+	if !strings.Contains(decision.guidance, "exasol status") {
+		t.Fatalf("expected recovery guidance, got %q", decision.guidance)
+	}
+}
+
+func TestStart_InitializedDeploymentReturnsErrLifecycleActionSkipped(t *testing.T) {
+	t.Parallel()
+
+	// Given: a deployment that has been initialized but not deployed.
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := InitDeployment(
+		context.Background(),
+		PresetRef{Name: presets.DefaultInfrastructure},
+		PresetRef{Name: presets.DefaultInstallation},
+		map[string]string{},
+		map[string]string{},
+		deployment,
+		false,
+		"0.0.0",
+	); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	// When: Start is called.
+	err := Start(context.Background(), deployment, false, 0)
+	// Then: the lifecycle action is skipped.
+	if !errors.Is(err, ErrLifecycleActionSkipped) {
+		t.Fatalf("expected ErrLifecycleActionSkipped, got %v", err)
+	}
+}
+
+func TestStart_MissingStateReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// Given: a deployment with no persisted launcher state.
+	deployment := config.NewDeploymentDir(t.TempDir())
+
+	// When: Start is called.
+	err := Start(context.Background(), deployment, false, 0)
+	// Then: a real error is returned, not a lifecycle skip.
+	if err == nil {
+		t.Fatal("expected an error when no launcher state has been persisted")
+	}
+	if errors.Is(err, ErrLifecycleActionSkipped) {
+		t.Fatal("expected a real error, not a lifecycle skip")
+	}
+}
+
+func TestStart_LockedDeploymentReturnsErrLifecycleActionSkipped(t *testing.T) {
+	t.Parallel()
+
+	// Given: a deployment that is exclusively locked by another process.
+	deployment := config.NewDeploymentDir(t.TempDir())
+	mutex, err := directorymutex.New(deployment.Root())
+	if err != nil {
+		t.Fatalf("expected mutex creation to succeed, got: %v", err)
+	}
+	if err := mutex.AcquireExclusive(context.Background()); err != nil {
+		t.Fatalf("expected exclusive lock to succeed, got: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = mutex.ReleaseExclusive(context.Background())
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	// When: Start is called.
+	err = Start(ctx, deployment, false, 0)
+	// Then: the lifecycle action is skipped.
+	if !errors.Is(err, ErrLifecycleActionSkipped) {
+		t.Fatalf("expected ErrLifecycleActionSkipped, got %v", err)
+	}
+}
+
+func TestStop_InitializedDeploymentReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	// Given: a deployment that has been initialized but not deployed.
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := InitDeployment(
+		context.Background(),
+		PresetRef{Name: presets.DefaultInfrastructure},
+		PresetRef{Name: presets.DefaultInstallation},
+		map[string]string{},
+		map[string]string{},
+		deployment,
+		false,
+		"0.0.0",
+	); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	// Then: calling Stop no-ops without error.
+	if err := Stop(context.Background(), deployment, false); err != nil {
+		t.Fatalf("expected an initialized-but-not-deployed deployment to no-op, got %v", err)
+	}
+}
+
+func TestStop_MissingStateReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// Given: a deployment with no persisted launcher state.
+	deployment := config.NewDeploymentDir(t.TempDir())
+
+	// Then: calling Stop returns an error.
+	if err := Stop(context.Background(), deployment, false); err == nil {
+		t.Fatal("expected an error when no launcher state has been persisted")
+	}
+}
+
+func TestStop_LockedDeploymentReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	// Given: a deployment that is exclusively locked by another process.
+	deployment := config.NewDeploymentDir(t.TempDir())
+	mutex, err := directorymutex.New(deployment.Root())
+	if err != nil {
+		t.Fatalf("expected mutex creation to succeed, got: %v", err)
+	}
+	if err := mutex.AcquireExclusive(context.Background()); err != nil {
+		t.Fatalf("expected exclusive lock to succeed, got: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = mutex.ReleaseExclusive(context.Background())
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	// Then: calling Stop is silently skipped without error.
+	if err := Stop(ctx, deployment, false); err != nil {
+		t.Fatalf("expected a locked deployment to be silently skipped, got %v", err)
 	}
 }
 

--- a/internal/deploy/deployment_control_helpers_test.go
+++ b/internal/deploy/deployment_control_helpers_test.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+)
+
+func TestNoLifecycleActionDoesNotRunOrShowInstructions(t *testing.T) {
+	t.Parallel()
+
+	decision := noLifecycleAction()
+
+	if decision.shouldRun || decision.guidance != "" || decision.showConnectionInstructions {
+		t.Fatalf("expected an inert decision, got %+v", decision)
+	}
+}
+
+func TestRunLifecycleActionRunsWithoutGuidance(t *testing.T) {
+	t.Parallel()
+
+	decision := runLifecycleAction()
+
+	if !decision.shouldRun || decision.guidance != "" {
+		t.Fatalf("expected a run decision with no guidance, got %+v", decision)
+	}
+}
+
+func TestSkipLifecycleActionWithConnectionInstructionsSetsFlag(t *testing.T) {
+	t.Parallel()
+
+	decision := skipLifecycleActionWithConnectionInstructions("already running")
+
+	if decision.shouldRun || decision.guidance != "already running" ||
+		!decision.showConnectionInstructions {
+		t.Fatalf("expected a skip decision showing connection instructions, got %+v", decision)
+	}
+}
+
+func TestOperationInProgressGuidanceMentionsBothOperations(t *testing.T) {
+	t.Parallel()
+
+	guidance := operationInProgressGuidance("deploy", "start")
+
+	if !strings.Contains(guidance, "deploy") || !strings.Contains(guidance, "exasol start") {
+		t.Fatalf("expected guidance to mention both operations, got %q", guidance)
+	}
+}
+
+func TestInterruptedOperationGuidanceMentionsBothOperations(t *testing.T) {
+	t.Parallel()
+
+	guidance := interruptedOperationGuidance("start", "stop")
+
+	if !strings.Contains(guidance, "start") || !strings.Contains(guidance, "exasol stop") {
+		t.Fatalf("expected guidance to mention both operations, got %q", guidance)
+	}
+}
+
+func TestLogLifecycleGuidanceIsANoopForEmptyMessage(t *testing.T) {
+	t.Parallel()
+
+	// Just verifying it doesn't panic; there's no observable output to assert.
+	logLifecycleGuidance("")
+	logLifecycleGuidance("some guidance")
+}
+
+func TestMarkOperationInterruptedPersistsInterruptedStateAndReturnsOriginalError(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	state := &config.ExasolPersonalState{DeploymentVersion: "0.0.0"}
+	if err := config.WriteExasolPersonalState(state, deployment); err != nil {
+		t.Fatalf("failed to write initial state: %v", err)
+	}
+
+	originalErr := errors.New("boom")
+
+	returnedErr := markOperationInterrupted(state, deployment, "deploy", originalErr)
+
+	if !errors.Is(returnedErr, originalErr) {
+		t.Fatalf("expected the original error to be returned, got %v", returnedErr)
+	}
+
+	persisted, err := config.ReadExasolPersonalState(deployment)
+	if err != nil {
+		t.Fatalf("failed to read persisted state: %v", err)
+	}
+	workflowState, err := persisted.GetWorkflowState()
+	if err != nil {
+		t.Fatalf("failed to get workflow state: %v", err)
+	}
+	interrupted, ok := workflowState.(*config.WorkflowStateInterrupted)
+	if !ok {
+		t.Fatalf("expected WorkflowStateInterrupted, got %T", workflowState)
+	}
+	if interrupted.InterruptedDuringOperation != "deploy" || interrupted.Error != "boom" {
+		t.Fatalf("unexpected interrupted state: %+v", interrupted)
+	}
+}

--- a/internal/deploy/diag_info_test.go
+++ b/internal/deploy/diag_info_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+)
+
+func TestGetDiagnosticDeploymentInfo_ReadsPersistedInfo(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := config.WriteDeploymentInfo(deployment.Root(), &config.DeploymentInfo{
+		DeploymentId: "test-deployment",
+		ClusterSize:  1,
+	}); err != nil {
+		t.Fatalf("failed to seed deployment info: %v", err)
+	}
+
+	info, err := GetDiagnosticDeploymentInfo(context.Background(), deployment)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if info.DeploymentId != "test-deployment" {
+		t.Fatalf("expected the persisted deployment info, got %+v", info)
+	}
+}
+
+func TestGetDiagnosticDeploymentInfo_MissingInfoReturnsError(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+
+	if _, err := GetDiagnosticDeploymentInfo(context.Background(), deployment); err == nil {
+		t.Fatal("expected an error when no deployment info has been persisted")
+	}
+}

--- a/internal/deploy/diag_local_test.go
+++ b/internal/deploy/diag_local_test.go
@@ -6,12 +6,54 @@ package deploy
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"testing"
 
 	"github.com/exasol/exasol-personal/internal/config"
 	"github.com/exasol/exasol-personal/internal/localruntime"
 )
+
+// TestDiagnoseLocal_NonLocalDeploymentShortCircuitsBeforeRunningAnyBinary
+// exercises the DiagnoseLocal wrapper (lock acquisition + real
+// newResourceManager) while staying on diagnoseLocalUnsafe's non-local
+// short-circuit path, so it never actually resolves or executes the real
+// embedded exasol-local-runner binary.
+func TestDiagnoseLocal_NonLocalDeploymentShortCircuitsBeforeRunningAnyBinary(t *testing.T) {
+	t.Setenv(localAllowUnsupportedEnv, "1")
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := os.MkdirAll(deployment.InfrastructureDir(), 0o700); err != nil {
+		t.Fatalf("create infrastructure dir failed: %v", err)
+	}
+	writeTestFile(t, deployment.InfrastructureManifestPath(), `
+name: Test Infrastructure
+description: test infrastructure
+backend: tofu
+`)
+
+	diagnostics, err := DiagnoseLocal(context.Background(), deployment)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !diagnostics.PlatformSupported {
+		t.Fatal("expected platform support to bypass via EXASOL_LOCAL_ALLOW_UNSUPPORTED_PLATFORM")
+	}
+	if diagnostics.VMRunning != nil {
+		t.Fatalf("expected no VM status check for a non-local deployment, got %+v", diagnostics)
+	}
+}
+
+func TestDiagnoseLocal_NilContextReturnsError(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+
+	_, err := DiagnoseLocal(nil, deployment) //nolint:staticcheck
+	if !errors.Is(err, ErrMissingContext) {
+		t.Fatalf("expected ErrMissingContext, got %v", err)
+	}
+}
 
 func TestDiagnoseLocalUnsafe_UnsupportedPlatform(t *testing.T) {
 	t.Parallel()
@@ -83,7 +125,7 @@ func TestDiagnoseLocalUnsafe_VMRunningReportsPortsAndHealth(t *testing.T) {
 
 	deployment := newLocalTestDeployment(t)
 	ensureLocalRuntimeWorkDir(t, deployment)
-	healthJSON := `{"ports":{"ssh":{"state":"reachable"},"db":{"state":"blocked"}}}`
+	healthJSON := sshReachableDBBlockedHealthJSON
 	manager := writeFakeCombinedRunner(t, `{"running":true}`, healthJSON)
 	writeFakeVMState(t, deployment, "192.168.64.5", 20022, 28563, 0)
 

--- a/internal/deploy/identity_test.go
+++ b/internal/deploy/identity_test.go
@@ -8,6 +8,66 @@ import (
 	"testing"
 )
 
+func TestPresetIdentityToken_NameBasedRef(t *testing.T) {
+	t.Parallel()
+
+	if got := presetIdentityToken(PresetRef{Name: "  aws  "}); got != "aws" {
+		t.Fatalf("expected trimmed name token, got %q", got)
+	}
+}
+
+func TestPresetIdentityToken_PathBasedRefUsesBaseName(t *testing.T) {
+	t.Parallel()
+
+	got := presetIdentityToken(PresetRef{Path: "/tmp/my presets/custom-infra/"})
+	if got != "custom-infra" {
+		t.Fatalf("expected the cleaned path's base name, got %q", got)
+	}
+}
+
+func TestPresetIdentityToken_BlankTokenFallsBackToUnknown(t *testing.T) {
+	t.Parallel()
+
+	const unknownToken = "unknown"
+
+	if got := presetIdentityToken(PresetRef{Name: "   "}); got != unknownToken {
+		t.Fatalf("expected %q for a blank preset name, got %q", unknownToken, got)
+	}
+}
+
+func TestPresetIdentityToken_ReplacesDelimitersAndSpaces(t *testing.T) {
+	t.Parallel()
+
+	got := presetIdentityToken(PresetRef{Name: "my;custom infra"})
+	if got != "my_custom_infra" {
+		t.Fatalf("expected delimiter-safe token, got %q", got)
+	}
+}
+
+func TestComputeClusterIdentity_JoinsAllComponents(t *testing.T) {
+	t.Parallel()
+
+	got := ComputeClusterIdentity(
+		"abcd1234",
+		PresetRef{Name: "aws"},
+		PresetRef{Name: "ubuntu"},
+	)
+	want := "exasol-personal;abcd1234;aws;ubuntu"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestComputeClusterIdentity_BlankDeploymentIdFallsBackToUnknown(t *testing.T) {
+	t.Parallel()
+
+	got := ComputeClusterIdentity("  ", PresetRef{Name: "aws"}, PresetRef{Name: "ubuntu"})
+	want := "exasol-personal;unknown;aws;ubuntu"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
 func TestGenerateDeploymentId_Format(t *testing.T) {
 	t.Parallel()
 

--- a/internal/deploy/info_test.go
+++ b/internal/deploy/info_test.go
@@ -10,6 +10,179 @@ import (
 	"github.com/exasol/exasol-personal/internal/config"
 )
 
+func TestDisplayHostname_NilDetailsReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	// Then
+	if got := (*ConnectionDetails)(nil).DisplayHostname(); got != "" {
+		t.Fatalf("expected an empty hostname for nil details, got %q", got)
+	}
+}
+
+func TestDisplayHostname_PrefersDisplayHostOverHostnameAndPublicIp(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	details := &ConnectionDetails{
+		DisplayHost: "display.example.test",
+		Hostname:    "internal.example.test",
+		PublicIp:    "203.0.113.1",
+	}
+
+	// Then
+	if got := details.DisplayHostname(); got != "display.example.test" {
+		t.Fatalf("expected DisplayHost to win, got %q", got)
+	}
+}
+
+func TestDisplayHostname_FallsBackToHostnameWhenDisplayHostIsBlank(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	details := &ConnectionDetails{Hostname: "internal.example.test", PublicIp: "203.0.113.1"}
+
+	// Then
+	if got := details.DisplayHostname(); got != "internal.example.test" {
+		t.Fatalf("expected Hostname to win over PublicIp, got %q", got)
+	}
+}
+
+func TestDisplayHostname_FallsBackToPublicIpWhenHostnameIsBlank(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	details := &ConnectionDetails{PublicIp: "203.0.113.1"}
+
+	// Then
+	if got := details.DisplayHostname(); got != "203.0.113.1" {
+		t.Fatalf("expected PublicIp to be used as a last resort, got %q", got)
+	}
+}
+
+func TestDisplayHostname_AllFieldsBlankReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	// Then
+	if got := (&ConnectionDetails{}).DisplayHostname(); got != "" {
+		t.Fatalf("expected an empty hostname when nothing is set, got %q", got)
+	}
+}
+
+func TestIsLocalBackend_NilDetailsIsFalse(t *testing.T) {
+	t.Parallel()
+
+	// Then
+	if (*ConnectionDetails)(nil).IsLocalBackend() {
+		t.Fatal("expected nil details to not be a local backend")
+	}
+}
+
+func TestIsLocalBackend_MatchesLocalBackendType(t *testing.T) {
+	t.Parallel()
+
+	// Then
+	if !(&ConnectionDetails{Backend: localDeploymentBackend}).IsLocalBackend() {
+		t.Fatal("expected the local backend type to be recognized")
+	}
+	// Then
+	if (&ConnectionDetails{Backend: "tofu"}).IsLocalBackend() {
+		t.Fatal("expected a non-local backend type to not be recognized as local")
+	}
+}
+
+func TestHasAdminUI_RequiresNonEmptyURL(t *testing.T) {
+	t.Parallel()
+
+	// Then
+	if (*ConnectionDetails)(nil).HasAdminUI() {
+		t.Fatal("expected nil details to not have an admin UI")
+	}
+	// Then
+	if (&ConnectionDetails{}).HasAdminUI() {
+		t.Fatal("expected no admin UI when unset")
+	}
+	// Then
+	if (&ConnectionDetails{AdminUI: &config.DeploymentAdminUI{}}).HasAdminUI() {
+		t.Fatal("expected no admin UI when the URL is blank")
+	}
+
+	// Given
+	details := &ConnectionDetails{AdminUI: &config.DeploymentAdminUI{URL: "https://admin.test"}}
+
+	// Then
+	if !details.HasAdminUI() {
+		t.Fatal("expected an admin UI when the URL is set")
+	}
+}
+
+func TestReadConnectionDetails_ResolvesFullConnectionInfo(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := config.WriteDeploymentInfo(deployment.Root(), &config.DeploymentInfo{
+		Backend:      localDeploymentBackend,
+		DeploymentId: "test-deployment",
+		Connection: &config.DeploymentConnection{
+			Host:   "127.0.0.1",
+			DBPort: 8563,
+		},
+	}); err != nil {
+		t.Fatalf("failed to seed deployment info: %v", err)
+	}
+	if err := config.WriteSecrets(deployment.Root(), &config.Secrets{
+		DbPassword:      "x",
+		AdminUiPassword: "y",
+	}); err != nil {
+		t.Fatalf("failed to seed secrets: %v", err)
+	}
+
+	// When
+	details, err := readConnectionDetails(deployment)
+	// Then
+	if err != nil {
+		t.Fatalf("expected connection details to resolve, got %v", err)
+	}
+	if details.Backend != localDeploymentBackend {
+		t.Fatalf("expected the backend to be carried over, got %q", details.Backend)
+	}
+	if details.Hostname != "127.0.0.1" || details.DBPort != 8563 {
+		t.Fatalf("expected the resolved host/port, got %+v", details)
+	}
+	if !details.AdminUISecured {
+		t.Fatal("expected AdminUISecured to be true when an admin UI password is set")
+	}
+}
+
+func TestReadConnectionDetails_MissingDeploymentInfoReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	deployment := config.NewDeploymentDir(t.TempDir())
+
+	// Then
+	if _, err := readConnectionDetails(deployment); err == nil {
+		t.Fatal("expected an error when no deployment info has been persisted")
+	}
+}
+
+func TestReadConnectionDetails_MissingConnectionReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := config.WriteDeploymentInfo(deployment.Root(), &config.DeploymentInfo{
+		DeploymentId: "test-deployment",
+	}); err != nil {
+		t.Fatalf("failed to seed deployment info: %v", err)
+	}
+
+	// Then
+	if _, err := readConnectionDetails(deployment); err == nil {
+		t.Fatal("expected an error when the deployment has no connection details")
+	}
+}
+
 func TestGetDeploymentInfoReportInitializedIncludesOverviewAndPresets(t *testing.T) {
 	t.Parallel()
 

--- a/internal/deploy/infrastructure_info_test.go
+++ b/internal/deploy/infrastructure_info_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/presets"
+)
+
+func TestGetInfrastructureInfo_ResolvesEmbeddedPreset(t *testing.T) {
+	t.Parallel()
+
+	info, err := GetInfrastructureInfo(presets.DefaultInfrastructure)
+	if err != nil {
+		t.Fatalf("expected the embedded preset to resolve, got %v", err)
+	}
+	if info.Name == "" {
+		t.Fatal("expected a non-empty infrastructure name")
+	}
+	if info.ShortDescription == "" {
+		t.Fatal("expected a non-empty short description")
+	}
+}
+
+func TestGetInfrastructureInfo_UnknownPresetReturnsError(t *testing.T) {
+	t.Parallel()
+
+	if _, err := GetInfrastructureInfo("does-not-exist"); err == nil {
+		t.Fatal("expected an error for an unknown infrastructure preset")
+	}
+}
+
+func TestGetInfrastructureInfoFromDir_ResolvesPathBasedPreset(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeTestFile(t, dir+"/infrastructure.yaml", `
+name: Test Infrastructure
+description: test infrastructure
+backend: local
+`)
+
+	info, err := GetInfrastructureInfoFromDir(dir)
+	if err != nil {
+		t.Fatalf("expected the path-based preset to resolve, got %v", err)
+	}
+	if info.Name != "Test Infrastructure" {
+		t.Fatalf("expected the manifest name, got %q", info.Name)
+	}
+	if info.LongDescription != "test infrastructure" {
+		t.Fatalf("expected the manifest description, got %q", info.LongDescription)
+	}
+}
+
+func TestGetInfrastructureInfoFromDir_MissingManifestReturnsError(t *testing.T) {
+	t.Parallel()
+
+	if _, err := GetInfrastructureInfoFromDir(t.TempDir()); err == nil {
+		t.Fatal("expected an error when the infrastructure manifest is missing")
+	}
+}
+
+func TestGetInfrastructureInfoFromPreset_NameBasedRef(t *testing.T) {
+	t.Parallel()
+
+	info, err := GetInfrastructureInfoFromPreset(PresetRef{Name: presets.DefaultInfrastructure})
+	if err != nil {
+		t.Fatalf("expected the embedded preset to resolve, got %v", err)
+	}
+	if info.Name == "" {
+		t.Fatal("expected a non-empty infrastructure name")
+	}
+}
+
+func TestGetInfrastructureInfoFromPreset_PathBasedRef(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeTestFile(t, dir+"/infrastructure.yaml", `
+name: Test Infrastructure
+description: test infrastructure
+backend: local
+`)
+
+	info, err := GetInfrastructureInfoFromPreset(PresetRef{Path: dir})
+	if err != nil {
+		t.Fatalf("expected the path-based preset to resolve, got %v", err)
+	}
+	if info.Name != "Test Infrastructure" {
+		t.Fatalf("expected the manifest name, got %q", info.Name)
+	}
+}

--- a/internal/deploy/init_test.go
+++ b/internal/deploy/init_test.go
@@ -247,3 +247,150 @@ func TestInitDeployment_ErrWhenDirNotEmpty(t *testing.T) {
 		t.Fatalf("expected ErrDeploymentDirectoryNotEmpty, got: %v", err)
 	}
 }
+
+func TestResolveInfrastructureInfo_ResolvesKnownPreset(t *testing.T) {
+	t.Parallel()
+
+	// When
+	info, err := ResolveInfrastructureInfo(presets.DefaultInfrastructure)
+	// Then
+	if err != nil {
+		t.Fatalf("expected the default infrastructure preset to resolve, got %v", err)
+	}
+	if info.Name == "" {
+		t.Fatal("expected a non-empty infrastructure name")
+	}
+}
+
+func TestResolveInfrastructureInfo_UnknownPresetReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// Then: an unknown preset name surfaces as an error.
+	if _, err := ResolveInfrastructureInfo("does-not-exist"); err == nil {
+		t.Fatal("expected an error for an unknown infrastructure preset")
+	}
+}
+
+func TestValidatePresetDir_MissingDirReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// When
+	err := validatePresetDir(filepath.Join(t.TempDir(), "missing"), "infrastructure.yaml")
+	// Then
+	if err == nil {
+		t.Fatal("expected an error for a missing preset directory")
+	}
+}
+
+func TestValidatePresetDir_NotADirectoryReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	filePath := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(filePath, []byte("x"), 0o600); err != nil {
+		t.Fatalf("failed to write file fixture: %v", err)
+	}
+
+	// Then: a preset path that is a file, not a directory, is rejected.
+	if err := validatePresetDir(filePath, "infrastructure.yaml"); err == nil {
+		t.Fatal("expected an error when the preset path is not a directory")
+	}
+}
+
+func TestValidatePresetDir_MissingRequiredFileReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	dir := t.TempDir()
+
+	// Then: a directory missing the required manifest file is rejected.
+	if err := validatePresetDir(dir, "infrastructure.yaml"); err == nil {
+		t.Fatal("expected an error when the required file is missing")
+	}
+}
+
+func TestValidatePresetDir_ValidDirectorySucceeds(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "infrastructure.yaml"), `
+name: Test Infrastructure
+description: test infrastructure
+backend: local
+`)
+
+	// Then: a directory containing the required manifest file passes validation.
+	if err := validatePresetDir(dir, "infrastructure.yaml"); err != nil {
+		t.Fatalf("expected a valid preset directory to pass validation, got %v", err)
+	}
+}
+
+func TestPresetLabel(t *testing.T) {
+	t.Parallel()
+
+	// Then: a named preset is labeled by its name.
+	if got := presetLabel(PresetRef{Name: "aws"}); got != "aws" {
+		t.Fatalf("expected the preset name, got %q", got)
+	}
+	// Then: a path-based preset is labeled by its path.
+	if got := presetLabel(PresetRef{Path: "/tmp/custom"}); got != "/tmp/custom" {
+		t.Fatalf("expected the preset path, got %q", got)
+	}
+}
+
+func TestValidateInfrastructurePreset_PathBasedPreset(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "infrastructure.yaml"), `
+name: Test Infrastructure
+description: test infrastructure
+backend: local
+`)
+
+	// Then: a valid path-based infrastructure preset passes validation.
+	if err := validateInfrastructurePreset(PresetRef{Path: dir}); err != nil {
+		t.Fatalf("expected a valid path-based preset to pass validation, got %v", err)
+	}
+}
+
+func TestValidateInfrastructurePreset_UnknownNameReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// When
+	err := validateInfrastructurePreset(PresetRef{Name: "does-not-exist"})
+	// Then
+	if err == nil {
+		t.Fatal("expected an error for an unknown infrastructure preset name")
+	}
+}
+
+func TestValidateInstallationPreset_PathBasedPreset(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	dir := t.TempDir()
+	writeTestFile(t, filepath.Join(dir, "installation.yaml"), `
+name: Test Installation
+description: test installation
+install: []
+`)
+
+	// Then: a valid path-based installation preset passes validation.
+	if err := validateInstallationPreset(PresetRef{Path: dir}); err != nil {
+		t.Fatalf("expected a valid path-based preset to pass validation, got %v", err)
+	}
+}
+
+func TestValidateInstallationPreset_UnknownNameReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// When
+	err := validateInstallationPreset(PresetRef{Name: "does-not-exist"})
+	// Then
+	if err == nil {
+		t.Fatal("expected an error for an unknown installation preset name")
+	}
+}

--- a/internal/deploy/install_steps_test.go
+++ b/internal/deploy/install_steps_test.go
@@ -4,9 +4,11 @@
 package deploy
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 
+	"github.com/exasol/exasol-personal/internal/config"
 	"github.com/exasol/exasol-personal/internal/presets"
 )
 
@@ -51,5 +53,17 @@ func TestBuildInstallTasks_PreservesRemoteAndLocalSteps(t *testing.T) {
 	if got := tasks[1].LocalCommand.Command; len(got) != 2 || got[0] != "echo" ||
 		got[1] != "hello" {
 		t.Fatalf("unexpected local command: %#v", got)
+	}
+}
+
+func TestRunInstallSteps_NoStepsIsNoop(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	manifest := &presets.InstallManifest{Install: presets.InstallSteps{}}
+
+	err := runInstallSteps(context.Background(), deployment, manifest, nil, nil)
+	if err != nil {
+		t.Fatalf("expected an install manifest with no steps to be a no-op, got %v", err)
 	}
 }

--- a/internal/deploy/installation_variables_test.go
+++ b/internal/deploy/installation_variables_test.go
@@ -1,0 +1,242 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/presets"
+)
+
+func TestWriteInstallationVariablesFile_NilSpecIsNoop(t *testing.T) {
+	t.Parallel()
+
+	err := writeInstallationVariablesFile(t.TempDir(), nil, "id", "cid", "url", nil)
+	if err != nil {
+		t.Fatalf("expected a nil spec to be a no-op, got %v", err)
+	}
+}
+
+func TestWriteInstallationVariablesFile_BlankOutputFileIsNoop(t *testing.T) {
+	t.Parallel()
+
+	spec := &presets.Variables{OutputFile: "   "}
+
+	err := writeInstallationVariablesFile(t.TempDir(), spec, "id", "cid", "url", nil)
+	if err != nil {
+		t.Fatalf("expected a blank outputFile to be a no-op, got %v", err)
+	}
+}
+
+func TestWriteInstallationVariablesFile_RejectsPathEscapingInstallDir(t *testing.T) {
+	t.Parallel()
+
+	spec := &presets.Variables{OutputFile: "../escape.json"}
+
+	err := writeInstallationVariablesFile(t.TempDir(), spec, "id", "cid", "url", nil)
+	if err == nil {
+		t.Fatal("expected an error when outputFile escapes the installation directory")
+	}
+}
+
+func TestWriteInstallationVariablesFile_AppliesDefaultsAndGovernedIdentity(t *testing.T) {
+	t.Parallel()
+
+	installDir := t.TempDir()
+	spec := &presets.Variables{
+		OutputFile: "resolved/values.json",
+		Vars: map[string]*presets.VariableDef{
+			"admin_password": {Type: "string", Default: "changeit"},
+		},
+	}
+
+	err := writeInstallationVariablesFile(
+		installDir, spec, "exasol-personal;abcd1234", "abcd1234", "https://example.test", nil,
+	)
+	if err != nil {
+		t.Fatalf("expected write to succeed, got %v", err)
+	}
+
+	resolved := readResolvedInstallationVariables(
+		t,
+		filepath.Join(installDir, "resolved/values.json"),
+	)
+	if resolved["deployment_id"] != "abcd1234" {
+		t.Fatalf("expected governed deployment_id, got %+v", resolved)
+	}
+	if resolved["cluster_identity"] != "exasol-personal;abcd1234" {
+		t.Fatalf("expected governed cluster_identity, got %+v", resolved)
+	}
+	if resolved["version_check_url"] != "https://example.test" {
+		t.Fatalf("expected governed version_check_url, got %+v", resolved)
+	}
+	if resolved["admin_password"] != "changeit" {
+		t.Fatalf("expected the manifest default to be applied, got %+v", resolved)
+	}
+}
+
+func TestWriteInstallationVariablesFile_OverridesReplaceDefaultsAndIgnoreUnknownNames(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	installDir := t.TempDir()
+	spec := &presets.Variables{
+		OutputFile: "values.json",
+		Vars: map[string]*presets.VariableDef{
+			"cluster_size": {Type: "number", Default: 1},
+		},
+	}
+
+	err := writeInstallationVariablesFile(
+		installDir, spec, "id", "cid", "url",
+		map[string]string{"cluster_size": "3", "does_not_exist": "ignored"},
+	)
+	if err != nil {
+		t.Fatalf("expected write to succeed, got %v", err)
+	}
+
+	resolved := readResolvedInstallationVariables(t, filepath.Join(installDir, "values.json"))
+	if resolved["cluster_size"] != float64(3) {
+		t.Fatalf("expected the override to replace the default, got %+v", resolved)
+	}
+	if _, present := resolved["does_not_exist"]; present {
+		t.Fatalf("expected an override for an unknown variable to be ignored, got %+v", resolved)
+	}
+}
+
+func TestWriteInstallationVariablesFile_ReservedNamesCannotBeOverridden(t *testing.T) {
+	t.Parallel()
+
+	installDir := t.TempDir()
+	spec := &presets.Variables{
+		OutputFile: "values.json",
+		Vars: map[string]*presets.VariableDef{
+			"deployment_id": {Type: "string", Default: "manifest-default"},
+		},
+	}
+
+	err := writeInstallationVariablesFile(
+		installDir, spec, "cid", "governed-id", "url",
+		map[string]string{"deployment_id": "attempted-override"},
+	)
+	if err != nil {
+		t.Fatalf("expected write to succeed, got %v", err)
+	}
+
+	resolved := readResolvedInstallationVariables(t, filepath.Join(installDir, "values.json"))
+	if resolved["deployment_id"] != "governed-id" {
+		t.Fatalf("expected the governed identity to win, got %+v", resolved)
+	}
+}
+
+func TestWriteInstallationVariablesFile_InvalidManifestDefaultReturnsError(t *testing.T) {
+	t.Parallel()
+
+	spec := &presets.Variables{
+		OutputFile: "values.json",
+		Vars: map[string]*presets.VariableDef{
+			"bad": {Type: "string", Default: []string{"unsupported"}},
+		},
+	}
+
+	err := writeInstallationVariablesFile(t.TempDir(), spec, "id", "cid", "url", nil)
+	if err == nil {
+		t.Fatal("expected an error for an unsupported manifest default type")
+	}
+}
+
+func TestWriteInstallationVariablesFile_InvalidOverrideValueReturnsError(t *testing.T) {
+	t.Parallel()
+
+	spec := &presets.Variables{
+		OutputFile: "values.json",
+		Vars: map[string]*presets.VariableDef{
+			"cluster_size": {Type: "number", Default: 1},
+		},
+	}
+
+	err := writeInstallationVariablesFile(
+		t.TempDir(), spec, "id", "cid", "url", map[string]string{"cluster_size": "not-a-number"},
+	)
+	if err == nil {
+		t.Fatal("expected an error for an override that doesn't match its declared type")
+	}
+}
+
+func readResolvedInstallationVariables(t *testing.T, path string) map[string]any {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read resolved installation variables: %v", err)
+	}
+
+	var resolved map[string]any
+	if err := json.Unmarshal(data, &resolved); err != nil {
+		t.Fatalf("failed to decode resolved installation variables: %v", err)
+	}
+
+	return resolved
+}
+
+func TestIsReservedInstallationVariableName(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]bool{
+		"deployment_id":     true,
+		"cluster_identity":  true,
+		"version_check_url": true,
+		"admin_password":    false,
+		"":                  false,
+	}
+	for name, want := range cases {
+		if got := isReservedInstallationVariableName(name); got != want {
+			t.Errorf("isReservedInstallationVariableName(%q) = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestParseInstallVarValue(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		varType string
+		raw     string
+		want    any
+		wantErr bool
+	}{
+		"bool true":         {varType: "bool", raw: "true", want: true},
+		"bool invalid":      {varType: "bool", raw: "nope", wantErr: true},
+		"number":            {varType: "number", raw: "3.5", want: 3.5},
+		"number invalid":    {varType: "number", raw: "nope", wantErr: true},
+		"string explicit":   {varType: "string", raw: "hello", want: "hello"},
+		"string blank type": {varType: "", raw: "hello", want: "hello"},
+		"unsupported type":  {varType: "list", raw: "x", wantErr: true},
+	}
+
+	for name, testCase := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseInstallVarValue(testCase.varType, testCase.raw)
+			if testCase.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if got != testCase.want {
+				t.Fatalf("expected %v, got %v", testCase.want, got)
+			}
+		})
+	}
+}

--- a/internal/deploy/local_backend_lifecycle_test.go
+++ b/internal/deploy/local_backend_lifecycle_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/localruntime"
+	"github.com/exasol/exasol-personal/internal/presets"
+)
+
+// fullLifecycleRunnerScript builds a fake exasol-local-runner responding to
+// every verb startLocalRuntime/stopLocalRuntime/destroyLocalRuntime issue.
+// "start" writes a fake VM state file directly (mirroring writeFakeVMState),
+// since startPreparedLocalRuntime removes any prior state before running
+// "start" and then immediately reads it back.
+func fullLifecycleRunnerScript(statePath string) string {
+	stateJSON := `{"vm_name":"exasol-local-vm","vm_ip":"127.0.0.1",` +
+		`"ports":{"ssh":20022,"db":8563,"ui":443}}`
+
+	return "#!/bin/sh\n" +
+		"case \"$1\" in\n" +
+		"  version) printf 'v1.0.0\\n' ;;\n" +
+		"  init) mkdir -p vm ;;\n" +
+		"  start) cat > " + statePath + " <<'EOF'\n" + stateJSON + "\nEOF\n" +
+		"    ;;\n" +
+		"  stop) exit 0 ;;\n" +
+		"  *) exit 0 ;;\n" +
+		"esac\n"
+}
+
+// newTestLocalBackend builds a localBackend against a real local-backend
+// deployment, backed by a fake exasol-local-runner that supports the full
+// version/init/start/stop lifecycle.
+func newTestLocalBackend(t *testing.T) *localBackend {
+	t.Helper()
+	skipOnWindows(t)
+	t.Setenv(localAllowUnsupportedEnv, "1")
+	t.Setenv(localSkipDatabaseWaitEnv, "1")
+
+	deployment := newLocalTestDeployment(t)
+	ensureLocalRuntimeWorkDir(t, deployment)
+	state := &config.ExasolPersonalState{DeploymentVersion: "0.0.0", VersionCheckEnabled: false}
+	if err := config.WriteExasolPersonalState(state, deployment); err != nil {
+		t.Fatalf("failed to write launcher state: %v", err)
+	}
+
+	paths := localruntime.NewPaths(deployment)
+	manager := newTestManagerForRunner(t, []byte(fullLifecycleRunnerScript(paths.StatePath)))
+	manifest := &presets.InfrastructureManifest{Backend: backendTypeLocal}
+
+	backend := newLocalBackend(deployment, manifest, localruntime.New(deployment, manager))
+
+	return backend
+}
+
+// nolint: paralleltest // avoids concurrent extract+exec of the fake runner (ETXTBSY flakes).
+func TestLocalBackendDeploySucceedsThroughPrepareAndStart(t *testing.T) {
+	backend := newTestLocalBackend(t)
+
+	var out, outErr bytes.Buffer
+
+	err := backend.Deploy(context.Background(), &out, &outErr, DeployOptions{})
+	if err != nil {
+		t.Fatalf("expected deploy to succeed, got %v", err)
+	}
+
+	info, err := config.ReadDeploymentInfo(backend.deployment)
+	if err != nil {
+		t.Fatalf("expected deployment info to be written, got %v", err)
+	}
+	if info.Connection == nil || info.Connection.DBPort != 8563 {
+		t.Fatalf("expected connection info from the fake VM state, got %+v", info.Connection)
+	}
+}
+
+// nolint: paralleltest // avoids concurrent extract+exec of the fake runner (ETXTBSY flakes).
+func TestLocalBackendStartSucceedsThroughPrepareAndStart(t *testing.T) {
+	backend := newTestLocalBackend(t)
+
+	var out, outErr bytes.Buffer
+
+	err := backend.Start(context.Background(), &out, &outErr, 0)
+	if err != nil {
+		t.Fatalf("expected start to succeed, got %v", err)
+	}
+}
+
+// nolint: paralleltest // avoids concurrent extract+exec of the fake runner (ETXTBSY flakes).
+func TestLocalBackendStopUpdatesDeploymentState(t *testing.T) {
+	backend := newTestLocalBackend(t)
+
+	if err := config.WriteDeploymentInfo(backend.deployment.Root(), &config.DeploymentInfo{
+		Backend:      localDeploymentBackend,
+		DeploymentId: "local",
+	}); err != nil {
+		t.Fatalf("failed to seed deployment info: %v", err)
+	}
+
+	var out, outErr bytes.Buffer
+	if err := backend.Stop(context.Background(), &out, &outErr); err != nil {
+		t.Fatalf("expected stop to succeed, got %v", err)
+	}
+
+	info, err := config.ReadDeploymentInfo(backend.deployment)
+	if err != nil {
+		t.Fatalf("failed to read deployment info: %v", err)
+	}
+	if info.DeploymentState != StatusStopped {
+		t.Fatalf("expected deployment state %q, got %q", StatusStopped, info.DeploymentState)
+	}
+}
+
+// nolint: paralleltest // avoids concurrent extract+exec of the fake runner (ETXTBSY flakes).
+func TestLocalBackendDestroyRemovesRuntimeAndArtifacts(t *testing.T) {
+	backend := newTestLocalBackend(t)
+
+	if err := config.WriteDeploymentInfo(backend.deployment.Root(), &config.DeploymentInfo{
+		Backend:      localDeploymentBackend,
+		DeploymentId: "local",
+	}); err != nil {
+		t.Fatalf("failed to seed deployment info: %v", err)
+	}
+	if err := config.WriteSecrets(backend.deployment.Root(), &config.Secrets{
+		DbPassword: "x",
+	}); err != nil {
+		t.Fatalf("failed to seed secrets: %v", err)
+	}
+
+	var out, outErr bytes.Buffer
+	if err := backend.Destroy(context.Background(), &out, &outErr); err != nil {
+		t.Fatalf("expected destroy to succeed, got %v", err)
+	}
+
+	if _, err := os.Stat(backend.deployment.NodeDetailsPath()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected node details to be removed, got %v", err)
+	}
+	if _, err := os.Stat(backend.deployment.SecretsPath()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected secrets to be removed, got %v", err)
+	}
+}

--- a/internal/deploy/local_backend_test.go
+++ b/internal/deploy/local_backend_test.go
@@ -531,6 +531,57 @@ func TestLocalContainerShellCommand_UsesMountedContainerRootfs(t *testing.T) {
 	}
 }
 
+func TestLocalSSHRemoteUnsafe_MissingDeploymentInfoReturnsError(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+
+	if _, err := localSSHRemoteUnsafe(deployment); err == nil {
+		t.Fatal("expected an error when no deployment info has been persisted")
+	}
+}
+
+func TestLocalSSHRemoteUnsafe_MissingConnectionReturnsError(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := config.WriteDeploymentInfo(deployment.Root(), &config.DeploymentInfo{
+		DeploymentId: "test-deployment",
+	}); err != nil {
+		t.Fatalf("failed to seed deployment info: %v", err)
+	}
+
+	if _, err := localSSHRemoteUnsafe(deployment); err == nil {
+		t.Fatal("expected an error when the deployment has no connection details")
+	}
+}
+
+func TestLocalBackendOpenHostShell_MissingConnectionReturnsErrorWithoutOpeningShell(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	backend := newLocalBackend(deployment, &presets.InfrastructureManifest{}, nil)
+
+	if err := backend.OpenHostShell(context.Background(), ""); err == nil {
+		t.Fatal("expected an error when no deployment info has been persisted")
+	}
+}
+
+func TestLocalBackendOpenCOSShell_MissingConnectionReturnsErrorWithoutOpeningShell(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	backend := newLocalBackend(deployment, &presets.InfrastructureManifest{}, nil)
+
+	if err := backend.OpenCOSShell(context.Background()); err == nil {
+		t.Fatal("expected an error when no deployment info has been persisted")
+	}
+}
+
 func assertConfigValue(
 	t *testing.T,
 	values []DeploymentConfigValue,

--- a/internal/deploy/local_reachability_test.go
+++ b/internal/deploy/local_reachability_test.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/exasol/exasol-personal/assets/resources"
 	"github.com/exasol/exasol-personal/internal/config"
 	"github.com/exasol/exasol-personal/internal/localruntime"
 	"github.com/exasol/exasol-personal/internal/runtimeartifacts"
@@ -31,13 +32,25 @@ const runnerZipEntryName = "launcher"
 // ResourceSpec.
 const exasolLocalRunnerResourceID = "exasol-local-runner"
 
+// sshReachableDBBlockedHealthJSON is a health-check response where the SSH
+// port is reachable but the database port is blocked: the network path is
+// fine, so this is never classified as a network-wide reachability problem.
+const sshReachableDBBlockedHealthJSON = `{"ports":` +
+	`{"ssh":{"state":"reachable"},"db":{"state":"blocked"}}}`
+
+// allPortsBlockedHealthJSON is a health-check response where every port is
+// blocked, the case classifyLocalReachability treats as a network-wide
+// reachability problem.
+const allPortsBlockedHealthJSON = `{"ports":` +
+	`{"ssh":{"state":"blocked"},"db":{"state":"blocked"}}}`
+
 func TestClassifyLocalReachability_AllPortsBlocked(t *testing.T) {
 	t.Parallel()
 	skipOnWindows(t)
 
 	deployment := newLocalTestDeployment(t)
 	ensureLocalRuntimeWorkDir(t, deployment)
-	blockedJSON := `{"ports":{"ssh":{"state":"blocked"},"db":{"state":"blocked"}}}`
+	blockedJSON := allPortsBlockedHealthJSON
 	manager := writeFakeCombinedRunner(t, "", blockedJSON)
 	localRuntime := localruntime.New(deployment, manager)
 
@@ -58,7 +71,7 @@ func TestClassifyLocalReachability_OnlyDatabasePortBlocked(t *testing.T) {
 	// network path itself is fine; the problem is database-specific.
 	deployment := newLocalTestDeployment(t)
 	ensureLocalRuntimeWorkDir(t, deployment)
-	mixedJSON := `{"ports":{"ssh":{"state":"reachable"},"db":{"state":"blocked"}}}`
+	mixedJSON := sshReachableDBBlockedHealthJSON
 	manager := writeFakeCombinedRunner(t, "", mixedJSON)
 	localRuntime := localruntime.New(deployment, manager)
 
@@ -104,6 +117,89 @@ func TestClassifyLocalReachability_HealthCheckUnavailableIsNoop(t *testing.T) {
 	if err := classifyLocalReachability(context.Background(), localRuntime); err != nil {
 		t.Fatalf("expected no-op when health-check is unavailable, got %v", err)
 	}
+}
+
+func TestLocalReachabilityError_ErrorAndUnwrap(t *testing.T) {
+	t.Parallel()
+
+	err := &localReachabilityError{}
+
+	if err.Error() != localReachabilityMessage {
+		t.Fatalf("expected the fixed reachability message, got %q", err.Error())
+	}
+	if !errors.Is(err, ErrLocalReachability) {
+		t.Fatal("expected Unwrap to expose ErrLocalReachability")
+	}
+}
+
+func TestDiagnoseLocalFailure_NilErrorIsNoop(t *testing.T) {
+	t.Parallel()
+
+	deployment := newLocalTestDeployment(t)
+	localRuntime := localruntime.New(deployment, nil)
+
+	if err := diagnoseLocalFailure(context.Background(), localRuntime, nil); err != nil {
+		t.Fatalf("expected nil error to stay nil, got %v", err)
+	}
+}
+
+// nolint: paralleltest // avoids concurrent extract+exec of the fake runner (ETXTBSY flakes).
+func TestDiagnoseLocalFailure_ReclassifiesWhenAllPortsBlocked(t *testing.T) {
+	skipOnWindows(t)
+
+	deployment := newLocalTestDeployment(t)
+	ensureLocalRuntimeWorkDir(t, deployment)
+	blockedJSON := allPortsBlockedHealthJSON
+	manager := writeFakeCombinedRunner(t, "", blockedJSON)
+	localRuntime := localruntime.New(deployment, manager)
+	originalErr := errors.New("original failure")
+
+	err := diagnoseLocalFailure(context.Background(), localRuntime, originalErr)
+
+	if !errors.Is(err, ErrLocalReachability) {
+		t.Fatalf("expected the error to be reclassified as a reachability error, got %v", err)
+	}
+}
+
+// nolint: paralleltest // avoids concurrent extract+exec of the fake runner (ETXTBSY flakes).
+func TestDiagnoseLocalFailure_KeepsOriginalErrorWhenReachable(t *testing.T) {
+	skipOnWindows(t)
+
+	deployment := newLocalTestDeployment(t)
+	ensureLocalRuntimeWorkDir(t, deployment)
+	reachableJSON := sshReachableDBBlockedHealthJSON
+	manager := writeFakeCombinedRunner(t, "", reachableJSON)
+	localRuntime := localruntime.New(deployment, manager)
+	originalErr := errors.New("original failure")
+
+	err := diagnoseLocalFailure(context.Background(), localRuntime, originalErr)
+
+	if !errors.Is(err, originalErr) {
+		t.Fatalf("expected the original error to be preserved, got %v", err)
+	}
+}
+
+// localRunnerResolvesOnThisPlatform reports whether the embedded
+// exasol-local-runner artifact declares support for the current GOOS/GOARCH,
+// checked dynamically against assets/resources/resources.yaml. Tests use
+// this instead of hardcoding darwin/arm64 so they keep covering the right
+// branch as more platforms gain local-backend support.
+func localRunnerResolvesOnThisPlatform(t *testing.T) bool {
+	t.Helper()
+
+	spec, err := runtimeartifacts.ParseSpec(resources.ResourcesYAML)
+	if err != nil {
+		t.Fatalf("failed to parse embedded resource spec: %v", err)
+	}
+
+	def, ok := spec[exasolLocalRunnerResourceID]
+	if !ok {
+		t.Fatalf("expected an %q entry in the embedded resource spec", exasolLocalRunnerResourceID)
+	}
+
+	_, resolveErr := def.Resolve(runtime.GOOS, runtime.GOARCH)
+
+	return resolveErr == nil
 }
 
 func skipOnWindows(t *testing.T) {

--- a/internal/deploy/node_lookup_test.go
+++ b/internal/deploy/node_lookup_test.go
@@ -1,0 +1,150 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+)
+
+func writeTestNodeDetails(t *testing.T, deployment config.DeploymentDir, nodeNames ...string) {
+	t.Helper()
+
+	nodes := make(map[string]config.DeploymentNode, len(nodeNames))
+	for _, name := range nodeNames {
+		keyRelPath := "keys/" + name + ".pem"
+		writeTestSSHKeyFile(t, deployment, keyRelPath)
+		nodes[name] = config.DeploymentNode{
+			PublicIp: "203.0.113.10",
+			Ssh: config.DeploymentSSH{
+				Username: "sys",
+				Port:     "22",
+				KeyFile:  keyRelPath,
+			},
+		}
+	}
+
+	if err := config.WriteDeploymentInfo(deployment.Root(), &config.DeploymentInfo{
+		Backend:      "tofu",
+		DeploymentId: "dep-1",
+		Nodes:        nodes,
+	}); err != nil {
+		t.Fatalf("failed to write deployment info: %v", err)
+	}
+}
+
+func TestNodeLookupFind_MatchesNodesByGlob(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	writeTestNodeDetails(t, deployment, "n11", "n12", "n21")
+
+	lookup := NewNodeLookup(deployment)
+
+	nodes, err := lookup.Find("n1*")
+	if err != nil {
+		t.Fatalf("expected glob match to succeed, got %v", err)
+	}
+
+	names := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		names = append(names, node.Name)
+	}
+	sort.Strings(names)
+	if len(names) != 2 || names[0] != "n11" || names[1] != "n12" {
+		t.Fatalf("expected [n11 n12], got %v", names)
+	}
+}
+
+func TestNodeLookupFind_MatchesAllNodesWithWildcard(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	writeTestNodeDetails(t, deployment, "n11", "n21")
+
+	lookup := NewNodeLookup(deployment)
+
+	nodes, err := lookup.Find("*")
+	if err != nil {
+		t.Fatalf("expected wildcard match to succeed, got %v", err)
+	}
+	if len(nodes) != 2 {
+		t.Fatalf("expected both nodes to match, got %+v", nodes)
+	}
+}
+
+func TestNodeLookupFind_NoMatchReturnsEmptyList(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	writeTestNodeDetails(t, deployment, "n11")
+
+	lookup := NewNodeLookup(deployment)
+
+	nodes, err := lookup.Find("does-not-exist")
+	if err != nil {
+		t.Fatalf("expected no error for a non-matching glob, got %v", err)
+	}
+	if len(nodes) != 0 {
+		t.Fatalf("expected no nodes to match, got %+v", nodes)
+	}
+}
+
+func TestNodeLookupFind_InvalidGlobReturnsError(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	writeTestNodeDetails(t, deployment, "n11")
+
+	lookup := NewNodeLookup(deployment)
+
+	_, err := lookup.Find("[")
+	if err == nil {
+		t.Fatal("expected an error for an invalid glob pattern")
+	}
+}
+
+func TestNodeLookupFind_MissingNodeDetailsReturnsError(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+
+	lookup := NewNodeLookup(deployment)
+
+	_, err := lookup.Find("*")
+	if err == nil {
+		t.Fatal("expected an error when node details are missing")
+	}
+}
+
+func TestNodeLookupFind_MissingKeyFileReturnsError(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := config.WriteDeploymentInfo(deployment.Root(), &config.DeploymentInfo{
+		Backend:      "tofu",
+		DeploymentId: "dep-1",
+		Nodes: map[string]config.DeploymentNode{
+			"n11": {
+				PublicIp: "203.0.113.10",
+				Ssh: config.DeploymentSSH{
+					Username: "sys",
+					Port:     "22",
+					KeyFile:  "keys/missing.pem",
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("failed to write deployment info: %v", err)
+	}
+
+	lookup := NewNodeLookup(deployment)
+
+	_, err := lookup.Find("*")
+	if err == nil {
+		t.Fatal("expected an error for a missing SSH key file")
+	}
+}

--- a/internal/deploy/preset_external_test.go
+++ b/internal/deploy/preset_external_test.go
@@ -15,6 +15,59 @@ import (
 	"github.com/exasol/exasol-personal/internal/runtimeartifacts"
 )
 
+func TestIsExternalPresetURI(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]bool{
+		"file:///tmp/preset":               true,
+		"http://example.com/preset.tar.gz": true,
+		"https://example.com/preset.zip":   true,
+		"git://example.com/repo.git":       true,
+		"git@github.com:org/repo.git":      true,
+		"aws":                              false,
+		"/local/path/to/preset":            false,
+		"":                                 false,
+	}
+	for uri, want := range cases {
+		if got := IsExternalPresetURI(uri); got != want {
+			t.Errorf("IsExternalPresetURI(%q) = %v, want %v", uri, got, want)
+		}
+	}
+}
+
+func TestManifestFilenameFor(t *testing.T) {
+	t.Parallel()
+
+	gotInfra := manifestFilenameFor(presets.PresetTypeInfrastructure)
+	if gotInfra != presets.InfrastructureManifestFilename {
+		t.Errorf("expected infrastructure manifest filename, got %q", gotInfra)
+	}
+	gotInstall := manifestFilenameFor(presets.PresetTypeInstallation)
+	if gotInstall != presets.InstallationManifestFilename {
+		t.Errorf("expected installation manifest filename, got %q", gotInstall)
+	}
+	if got := manifestFilenameFor("unknown"); got != "" {
+		t.Errorf("expected empty filename for unknown preset type, got %q", got)
+	}
+}
+
+func TestNeedsExtraction(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]bool{
+		"https://example.com/preset.tar.gz": true,
+		"https://example.com/preset.tgz":    true,
+		"https://example.com/preset.zip":    true,
+		"https://example.com/preset":        false,
+		"file:///tmp/preset-dir":            false,
+	}
+	for url, want := range cases {
+		if got := needsExtraction(url); got != want {
+			t.Errorf("needsExtraction(%q) = %v, want %v", url, got, want)
+		}
+	}
+}
+
 func TestResolvePreset_NonGitURLWithRefReturnsError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/deploy/preset_identity_test.go
+++ b/internal/deploy/preset_identity_test.go
@@ -5,6 +5,7 @@ package deploy
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/exasol/exasol-personal/internal/config"
@@ -74,6 +75,47 @@ func TestResolveDeploymentPresetIdentity_DerivesForOldStyleDeploymentWithoutWrit
 	}
 	if state.InfrastructurePresetIdentity != "" || state.InstallationPresetIdentity != "" {
 		t.Fatal("expected ResolveDeploymentPresetIdentity not to persist the derived identity")
+	}
+}
+
+func TestPresetIdentityOf_NameBasedRef(t *testing.T) {
+	t.Parallel()
+
+	// Then: a name-based ref with surrounding whitespace resolves to a trimmed name-based identity.
+	if got := presetIdentityOf(PresetRef{Name: " aws "}); got != "name:aws" {
+		t.Fatalf("expected a trimmed name identity, got %q", got)
+	}
+}
+
+func TestPresetIdentityOf_PathBasedRefIsAbsoluteAndCleaned(t *testing.T) {
+	t.Parallel()
+
+	// Given a path-based preset ref with a non-canonical path.
+	dir := t.TempDir()
+
+	// When its identity is computed.
+	got := presetIdentityOf(PresetRef{Path: dir + "/./"})
+	// Then it returns an absolute, cleaned path-based identity.
+	want := "path:" + filepath.Clean(dir)
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestPresetIdentityDisplay_StripsKnownPrefixes(t *testing.T) {
+	t.Parallel()
+
+	// Given identities with name/path prefixes and one with no known prefix.
+	cases := map[string]string{
+		"name:aws":         "aws",
+		"path:/tmp/custom": "/tmp/custom",
+		"unknown-format":   "unknown-format",
+	}
+	for identity, want := range cases {
+		// Then: known prefixes are stripped and unknown identities pass through unchanged.
+		if got := presetIdentityDisplay(identity); got != want {
+			t.Errorf("presetIdentityDisplay(%q) = %q, want %q", identity, got, want)
+		}
 	}
 }
 

--- a/internal/deploy/ready_test.go
+++ b/internal/deploy/ready_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/localruntime"
+)
+
+// withFakeVerifyDatabaseConnection swaps the package-level
+// verifyDatabaseConnectionFn seam so WaitForDatabaseStarted/
+// WaitForLocalDatabaseStarted can be driven without a real database.
+func withFakeVerifyDatabaseConnection(
+	t *testing.T,
+	fn func(context.Context, config.DeploymentDir) error,
+) {
+	t.Helper()
+
+	original := verifyDatabaseConnectionFn
+	verifyDatabaseConnectionFn = fn
+	t.Cleanup(func() {
+		verifyDatabaseConnectionFn = original
+	})
+}
+
+//nolint:paralleltest // mutates the package-level verifyDatabaseConnectionFn seam.
+func TestWaitForDatabaseStarted_SucceedsImmediatelyWhenConnectionVerified(t *testing.T) {
+	withFakeVerifyDatabaseConnection(t, func(context.Context, config.DeploymentDir) error {
+		return nil
+	})
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+
+	if err := WaitForDatabaseStarted(context.Background(), deployment); err != nil {
+		t.Fatalf("expected an immediately-ready database to succeed, got %v", err)
+	}
+}
+
+//nolint:paralleltest // mutates the package-level verifyDatabaseConnectionFn seam.
+func TestWaitForDatabaseStarted_PropagatesLastErrorWhenContextEnds(t *testing.T) {
+	probeErr := errors.New("connection refused")
+	withFakeVerifyDatabaseConnection(t, func(context.Context, config.DeploymentDir) error {
+		return probeErr
+	})
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := WaitForDatabaseStarted(ctx, deployment)
+	if !errors.Is(err, probeErr) {
+		t.Fatalf("expected the last probe error to surface, got %v", err)
+	}
+}
+
+//nolint:paralleltest // mutates the package-level verifyDatabaseConnectionFn seam.
+func TestWaitForLocalDatabaseStarted_NonLocalDeploymentStillPolls(t *testing.T) {
+	withFakeVerifyDatabaseConnection(t, func(context.Context, config.DeploymentDir) error {
+		return nil
+	})
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := os.MkdirAll(deployment.InfrastructureDir(), 0o700); err != nil {
+		t.Fatalf("create infrastructure dir failed: %v", err)
+	}
+	writeTestFile(t, deployment.InfrastructureManifestPath(), `
+name: Test Infrastructure
+description: test infrastructure
+backend: tofu
+`)
+
+	runtime := localruntime.New(deployment, nil)
+
+	if err := WaitForLocalDatabaseStarted(context.Background(), runtime); err != nil {
+		t.Fatalf("expected a non-local deployment to skip reachability and poll, got %v", err)
+	}
+}
+
+// nolint: paralleltest // avoids concurrent extract+exec of the fake runner (ETXTBSY flakes).
+func TestWaitForLocalDatabaseStarted_FailsFastOnBlockedReachability(t *testing.T) {
+	skipOnWindows(t)
+
+	deployment := newLocalTestDeployment(t)
+	ensureLocalRuntimeWorkDir(t, deployment)
+	blockedJSON := allPortsBlockedHealthJSON
+	manager := writeFakeCombinedRunner(t, "", blockedJSON)
+	runtime := localruntime.New(deployment, manager)
+
+	err := WaitForLocalDatabaseStarted(context.Background(), runtime)
+	if !errors.Is(err, ErrLocalReachability) {
+		t.Fatalf("expected a reachability error before any DB polling, got %v", err)
+	}
+}

--- a/internal/deploy/remove_test.go
+++ b/internal/deploy/remove_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+)
+
+func TestRemoveDeploymentDirectoryRoot_RemovesEmptyDirectory(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+
+	if err := removeDeploymentDirectoryRoot(deployment); err != nil {
+		t.Fatalf("expected an empty directory to be removed, got %v", err)
+	}
+	if _, err := os.Stat(deployment.Root()); !os.IsNotExist(err) {
+		t.Fatalf("expected the directory to no longer exist, got %v", err)
+	}
+}
+
+func TestRemoveDeploymentDirectoryRoot_AlreadyRemovedIsNoop(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir() + "/already-gone")
+
+	if err := removeDeploymentDirectoryRoot(deployment); err != nil {
+		t.Fatalf("expected a missing directory to be a no-op, got %v", err)
+	}
+}
+
+func TestRemoveDeploymentDirectoryRoot_NonEmptyDirectoryReturnsWrappedError(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := os.WriteFile(deployment.Resolve("stray.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("failed to write stray file: %v", err)
+	}
+
+	err := removeDeploymentDirectoryRoot(deployment)
+	if err == nil {
+		t.Fatal("expected a non-empty directory to fail removal")
+	}
+}
+
+func TestEnsureRemovableDeploymentDirectory_RejectsPathThatIsNotADirectory(t *testing.T) {
+	t.Parallel()
+
+	filePath := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(filePath, []byte("x"), 0o600); err != nil {
+		t.Fatalf("failed to write file fixture: %v", err)
+	}
+	deployment := config.NewDeploymentDir(filePath)
+
+	err := ensureRemovableDeploymentDirectory(deployment)
+	if err == nil {
+		t.Fatal("expected an error when the deployment root is a regular file")
+	}
+}
+
+func TestPathIsInside(t *testing.T) {
+	t.Parallel()
+
+	parent := t.TempDir()
+
+	cases := map[string]struct {
+		child string
+		want  bool
+	}{
+		"nested path":    {child: filepath.Join(parent, "sub", "leaf"), want: true},
+		"same path":      {child: parent, want: true},
+		"sibling path":   {child: parent + "-sibling", want: false},
+		"unrelated path": {child: filepath.Join(t.TempDir(), "other"), want: false},
+	}
+
+	for name, testCase := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := pathIsInside(parent, testCase.child); got != testCase.want {
+				t.Errorf("pathIsInside(%q, %q) = %v, want %v",
+					parent, testCase.child, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestRegularFileExists(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(filePath, []byte("x"), 0o600); err != nil {
+		t.Fatalf("failed to write file fixture: %v", err)
+	}
+
+	exists, err := regularFileExists(filePath)
+	if err != nil || !exists {
+		t.Fatalf("expected an existing regular file to be reported, got exists=%v err=%v",
+			exists, err)
+	}
+
+	exists, err = regularFileExists(filepath.Join(dir, "missing.txt"))
+	if err != nil || exists {
+		t.Fatalf("expected a missing file to be reported absent, got exists=%v err=%v",
+			exists, err)
+	}
+
+	exists, err = regularFileExists(dir)
+	if err != nil || exists {
+		t.Fatalf("expected a directory to not count as a regular file, got exists=%v err=%v",
+			exists, err)
+	}
+}

--- a/internal/deploy/shared_test.go
+++ b/internal/deploy/shared_test.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/exasol/exasol-personal/internal/config"
+)
+
+func TestGetn11DetailsReturnsErrNoNodesFoundWhenDeploymentHasNoNodes(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := config.WriteDeploymentInfo(deployment.Root(), &config.DeploymentInfo{
+		Backend:      "tofu",
+		DeploymentId: "dep-1",
+	}); err != nil {
+		t.Fatalf("failed to write deployment info: %v", err)
+	}
+
+	_, err := Getn11Details(deployment)
+
+	if !errors.Is(err, ErrNoNodesFound) {
+		t.Fatalf("expected ErrNoNodesFound, got %v", err)
+	}
+}
+
+func TestGetn11DetailsResolvesSSHDetailsForFirstNode(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	writeTestSSHKeyFile(t, deployment, "keys/n11.pem")
+	if err := config.WriteDeploymentInfo(deployment.Root(), &config.DeploymentInfo{
+		Backend:      "tofu",
+		DeploymentId: "dep-1",
+		Nodes: map[string]config.DeploymentNode{
+			"n11": {
+				PublicIp: "203.0.113.10",
+				Ssh: config.DeploymentSSH{
+					Username: "sys",
+					Port:     "22",
+					KeyFile:  "keys/n11.pem",
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("failed to write deployment info: %v", err)
+	}
+
+	details, err := Getn11Details(deployment)
+	if err != nil {
+		t.Fatalf("expected SSH details to resolve, got %v", err)
+	}
+	if details.Host != "203.0.113.10" || details.User != "sys" || details.Port != "22" {
+		t.Fatalf("unexpected SSH details: %+v", details)
+	}
+}
+
+func TestPollWithBackoffReturnsImmediatelyWhenConditionIsAlreadyMet(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+
+	err := PollWithBackoff(context.Background(), func(context.Context) (bool, error) {
+		calls++
+
+		return true, nil
+	}, WaitParams{InitialBackoff: 1, MaxBackoff: 1})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected exactly one condition check, got %d", calls)
+	}
+}
+
+func TestPollWithBackoffRetriesUntilConditionSucceeds(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+
+	err := PollWithBackoff(context.Background(), func(context.Context) (bool, error) {
+		calls++
+
+		return calls >= 2, nil
+	}, WaitParams{InitialBackoff: 1, MaxBackoff: 1})
+	if err != nil {
+		t.Fatalf("expected eventual success, got %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected exactly two condition checks, got %d", calls)
+	}
+}
+
+func TestPollWithBackoffReturnsLastConditionErrorOnTimeout(t *testing.T) {
+	t.Parallel()
+
+	persistentErr := errors.New("database not ready yet")
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := PollWithBackoff(ctx, func(context.Context) (bool, error) {
+		return false, persistentErr
+	}, WaitParams{InitialBackoff: 1, MaxBackoff: 1})
+
+	if !errors.Is(err, persistentErr) {
+		t.Fatalf("expected the last condition error to surface, got %v", err)
+	}
+}
+
+func TestPollWithBackoffReturnsContextErrorWhenConditionNeverErrors(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := PollWithBackoff(ctx, func(context.Context) (bool, error) {
+		return false, nil
+	}, WaitParams{InitialBackoff: 1, MaxBackoff: 1})
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded, got %v", err)
+	}
+}

--- a/internal/deploy/shell_test.go
+++ b/internal/deploy/shell_test.go
@@ -1,0 +1,145 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+)
+
+func TestOpenHostShell_MissingManifestReturnsErrorWithoutOpeningShell(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+
+	if err := OpenHostShell(context.Background(), deployment, ""); err == nil {
+		t.Fatal("expected an error when no infrastructure manifest has been extracted")
+	}
+}
+
+func TestOpenCOSShell_MissingManifestReturnsErrorWithoutOpeningShell(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+
+	if err := OpenCOSShell(context.Background(), deployment); err == nil {
+		t.Fatal("expected an error when no infrastructure manifest has been extracted")
+	}
+}
+
+func writeTestSSHKeyFile(t *testing.T, deployment config.DeploymentDir, relPath string) {
+	t.Helper()
+
+	absPath := deployment.Resolve(relPath)
+	if err := os.MkdirAll(filepath.Dir(absPath), 0o700); err != nil {
+		t.Fatalf("failed to create key directory: %v", err)
+	}
+	if err := os.WriteFile(absPath, []byte("fake-private-key"), 0o600); err != nil {
+		t.Fatalf("failed to write fake key file: %v", err)
+	}
+}
+
+func TestSshRemoteForNodeUnsafeReturnsErrNoNodesFoundWhenDeploymentHasNoNodes(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := config.WriteDeploymentInfo(deployment.Root(), &config.DeploymentInfo{
+		Backend:      "tofu",
+		DeploymentId: "dep-1",
+	}); err != nil {
+		t.Fatalf("failed to write deployment info: %v", err)
+	}
+
+	_, err := sshRemoteForNodeUnsafe(deployment, "")
+
+	if !errors.Is(err, ErrNoNodesFound) {
+		t.Fatalf("expected ErrNoNodesFound, got %v", err)
+	}
+}
+
+func TestSshRemoteForNodeUnsafeReturnsErrorForUnknownExplicitNode(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := config.WriteDeploymentInfo(deployment.Root(), &config.DeploymentInfo{
+		Backend:      "tofu",
+		DeploymentId: "dep-1",
+		Nodes: map[string]config.DeploymentNode{
+			"n11": {PublicIp: "203.0.113.10"},
+		},
+	}); err != nil {
+		t.Fatalf("failed to write deployment info: %v", err)
+	}
+
+	_, err := sshRemoteForNodeUnsafe(deployment, "does-not-exist")
+
+	if !errors.Is(err, config.ErrUnknownNodeName) {
+		t.Fatalf("expected ErrUnknownNodeName, got %v", err)
+	}
+}
+
+func TestSshRemoteForNodeUnsafeWrapsMissingKeyFileError(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := config.WriteDeploymentInfo(deployment.Root(), &config.DeploymentInfo{
+		Backend:      "tofu",
+		DeploymentId: "dep-1",
+		Nodes: map[string]config.DeploymentNode{
+			"n11": {
+				PublicIp: "203.0.113.10",
+				Ssh: config.DeploymentSSH{
+					Username: "sys",
+					Port:     "22",
+					KeyFile:  "keys/missing.pem",
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("failed to write deployment info: %v", err)
+	}
+
+	_, err := sshRemoteForNodeUnsafe(deployment, "")
+
+	if err == nil || !strings.Contains(err.Error(), "could not read SSH key file") {
+		t.Fatalf("expected a missing SSH key file error, got %v", err)
+	}
+}
+
+func TestSshRemoteForNodeUnsafeResolvesSingleNodeByDefault(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	writeTestSSHKeyFile(t, deployment, "keys/n11.pem")
+	if err := config.WriteDeploymentInfo(deployment.Root(), &config.DeploymentInfo{
+		Backend:      "tofu",
+		DeploymentId: "dep-1",
+		Nodes: map[string]config.DeploymentNode{
+			"n11": {
+				PublicIp: "203.0.113.10",
+				Ssh: config.DeploymentSSH{
+					Username: "sys",
+					Port:     "22",
+					KeyFile:  "keys/n11.pem",
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("failed to write deployment info: %v", err)
+	}
+
+	remoteHost, err := sshRemoteForNodeUnsafe(deployment, "")
+	if err != nil {
+		t.Fatalf("expected the sole node to resolve without an explicit selection, got %v", err)
+	}
+	if remoteHost == nil {
+		t.Fatal("expected a non-nil SSH remote")
+	}
+}

--- a/internal/deploy/slc_test.go
+++ b/internal/deploy/slc_test.go
@@ -4,12 +4,228 @@
 package deploy
 
 import (
+	"context"
 	"errors"
 	"os"
+	"reflect"
+	"runtime"
 	"testing"
 
 	"github.com/exasol/exasol-personal/internal/config"
 )
+
+// newDeployedLocalTestDeployment builds a local-backend deployment whose
+// workflow state is past "initialized" (SLC operations require an actual
+// deployment to modify), seeded with installedSLCs if any are given.
+func newDeployedLocalTestDeployment(
+	t *testing.T,
+	installedSLCs []config.InstalledSLC,
+) config.DeploymentDir {
+	t.Helper()
+
+	deployment := newLocalTestDeployment(t)
+	state := &config.ExasolPersonalState{
+		DeploymentVersion: "0.0.0",
+		InstalledSLCs:     installedSLCs,
+	}
+	stopped := &config.WorkflowStateStopped{}
+	if err := state.SetWorkflowStateAndWrite(stopped, deployment); err != nil {
+		t.Fatalf("failed to write launcher state: %v", err)
+	}
+
+	return deployment
+}
+
+func TestInstallSLCRejectsNonLocalDeployment(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := os.MkdirAll(deployment.InfrastructureDir(), 0o700); err != nil {
+		t.Fatalf("failed to create infrastructure dir: %v", err)
+	}
+	writeTestFile(t, deployment.InfrastructureManifestPath(), `
+name: Test Infrastructure
+description: test infrastructure
+backend: tofu
+`)
+
+	_, err := InstallSLC(context.Background(), deployment, "python3", false, false, nil)
+
+	if !errors.Is(err, ErrSLCNotSupported) {
+		t.Fatalf("expected ErrSLCNotSupported for a non-local deployment, got %v", err)
+	}
+}
+
+func TestInstallSLCRejectsDeploymentNotYetDeployed(t *testing.T) {
+	t.Parallel()
+
+	deployment := newLocalTestDeployment(t)
+	state := &config.ExasolPersonalState{DeploymentVersion: "0.0.0"}
+	initialized := &config.WorkflowStateInitialized{}
+	if err := state.SetWorkflowStateAndWrite(initialized, deployment); err != nil {
+		t.Fatalf("failed to write launcher state: %v", err)
+	}
+
+	_, err := InstallSLC(context.Background(), deployment, "python3", false, false, nil)
+
+	if !errors.Is(err, ErrDeploymentNotPresent) {
+		t.Fatalf("expected ErrDeploymentNotPresent, got %v", err)
+	}
+}
+
+func TestUpdateSLCRejectsNonLocalDeployment(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := os.MkdirAll(deployment.InfrastructureDir(), 0o700); err != nil {
+		t.Fatalf("failed to create infrastructure dir: %v", err)
+	}
+	writeTestFile(t, deployment.InfrastructureManifestPath(), `
+name: Test Infrastructure
+description: test infrastructure
+backend: tofu
+`)
+
+	_, err := UpdateSLC(context.Background(), deployment, "python3", false, false, nil)
+
+	if !errors.Is(err, ErrSLCNotSupported) {
+		t.Fatalf("expected ErrSLCNotSupported for a non-local deployment, got %v", err)
+	}
+}
+
+func TestUpdateSLCRejectsDeploymentNotYetDeployed(t *testing.T) {
+	t.Parallel()
+
+	deployment := newLocalTestDeployment(t)
+	state := &config.ExasolPersonalState{DeploymentVersion: "0.0.0"}
+	initialized := &config.WorkflowStateInitialized{}
+	if err := state.SetWorkflowStateAndWrite(initialized, deployment); err != nil {
+		t.Fatalf("failed to write launcher state: %v", err)
+	}
+
+	_, err := UpdateSLC(context.Background(), deployment, "python3", false, false, nil)
+
+	if !errors.Is(err, ErrDeploymentNotPresent) {
+		t.Fatalf("expected ErrDeploymentNotPresent, got %v", err)
+	}
+}
+
+func TestRemoveSLCRejectsNonLocalDeployment(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := os.MkdirAll(deployment.InfrastructureDir(), 0o700); err != nil {
+		t.Fatalf("failed to create infrastructure dir: %v", err)
+	}
+	writeTestFile(t, deployment.InfrastructureManifestPath(), `
+name: Test Infrastructure
+description: test infrastructure
+backend: tofu
+`)
+
+	_, err := RemoveSLC(context.Background(), deployment, "python3", false, false, nil)
+
+	if !errors.Is(err, ErrSLCNotSupported) {
+		t.Fatalf("expected ErrSLCNotSupported for a non-local deployment, got %v", err)
+	}
+}
+
+func TestRemoveSLCRejectsDeploymentNotYetDeployed(t *testing.T) {
+	t.Parallel()
+
+	deployment := newLocalTestDeployment(t)
+	state := &config.ExasolPersonalState{DeploymentVersion: "0.0.0"}
+	initialized := &config.WorkflowStateInitialized{}
+	if err := state.SetWorkflowStateAndWrite(initialized, deployment); err != nil {
+		t.Fatalf("failed to write launcher state: %v", err)
+	}
+
+	_, err := RemoveSLC(context.Background(), deployment, "python3", false, false, nil)
+
+	if !errors.Is(err, ErrDeploymentNotPresent) {
+		t.Fatalf("expected ErrDeploymentNotPresent, got %v", err)
+	}
+}
+
+func TestRemoveSLCReturnsNotFoundWhenAliasIsNotInstalled(t *testing.T) {
+	t.Parallel()
+
+	deployment := newDeployedLocalTestDeployment(t, nil)
+
+	result, err := RemoveSLC(context.Background(), deployment, "python3", false, false, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if result.Found || result.Changed {
+		t.Fatalf("expected not-found no-op result, got %+v", result)
+	}
+}
+
+// RemoveSLC never touches the SLC catalog (unlike Install/Update), so its full
+// restart=false logic is reachable on every architecture, not just the
+// catalog's arm64-only entries.
+func TestRemoveSLCWithoutRestartRecordsRemovalAndDefersActivation(t *testing.T) {
+	t.Parallel()
+
+	installed := []config.InstalledSLC{
+		{
+			Language: "python",
+			Flavor:   "python-3.12",
+			Version:  "3.12",
+			Image:    "docker.io/exasol/script-language-container:python-3.12",
+			Target:   "/exa/slc/python-3.12",
+			Aliases:  []string{"PYTHON3", "PYTHON312"},
+		},
+	}
+	deployment := newDeployedLocalTestDeployment(t, installed)
+
+	result, err := RemoveSLC(context.Background(), deployment, "python3", false, false, nil)
+	if err != nil {
+		t.Fatalf("expected removal to succeed, got %v", err)
+	}
+
+	if !result.Found || !result.Changed {
+		t.Fatalf("expected a found, changed removal, got %+v", result)
+	}
+	if result.Outcome != SLCApplyDeferred {
+		t.Fatalf("expected deferred activation without --restart, got %s", result.Outcome)
+	}
+	if result.Entry == nil || result.Entry.Flavor != installed[0].Flavor {
+		t.Fatalf("expected removed entry to be reported, got %+v", result.Entry)
+	}
+
+	state, err := config.ReadExasolPersonalState(deployment)
+	if err != nil {
+		t.Fatalf("failed to read state: %v", err)
+	}
+	if len(state.InstalledSLCs) != 0 {
+		t.Fatalf("expected the SLC to be removed from state, got %+v", state.InstalledSLCs)
+	}
+}
+
+func TestRemoveSLCWithoutRestartLeavesOtherInstalledSLCsUntouched(t *testing.T) {
+	t.Parallel()
+
+	installed := []config.InstalledSLC{
+		{Language: "python", Flavor: "python-3.12", Aliases: []string{"PYTHON3"}},
+		{Language: "java", Flavor: "java-17", Aliases: []string{"JAVA"}},
+	}
+	deployment := newDeployedLocalTestDeployment(t, installed)
+
+	_, err := RemoveSLC(context.Background(), deployment, "python3", false, false, nil)
+	if err != nil {
+		t.Fatalf("expected removal to succeed, got %v", err)
+	}
+
+	state, err := config.ReadExasolPersonalState(deployment)
+	if err != nil {
+		t.Fatalf("failed to read state: %v", err)
+	}
+	if len(state.InstalledSLCs) != 1 || state.InstalledSLCs[0].Flavor != "java-17" {
+		t.Fatalf("expected only java-17 to remain, got %+v", state.InstalledSLCs)
+	}
+}
 
 func TestInstalledFlavors(t *testing.T) {
 	t.Parallel()
@@ -196,5 +412,135 @@ func TestLocalRunnerSlcArgsFromState(t *testing.T) {
 		if args[i] != want[i] {
 			t.Errorf("args[%d] = %q, want %q", i, args[i], want[i])
 		}
+	}
+}
+
+func TestSLCApplyOutcomeStringAndMarshalText(t *testing.T) {
+	t.Parallel()
+
+	cases := map[SLCApplyOutcome]string{
+		SLCApplyNone:        "none",
+		SLCApplyRestarted:   "restarted",
+		SLCApplyStarted:     "started",
+		SLCApplyDeferred:    "deferred",
+		SLCApplyOutcome(99): "unknown",
+	}
+	for outcome, want := range cases {
+		if got := outcome.String(); got != want {
+			t.Errorf("String() for %d = %q, want %q", outcome, got, want)
+		}
+		text, err := outcome.MarshalText()
+		if err != nil {
+			t.Fatalf("MarshalText() error: %v", err)
+		}
+		if string(text) != want {
+			t.Errorf("MarshalText() for %d = %q, want %q", outcome, string(text), want)
+		}
+	}
+}
+
+func TestConfirmOrCancel(t *testing.T) {
+	t.Parallel()
+
+	if err := confirmOrCancel(nil); err != nil {
+		t.Fatalf("expected a nil confirm func to be treated as already-approved, got %v", err)
+	}
+
+	approved := func() (bool, error) { return true, nil }
+	if err := confirmOrCancel(approved); err != nil {
+		t.Fatalf("expected approval to succeed, got %v", err)
+	}
+
+	declined := func() (bool, error) { return false, nil }
+	if err := confirmOrCancel(declined); !errors.Is(err, ErrSLCOperationCancelled) {
+		t.Fatalf("expected ErrSLCOperationCancelled, got %v", err)
+	}
+
+	failing := func() (bool, error) { return false, errors.New("prompt failed") }
+	if err := confirmOrCancel(failing); err == nil || errors.Is(err, ErrSLCOperationCancelled) {
+		t.Fatalf("expected the confirm function's own error to propagate, got %v", err)
+	}
+}
+
+func TestEntriesFromInstalledAndToInstalledSLCRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	const flavor = "python-3.12"
+	installed := []config.InstalledSLC{
+		{
+			Language: "python",
+			Flavor:   flavor,
+			Version:  "3.12",
+			Image:    "docker.io/x:pytag",
+			Target:   "/exa/slc/" + flavor,
+			Aliases:  []string{"PYTHON3"},
+		},
+	}
+
+	entries := entriesFromInstalled(installed)
+
+	if len(entries) != 1 || entries[0].Flavor != flavor ||
+		entries[0].Image != "docker.io/x:pytag" {
+		t.Fatalf("unexpected entries: %+v", entries)
+	}
+
+	roundTripped := toInstalledSLC(entries[0])
+	if !reflect.DeepEqual(roundTripped, installed[0]) {
+		t.Fatalf("expected round-trip to reproduce the original entry, got %+v, want %+v",
+			roundTripped, installed[0])
+	}
+}
+
+func TestInstalledEntriesWrapsStateInstalledSLCs(t *testing.T) {
+	t.Parallel()
+
+	const flavor = "python-3.12"
+	state := &config.ExasolPersonalState{
+		InstalledSLCs: []config.InstalledSLC{{Flavor: flavor}},
+	}
+
+	entries := installedEntries(state)
+
+	if len(entries) != 1 || entries[0].Flavor != flavor {
+		t.Fatalf("unexpected entries: %+v", entries)
+	}
+}
+
+func TestSLCStatusesSurfacesCatalogErrorsCleanly(t *testing.T) {
+	t.Parallel()
+
+	// The embedded SLC catalog only declares arm64 entries today; on any
+	// other architecture (this test always runs on the CI/dev host's real
+	// GOARCH), SLCStatuses must surface that as a clean error rather than
+	// panicking or silently returning an empty list.
+	deployment := config.NewDeploymentDir(t.TempDir())
+
+	_, err := SLCStatuses(deployment)
+
+	if runtime.GOARCH == "arm64" {
+		if err != nil {
+			t.Fatalf("expected no error on a supported architecture, got %v", err)
+		}
+	} else if err == nil {
+		t.Fatal("expected an architecture-unsupported error on an unsupported GOARCH")
+	}
+}
+
+// TestIsLocalDeploymentRunning_UnresolvableRunnerReturnsFalse mirrors
+// TestLocalVMStoppedStatus_UnresolvableRunnerReturnsNil in status_test.go:
+// the embedded exasol-local-runner artifact only resolves on darwin/arm64,
+// so on any other platform isLocalDeploymentRunning must degrade to false
+// rather than propagate the resolution error.
+func TestIsLocalDeploymentRunning_UnresolvableRunnerReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	if localRunnerResolvesOnThisPlatform(t) {
+		t.Skip("the embedded runner resolves on this platform; this covers the failure path")
+	}
+
+	deployment := newLocalTestDeployment(t)
+
+	if isLocalDeploymentRunning(context.Background(), deployment) {
+		t.Fatal("expected false when the local runner can't be resolved")
 	}
 }

--- a/internal/deploy/status_test.go
+++ b/internal/deploy/status_test.go
@@ -5,6 +5,8 @@ package deploy
 
 import (
 	"context"
+	"errors"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -80,6 +82,146 @@ func TestStatus_ReportsOperationInProgressWhenLockedBeforeStateFileExists(t *tes
 	}
 	if status.Message == "" {
 		t.Fatal("expected operation-in-progress message, got empty message")
+	}
+}
+
+func TestStatusUnsafe_ReportsNotInitializedForMissingDirectory(t *testing.T) {
+	t.Parallel()
+
+	// Given: an uninitialized deployment directory.
+	deployment := config.NewDeploymentDir(t.TempDir())
+
+	// When: status is requested via the unsafe (unlocked) path.
+	status, err := StatusUnsafe(context.Background(), deployment)
+	// Then: the status object reports not initialized for the active deployment directory.
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if status.Status != StatusNotInitialized {
+		t.Fatalf("expected status %q, got %q", StatusNotInitialized, status.Status)
+	}
+	if status.DeploymentDir != deployment.Root() {
+		t.Fatalf("expected deployment dir %q, got %q", deployment.Root(), status.DeploymentDir)
+	}
+}
+
+// TestLocalVMStoppedStatus_UnresolvableRunnerReturnsNil exercises
+// localVMStoppedStatus's real newResourceManager()/Status() path for a local
+// deployment. The embedded exasol-local-runner artifact only exists for
+// darwin/arm64 (see assets/resources/resources.yaml), so on any other
+// platform Status() fails to resolve it and localVMStoppedStatus must
+// degrade to nil rather than propagate that error, exactly as it does for a
+// genuinely offline VM daemon.
+func TestLocalVMStoppedStatus_UnresolvableRunnerReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	// Given: a platform where the embedded local runner cannot be resolved.
+	if localRunnerResolvesOnThisPlatform(t) {
+		t.Skip("the embedded runner resolves on this platform; this covers the failure path")
+	}
+
+	deployment := newLocalTestDeployment(t)
+
+	// Then: the stopped-status check degrades to nil instead of propagating
+	// the resolution error.
+	if got := localVMStoppedStatus(context.Background(), deployment); got != nil {
+		t.Fatalf("expected nil when the local runner can't be resolved, got %+v", got)
+	}
+}
+
+func TestLocalVMStoppedStatus_NonLocalDeploymentReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	// Given: a deployment backed by a non-local infrastructure preset.
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := os.MkdirAll(deployment.InfrastructureDir(), 0o700); err != nil {
+		t.Fatalf("create infrastructure dir failed: %v", err)
+	}
+	writeTestFile(t, deployment.InfrastructureManifestPath(), `
+name: Test Infrastructure
+description: test infrastructure
+backend: tofu
+`)
+
+	// Then: the stopped-status check returns nil because the deployment
+	// is not local.
+	if got := localVMStoppedStatus(context.Background(), deployment); got != nil {
+		t.Fatalf("expected nil for a non-local deployment, got %+v", got)
+	}
+}
+
+func TestStaleOperationInProgressMessage_DeployOperation(t *testing.T) {
+	t.Parallel()
+
+	// When: the stale in-progress message is built for a deploy operation.
+	msg := staleOperationInProgressMessage(config.DeployOperation)
+	// Then: it includes deploy-specific guidance.
+	if !strings.Contains(msg, "previous deploy operation") {
+		t.Fatalf("expected deploy-specific guidance, got %q", msg)
+	}
+}
+
+func TestStaleOperationInProgressMessage_UnknownOperationFallsBackToGenericGuidance(t *testing.T) {
+	t.Parallel()
+
+	// When: the stale in-progress message is built for an unrecognized operation.
+	msg := staleOperationInProgressMessage("start")
+	// Then: it falls back to generic guidance that still names the operation.
+	if !strings.Contains(msg, "previous start operation") {
+		t.Fatalf("expected the operation name to be included, got %q", msg)
+	}
+}
+
+func TestBuildInterruptMessage_DeployOperation(t *testing.T) {
+	t.Parallel()
+
+	// When: the interrupt message is built for a deploy operation.
+	msg := buildInterruptMessage(config.DeployOperation)
+	// Then: it includes deploy-specific guidance.
+	if !strings.Contains(msg, "Please run `deploy`") {
+		t.Fatalf("expected deploy-specific guidance, got %q", msg)
+	}
+}
+
+func TestBuildInterruptMessage_DefaultOperation(t *testing.T) {
+	t.Parallel()
+
+	// When: the interrupt message is built for an unrecognized operation.
+	msg := buildInterruptMessage("start")
+	// Then: it falls back to generic start/stop guidance.
+	if !strings.Contains(msg, "Please run `start` or `stop`") {
+		t.Fatalf("expected generic start/stop guidance, got %q", msg)
+	}
+}
+
+func TestStatusFromLockError_ContextCanceledPropagates(t *testing.T) {
+	t.Parallel()
+
+	// When: a lock error is translated for a canceled context.
+	status, err := statusFromLockError(context.Canceled)
+	// Then: no status is returned and the canceled error propagates.
+	if status != nil {
+		t.Fatalf("expected no status for a canceled context, got %+v", status)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected the canceled error to propagate, got %v", err)
+	}
+}
+
+func TestStatusFromLockError_UnknownErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	// Given: an error unrelated to context cancellation.
+	unexpected := errors.New("boom")
+
+	// When: a lock error is translated for an unexpected error.
+	status, err := statusFromLockError(unexpected)
+	// Then: no status is returned and the unexpected error propagates unchanged.
+	if status != nil {
+		t.Fatalf("expected no status for an unexpected error, got %+v", status)
+	}
+	if !errors.Is(err, unexpected) {
+		t.Fatalf("expected the unexpected error to propagate, got %v", err)
 	}
 }
 

--- a/internal/deploy/tofu_backend_test.go
+++ b/internal/deploy/tofu_backend_test.go
@@ -1,0 +1,443 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/presets"
+	"github.com/exasol/exasol-personal/internal/runtimeartifacts"
+	"github.com/exasol/exasol-personal/internal/tofu"
+	"github.com/zclconf/go-cty/cty"
+)
+
+const tofuResourceID = "tofu"
+
+// writeFakeTofuManager builds a Manager whose "tofu" resource resolves to a
+// fake tofu/OpenTofu executable, so tofuBackend.Deploy/Destroy/Stop exercise
+// their real init/plan/apply/destroy wiring without needing the real binary.
+func writeFakeTofuManager(t *testing.T, scriptContent string) *runtimeartifacts.Manager {
+	t.Helper()
+
+	zipPath := filepath.Join(t.TempDir(), "tofu.zip")
+	file, err := os.Create(zipPath)
+	if err != nil {
+		t.Fatalf("failed to create tofu zip fixture: %v", err)
+	}
+	defer file.Close()
+
+	writer := zip.NewWriter(file)
+	header := &zip.FileHeader{Name: "tofu", Method: zip.Deflate}
+	header.SetMode(testRunnerExecutableMode)
+	entry, err := writer.CreateHeader(header)
+	if err != nil {
+		t.Fatalf("failed to create tofu zip entry: %v", err)
+	}
+	if _, err := entry.Write([]byte(scriptContent)); err != nil {
+		t.Fatalf("failed to write tofu zip entry: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("failed to close tofu zip fixture: %v", err)
+	}
+
+	spec := runtimeartifacts.ResourceSpec{
+		tofuResourceID: {
+			Extract: true,
+			Artifact: map[string]runtimeartifacts.ArtifactSpec{
+				"any": {URL: zipPath, ResourcePath: "tofu"},
+			},
+		},
+	}
+
+	return runtimeartifacts.NewResourceManagerForPlatform(
+		spec,
+		t.TempDir(),
+		runtime.GOOS,
+		runtime.GOARCH,
+	)
+}
+
+// newTestTofuBackend builds a tofuBackend against a real deployment directory
+// with a minimal variables file, backed by a fake tofu executable.
+func newTestTofuBackend(t *testing.T, tofuScript string) *tofuBackend {
+	t.Helper()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	manifest := &presets.InfrastructureManifest{
+		Backend: backendTypeTofu,
+		Tofu:    &presets.InfrastructureTofu{},
+	}
+	manager := writeFakeTofuManager(t, tofuScript)
+
+	backend := newTofuBackend(deployment, manifest, manager)
+
+	if err := os.MkdirAll(backend.cfg.WorkDir(), 0o750); err != nil {
+		t.Fatalf("failed to create infrastructure dir: %v", err)
+	}
+	variablesTF := `variable "region" {
+  type    = string
+  default = "us-east-1"
+}
+`
+	if err := os.WriteFile(backend.cfg.VariablesFile(), []byte(variablesTF), 0o600); err != nil {
+		t.Fatalf("failed to write variables file: %v", err)
+	}
+
+	return backend
+}
+
+const alwaysSucceedTofuScript = "#!/bin/sh\nexit 0\n"
+
+func failOnSubcommandTofuScript(subcommand string) string {
+	return "#!/bin/sh\nif [ \"$1\" = \"" + subcommand + "\" ]; then exit 1; fi\nexit 0\n"
+}
+
+// nolint: paralleltest // avoids concurrent extract+exec of the fake tofu binary (ETXTBSY flakes).
+func TestTofuBackendDeploySucceedsThroughInitPlanApply(t *testing.T) {
+	backend := newTestTofuBackend(t, alwaysSucceedTofuScript)
+
+	var out, outErr bytes.Buffer
+
+	err := backend.Deploy(context.Background(), &out, &outErr, DeployOptions{})
+	if err != nil {
+		t.Fatalf("expected deploy to succeed, got %v", err)
+	}
+}
+
+// nolint: paralleltest // avoids concurrent extract+exec of the fake tofu binary (ETXTBSY flakes).
+func TestTofuBackendDeployStopsAtPlanFailureWithoutApplying(t *testing.T) {
+	backend := newTestTofuBackend(t, failOnSubcommandTofuScript("plan"))
+
+	var out, outErr bytes.Buffer
+
+	err := backend.Deploy(context.Background(), &out, &outErr, DeployOptions{})
+	if err == nil {
+		t.Fatal("expected deploy to fail when plan fails")
+	}
+}
+
+func TestTofuBackendDeployIsANoopWithoutTofuConfiguration(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	backend := newTofuBackend(deployment, &presets.InfrastructureManifest{Backend: "local"}, nil)
+
+	var out, outErr bytes.Buffer
+
+	err := backend.Deploy(context.Background(), &out, &outErr, DeployOptions{})
+	if err != nil {
+		t.Fatalf("expected a no-op deploy without tofu config, got %v", err)
+	}
+}
+
+// nolint: paralleltest // avoids concurrent extract+exec of the fake tofu binary (ETXTBSY flakes).
+func TestTofuBackendDestroySucceedsThroughInitAndDestroy(t *testing.T) {
+	backend := newTestTofuBackend(t, alwaysSucceedTofuScript)
+
+	var out, outErr bytes.Buffer
+
+	err := backend.Destroy(context.Background(), &out, &outErr)
+	if err != nil {
+		t.Fatalf("expected destroy to succeed, got %v", err)
+	}
+}
+
+// nolint: paralleltest // avoids concurrent extract+exec of the fake tofu binary (ETXTBSY flakes).
+func TestTofuBackendDestroyPropagatesDestroyFailure(t *testing.T) {
+	backend := newTestTofuBackend(t, failOnSubcommandTofuScript("destroy"))
+
+	var out, outErr bytes.Buffer
+
+	err := backend.Destroy(context.Background(), &out, &outErr)
+	if err == nil {
+		t.Fatal("expected destroy to fail when the destroy step fails")
+	}
+}
+
+func TestTofuBackendDestroyIsANoopWithoutTofuConfiguration(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	backend := newTofuBackend(deployment, &presets.InfrastructureManifest{Backend: "local"}, nil)
+
+	var out, outErr bytes.Buffer
+	if err := backend.Destroy(context.Background(), &out, &outErr); err != nil {
+		t.Fatalf("expected a no-op destroy without tofu config, got %v", err)
+	}
+}
+
+// nolint: paralleltest // avoids concurrent extract+exec of the fake tofu binary (ETXTBSY flakes).
+func TestTofuBackendStopAppliesStoppedPowerState(t *testing.T) {
+	backend := newTestTofuBackend(t, alwaysSucceedTofuScript)
+
+	var out, outErr bytes.Buffer
+	if err := backend.Stop(context.Background(), &out, &outErr); err != nil {
+		t.Fatalf("expected stop to succeed, got %v", err)
+	}
+}
+
+// nolint: paralleltest // avoids concurrent extract+exec of the fake tofu binary (ETXTBSY flakes).
+func TestTofuBackendStopPropagatesApplyFailure(t *testing.T) {
+	backend := newTestTofuBackend(t, failOnSubcommandTofuScript("apply"))
+
+	var out, outErr bytes.Buffer
+
+	err := backend.Stop(context.Background(), &out, &outErr)
+	if err == nil {
+		t.Fatal("expected stop to fail when tofu apply fails")
+	}
+}
+
+func TestTofuBackendApplyActionIsANoopWithoutTofuConfiguration(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	backend := newTofuBackend(deployment, &presets.InfrastructureManifest{Backend: "local"}, nil)
+
+	var out, outErr bytes.Buffer
+
+	err := backend.applyAction(context.Background(), "power_state=stopped", &out, &outErr)
+	if err != nil {
+		t.Fatalf("expected a no-op apply action without tofu config, got %v", err)
+	}
+}
+
+func TestTofuBackendValidateEnvironmentAndSetupWorkspaceAreNoops(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	backend := newTofuBackend(deployment, &presets.InfrastructureManifest{Backend: "local"}, nil)
+
+	if err := backend.ValidateEnvironment(); err != nil {
+		t.Fatalf("expected ValidateEnvironment to be a no-op, got %v", err)
+	}
+	if err := backend.SetupWorkspace(context.Background()); err != nil {
+		t.Fatalf("expected SetupWorkspace to be a no-op without tofu config, got %v", err)
+	}
+}
+
+func TestTofuBackendReadConfigurationIsEmptyWithoutTofuConfiguration(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	backend := newTofuBackend(deployment, &presets.InfrastructureManifest{Backend: "local"}, nil)
+
+	values, err := backend.ReadConfiguration()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(values) != 0 {
+		t.Fatalf("expected no configuration values without tofu config, got %+v", values)
+	}
+}
+
+// newTestTofuBackendNoBinary builds a tofuBackend for read-only paths
+// (ReadConfiguration/ReadDeploymentConfigVariables) that never need to
+// resolve or exec the tofu binary itself.
+func newTestTofuBackendNoBinary(t *testing.T, variablesTF string) *tofuBackend {
+	t.Helper()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	manifest := &presets.InfrastructureManifest{
+		Backend: backendTypeTofu,
+		Tofu:    &presets.InfrastructureTofu{},
+	}
+	backend := newTofuBackend(deployment, manifest, nil)
+
+	if err := os.MkdirAll(backend.cfg.WorkDir(), 0o750); err != nil {
+		t.Fatalf("failed to create infrastructure dir: %v", err)
+	}
+	if err := os.WriteFile(backend.cfg.VariablesFile(), []byte(variablesTF), 0o600); err != nil {
+		t.Fatalf("failed to write variables file: %v", err)
+	}
+
+	return backend
+}
+
+const reservedNameVariablesTF = `variable "region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "deployment_id" {
+  type    = string
+  default = ""
+}
+`
+
+func TestTofuBackendReadDeploymentConfigVariablesExcludesReservedNames(t *testing.T) {
+	t.Parallel()
+
+	backend := newTestTofuBackendNoBinary(t, reservedNameVariablesTF)
+
+	variables, err := backend.ReadDeploymentConfigVariables()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if _, ok := variables["region"]; !ok {
+		t.Fatalf("expected 'region' to be exposed, got %+v", variables)
+	}
+	if _, ok := variables["deployment_id"]; ok {
+		t.Fatalf("expected launcher-reserved 'deployment_id' to be excluded, got %+v", variables)
+	}
+}
+
+func TestTofuBackendReadConfigurationReflectsWrittenOverrides(t *testing.T) {
+	t.Parallel()
+
+	backend := newTestTofuBackendNoBinary(t, reservedNameVariablesTF)
+
+	tfvars := "region = \"eu-central-1\"\n"
+	if err := os.WriteFile(backend.cfg.VarsOutputFile(), []byte(tfvars), 0o600); err != nil {
+		t.Fatalf("failed to write vars output file: %v", err)
+	}
+
+	values, err := backend.ReadConfiguration()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	var region *DeploymentConfigValue
+	for i := range values {
+		if values[i].Name == "region" {
+			region = &values[i]
+		}
+		if values[i].Name == "deployment_id" {
+			t.Fatalf("expected reserved variable to be excluded, got %+v", values[i])
+		}
+	}
+	if region == nil {
+		t.Fatal("expected a 'region' configuration value")
+	}
+	if region.Value != "eu-central-1" || region.Default != "us-east-1" {
+		t.Fatalf("expected current override and preset default, got %+v", region)
+	}
+}
+
+func TestReadTofuPresetConfigVariablesFromPathPreset(t *testing.T) {
+	t.Parallel()
+
+	presetDir := t.TempDir()
+	tofuManifest := presets.InfrastructureTofu{}
+	tofuCfg := tofu.NewTofuConfigFromPreset(presetDir, tofuManifest)
+	if err := os.MkdirAll(presetDir, 0o750); err != nil {
+		t.Fatalf("failed to create preset dir: %v", err)
+	}
+	variablesData := []byte(reservedNameVariablesTF)
+	if err := os.WriteFile(tofuCfg.VariablesFile(), variablesData, 0o600); err != nil {
+		t.Fatalf("failed to write variables file: %v", err)
+	}
+
+	variables, err := readTofuPresetConfigVariables(PresetRef{Path: presetDir}, tofuManifest)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if _, ok := variables["region"]; !ok {
+		t.Fatalf("expected 'region' to be exposed, got %+v", variables)
+	}
+	if _, ok := variables["deployment_id"]; ok {
+		t.Fatalf("expected reserved 'deployment_id' to be excluded, got %+v", variables)
+	}
+}
+
+func TestTofuVariableDefinitionsFiltersReservedAndNilVariables(t *testing.T) {
+	t.Parallel()
+
+	definitions := tofuVariableDefinitions(map[string]*tofu.Variable{
+		"region":         {Type: "string", Value: cty.StringVal("us-east-1")},
+		"deployment_id":  {Type: "string", Value: cty.StringVal("")},
+		"nil-entry-safe": nil,
+	})
+
+	if len(definitions) != 1 {
+		t.Fatalf("expected exactly one exposed variable, got %+v", definitions)
+	}
+	if _, ok := definitions["region"]; !ok {
+		t.Fatalf("expected 'region' to be exposed, got %+v", definitions)
+	}
+}
+
+func TestCtyDefaultDisplayHandlesNullUnknownAndConcreteValues(t *testing.T) {
+	t.Parallel()
+
+	if got := ctyDefaultDisplay(cty.NullVal(cty.String)); got != "" {
+		t.Fatalf("expected empty display for a null value, got %q", got)
+	}
+	if got := ctyDefaultDisplay(cty.UnknownVal(cty.String)); got != "" {
+		t.Fatalf("expected empty display for an unknown value, got %q", got)
+	}
+	if got := ctyDefaultDisplay(cty.StringVal("us-east-1")); got != `"us-east-1"` {
+		t.Fatalf("expected JSON-encoded string, got %q", got)
+	}
+}
+
+func TestTofuBackendOpenHostShellPropagatesSSHResolutionError(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := config.WriteDeploymentInfo(deployment.Root(), &config.DeploymentInfo{
+		Backend:      backendTypeTofu,
+		DeploymentId: "dep-1",
+	}); err != nil {
+		t.Fatalf("failed to write deployment info: %v", err)
+	}
+	manifest := &presets.InfrastructureManifest{Backend: backendTypeTofu}
+	backend := newTofuBackend(deployment, manifest, nil)
+
+	err := backend.OpenHostShell(context.Background(), "")
+
+	if !errors.Is(err, ErrNoNodesFound) {
+		t.Fatalf("expected ErrNoNodesFound, got %v", err)
+	}
+}
+
+func TestTofuBackendOpenCOSShellPropagatesSSHResolutionError(t *testing.T) {
+	t.Parallel()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := config.WriteDeploymentInfo(deployment.Root(), &config.DeploymentInfo{
+		Backend:      backendTypeTofu,
+		DeploymentId: "dep-1",
+	}); err != nil {
+		t.Fatalf("failed to write deployment info: %v", err)
+	}
+	manifest := &presets.InfrastructureManifest{Backend: backendTypeTofu}
+	backend := newTofuBackend(deployment, manifest, nil)
+
+	err := backend.OpenCOSShell(context.Background())
+
+	if !errors.Is(err, config.ErrUnknownNodeName) {
+		t.Fatalf("expected ErrUnknownNodeName (no n11 node present), got %v", err)
+	}
+}
+
+func TestCtyScalarConversionsRejectUnknownOrNullValues(t *testing.T) {
+	t.Parallel()
+
+	unknown := cty.UnknownVal(cty.String)
+	if _, err := ctyScalarToRawString(unknown); err == nil {
+		t.Fatal("expected ctyScalarToRawString to reject an unknown value")
+	}
+	if _, err := ctyScalarToGoValue(unknown); err == nil {
+		t.Fatal("expected ctyScalarToGoValue to reject an unknown value")
+	}
+
+	null := cty.NullVal(cty.String)
+	if _, err := ctyScalarToRawString(null); err == nil {
+		t.Fatal("expected ctyScalarToRawString to reject a null value")
+	}
+	if _, err := ctyScalarToGoValue(null); err == nil {
+		t.Fatal("expected ctyScalarToGoValue to reject a null value")
+	}
+}

--- a/internal/deploy/version_check_test.go
+++ b/internal/deploy/version_check_test.go
@@ -4,8 +4,16 @@
 package deploy
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/exasol/exasol-personal/internal/config"
 )
 
 func TestIsVersionUpdateAvailable_UsesSemanticVersionOrdering(t *testing.T) {
@@ -114,5 +122,292 @@ func TestIsVersionUpdateAvailable_RejectsInvalidVersionData(t *testing.T) {
 				t.Fatalf("expected error to contain %q, got %q", test.expectedError, err)
 			}
 		})
+	}
+}
+
+func TestParseVersionCheckResponse_ParsesValidJSON(t *testing.T) {
+	t.Parallel()
+
+	// Given a valid version check response body.
+	body := strings.NewReader(`{"latestVersion":{"version":"1.2.3","filename":"exasol"}}`)
+
+	// When it is parsed.
+	response, err := parseVersionCheckResponse(body)
+	// Then it succeeds and returns the parsed version.
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if response.LatestVersion.Version != "1.2.3" {
+		t.Fatalf("expected version 1.2.3, got %q", response.LatestVersion.Version)
+	}
+}
+
+func TestParseVersionCheckResponse_RejectsInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	// When an invalid JSON body is parsed.
+	_, err := parseVersionCheckResponse(strings.NewReader("{not json"))
+	// Then it returns an error.
+	if err == nil {
+		t.Fatal("expected an error for invalid JSON")
+	}
+}
+
+// version_check_details_test.go already covers ClusterIdentity resolution;
+// this only adds the OS/Architecture/Category mapping, which isn't covered there.
+func TestGetVersionCheckDetails_MapsOSAndArchitecture(t *testing.T) {
+	t.Parallel()
+
+	// Given no deployment context.
+	var noDeployment config.DeploymentDir
+
+	// When version check details are gathered.
+	details := GetVersionCheckDetails(noDeployment)
+
+	// Then the category, OS, and architecture are populated.
+	if details.Category != VersionCheckCategory {
+		t.Fatalf("expected category %q, got %q", VersionCheckCategory, details.Category)
+	}
+	if details.OperatingSystem == "" || details.Architecture == "" {
+		t.Fatalf("expected non-empty OS/architecture, got %+v", details)
+	}
+}
+
+func TestCheckLatestVersion_SendsExpectedQueryParamsAndParsesResponse(t *testing.T) {
+	t.Parallel()
+
+	// Given a test server that records the requested query and returns a version.
+	var gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(VersionCheckResponse{
+			LatestVersion: LatestVersionInfo{Version: "9.9.9"},
+		})
+	}))
+	defer server.Close()
+
+	details := &VersionCheckDetails{
+		OperatingSystem: "Linux",
+		Architecture:    "x86_64",
+		Category:        VersionCheckCategory,
+		ClusterIdentity: "cluster-xyz",
+		URL:             server.URL,
+	}
+
+	// When the latest version is checked.
+	response, err := CheckLatestVersion(context.Background(), details, "1.0.0")
+	// Then it succeeds, parses the response, and sends the expected query parameters.
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if response.LatestVersion.Version != "9.9.9" {
+		t.Fatalf("expected version 9.9.9, got %q", response.LatestVersion.Version)
+	}
+
+	query, err := url.ParseQuery(gotQuery)
+	if err != nil {
+		t.Fatalf("failed to parse recorded query %q: %v", gotQuery, err)
+	}
+	for param, want := range map[string]string{
+		"category":        VersionCheckCategory,
+		"operatingSystem": "Linux",
+		"architecture":    "x86_64",
+		"version":         "1.0.0",
+		"identity":        "cluster-xyz",
+	} {
+		if got := query.Get(param); got != want {
+			t.Fatalf("expected %s=%q, got %q (full query %q)", param, want, got, gotQuery)
+		}
+	}
+}
+
+func TestCheckLatestVersion_NonOKStatusReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// Given a test server that returns a non-OK status with a body.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	defer server.Close()
+
+	details := &VersionCheckDetails{URL: server.URL}
+
+	// When the latest version is checked.
+	_, err := CheckLatestVersion(context.Background(), details, "1.0.0")
+
+	// Then it returns an error mentioning the response body.
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected an error mentioning the response body, got %v", err)
+	}
+}
+
+func TestFetchLatestVersion_UsesEnvOverrideURL(t *testing.T) {
+	// Given a test server and an env override URL pointing to it.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(VersionCheckResponse{
+			LatestVersion: LatestVersionInfo{Version: "5.0.0"},
+		})
+	}))
+	defer server.Close()
+	t.Setenv(VersionCheckURLEnvVar, server.URL)
+
+	var noDeployment config.DeploymentDir
+
+	// When the latest version is fetched.
+	response, err := FetchLatestVersion(context.Background(), "1.0.0", noDeployment)
+	// Then it succeeds using the overridden URL.
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if response.LatestVersion.Version != "5.0.0" {
+		t.Fatalf("expected version 5.0.0, got %q", response.LatestVersion.Version)
+	}
+}
+
+func TestCheckLatestVersionUpdate_ReportsWhenUpdateIsAvailable(t *testing.T) {
+	// Given a test server reporting a newer version, reachable via the env override.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(VersionCheckResponse{
+			LatestVersion: LatestVersionInfo{Version: "2.0.0"},
+		})
+	}))
+	defer server.Close()
+	t.Setenv(VersionCheckURLEnvVar, server.URL)
+
+	var noDeployment config.DeploymentDir
+
+	// When update availability is checked.
+	available, latest, err := CheckLatestVersionUpdate(
+		context.Background(), "1.0.0", noDeployment,
+	)
+	// Then it reports the update as available with the latest version.
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !available || latest != "2.0.0" {
+		t.Fatalf("expected an available update to 2.0.0, got available=%v latest=%q",
+			available, latest)
+	}
+}
+
+func TestMustDoVersionCheck_RespectsDisabledFlag(t *testing.T) {
+	t.Parallel()
+
+	// Given version checking disabled in state.
+	state := &config.ExasolPersonalState{VersionCheckEnabled: false}
+
+	// Then: checking whether a version check must run is skipped.
+	if MustDoVersionCheck(state) {
+		t.Fatal("expected version check to be skipped when disabled")
+	}
+}
+
+func TestMustDoVersionCheck_SkipsWithinThrottleWindow(t *testing.T) {
+	t.Parallel()
+
+	// Given a check that ran just now.
+	state := &config.ExasolPersonalState{
+		VersionCheckEnabled: true,
+		LastVersionCheck:    time.Now(),
+	}
+
+	// Then: checking whether a version check must run is throttled shortly after the last check.
+	if MustDoVersionCheck(state) {
+		t.Fatal("expected version check to be throttled shortly after the last check")
+	}
+}
+
+func TestPerformSilentVersionCheck_DisabledSkipsCheck(t *testing.T) {
+	t.Parallel()
+
+	// Given a deployment with version checking disabled.
+	deployment := config.NewDeploymentDir(t.TempDir())
+	state := &config.ExasolPersonalState{VersionCheckEnabled: false}
+	if err := config.WriteExasolPersonalState(state, deployment); err != nil {
+		t.Fatalf("failed to seed launcher state: %v", err)
+	}
+
+	// When a silent version check is performed.
+	result, err := PerformSilentVersionCheck(context.Background(), deployment, "1.0.0")
+	// Then it succeeds without performing the check.
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if result.Checked {
+		t.Fatalf("expected the check to be skipped when disabled, got %+v", result)
+	}
+}
+
+func TestPerformSilentVersionCheck_PerformsCheckAndPersistsResult(t *testing.T) {
+	// Given a test server reporting a newer version and a deployment whose throttle
+	// window has expired.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(VersionCheckResponse{
+			LatestVersion: LatestVersionInfo{Version: "2.0.0"},
+		})
+	}))
+	defer server.Close()
+	t.Setenv(VersionCheckURLEnvVar, server.URL)
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	state := &config.ExasolPersonalState{
+		VersionCheckEnabled: true,
+		LastVersionCheck:    time.Now().Add(-48 * time.Hour),
+	}
+	if err := config.WriteExasolPersonalState(state, deployment); err != nil {
+		t.Fatalf("failed to seed launcher state: %v", err)
+	}
+
+	// When a silent version check is performed.
+	result, err := PerformSilentVersionCheck(context.Background(), deployment, "1.0.0")
+	// Then it performs the check, reports the available update, and persists the
+	// new check time.
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !result.Checked || !result.UpdateAvailable || result.LatestVersion != "2.0.0" {
+		t.Fatalf("expected a completed check reporting an available update, got %+v", result)
+	}
+
+	persisted, readErr := config.ReadExasolPersonalState(deployment)
+	if readErr != nil {
+		t.Fatalf("failed to read persisted state: %v", readErr)
+	}
+	if !persisted.LastVersionCheck.After(state.LastVersionCheck) {
+		t.Fatalf("expected LastVersionCheck to be updated, got %v", persisted.LastVersionCheck)
+	}
+}
+
+func TestPerformSilentVersionCheck_MissingStateReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// Given a deployment with no persisted launcher state.
+	deployment := config.NewDeploymentDir(t.TempDir())
+
+	// When a silent version check is performed.
+	result, err := PerformSilentVersionCheck(context.Background(), deployment, "1.0.0")
+	// Then it returns an error and reports no check performed.
+	if err == nil {
+		t.Fatal("expected an error when no launcher state has been persisted")
+	}
+	if result.Checked {
+		t.Fatalf("expected no check to be reported on error, got %+v", result)
+	}
+}
+
+func TestMustDoVersionCheck_RunsAfterThrottleWindowExpires(t *testing.T) {
+	t.Parallel()
+
+	// Given a check that ran well outside the throttle window.
+	state := &config.ExasolPersonalState{
+		VersionCheckEnabled: true,
+		LastVersionCheck:    time.Now().Add(-48 * time.Hour),
+	}
+
+	// Then: a version check must run once the throttle window has passed.
+	if !MustDoVersionCheck(state) {
+		t.Fatal("expected version check to run once the throttle window has passed")
 	}
 }

--- a/internal/directorymutex/directorymutex_test.go
+++ b/internal/directorymutex/directorymutex_test.go
@@ -363,3 +363,181 @@ func holdShared(mutex *DirectoryMutex, acquired chan<- struct{}, release <-chan 
 
 	return nil
 }
+
+func TestWithExclusiveRunsCallbackWhileHeldAndReleasesAfter(t *testing.T) {
+	t.Parallel()
+
+	// Given a fresh mutex
+	mutex, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("new mutex: %v", err)
+	}
+
+	// When running a callback under WithExclusive
+	var statusDuringCallback Status
+	callbackErr := mutex.WithExclusive(context.Background(), nil, func(any) error {
+		statusDuringCallback, err = mutex.Status()
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	// Then the lock was held during the callback and released after
+	if callbackErr != nil {
+		t.Fatalf("expected WithExclusive to succeed, got %v", callbackErr)
+	}
+	if !statusDuringCallback.Locked || statusDuringCallback.Mode != modeExclusiveString {
+		t.Fatalf("expected an exclusive lock during the callback, got %+v", statusDuringCallback)
+	}
+	statusAfter, err := mutex.Status()
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if statusAfter.Locked {
+		t.Fatalf("expected the lock to be released after WithExclusive, got %+v", statusAfter)
+	}
+}
+
+func TestWithSharedRunsCallbackWhileHeldAndReleasesAfter(t *testing.T) {
+	t.Parallel()
+
+	// Given a fresh mutex
+	mutex, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("new mutex: %v", err)
+	}
+
+	// When running a callback under WithShared
+	var statusDuringCallback Status
+	callbackErr := mutex.WithShared(context.Background(), nil, func(any) error {
+		statusDuringCallback, err = mutex.Status()
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	// Then the lock was held (shared) during the callback and released after
+	if callbackErr != nil {
+		t.Fatalf("expected WithShared to succeed, got %v", callbackErr)
+	}
+	if !statusDuringCallback.Locked || statusDuringCallback.Mode != modeSharedString {
+		t.Fatalf("expected a shared lock during the callback, got %+v", statusDuringCallback)
+	}
+	statusAfter, err := mutex.Status()
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if statusAfter.Locked {
+		t.Fatalf("expected the lock to be released after WithShared, got %+v", statusAfter)
+	}
+}
+
+func TestWithExclusivePropagatesCallbackErrorAndStillReleases(t *testing.T) {
+	t.Parallel()
+
+	// Given a fresh mutex
+	mutex, err := New(t.TempDir())
+	if err != nil {
+		t.Fatalf("new mutex: %v", err)
+	}
+	callbackErr := errors.New("callback failed")
+
+	// When the callback itself fails
+	returnedErr := mutex.WithExclusive(context.Background(), nil, func(any) error {
+		return callbackErr
+	})
+
+	// Then the callback's error is returned and the lock is still released
+	if !errors.Is(returnedErr, callbackErr) {
+		t.Fatalf("expected the callback error to propagate, got %v", returnedErr)
+	}
+	status, err := mutex.Status()
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if status.Locked {
+		t.Fatalf("expected the lock to be released even after a callback error, got %+v", status)
+	}
+}
+
+func TestWithExclusiveDoesNotRunCallbackWhenAcquireFails(t *testing.T) {
+	t.Parallel()
+
+	// Given an exclusive lock already held by someone else
+	dir := t.TempDir()
+	mutex, err := New(dir)
+	if err != nil {
+		t.Fatalf("new mutex: %v", err)
+	}
+	acquired := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		done <- holdExclusive(mutex, acquired, release)
+	}()
+	<-acquired
+	defer func() {
+		close(release)
+		<-done
+	}()
+
+	// When WithExclusive is attempted with an already-expired context
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+	<-ctx.Done()
+
+	callbackRan := false
+	err = mutex.WithExclusive(ctx, nil, func(any) error {
+		callbackRan = true
+
+		return nil
+	})
+
+	// Then the callback never runs and the acquire error is returned
+	if err == nil {
+		t.Fatal("expected an acquire error, got nil")
+	}
+	if callbackRan {
+		t.Fatal("expected the callback not to run when the lock could not be acquired")
+	}
+}
+
+func TestCallWithPanicSafetyErrorReturnsFunctionResult(t *testing.T) {
+	t.Parallel()
+
+	// Given a function that returns an error normally
+	wantErr := errors.New("boom")
+
+	// When calling it through callWithPanicSafetyError
+	gotErr := callWithPanicSafetyError(func(any) error {
+		return wantErr
+	}, nil)
+
+	// Then its return value passes through unchanged
+	if !errors.Is(gotErr, wantErr) {
+		t.Fatalf("expected %v, got %v", wantErr, gotErr)
+	}
+}
+
+func TestCallWithPanicSafetyErrorRePanicsRatherThanSwallowing(t *testing.T) {
+	t.Parallel()
+
+	// Then the panic propagates to the caller instead of being swallowed
+	defer func() {
+		recovered := recover()
+		if recovered != "boom" {
+			t.Fatalf("expected the panic to propagate with value %q, got %v", "boom", recovered)
+		}
+	}()
+
+	// When calling a function that panics through callWithPanicSafetyError
+	_ = callWithPanicSafetyError(func(any) error {
+		panic("boom")
+	}, nil)
+
+	t.Fatal("expected callWithPanicSafetyError to re-panic before reaching this point")
+}

--- a/internal/directorymutex/directorymutex_test.go
+++ b/internal/directorymutex/directorymutex_test.go
@@ -273,6 +273,82 @@ func TestClearLockRemovesMarker(t *testing.T) {
 	}
 }
 
+func TestWrapAcquireError_WrapsContextDeadlineExceeded(t *testing.T) {
+	t.Parallel()
+
+	err := wrapAcquireError(context.DeadlineExceeded)
+
+	if !errors.Is(err, ErrAcquireTimeout) {
+		t.Fatalf("expected ErrAcquireTimeout, got %v", err)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected the original deadline error to remain unwrappable, got %v", err)
+	}
+}
+
+func TestWrapAcquireError_PassesThroughOtherErrors(t *testing.T) {
+	t.Parallel()
+
+	original := errors.New("some other failure")
+
+	if got := wrapAcquireError(original); !errors.Is(got, original) {
+		t.Fatalf("expected the original error to pass through unchanged, got %v", got)
+	}
+}
+
+func TestWithTimeoutIfMissing_CreatesTimeoutForNilContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := withTimeoutIfMissing(nil, time.Second) //nolint:staticcheck
+	defer cancel()
+
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		t.Fatal("expected a deadline to be applied for a nil context")
+	}
+}
+
+func TestWithTimeoutIfMissing_PreservesExistingDeadline(t *testing.T) {
+	t.Parallel()
+
+	original, originalCancel := context.WithTimeout(context.Background(), time.Minute)
+	defer originalCancel()
+
+	ctx, cancel := withTimeoutIfMissing(original, time.Second)
+	defer cancel()
+
+	if ctx != original {
+		t.Fatal("expected the caller-provided context with a deadline to be reused as-is")
+	}
+}
+
+func TestWithTimeoutIfMissing_AppliesTimeoutWhenContextHasNoDeadline(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := withTimeoutIfMissing(context.Background(), time.Second)
+	defer cancel()
+
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		t.Fatal("expected a deadline to be applied when the context has none")
+	}
+}
+
+func TestClearLockWithoutMarkerIsNoop(t *testing.T) {
+	t.Parallel()
+
+	// Given a mutex whose directory has never been locked
+	dir := t.TempDir()
+	mutex, err := New(dir)
+	if err != nil {
+		t.Fatalf("new mutex: %v", err)
+	}
+
+	// When force-clearing the lock
+	// Then it succeeds without error, since there is nothing to remove
+	if err := mutex.ClearLock(); err != nil {
+		t.Fatalf("expected clearing an absent lock to be a no-op, got %v", err)
+	}
+}
+
 // nolint: paralleltest
 func TestSharedLockStressLeavesUnlocked(t *testing.T) {
 	t.Skip("Flaky. With 'invalid marker' error. Somebody fix it")

--- a/internal/presets/infrastructure_manifest_test.go
+++ b/internal/presets/infrastructure_manifest_test.go
@@ -4,6 +4,9 @@
 package presets
 
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -76,5 +79,73 @@ func TestBuiltInCloudPresetsEmitAdminUIMetadata(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestReadInfrastructureManifestFromDir_MissingFileReturnsWrappedError(t *testing.T) {
+	t.Parallel()
+
+	// Given / When
+	_, err := ReadInfrastructureManifestFromDir(t.TempDir())
+	// Then
+	if err == nil {
+		t.Fatal("expected an error for a missing manifest file")
+	}
+}
+
+func TestReadInfrastructureManifestFromDir_ParsesRealManifestFile(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	dir := t.TempDir()
+	manifestYAML := "name: Test Infra\ndescription: test infra\nbackend: local\n"
+	path := filepath.Join(dir, InfrastructureManifestFilename)
+	if err := os.WriteFile(path, []byte(manifestYAML), 0o600); err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+
+	// When
+	manifest, err := ReadInfrastructureManifestFromDir(dir)
+	// Then
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if manifest.Name != "Test Infra" {
+		t.Fatalf("expected manifest name to be parsed, got %q", manifest.Name)
+	}
+}
+
+func TestParseInfrastructureManifest_RejectsMissingName(t *testing.T) {
+	t.Parallel()
+
+	// Given / When
+	_, err := parseInfrastructureManifest([]byte("description: test infra\n"))
+
+	// Then
+	if !errors.Is(err, ErrMissingName) {
+		t.Fatalf("expected ErrMissingName, got %v", err)
+	}
+}
+
+func TestParseInfrastructureManifest_RejectsMissingDescription(t *testing.T) {
+	t.Parallel()
+
+	// Given / When
+	_, err := parseInfrastructureManifest([]byte("name: Test\n"))
+
+	// Then
+	if !errors.Is(err, ErrMissingDescription) {
+		t.Fatalf("expected ErrMissingDescription, got %v", err)
+	}
+}
+
+func TestReadInfrastructureManifest_UnknownPresetReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// Given / When
+	_, err := ReadInfrastructureManifest("does-not-exist")
+	// Then
+	if err == nil {
+		t.Fatal("expected an error for an unknown infrastructure preset")
 	}
 }

--- a/internal/presets/install_manifest_test.go
+++ b/internal/presets/install_manifest_test.go
@@ -3,7 +3,12 @@
 
 package presets
 
-import "testing"
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestParseInstallManifest_ReadsCompatibilityRequirements(t *testing.T) {
 	t.Parallel()
@@ -68,5 +73,224 @@ func TestParseInstallManifest_ReadsLocalCommandSteps(t *testing.T) {
 	}
 	if manifest.Install[0].LocalCommand == nil {
 		t.Fatal("expected localCommand step to be populated")
+	}
+}
+
+func TestReadInstallManifestFromDir_MissingFileReturnsWrappedError(t *testing.T) {
+	t.Parallel()
+
+	// Given / When
+	_, err := ReadInstallManifestFromDir(t.TempDir())
+	// Then
+	if err == nil {
+		t.Fatal("expected an error for a missing manifest file")
+	}
+}
+
+func TestReadInstallManifestFromDir_ParsesRealManifestFile(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	dir := t.TempDir()
+	manifestYAML := "name: Test Install\ndescription: test install\n"
+	path := filepath.Join(dir, InstallationManifestFilename)
+	if err := os.WriteFile(path, []byte(manifestYAML), 0o600); err != nil {
+		t.Fatalf("failed to write manifest: %v", err)
+	}
+
+	// When
+	manifest, err := ReadInstallManifestFromDir(dir)
+	// Then
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if manifest.Name != "Test Install" {
+		t.Fatalf("expected manifest name to be parsed, got %q", manifest.Name)
+	}
+}
+
+func TestReadInstallManifest_ReadsRealEmbeddedLocalPreset(t *testing.T) {
+	t.Parallel()
+
+	// Given / When
+	manifest, err := ReadInstallManifest("local")
+	// Then
+	if err != nil {
+		t.Fatalf("expected the embedded 'local' install preset to load, got %v", err)
+	}
+	if manifest.Name == "" {
+		t.Fatal("expected the embedded manifest to declare a name")
+	}
+}
+
+func TestReadInstallManifest_UnknownPresetReturnsError(t *testing.T) {
+	t.Parallel()
+
+	// Given / When
+	_, err := ReadInstallManifest("does-not-exist")
+	// Then
+	if err == nil {
+		t.Fatal("expected an error for an unknown installation preset")
+	}
+}
+
+func TestVariableDefDefaultScalar(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	cases := map[string]struct {
+		def     *VariableDef
+		wantErr error
+	}{
+		"nil definition":  {def: nil, wantErr: ErrInvalidInstallationVariable},
+		"missing default": {def: &VariableDef{}, wantErr: ErrInvalidInstallationVariable},
+		"unsupported type": {
+			def:     &VariableDef{Default: []string{"a"}},
+			wantErr: ErrInvalidInstallationVariable,
+		},
+		"valid string default": {def: &VariableDef{Default: "value"}},
+		"valid bool default":   {def: &VariableDef{Default: true}},
+		"valid number default": {def: &VariableDef{Default: 3}},
+	}
+
+	for name, testCase := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// When
+			value, err := testCase.def.DefaultScalar()
+
+			// Then
+			if testCase.wantErr != nil {
+				if !errors.Is(err, testCase.wantErr) {
+					t.Fatalf("expected %v, got %v", testCase.wantErr, err)
+				}
+
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if value != testCase.def.Default {
+				t.Fatalf("expected default value %v, got %v", testCase.def.Default, value)
+			}
+		})
+	}
+}
+
+func TestVariableDefEffectiveType(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	cases := map[string]struct {
+		def     *VariableDef
+		want    string
+		wantErr bool
+	}{
+		"explicit valid type":   {def: &VariableDef{Type: "bool", Default: true}, want: "bool"},
+		"explicit invalid type": {def: &VariableDef{Type: "object"}, wantErr: true},
+		"inferred from bool":    {def: &VariableDef{Default: true}, want: "bool"},
+		"inferred from number":  {def: &VariableDef{Default: 3}, want: "number"},
+		"inferred from string":  {def: &VariableDef{Default: "x"}, want: "string"},
+		"nil definition":        {def: nil, wantErr: true},
+	}
+
+	for name, testCase := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// When
+			got, err := testCase.def.EffectiveType()
+
+			// Then
+			if testCase.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if got != testCase.want {
+				t.Fatalf("expected %q, got %q", testCase.want, got)
+			}
+		})
+	}
+}
+
+func TestInstallStepUnmarshalYAML_FlattenedStyleIsTreatedAsRemoteExec(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	manifestRaw := []byte(
+		"name: Test Install\n" +
+			"description: test install\n" +
+			"install:\n" +
+			"  - description: run remotely\n" +
+			"    filename: monitor.sh\n",
+	)
+
+	// When
+	manifest, err := parseInstallManifest(manifestRaw)
+	// Then
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(manifest.Install) != 1 || manifest.Install[0].RemoteExec == nil {
+		t.Fatalf(
+			"expected the flattened step to be treated as remoteExec, got %+v",
+			manifest.Install,
+		)
+	}
+	if manifest.Install[0].RemoteExec.Filename != "monitor.sh" {
+		t.Fatalf("expected filename to be parsed, got %+v", manifest.Install[0].RemoteExec)
+	}
+}
+
+func TestInstallStepUnmarshalYAML_RejectsBothTaskTypesSet(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	manifestRaw := []byte(
+		"name: Test Install\n" +
+			"description: test install\n" +
+			"install:\n" +
+			"  - remoteExec:\n" +
+			"      filename: monitor.sh\n" +
+			"    localCommand:\n" +
+			"      command: [\"echo\", \"hi\"]\n",
+	)
+
+	// When
+	_, err := parseInstallManifest(manifestRaw)
+	// Then
+	if err == nil {
+		t.Fatal("expected an error when both task types are set on one step")
+	}
+}
+
+func TestInstallStepsUnmarshalYAML_WrapsSingleStepObject(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	manifestRaw := []byte(
+		"name: Test Install\n" +
+			"description: test install\n" +
+			"install:\n" +
+			"  remoteExec:\n" +
+			"    description: run remotely\n" +
+			"    filename: monitor.sh\n",
+	)
+
+	// When
+	manifest, err := parseInstallManifest(manifestRaw)
+	// Then
+	if err != nil {
+		t.Fatalf("expected a single step object to be wrapped, got %v", err)
+	}
+	if len(manifest.Install) != 1 || manifest.Install[0].RemoteExec == nil {
+		t.Fatalf("expected exactly one wrapped remoteExec step, got %+v", manifest.Install)
 	}
 }

--- a/internal/presets/operations_test.go
+++ b/internal/presets/operations_test.go
@@ -1,0 +1,205 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package presets
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const localPresetName = "local"
+
+func TestPresetRefIsPath(t *testing.T) {
+	t.Parallel()
+
+	if (PresetRef{Name: "local"}).IsPath() {
+		t.Fatal("expected a name-only ref to not be a path")
+	}
+	if !(PresetRef{Path: "/some/dir"}).IsPath() {
+		t.Fatal("expected a ref with a path to be a path")
+	}
+	if (PresetRef{Path: "   "}).IsPath() {
+		t.Fatal("expected a whitespace-only path to not count as a path")
+	}
+}
+
+func TestListEmbeddedInfrastructuresPresets_ReturnsRealSortedNames(t *testing.T) {
+	t.Parallel()
+
+	names := ListEmbeddedInfrastructuresPresets()
+
+	if len(names) == 0 {
+		t.Fatal("expected at least one embedded infrastructure preset")
+	}
+	found := false
+	for i, name := range names {
+		if name == localPresetName {
+			found = true
+		}
+		if i > 0 && names[i-1] > name {
+			t.Fatalf("expected sorted names, got %v", names)
+		}
+	}
+	if !found {
+		t.Fatalf("expected 'local' among embedded infrastructure presets, got %v", names)
+	}
+}
+
+func TestListEmbeddedInstallationsPresets_ReturnsRealSortedNames(t *testing.T) {
+	t.Parallel()
+
+	names := ListEmbeddedInstallationsPresets()
+
+	if len(names) == 0 {
+		t.Fatal("expected at least one embedded installation preset")
+	}
+	found := false
+	for i, name := range names {
+		if name == localPresetName {
+			found = true
+		}
+		if i > 0 && names[i-1] > name {
+			t.Fatalf("expected sorted names, got %v", names)
+		}
+	}
+	if !found {
+		t.Fatalf("expected 'local' among embedded installation presets, got %v", names)
+	}
+}
+
+func TestWriteInfrastructureDir_WritesRealEmbeddedPresetContent(t *testing.T) {
+	t.Parallel()
+
+	outDir := t.TempDir()
+
+	if err := WriteInfrastructureDir("local", outDir); err != nil {
+		t.Fatalf("expected the embedded 'local' preset to be written, got %v", err)
+	}
+
+	manifestPath := filepath.Join(outDir, InfrastructureManifestFilename)
+	if _, err := os.Stat(manifestPath); err != nil {
+		t.Fatalf("expected infrastructure manifest to be written, got %v", err)
+	}
+}
+
+func TestWriteInfrastructureDir_UnknownPresetReturnsError(t *testing.T) {
+	t.Parallel()
+
+	err := WriteInfrastructureDir("does-not-exist", t.TempDir())
+
+	if !errors.Is(err, ErrUnknownInfrastructure) {
+		t.Fatalf("expected ErrUnknownInfrastructure, got %v", err)
+	}
+}
+
+func TestWriteInstallDir_WritesRealEmbeddedPresetContent(t *testing.T) {
+	t.Parallel()
+
+	outDir := t.TempDir()
+
+	if err := WriteInstallDir("local", outDir); err != nil {
+		t.Fatalf("expected the embedded 'local' preset to be written, got %v", err)
+	}
+
+	manifestPath := filepath.Join(outDir, InstallationManifestFilename)
+	if _, err := os.Stat(manifestPath); err != nil {
+		t.Fatalf("expected installation manifest to be written, got %v", err)
+	}
+}
+
+func TestWriteInstallDir_UnknownPresetReturnsError(t *testing.T) {
+	t.Parallel()
+
+	err := WriteInstallDir("does-not-exist", t.TempDir())
+
+	if !errors.Is(err, ErrUnknownInstallation) {
+		t.Fatalf("expected ErrUnknownInstallation, got %v", err)
+	}
+}
+
+func TestWriteSharedDir_WritesSharedAssetFiles(t *testing.T) {
+	t.Parallel()
+
+	outDir := t.TempDir()
+
+	if err := WriteSharedDir(outDir); err != nil {
+		t.Fatalf("expected shared assets to be written, got %v", err)
+	}
+
+	for _, name := range []string{"eula.txt", "sample.sql"} {
+		if _, err := os.Stat(filepath.Join(outDir, name)); err != nil {
+			t.Fatalf("expected shared asset %q to be written, got %v", name, err)
+		}
+	}
+}
+
+func TestReadInfrastructureFile_ReadsRealManifestBytes(t *testing.T) {
+	t.Parallel()
+
+	data, err := ReadInfrastructureFile("local", InfrastructureManifestFilename)
+	if err != nil {
+		t.Fatalf("expected the embedded manifest file to be readable, got %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("expected non-empty manifest content")
+	}
+}
+
+func TestReadInfrastructureFile_MissingFileReturnsError(t *testing.T) {
+	t.Parallel()
+
+	_, err := ReadInfrastructureFile("local", "does-not-exist.yaml")
+	if err == nil {
+		t.Fatal("expected an error for a missing embedded file")
+	}
+}
+
+func TestExtractPreset_PathBasedCopiesFromDisk(t *testing.T) {
+	t.Parallel()
+
+	srcDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(srcDir, "marker.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("failed to write marker file: %v", err)
+	}
+	dstDir := filepath.Join(t.TempDir(), "extracted")
+
+	writeEmbeddedCalled := false
+
+	err := ExtractPreset(PresetRef{Path: srcDir}, dstDir, func(string, string) error {
+		writeEmbeddedCalled = true
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected path-based extraction to succeed, got %v", err)
+	}
+	if writeEmbeddedCalled {
+		t.Fatal("expected writeEmbedded not to be called for a path-based preset")
+	}
+	if _, err := os.Stat(filepath.Join(dstDir, "marker.txt")); err != nil {
+		t.Fatalf("expected marker file to be copied, got %v", err)
+	}
+}
+
+func TestExtractPreset_NameBasedDelegatesToWriteEmbedded(t *testing.T) {
+	t.Parallel()
+
+	var gotName, gotOutDir string
+
+	err := ExtractPreset(PresetRef{Name: "local"}, "/some/out", func(name, outDir string) error {
+		gotName = name
+		gotOutDir = outDir
+
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if gotName != "local" || gotOutDir != "/some/out" {
+		t.Fatalf("expected writeEmbedded to be called with (local, /some/out), got (%s, %s)",
+			gotName, gotOutDir)
+	}
+}

--- a/internal/remote/ssh_test.go
+++ b/internal/remote/ssh_test.go
@@ -1,0 +1,356 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package remote
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// sshExecResult is what a fake session's "exec" handler sends back over the
+// wire: stdout/stderr bytes and a final exit-status.
+type sshExecResult struct {
+	stdout     string
+	stderr     string
+	exitStatus uint32
+}
+
+// startTestSSHServer runs a minimal in-process SSH server that accepts any
+// client public key and forwards the first "exec" request on the first
+// session channel to onExec, letting tests exercise the real wire protocol
+// startSSHSession/RunScript use, without a live host. onSignal, if non-nil,
+// is called for every "signal" channel request received while exec runs.
+func startTestSSHServer(
+	t *testing.T,
+	onExec func(command string, stdin []byte) sshExecResult,
+	onSignal func(signal string),
+) string {
+	t.Helper()
+
+	_, hostKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate host key: %v", err)
+	}
+	signer, err := ssh.NewSignerFromKey(hostKey)
+	if err != nil {
+		t.Fatalf("failed to build host signer: %v", err)
+	}
+
+	config := &ssh.ServerConfig{
+		PublicKeyCallback: func(_ ssh.ConnMetadata, _ ssh.PublicKey) (*ssh.Permissions, error) {
+			//nolint:nilnil // ssh's own contract for "accept, no restrictions".
+			return nil, nil
+		},
+	}
+	config.AddHostKey(signer)
+
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		serverConn, chans, reqs, err := ssh.NewServerConn(conn, config)
+		if err != nil {
+			return
+		}
+		defer serverConn.Close()
+		go ssh.DiscardRequests(reqs)
+
+		for newChannel := range chans {
+			if newChannel.ChannelType() != "session" {
+				_ = newChannel.Reject(ssh.UnknownChannelType, "unsupported channel type")
+				continue
+			}
+			channel, requests, err := newChannel.Accept()
+			if err != nil {
+				return
+			}
+			handleTestSSHSession(channel, requests, onExec, onSignal)
+		}
+	}()
+
+	return listener.Addr().String()
+}
+
+// handleTestSSHSession dispatches "exec" to its own goroutine so the main
+// loop keeps consuming requests (in particular "signal") while the exec
+// handler is still running/blocked, matching how a real sshd session behaves.
+func handleTestSSHSession(
+	channel ssh.Channel,
+	requests <-chan *ssh.Request,
+	onExec func(command string, stdin []byte) sshExecResult,
+	onSignal func(signal string),
+) {
+	for req := range requests {
+		switch req.Type {
+		case "exec":
+			handleTestSSHExec(channel, req, onExec)
+		case "signal":
+			handleTestSSHSignal(req, onSignal)
+		default:
+			if req.WantReply {
+				_ = req.Reply(false, nil)
+			}
+		}
+	}
+}
+
+// handleTestSSHExec replies to the "exec" request and runs onExec in its own
+// goroutine so the session's main loop keeps consuming requests while it runs.
+func handleTestSSHExec(
+	channel ssh.Channel,
+	req *ssh.Request,
+	onExec func(command string, stdin []byte) sshExecResult,
+) {
+	var payload struct{ Command string }
+	_ = ssh.Unmarshal(req.Payload, &payload)
+	_ = req.Reply(true, nil)
+
+	go runTestSSHExec(channel, payload.Command, onExec)
+}
+
+func runTestSSHExec(
+	channel ssh.Channel,
+	command string,
+	onExec func(command string, stdin []byte) sshExecResult,
+) {
+	defer channel.Close()
+
+	stdin, _ := io.ReadAll(channel)
+	result := sshExecResult{}
+	if onExec != nil {
+		result = onExec(command, stdin)
+	}
+	if result.stdout != "" {
+		_, _ = channel.Write([]byte(result.stdout))
+	}
+	if result.stderr != "" {
+		_, _ = channel.Stderr().Write([]byte(result.stderr))
+	}
+	_, _ = channel.SendRequest(
+		"exit-status",
+		false,
+		ssh.Marshal(struct{ Status uint32 }{result.exitStatus}),
+	)
+}
+
+func handleTestSSHSignal(req *ssh.Request, onSignal func(signal string)) {
+	var payload struct{ Signal string }
+	_ = ssh.Unmarshal(req.Payload, &payload)
+	if onSignal != nil {
+		onSignal(payload.Signal)
+	}
+	if req.WantReply {
+		_ = req.Reply(true, nil)
+	}
+}
+
+// newTestSSHConnectionOptions generates a fresh client key pair (the test
+// server accepts any public key) and points it at addr.
+func newTestSSHConnectionOptions(t *testing.T, addr string) *SSHConnectionOptions {
+	t.Helper()
+
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate client key: %v", err)
+	}
+	block, err := ssh.MarshalPrivateKey(priv, "")
+	if err != nil {
+		t.Fatalf("failed to marshal client key: %v", err)
+	}
+
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("failed to split test server address: %v", err)
+	}
+
+	return &SSHConnectionOptions{
+		Host: host,
+		Port: port,
+		User: "exasol",
+		Key:  pem.EncodeToMemory(block),
+	}
+}
+
+func TestStartSSHSessionReturnsWrappedErrorForUnparseablePrivateKey(t *testing.T) {
+	t.Parallel()
+
+	_, err := startSSHSession(&SSHConnectionOptions{
+		Host: "127.0.0.1",
+		Port: "22",
+		User: "exasol",
+		Key:  []byte("not a private key"),
+	})
+
+	if err == nil || !strings.Contains(err.Error(), "unable to parse private key") {
+		t.Fatalf("expected private key parse error, got %v", err)
+	}
+}
+
+func TestStartSSHSessionMapsDialFailureToErrFailedToConnect(t *testing.T) {
+	t.Parallel()
+
+	// Bind then immediately close a listener to obtain a port nothing is
+	// listening on, so the dial fails fast and deterministically.
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to reserve a port: %v", err)
+	}
+	addr := listener.Addr().String()
+	if err := listener.Close(); err != nil {
+		t.Fatalf("failed to close listener: %v", err)
+	}
+
+	options := newTestSSHConnectionOptions(t, addr)
+
+	_, err = startSSHSession(options)
+
+	if !errors.Is(err, ErrFailedToConnect) {
+		t.Fatalf("expected ErrFailedToConnect, got %v", err)
+	}
+}
+
+func TestRunScriptNormalizesCRLFAndRunsBashWithScriptOnStdin(t *testing.T) {
+	t.Parallel()
+
+	var receivedCommand string
+	var receivedStdin []byte
+	addr := startTestSSHServer(t, func(command string, stdin []byte) sshExecResult {
+		receivedCommand = command
+		receivedStdin = stdin
+
+		return sshExecResult{stdout: "hello from remote\n", exitStatus: 0}
+	}, nil)
+
+	remoteHost := NewSshRemote(newTestSSHConnectionOptions(t, addr))
+
+	script := strings.NewReader("echo one\r\necho two\r\n")
+	var stdout, stderr strings.Builder
+
+	if err := remoteHost.RunScript(context.Background(), script, &stdout, &stderr); err != nil {
+		t.Fatalf("expected script run to succeed, got %v", err)
+	}
+
+	if receivedCommand != "/bin/bash" {
+		t.Fatalf("expected remote command to be /bin/bash, got %q", receivedCommand)
+	}
+	if string(receivedStdin) != "echo one\necho two\n" {
+		t.Fatalf("expected CRLF to be normalized to LF, got %q", string(receivedStdin))
+	}
+	if stdout.String() != "hello from remote\n" {
+		t.Fatalf("expected remote stdout to be forwarded, got %q", stdout.String())
+	}
+}
+
+func TestRunScriptReturnsErrorWhenRemoteCommandFails(t *testing.T) {
+	t.Parallel()
+
+	addr := startTestSSHServer(t, func(_ string, _ []byte) sshExecResult {
+		return sshExecResult{stderr: "boom\n", exitStatus: 1}
+	}, nil)
+
+	remoteHost := NewSshRemote(newTestSSHConnectionOptions(t, addr))
+
+	var stdout, stderr strings.Builder
+	script := strings.NewReader("false\n")
+	err := remoteHost.RunScript(context.Background(), script, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("expected a non-nil error when the remote command exits non-zero")
+	}
+	var exitErr *ssh.ExitError
+	if !errors.As(err, &exitErr) || exitErr.ExitStatus() != 1 {
+		t.Fatalf("expected an ssh.ExitError with status 1, got %v", err)
+	}
+	if stderr.String() != "boom\n" {
+		t.Fatalf("expected remote stderr to be forwarded, got %q", stderr.String())
+	}
+}
+
+// TestShell_ReturnsErrorWhenPtyRequestRejected exercises Shell's real
+// startSSHSession + configureSSHSessionPty wiring against the in-process test
+// server. The server only understands "exec"/"signal" (see
+// handleTestSSHSession) and rejects every other channel request by default,
+// so the client-side session.RequestPty call fails deterministically at the
+// SSH protocol level -- this needs no real TTY and is stable on any platform.
+func TestShell_ReturnsErrorWhenPtyRequestRejected(t *testing.T) {
+	t.Parallel()
+
+	addr := startTestSSHServer(t, nil, nil)
+	remoteHost := NewSshRemote(newTestSSHConnectionOptions(t, addr))
+
+	var stdout, stderr strings.Builder
+	err := remoteHost.Shell(context.Background(), &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "pseudo terminal") {
+		t.Fatalf("expected a pty request failure, got %v", err)
+	}
+}
+
+func TestRunInteractiveCommand_ReturnsErrorWhenPtyRequestRejected(t *testing.T) {
+	t.Parallel()
+
+	addr := startTestSSHServer(t, nil, nil)
+	remoteHost := NewSshRemote(newTestSSHConnectionOptions(t, addr))
+
+	var stdout, stderr strings.Builder
+	err := remoteHost.RunInteractiveCommand(context.Background(), "echo hi", &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "pseudo terminal") {
+		t.Fatalf("expected a pty request failure, got %v", err)
+	}
+}
+
+func TestRunScriptSendsSIGINTToRemoteWhenContextIsCancelled(t *testing.T) {
+	t.Parallel()
+
+	received := make(chan string, 1)
+	unblock := make(chan struct{})
+	addr := startTestSSHServer(t, func(_ string, _ []byte) sshExecResult {
+		// Block until the client's cancellation-triggered signal arrives (or
+		// time out, so a failure to signal doesn't hang the test forever).
+		select {
+		case <-unblock:
+		case <-time.After(2 * time.Second):
+		}
+
+		return sshExecResult{exitStatus: 0}
+	}, func(signal string) {
+		received <- signal
+		close(unblock)
+	})
+
+	remoteHost := NewSshRemote(newTestSSHConnectionOptions(t, addr))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Already cancelled: RunScript's watcher goroutine should signal immediately.
+
+	var stdout, stderr strings.Builder
+	script := strings.NewReader("sleep 100\n")
+	if err := remoteHost.RunScript(ctx, script, &stdout, &stderr); err != nil {
+		t.Fatalf("expected script run to complete cleanly after signalling, got %v", err)
+	}
+
+	select {
+	case signal := <-received:
+		if signal != string(ssh.SIGINT) {
+			t.Fatalf("expected SIGINT, got signal %q", signal)
+		}
+	default:
+		t.Fatal("expected the remote command to receive a signal, got none")
+	}
+}

--- a/internal/runtimeartifacts/cache_test.go
+++ b/internal/runtimeartifacts/cache_test.go
@@ -374,6 +374,161 @@ func TestCacheCleanAllWipesCacheContentsAndResetsMetadata(t *testing.T) {
 	}
 }
 
+func TestCacheListReturnsEntriesSortedByID(t *testing.T) {
+	t.Parallel()
+
+	cache := newTestCache(t, testNow())
+	index := emptyCacheIndex()
+	now := testNow()
+	seedCacheEntry(t, cache, &index, "zeta", "zeta-payload", checksumString("zeta-payload"), now)
+	seedCacheEntry(t, cache, &index, "alpha", "alpha-payload", checksumString("alpha-payload"), now)
+	writeTestIndex(t, cache, index)
+
+	entries, err := cache.List(context.Background())
+	if err != nil {
+		t.Fatalf("expected list to succeed, got %v", err)
+	}
+
+	if len(entries) != 2 || entries[0].ID != "alpha" || entries[1].ID != "zeta" {
+		t.Fatalf("expected entries sorted by id, got %+v", entries)
+	}
+	if entries[0].SizeBytes != int64(len("alpha-payload")) {
+		t.Fatalf("expected entry size to match artifact content, got %+v", entries[0])
+	}
+}
+
+func TestCacheListReturnsEmptyOnFreshCacheWithoutError(t *testing.T) {
+	t.Parallel()
+
+	cache := newTestCache(t, testNow())
+
+	entries, err := cache.List(context.Background())
+	if err != nil {
+		t.Fatalf("expected list on a fresh cache to succeed, got %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected no entries, got %+v", entries)
+	}
+	if _, err := os.Stat(cache.configPath); err != nil {
+		t.Fatalf("expected list to create the cache config as a side effect, got %v", err)
+	}
+}
+
+func TestCacheListPropagatesLockContentionError(t *testing.T) {
+	t.Parallel()
+
+	cache := newTestCache(t, testNow())
+	if err := os.MkdirAll(cache.Root(), dirPerm); err != nil {
+		t.Fatalf("failed to create cache root: %v", err)
+	}
+	mutex, err := directorymutex.New(cache.Root())
+	if err != nil {
+		t.Fatalf("failed to create mutex: %v", err)
+	}
+	if err := mutex.AcquireExclusive(context.Background()); err != nil {
+		t.Fatalf("failed to acquire mutex: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = mutex.ReleaseExclusive(context.Background())
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	_, err = cache.List(ctx)
+
+	if !errors.Is(err, ErrCacheLocked) {
+		t.Fatalf("expected cache locked error, got %v", err)
+	}
+}
+
+func TestCacheCleanPartialDownloadsRemovesStagedFilesButKeepsIndexedArtifacts(t *testing.T) {
+	t.Parallel()
+
+	cache := newTestCache(t, testNow())
+	index := emptyCacheIndex()
+	keptSum := checksumString("payload")
+	kept := seedCacheEntry(t, cache, &index, "kept", "payload", keptSum, testNow())
+	writeTestIndex(t, cache, index)
+
+	staged := filepath.Join(cache.downloadsRoot(), "download-123456")
+	if err := os.MkdirAll(staged, dirPerm); err != nil {
+		t.Fatalf("failed to create staged download directory: %v", err)
+	}
+	stagedFile := filepath.Join(staged, "payload.tmp")
+	if err := os.WriteFile(stagedFile, []byte("partial-content"), filePerm); err != nil {
+		t.Fatalf("failed to write staged partial download: %v", err)
+	}
+
+	opts := CleanOptions{Mode: CleanupModePartialDownloads}
+	summary, err := cache.Clean(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("expected partial-download clean to succeed, got %v", err)
+	}
+
+	if summary.Mode != CleanupModePartialDownloads || summary.RemovedEntries != 1 {
+		t.Fatalf("unexpected partial-download cleanup summary: %+v", summary)
+	}
+	if summary.RemovedBytes != int64(len("partial-content")) {
+		t.Fatalf("expected removed bytes to match staged file size, got %d", summary.RemovedBytes)
+	}
+	if _, err := os.Stat(staged); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected staged partial download to be removed, got %v", err)
+	}
+	if _, err := os.Stat(cache.absolutePath(kept.EntryPath)); err != nil {
+		t.Fatalf("expected indexed artifact to be untouched, got %v", err)
+	}
+	read, _, err := cache.readIndex()
+	if err != nil {
+		t.Fatalf("failed to read index: %v", err)
+	}
+	if _, ok := read.Entries["kept"]; !ok {
+		t.Fatal("expected indexed artifact metadata to remain after partial-download cleanup")
+	}
+}
+
+func TestCacheCleanPartialDownloadsDryRunPreservesStagedFiles(t *testing.T) {
+	t.Parallel()
+
+	cache := newTestCache(t, testNow())
+	staged := filepath.Join(cache.downloadsRoot(), "download-abcdef")
+	if err := os.MkdirAll(staged, dirPerm); err != nil {
+		t.Fatalf("failed to create staged download directory: %v", err)
+	}
+	stagedFile := filepath.Join(staged, "payload.tmp")
+	if err := os.WriteFile(stagedFile, []byte("partial"), filePerm); err != nil {
+		t.Fatalf("failed to write staged file: %v", err)
+	}
+
+	summary, err := cache.Clean(context.Background(), CleanOptions{
+		Mode:   CleanupModePartialDownloads,
+		DryRun: true,
+	})
+	if err != nil {
+		t.Fatalf("expected dry-run partial-download clean to succeed, got %v", err)
+	}
+	if !summary.DryRun || summary.RemovedEntries != 1 {
+		t.Fatalf("unexpected dry-run summary: %+v", summary)
+	}
+	if _, err := os.Stat(staged); err != nil {
+		t.Fatalf("expected dry-run to keep the staged download, got %v", err)
+	}
+}
+
+func TestCacheCleanPartialDownloadsIsNoopWhenNoneAreStaged(t *testing.T) {
+	t.Parallel()
+
+	cache := newTestCache(t, testNow())
+
+	opts := CleanOptions{Mode: CleanupModePartialDownloads}
+	summary, err := cache.Clean(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("expected clean to succeed on a cache that never staged downloads, got %v", err)
+	}
+	if summary.RemovedEntries != 0 || summary.RemovedBytes != 0 {
+		t.Fatalf("expected empty summary, got %+v", summary)
+	}
+}
+
 func TestCacheDiagnoseReportsChecksumMismatchAndUnexpectedPaths(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tofu/config_test.go
+++ b/internal/tofu/config_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package tofu
+
+import (
+	"path"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/presets"
+)
+
+func TestNewTofuConfigFromPresetDerivesFilePathsFromInfraDir(t *testing.T) {
+	t.Parallel()
+
+	infraDir := "/deployment/infrastructure"
+
+	cfg := NewTofuConfigFromPreset(infraDir, presets.InfrastructureTofu{})
+
+	if cfg.WorkDir() != infraDir {
+		t.Fatalf("expected work dir %q, got %q", infraDir, cfg.WorkDir())
+	}
+	if cfg.PlanFile() != path.Join(infraDir, DefaultPlanFile) {
+		t.Fatalf("expected default plan file, got %q", cfg.PlanFile())
+	}
+	if cfg.StateFile() != path.Join(infraDir, DefaultStateFile) {
+		t.Fatalf("expected default state file, got %q", cfg.StateFile())
+	}
+	if cfg.VariablesFile() != path.Join(infraDir, DefaultVariablesFile) {
+		t.Fatalf("expected default variables file, got %q", cfg.VariablesFile())
+	}
+	if cfg.VarsOutputFile() != path.Join(infraDir, DefaultVarsOutput) {
+		t.Fatalf("expected default vars output file, got %q", cfg.VarsOutputFile())
+	}
+}
+
+// Both the variables file and the vars-output file are always joined onto
+// workDir, whether the preset supplies a custom relative path or falls back
+// to the default — there's no "absolute/verbatim" branch for either.
+func TestNewTofuConfigFromPresetHonorsCustomRelativeFilePaths(t *testing.T) {
+	t.Parallel()
+
+	infraDir := "/deployment/infrastructure"
+
+	cfg := NewTofuConfigFromPreset(infraDir, presets.InfrastructureTofu{
+		VariablesFile:  "custom-variables.tf",
+		VarsOutputFile: "custom-vars.tfvars",
+	})
+
+	if cfg.VariablesFile() != path.Join(infraDir, "custom-variables.tf") {
+		t.Fatalf("expected custom variables file joined onto workDir, got %q", cfg.VariablesFile())
+	}
+	if cfg.VarsOutputFile() != path.Join(infraDir, "custom-vars.tfvars") {
+		t.Fatalf(
+			"expected custom vars output file joined onto workDir, got %q",
+			cfg.VarsOutputFile(),
+		)
+	}
+}

--- a/internal/tofu/operarations_test.go
+++ b/internal/tofu/operarations_test.go
@@ -4,13 +4,140 @@
 package tofu
 
 import (
+	"context"
+	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/exasol/exasol-personal/internal/presets"
 )
+
+// withFakeTofuBinary swaps execCommandContext so the real tofu binary is
+// never invoked, and reports the args each Init/Plan/Apply/Destroy call
+// would have executed it with.
+func withFakeTofuBinary(t *testing.T) *[]string {
+	t.Helper()
+
+	var gotArgs []string
+	orig := execCommandContext
+	execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		gotArgs = append([]string{name}, args...)
+
+		return exec.CommandContext(ctx, "true")
+	}
+	t.Cleanup(func() { execCommandContext = orig })
+
+	return &gotArgs
+}
+
+func fakeTofuOperationsConfig() *Config {
+	return &Config{
+		workDir:        "/tmp",
+		tofuBinaryPath: "/bin/tofu",
+		varsOutputFile: "/vars.tfvars",
+		planeFile:      "/plan.tfplan",
+		stateFile:      "/state.tfstate",
+	}
+}
+
+// nolint: paralleltest
+func TestInitialize_RunsTofuInitWithConfiguredLockfileMode(t *testing.T) {
+	gotArgs := withFakeTofuBinary(t)
+
+	err := Initialize(
+		context.Background(),
+		fakeTofuOperationsConfig(),
+		io.Discard,
+		io.Discard,
+		LockfileUpdate,
+	)
+	if err != nil {
+		t.Fatalf("Initialize() returned error: %v", err)
+	}
+
+	want := []string{"/bin/tofu", "init", "-lockfile=update"}
+	if strings.Join(*gotArgs, " ") != strings.Join(want, " ") {
+		t.Fatalf("unexpected args.\nwant: %v\ngot:  %v", want, *gotArgs)
+	}
+}
+
+// nolint: paralleltest
+func TestPlan_RunsTofuPlanWithConfiguredPaths(t *testing.T) {
+	gotArgs := withFakeTofuBinary(t)
+
+	err := Plan(context.Background(), fakeTofuOperationsConfig(), io.Discard, io.Discard)
+	if err != nil {
+		t.Fatalf("Plan() returned error: %v", err)
+	}
+
+	want := []string{
+		"/bin/tofu", "plan", "-out=/plan.tfplan", "-var-file=/vars.tfvars",
+		"-state=/state.tfstate", "-state-out=/state.tfstate",
+	}
+	if strings.Join(*gotArgs, " ") != strings.Join(want, " ") {
+		t.Fatalf("unexpected args.\nwant: %v\ngot:  %v", want, *gotArgs)
+	}
+}
+
+// nolint: paralleltest
+func TestApplyPlan_RunsTofuApplyFromThePlanFileOnly(t *testing.T) {
+	gotArgs := withFakeTofuBinary(t)
+
+	err := ApplyPlan(context.Background(), fakeTofuOperationsConfig(), io.Discard, io.Discard)
+	if err != nil {
+		t.Fatalf("ApplyPlan() returned error: %v", err)
+	}
+
+	want := []string{
+		"/bin/tofu",
+		"apply",
+		"--auto-approve",
+		"-state=/state.tfstate",
+		"/plan.tfplan",
+	}
+	if strings.Join(*gotArgs, " ") != strings.Join(want, " ") {
+		t.Fatalf("unexpected args.\nwant: %v\ngot:  %v", want, *gotArgs)
+	}
+}
+
+// nolint: paralleltest
+func TestApplyAction_RunsTofuApplyWithActionVarAndVarsFile(t *testing.T) {
+	gotArgs := withFakeTofuBinary(t)
+
+	cfg := fakeTofuOperationsConfig()
+	err := ApplyAction(context.Background(), cfg, "instance_action=Stop", io.Discard, io.Discard)
+	if err != nil {
+		t.Fatalf("ApplyAction() returned error: %v", err)
+	}
+
+	want := []string{
+		"/bin/tofu", "apply", "--auto-approve", "-var=instance_action=Stop",
+		"-var-file=/vars.tfvars", "-state=/state.tfstate",
+	}
+	if strings.Join(*gotArgs, " ") != strings.Join(want, " ") {
+		t.Fatalf("unexpected args.\nwant: %v\ngot:  %v", want, *gotArgs)
+	}
+}
+
+// nolint: paralleltest
+func TestDestroy_RunsTofuDestroyWithConfiguredPaths(t *testing.T) {
+	gotArgs := withFakeTofuBinary(t)
+
+	err := Destroy(context.Background(), fakeTofuOperationsConfig(), io.Discard, io.Discard)
+	if err != nil {
+		t.Fatalf("Destroy() returned error: %v", err)
+	}
+
+	want := []string{
+		"/bin/tofu", "destroy", "-var-file=/vars.tfvars", "--auto-approve", "-state=/state.tfstate",
+	}
+	if strings.Join(*gotArgs, " ") != strings.Join(want, " ") {
+		t.Fatalf("unexpected args.\nwant: %v\ngot:  %v", want, *gotArgs)
+	}
+}
 
 func expectNoErr(t *testing.T, err error) {
 	t.Helper()

--- a/internal/tofu/runner_test.go
+++ b/internal/tofu/runner_test.go
@@ -21,6 +21,206 @@ func TestTofuRunnerInit_UsesUpdateLockfileWhenEnabled(t *testing.T) {
 	testTofuRunnerInitArgs(t, LockfileUpdate, []string{"/bin/tofu", "init", "-lockfile=update"})
 }
 
+// nolint: paralleltest
+func TestTofuRunnerPlan_BuildsArgsWithAndWithoutState(t *testing.T) {
+	cases := map[string]struct {
+		stateFilePath string
+		wantArgs      []string
+	}{
+		"without state": {
+			stateFilePath: "",
+			wantArgs: []string{
+				"/bin/tofu",
+				"plan",
+				"-out=/plan.tfplan",
+				"-var-file=/vars.tfvars",
+			},
+		},
+		"with state": {
+			stateFilePath: "/state.tfstate",
+			wantArgs: []string{
+				"/bin/tofu", "plan", "-out=/plan.tfplan", "-var-file=/vars.tfvars",
+				"-state=/state.tfstate", "-state-out=/state.tfstate",
+			},
+		},
+	}
+
+	for name, testCase := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+
+			var gotArgs []string
+			orig := execCommandContext
+			execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+				gotArgs = append([]string{name}, args...)
+
+				return exec.CommandContext(ctx, "true")
+			}
+			defer func() { execCommandContext = orig }()
+
+			runner, err := NewTofuRunner(
+				ctx,
+				&Config{workDir: "/tmp", tofuBinaryPath: "/bin/tofu"},
+				io.Discard,
+				io.Discard,
+			)
+			if err != nil {
+				t.Fatalf("NewTofuRunner() returned error: %v", err)
+			}
+
+			err = runner.Plan(ctx, "/plan.tfplan", "/vars.tfvars", testCase.stateFilePath)
+			if err != nil {
+				t.Fatalf("Plan() returned error: %v", err)
+			}
+
+			if !reflect.DeepEqual(gotArgs, testCase.wantArgs) {
+				t.Fatalf(
+					"%s: unexpected args.\nwant: %v\ngot:  %v",
+					name,
+					testCase.wantArgs,
+					gotArgs,
+				)
+			}
+		})
+	}
+}
+
+// nolint: paralleltest
+func TestTofuRunnerApply_BuildsArgsFromOptions(t *testing.T) {
+	cases := map[string]struct {
+		opts     ApplyOptions
+		wantArgs []string
+	}{
+		"plan file, no vars (start/stop)": {
+			opts: ApplyOptions{PlanFilePath: "/plan.tfplan", StateFilePath: "/state.tfstate"},
+			wantArgs: []string{
+				"/bin/tofu",
+				"apply",
+				"--auto-approve",
+				"-state=/state.tfstate",
+				"/plan.tfplan",
+			},
+		},
+		"vars and var-args, no plan file": {
+			opts: ApplyOptions{
+				VarArgs:       []string{"instance_action=Stop"},
+				VarsFilePath:  "/vars.tfvars",
+				StateFilePath: "/state.tfstate",
+			},
+			wantArgs: []string{
+				"/bin/tofu", "apply", "--auto-approve", "-var=instance_action=Stop",
+				"-var-file=/vars.tfvars", "-state=/state.tfstate",
+			},
+		},
+		"empty var-args entries are skipped": {
+			opts:     ApplyOptions{VarArgs: []string{"", "keep=me", ""}},
+			wantArgs: []string{"/bin/tofu", "apply", "--auto-approve", "-var=keep=me"},
+		},
+	}
+
+	for name, testCase := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+
+			var gotArgs []string
+			orig := execCommandContext
+			execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+				gotArgs = append([]string{name}, args...)
+
+				return exec.CommandContext(ctx, "true")
+			}
+			defer func() { execCommandContext = orig }()
+
+			runner, err := NewTofuRunner(
+				ctx,
+				&Config{workDir: "/tmp", tofuBinaryPath: "/bin/tofu"},
+				io.Discard,
+				io.Discard,
+			)
+			if err != nil {
+				t.Fatalf("NewTofuRunner() returned error: %v", err)
+			}
+
+			if err := runner.Apply(ctx, testCase.opts); err != nil {
+				t.Fatalf("Apply() returned error: %v", err)
+			}
+
+			if !reflect.DeepEqual(gotArgs, testCase.wantArgs) {
+				t.Fatalf(
+					"%s: unexpected args.\nwant: %v\ngot:  %v",
+					name,
+					testCase.wantArgs,
+					gotArgs,
+				)
+			}
+		})
+	}
+}
+
+// nolint: paralleltest
+func TestTofuRunnerDestroy_BuildsArgsWithAndWithoutState(t *testing.T) {
+	cases := map[string]struct {
+		stateFilePath string
+		wantArgs      []string
+	}{
+		"without state": {
+			stateFilePath: "",
+			wantArgs: []string{
+				"/bin/tofu",
+				"destroy",
+				"-var-file=/vars.tfvars",
+				"--auto-approve",
+			},
+		},
+		"with state": {
+			stateFilePath: "/state.tfstate",
+			wantArgs: []string{
+				"/bin/tofu", "destroy", "-var-file=/vars.tfvars", "--auto-approve",
+				"-state=/state.tfstate",
+			},
+		},
+	}
+
+	for name, testCase := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+
+			var gotArgs []string
+			orig := execCommandContext
+			execCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+				gotArgs = append([]string{name}, args...)
+
+				return exec.CommandContext(ctx, "true")
+			}
+			defer func() { execCommandContext = orig }()
+
+			runner, err := NewTofuRunner(
+				ctx,
+				&Config{workDir: "/tmp", tofuBinaryPath: "/bin/tofu"},
+				io.Discard,
+				io.Discard,
+			)
+			if err != nil {
+				t.Fatalf("NewTofuRunner() returned error: %v", err)
+			}
+
+			err = runner.Destroy(ctx, "/vars.tfvars", testCase.stateFilePath)
+			if err != nil {
+				t.Fatalf("Destroy() returned error: %v", err)
+			}
+
+			if !reflect.DeepEqual(gotArgs, testCase.wantArgs) {
+				t.Fatalf(
+					"%s: unexpected args.\nwant: %v\ngot:  %v",
+					name,
+					testCase.wantArgs,
+					gotArgs,
+				)
+			}
+		})
+	}
+}
+
 func testTofuRunnerInitArgs(t *testing.T, lockfileMode LockfileMode, wantArgs []string) {
 	t.Helper()
 

--- a/internal/tofu/variables_test.go
+++ b/internal/tofu/variables_test.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package tofu
+
+import (
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestParseVarsValuesFileReturnsTopLevelAssignedValues(t *testing.T) {
+	t.Parallel()
+
+	content := `
+region = "eu-central-1"
+instance_count = 3
+enabled = true
+`
+
+	values, err := ParseVarsValuesFile([]byte(content), "vars.tfvars")
+	if err != nil {
+		t.Fatalf("expected parsing to succeed, got %v", err)
+	}
+
+	if !values["region"].RawEquals(cty.StringVal("eu-central-1")) {
+		t.Fatalf("expected region to be eu-central-1, got %#v", values["region"])
+	}
+	if !values["instance_count"].RawEquals(cty.NumberIntVal(3)) {
+		t.Fatalf("expected instance_count to be 3, got %#v", values["instance_count"])
+	}
+	if !values["enabled"].RawEquals(cty.True) {
+		t.Fatalf("expected enabled to be true, got %#v", values["enabled"])
+	}
+}
+
+func TestParseVarsValuesFileRejectsInvalidHCL(t *testing.T) {
+	t.Parallel()
+
+	_, err := ParseVarsValuesFile([]byte("region = "), "vars.tfvars")
+	if err == nil {
+		t.Fatal("expected an error for malformed HCL, got nil")
+	}
+}

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -1,0 +1,338 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package util
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnsureDirCreatesMissingDirectory(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "nested", "dir")
+
+	if err := EnsureDir(path); err != nil {
+		t.Fatalf("expected directory creation to succeed, got %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil || !info.IsDir() {
+		t.Fatalf("expected %s to exist as a directory, got info=%v err=%v", path, info, err)
+	}
+}
+
+func TestEnsureDirIsANoopWhenDirectoryAlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	path := t.TempDir()
+
+	if err := EnsureDir(path); err != nil {
+		t.Fatalf("expected no-op success on an existing directory, got %v", err)
+	}
+}
+
+func TestEnsureDirRejectsAnExistingNonDirectoryPath(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(path, []byte("data"), 0o600); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	err := EnsureDir(path)
+
+	if !errors.Is(err, ErrPathIsNotDir) {
+		t.Fatalf("expected ErrPathIsNotDir, got %v", err)
+	}
+}
+
+func TestListDirReturnsEntryNames(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	for _, name := range []string{"a.txt", "b.txt"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o600); err != nil {
+			t.Fatalf("failed to write %s: %v", name, err)
+		}
+	}
+
+	entries, err := ListDir(dir, -1)
+	if err != nil {
+		t.Fatalf("expected listing to succeed, got %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %v", entries)
+	}
+}
+
+func TestListDirRespectsMaxEntriesWithoutErroringAtTheLimit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	for _, name := range []string{"a.txt", "b.txt", "c.txt"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o600); err != nil {
+			t.Fatalf("failed to write %s: %v", name, err)
+		}
+	}
+
+	entries, err := ListDir(dir, 2)
+	if err != nil {
+		t.Fatalf("expected a bounded listing to succeed (io.EOF is swallowed), got %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected exactly 2 entries, got %v", entries)
+	}
+}
+
+func TestListDirRejectsANonDirectoryPath(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(path, []byte("data"), 0o600); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	_, err := ListDir(path, -1)
+
+	if !errors.Is(err, ErrPathIsNotDir) {
+		t.Fatalf("expected ErrPathIsNotDir, got %v", err)
+	}
+}
+
+func TestListDirPropagatesStatErrorForMissingPath(t *testing.T) {
+	t.Parallel()
+
+	_, err := ListDir(filepath.Join(t.TempDir(), "missing"), -1)
+
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected os.ErrNotExist, got %v", err)
+	}
+}
+
+func TestAbsPathNoFailReturnsAbsolutePath(t *testing.T) {
+	t.Parallel()
+
+	if !filepath.IsAbs(AbsPathNoFail("relative/path")) {
+		t.Fatal("expected an absolute path")
+	}
+
+	absolute := filepath.Join(t.TempDir(), "already-absolute")
+	if AbsPathNoFail(absolute) != absolute {
+		t.Fatalf("expected an already-absolute path to be returned unchanged, got %q",
+			AbsPathNoFail(absolute))
+	}
+}
+
+func TestOptionalUnwrapsPresentAndAbsentValues(t *testing.T) {
+	t.Parallel()
+
+	value, isPresent := New(42).Unwrap()
+	if !isPresent || value != 42 {
+		t.Fatalf("expected (42, true), got (%v, %v)", value, isPresent)
+	}
+
+	value, isPresent = Nothing[int]().Unwrap()
+	if isPresent || value != 0 {
+		t.Fatalf("expected (0, false), got (%v, %v)", value, isPresent)
+	}
+}
+
+func TestLoggedErrorWrapsWithoutContext(t *testing.T) {
+	t.Parallel()
+
+	base := errors.New("boom")
+
+	err := LoggedError(base, "")
+
+	if !errors.Is(err, base) {
+		t.Fatalf("expected wrapped error to satisfy errors.Is(base), got %v", err)
+	}
+}
+
+func TestLoggedErrorWrapsWithContextAndKeyValueArgs(t *testing.T) {
+	t.Parallel()
+
+	base := errors.New("boom")
+
+	err := LoggedError(base, "operation failed", "path", "/tmp/x")
+
+	if !errors.Is(err, base) {
+		t.Fatalf("expected wrapped error to satisfy errors.Is(base), got %v", err)
+	}
+	msg := err.Error()
+	for _, want := range []string{"boom", "operation failed", "path=", `"/tmp/x"`} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("expected message to contain %q, got %q", want, msg)
+		}
+	}
+}
+
+func TestCombineWritersHandlesNilAndBothSet(t *testing.T) {
+	t.Parallel()
+
+	var first, second bytes.Buffer
+
+	if CombineWriters(nil, nil) != nil {
+		t.Fatal("expected nil when both writers are nil")
+	}
+	if CombineWriters(&first, nil) != io.Writer(&first) {
+		t.Fatal("expected the first writer to be returned when second is nil")
+	}
+	if CombineWriters(nil, &second) != io.Writer(&second) {
+		t.Fatal("expected the second writer to be returned when first is nil")
+	}
+
+	combined := CombineWriters(&first, &second)
+	if _, err := combined.Write([]byte("hello")); err != nil {
+		t.Fatalf("expected combined write to succeed, got %v", err)
+	}
+	if first.String() != "hello" || second.String() != "hello" {
+		t.Fatalf("expected both writers to receive the data, got %q and %q",
+			first.String(), second.String())
+	}
+}
+
+func TestGetTerminalWidthReturnsFalseWhenStdoutIsNotATerminal(t *testing.T) {
+	t.Parallel()
+
+	// go test redirects stdout away from a real terminal, so this exercises
+	// the real, common non-interactive path deterministically.
+	if _, ok := GetTerminalWidth(); ok {
+		t.Skip("stdout is unexpectedly a terminal in this environment")
+	}
+}
+
+func TestIsInteractiveStdinReturnsFalseWhenStdinIsNotATerminal(t *testing.T) {
+	t.Parallel()
+
+	// go test redirects stdin away from a real terminal, so this exercises
+	// the real, common non-interactive path deterministically.
+	if IsInteractiveStdin() {
+		t.Skip("stdin is unexpectedly a terminal in this environment")
+	}
+}
+
+func TestCopyDirErrorFormatsBySpecificity(t *testing.T) {
+	t.Parallel()
+
+	base := errors.New("underlying")
+
+	cases := map[string]struct {
+		err  *CopyDirError
+		want string
+	}{
+		"src and dst": {
+			err:  &CopyDirError{Op: "copy", Src: "/a", Dst: "/b", Err: base},
+			want: "copy (/a -> /b): underlying",
+		},
+		"src only": {
+			err:  &CopyDirError{Op: "stat source", Src: "/a", Err: base},
+			want: "stat source (/a): underlying",
+		},
+		"neither": {
+			err:  &CopyDirError{Op: "copy", Err: base},
+			want: "copy: underlying",
+		},
+	}
+	for name, testCase := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := testCase.err.Error(); got != testCase.want {
+				t.Fatalf("%s: got %q, want %q", name, got, testCase.want)
+			}
+			if !errors.Is(testCase.err, base) {
+				t.Fatalf("%s: expected Unwrap to expose the underlying error", name)
+			}
+		})
+	}
+}
+
+func TestCopyDirCopiesFilesAndSubdirectories(t *testing.T) {
+	t.Parallel()
+
+	src := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(src, "sub"), 0o750); err != nil {
+		t.Fatalf("failed to create source subdirectory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "top.txt"), []byte("top"), 0o600); err != nil {
+		t.Fatalf("failed to write top-level file: %v", err)
+	}
+	nestedPath := filepath.Join(src, "sub", "nested.txt")
+	if err := os.WriteFile(nestedPath, []byte("nested"), 0o600); err != nil {
+		t.Fatalf("failed to write nested file: %v", err)
+	}
+
+	dst := filepath.Join(t.TempDir(), "copy-target")
+
+	if err := CopyDir(src, dst); err != nil {
+		t.Fatalf("expected copy to succeed, got %v", err)
+	}
+
+	top, err := os.ReadFile(filepath.Join(dst, "top.txt"))
+	if err != nil || string(top) != "top" {
+		t.Fatalf("expected top-level file to be copied, got %q, err %v", top, err)
+	}
+	nested, err := os.ReadFile(filepath.Join(dst, "sub", "nested.txt"))
+	if err != nil || string(nested) != "nested" {
+		t.Fatalf("expected nested file to be copied, got %q, err %v", nested, err)
+	}
+}
+
+func TestCopyDirRejectsNonexistentSource(t *testing.T) {
+	t.Parallel()
+
+	err := CopyDir(filepath.Join(t.TempDir(), "missing"), t.TempDir())
+
+	var copyErr *CopyDirError
+	if !errors.As(err, &copyErr) || copyErr.Op != "stat source" {
+		t.Fatalf("expected a 'stat source' CopyDirError, got %v", err)
+	}
+}
+
+func TestCopyDirRejectsNonDirectorySource(t *testing.T) {
+	t.Parallel()
+
+	src := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(src, []byte("data"), 0o600); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	err := CopyDir(src, t.TempDir())
+
+	if !errors.Is(err, ErrSourceNotDir) {
+		t.Fatalf("expected ErrSourceNotDir, got %v", err)
+	}
+}
+
+// A destination that already exists as a plain file is rejected by the
+// os.MkdirAll call itself (it cannot create a directory where a file already
+// sits), surfacing as a "create destination" CopyDirError rather than ever
+// reaching the later ErrDestNotDir check.
+func TestCopyDirRejectsDestinationThatIsAFile(t *testing.T) {
+	t.Parallel()
+
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "a.txt"), []byte("a"), 0o600); err != nil {
+		t.Fatalf("failed to write source file: %v", err)
+	}
+
+	dst := filepath.Join(t.TempDir(), "dst-is-a-file")
+	if err := os.WriteFile(dst, []byte("occupied"), 0o600); err != nil {
+		t.Fatalf("failed to write destination file: %v", err)
+	}
+
+	err := CopyDir(src, dst)
+
+	var copyErr *CopyDirError
+	if !errors.As(err, &copyErr) || copyErr.Op != "create destination" {
+		t.Fatalf("expected a 'create destination' CopyDirError, got %v", err)
+	}
+}


### PR DESCRIPTION
## Description

Adds unit tests across previously under-covered packages (`cmd/exasol`, `internal/deploy`, `internal/config`, `internal/connect`, `internal/tofu`, `internal/presets`, `internal/remote`, `internal/runtimeartifacts`, `internal/directorymutex`, `internal/compatibility`, `internal/util`) to raise exasol-personal's combined test coverage. No production code changes.

## Related Issue

SPOT-32050

## Type of Change

- [x] `test`: Test additions or changes

## Changes Made

- Added tests for deployment lifecycle, status, initialization, and configuration resolution in `internal/deploy`
- Added tests for launcher state, manifests, secrets, and connection info in `internal/config`
- Added tests for shell execution, driver logging, statement classification, and table rendering in `internal/connect`
- Added tests for Tofu config, runner, and variable parsing in `internal/tofu`
- Added tests for manifest parsing and preset operations in `internal/presets`
- Added tests for SSH session handling in `internal/remote`
- Added tests for cache management edge cases in `internal/runtimeartifacts`
- Added tests for shared/exclusive lock edge cases and error wrapping in `internal/directorymutex`
- Added tests for deployment directory compatibility checks in `internal/compatibility`
- Added tests for filesystem and terminal helpers in `internal/util`
- Added tests for CLI commands (cache, config, deployments, presets, SLC) and flag/usage/log handling in `cmd/exasol`

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

### Test Details

`task lint`, `task build`, and `go test -race ./...` pass on this branch.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [ ] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

No CHANGELOG entry — test-only changes with no user-visible behavior impact.
