### PR TITLE
fix: Resolve additional SonarCloud security and maintainability findings

### DIFF
--- a/.github/actions/setup-codesigntool/action.yml
+++ b/.github/actions/setup-codesigntool/action.yml
@@ -45,7 +45,7 @@ runs:
         echo "URL: ${DOWNLOAD_URL}"
         
         # Download with GitHub token to avoid rate limiting
-        curl -sSLf --retry 3 --retry-delay 5 \
+        curl -sSLf --proto '=https' --retry 3 --retry-delay 5 \
           -H "Authorization: token ${GITHUB_TOKEN}" \
           -o CodeSignTool.zip "$DOWNLOAD_URL"
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -180,7 +180,14 @@ tasks:
       INFRA: '{{default "aws" .INFRA}}'
       TEST: '{{default "" .TEST}}'
       STACKIT_PROJECT_ID: '{{default "" .STACKIT_PROJECT_ID}}'
+      GOCOVERDIR_PATH: '{{.ROOT_PATH}}{{.SEP}}covdata-deployment'
+    env:
+      # The exasol binary is always built with COVERAGE=true in CI; without
+      # GOCOVERDIR it prints a warning on every invocation that pollutes
+      # stdout and breaks tests asserting exact output.
+      GOCOVERDIR: '{{.GOCOVERDIR_PATH}}'
     cmds:
+      - rm -rf {{.GOCOVERDIR_PATH}} && mkdir -p {{.GOCOVERDIR_PATH}}
       - |
         poetry run pytest -vv --exasol-path={{.BUILD_DIR}}{{.SEP}}{{.BINARY_NAME}} --infra={{.INFRA}} {{if .STACKIT_PROJECT_ID}}--stackit-project-id={{.STACKIT_PROJECT_ID}}{{end}} {{.TESTS_DIR}}{{.SEP}}tests{{.SEP}}deployment{{if .TEST}}{{.SEP}}{{.TEST}}{{end}}
 
@@ -191,7 +198,12 @@ tasks:
     vars:
       INFRA: '{{default "aws" .INFRA}}'
       STACKIT_PROJECT_ID: '{{default "" .STACKIT_PROJECT_ID}}'
+      GOCOVERDIR_PATH: '{{.ROOT_PATH}}{{.SEP}}covdata-deployment'
+    env:
+      # See tests-deployment: avoids the GOCOVERDIR-not-set warning leaking into test output.
+      GOCOVERDIR: '{{.GOCOVERDIR_PATH}}'
     cmds:
+      - rm -rf {{.GOCOVERDIR_PATH}} && mkdir -p {{.GOCOVERDIR_PATH}}
       - |
         poetry run pytest -vv --exasol-path={{.BUILD_DIR}}{{.SEP}}{{.BINARY_NAME}} --infra={{.INFRA}} {{if .STACKIT_PROJECT_ID}}--stackit-project-id={{.STACKIT_PROJECT_ID}}{{end}} -m "infrastructure_e2e" {{.TESTS_DIR}}{{.SEP}}tests{{.SEP}}deployment
 
@@ -202,7 +214,12 @@ tasks:
     vars:
       INFRA: '{{default "aws" .INFRA}}'
       STACKIT_PROJECT_ID: '{{default "" .STACKIT_PROJECT_ID}}'
+      GOCOVERDIR_PATH: '{{.ROOT_PATH}}{{.SEP}}covdata-deployment'
+    env:
+      # See tests-deployment: avoids the GOCOVERDIR-not-set warning leaking into test output.
+      GOCOVERDIR: '{{.GOCOVERDIR_PATH}}'
     cmds:
+      - rm -rf {{.GOCOVERDIR_PATH}} && mkdir -p {{.GOCOVERDIR_PATH}}
       - |
         poetry run pytest -vv --exasol-path={{.BUILD_DIR}}{{.SEP}}{{.BINARY_NAME}} --infra={{.INFRA}} {{if .STACKIT_PROJECT_ID}}--stackit-project-id={{.STACKIT_PROJECT_ID}}{{end}} -m "installation_e2e" {{.TESTS_DIR}}{{.SEP}}tests{{.SEP}}deployment
 
@@ -210,7 +227,13 @@ tasks:
     desc: Run local VM deployment tests (macOS Apple Silicon only)
     deps: [tests-setup]
     dir: '{{.TESTS_DIR}}'
+    vars:
+      GOCOVERDIR_PATH: '{{.ROOT_PATH}}{{.SEP}}covdata-deployment'
+    env:
+      # See tests-deployment: avoids the GOCOVERDIR-not-set warning leaking into test output.
+      GOCOVERDIR: '{{.GOCOVERDIR_PATH}}'
     cmds:
+      - rm -rf {{.GOCOVERDIR_PATH}} && mkdir -p {{.GOCOVERDIR_PATH}}
       - poetry run pytest -vv --exasol-path={{.BUILD_DIR}}{{.SEP}}{{.BINARY_NAME}} --infra=local -m "local_e2e" {{.TESTS_DIR}}{{.SEP}}tests{{.SEP}}deployment
 
   lint-ruff:

--- a/assets/infrastructure/aws/main.tf
+++ b/assets/infrastructure/aws/main.tf
@@ -162,6 +162,31 @@ resource "aws_s3_bucket" "remote_archive_volume" {
   }
 }
 
+resource "aws_s3_bucket_policy" "remote_archive_volume" {
+  count  = var.s3_archive_enabled ? 1 : 0
+  bucket = aws_s3_bucket.remote_archive_volume[0].id
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid       = "DenyInsecureTransport",
+        Effect    = "Deny",
+        Principal = "*",
+        Action    = "s3:*",
+        Resource = [
+          aws_s3_bucket.remote_archive_volume[0].arn,
+          "${aws_s3_bucket.remote_archive_volume[0].arn}/*"
+        ],
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
+      }
+    ]
+  })
+}
+
 resource "aws_s3_bucket" "bootstrap_assets" {
   bucket = local.bootstrap_assets_bucket_id
 
@@ -177,10 +202,14 @@ resource "aws_s3_bucket" "bootstrap_assets" {
 resource "aws_s3_bucket_public_access_block" "bootstrap_assets" {
   bucket = aws_s3_bucket.bootstrap_assets.id
 
+  # The bucket policy below grants anonymous reads only via a
+  # Condition on aws:sourceVpce, which AWS's Block Public Access
+  # evaluator recognizes as restricting — so it is not treated as a
+  # public grant and attaching it does not require loosening these.
   block_public_acls       = true
   ignore_public_acls      = true
-  block_public_policy     = false
-  restrict_public_buckets = false
+  block_public_policy     = true
+  restrict_public_buckets = true
 }
 
 resource "aws_s3_bucket_policy" "bootstrap_assets" {

--- a/assets/infrastructure/azure/main.tf
+++ b/assets/infrastructure/azure/main.tf
@@ -354,7 +354,11 @@ resource "azurerm_managed_disk" "data_disks" {
   disk_size_gb         = var.data_volume_size
   tags                 = local.common_tags
 
-  public_network_access_enabled = true
+  # This disk is only ever attached to a VM over Azure's internal storage
+  # fabric (see azurerm_virtual_machine_data_disk_attachment below); it is
+  # never imported/exported via the direct-upload data-plane endpoint that
+  # this flag controls.
+  public_network_access_enabled = false
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "data_disks" {

--- a/assets/infrastructure/exoscale/main.tf
+++ b/assets/infrastructure/exoscale/main.tf
@@ -50,6 +50,13 @@ resource "aws_s3_bucket" "remote_archive_volume" {
   force_destroy = true
 }
 
+# Unlike the AWS and STACKIT presets, this bucket (and bootstrap_assets below)
+# has no bucket policy denying non-HTTPS transport: Exoscale SOS validates
+# bucket policies against its own, undocumented IAM v3 policy spec rather than
+# AWS's bucket-policy grammar, so AWS-style policies are rejected outright.
+# Transport is still HTTPS-only in practice, since every access to these
+# buckets goes through the hardcoded https:// SOS endpoint (see sos_endpoint
+# above and cloudinit.tf) rather than through a policy-level restriction.
 resource "aws_s3_bucket" "bootstrap_assets" {
   provider = aws.sos
   bucket   = local.bootstrap_assets_bucket_id

--- a/assets/infrastructure/stackit/main.tf
+++ b/assets/infrastructure/stackit/main.tf
@@ -198,6 +198,21 @@ resource "minio_s3_bucket_anonymous_access" "bootstrap_assets" {
             "aws:SourceIp" = local.bootstrap_source_cidrs
           }
         }
+      },
+      {
+        Sid       = "DenyInsecureTransport"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          "urn:sgws:s3:::${minio_s3_bucket.bootstrap_assets.bucket}",
+          "urn:sgws:s3:::${minio_s3_bucket.bootstrap_assets.bucket}/*"
+        ]
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
       }
     ]
   })

--- a/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/prepareExasol.sh
+++ b/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/prepareExasol.sh
@@ -25,7 +25,7 @@ log_step_info "Preparing system..."
 
 log_substep_info "Downloading c4 ...${c4_version}"
 
-if ! curl -fsSL -O "https://x-up.s3.amazonaws.com/releases/c4/linux/x86_64/${c4_version}/c4"; then
+if ! curl -fsSL --proto '=https' -O "https://x-up.s3.amazonaws.com/releases/c4/linux/x86_64/${c4_version}/c4"; then
   log_error "Failed to download c4 binary from remote server"
   exit 1
 fi

--- a/cmd/exasol/compatibility_test.go
+++ b/cmd/exasol/compatibility_test.go
@@ -174,39 +174,35 @@ func TestDeploymentCompatibilityRules_MinorBaselineAndNeverNewerThanLauncher(t *
 
 	// Given: test cases spanning the contract space: allowed versions, too-new deployments,
 	// and deployments that are too old for the declared minimum.
+	// wantReason is nil for cases that are expected to be allowed.
 	testCases := []struct {
 		name              string
 		deploymentVersion string
 		launcherVersion   string
-		allowed           bool
-		reason            deploymentcompatibility.Reason
+		wantReason        *deploymentcompatibility.Reason
 	}{
 		{
 			name:              "allows same minor at patch 0",
 			deploymentVersion: "1.2.0",
 			launcherVersion:   "1.2.5",
-			allowed:           true,
 		},
 		{
 			name:              "rejects deployment newer patch than launcher",
 			deploymentVersion: "1.2.7",
 			launcherVersion:   "1.2.5",
-			allowed:           false,
-			reason:            deploymentcompatibility.ReasonDeploymentNewerThanLauncher,
+			wantReason:        reasonPtr(deploymentcompatibility.ReasonDeploymentNewerThanLauncher),
 		},
 		{
 			name:              "rejects deployment newer minor than launcher",
 			deploymentVersion: "1.3.0",
 			launcherVersion:   "1.2.5",
-			allowed:           false,
-			reason:            deploymentcompatibility.ReasonDeploymentNewerThanLauncher,
+			wantReason:        reasonPtr(deploymentcompatibility.ReasonDeploymentNewerThanLauncher),
 		},
 		{
 			name:              "rejects deployment older than minimum minor",
 			deploymentVersion: "1.1.9",
 			launcherVersion:   "1.2.5",
-			allowed:           false,
-			reason:            deploymentcompatibility.ReasonDeploymentTooOld,
+			wantReason:        reasonPtr(deploymentcompatibility.ReasonDeploymentTooOld),
 		},
 	}
 
@@ -222,30 +218,43 @@ func TestDeploymentCompatibilityRules_MinorBaselineAndNeverNewerThanLauncher(t *
 			)
 
 			// Then: the result matches the rule expectations.
-			if res.Allowed != testcase.allowed {
-				t.Fatalf(
-					"expected allowed=%v, got allowed=%v (err=%v)",
-					testcase.allowed,
-					res.Allowed,
-					res.Err,
-				)
-			}
-			if testcase.allowed {
-				if res.Err != nil {
-					t.Fatalf("expected nil error when allowed, got: %v", res.Err)
-				}
-
-				return
-			}
-
-			var inc *deploymentcompatibility.IncompatibleError
-			if !errors.As(res.Err, &inc) {
-				t.Fatalf("expected IncompatibleError, got %T: %v", res.Err, res.Err)
-			}
-			if inc.Reason != testcase.reason {
-				t.Fatalf("expected reason %q, got %q", testcase.reason, inc.Reason)
-			}
+			assertDeploymentCompatibilityResult(t, res, testcase.wantReason)
 		})
+	}
+}
+
+func reasonPtr(reason deploymentcompatibility.Reason) *deploymentcompatibility.Reason {
+	return &reason
+}
+
+// assertDeploymentCompatibilityResult checks a compatibility result against the expected
+// outcome. A nil wantReason means the result must be allowed with no error; otherwise the
+// result must be an IncompatibleError with that reason.
+func assertDeploymentCompatibilityResult(
+	t *testing.T,
+	res deploymentcompatibility.Result,
+	wantReason *deploymentcompatibility.Reason,
+) {
+	t.Helper()
+
+	wantAllowed := wantReason == nil
+	if res.Allowed != wantAllowed {
+		t.Fatalf("expected allowed=%v, got allowed=%v (err=%v)", wantAllowed, res.Allowed, res.Err)
+	}
+	if wantAllowed {
+		if res.Err != nil {
+			t.Fatalf("expected nil error when allowed, got: %v", res.Err)
+		}
+
+		return
+	}
+
+	var inc *deploymentcompatibility.IncompatibleError
+	if !errors.As(res.Err, &inc) {
+		t.Fatalf("expected IncompatibleError, got %T: %v", res.Err, res.Err)
+	}
+	if inc.Reason != *wantReason {
+		t.Fatalf("expected reason %q, got %q", *wantReason, inc.Reason)
 	}
 }
 

--- a/cmd/exasol/infra_variables.go
+++ b/cmd/exasol/infra_variables.go
@@ -168,55 +168,85 @@ func registerInfrastructureVariableFlags(
 		if cmd == nil {
 			continue
 		}
-		if cmd.Annotations == nil {
-			cmd.Annotations = map[string]string{}
-		}
-		cmd.Annotations[infraPresetLabelAnnotationKey] = label
-
-		for name, variable := range vars {
-			if strings.TrimSpace(variable.Name) != "" {
-				name = variable.Name
-			}
-
-			flagName := strings.ReplaceAll(name, "_", "-")
-			if cmd.Flags().Lookup(flagName) != nil || cmd.InheritedFlags().Lookup(flagName) != nil {
-				return fmt.Errorf(
-					"infrastructure variable flag name conflict: "+
-						"--%s is already defined (preset: %s)",
-					flagName,
-					label,
-				)
-			}
-
-			usage := strings.TrimSpace(variable.Description)
-			if strings.TrimSpace(usage) == "" {
-				usage = "Infrastructure variable"
-			}
-			if strings.TrimSpace(variable.DefaultDisplay) != "" {
-				usage += fmt.Sprintf(" (default: %s)", variable.DefaultDisplay)
-			}
-			if variable.Required {
-				usage += " (required)"
-			}
-
-			switch variable.Type {
-			case deploy.ConfigVariableTypeBool:
-				cmd.Flags().Bool(flagName, false, usage)
-			case deploy.ConfigVariableTypeNumber:
-				cmd.Flags().Var(&numberFlag{}, flagName, usage)
-			case deploy.ConfigVariableTypeString:
-				cmd.Flags().String(flagName, "", usage)
-			default:
-				cmd.Flags().String(flagName, "", usage)
-			}
-			if f := cmd.Flags().Lookup(flagName); f != nil {
-				f.DefValue = ""
-			}
-			infraFlagToVarName[flagName] = name
+		if err := registerInfrastructureVariableFlagsForCommand(cmd, vars, label); err != nil {
+			return err
 		}
 	}
 
 	return nil
+}
+
+func registerInfrastructureVariableFlagsForCommand(
+	cmd *cobra.Command,
+	vars map[string]deploy.ConfigVariableDefinition,
+	label string,
+) error {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations[infraPresetLabelAnnotationKey] = label
+
+	for name, variable := range vars {
+		if strings.TrimSpace(variable.Name) != "" {
+			name = variable.Name
+		}
+		if err := registerInfrastructureVariableFlag(cmd, name, variable, label); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func registerInfrastructureVariableFlag(
+	cmd *cobra.Command,
+	name string,
+	variable deploy.ConfigVariableDefinition,
+	label string,
+) error {
+	flagName := strings.ReplaceAll(name, "_", "-")
+	if cmd.Flags().Lookup(flagName) != nil || cmd.InheritedFlags().Lookup(flagName) != nil {
+		return fmt.Errorf(
+			"infrastructure variable flag name conflict: "+
+				"--%s is already defined (preset: %s)",
+			flagName,
+			label,
+		)
+	}
+
+	usage := infrastructureVariableFlagUsage(variable)
+
+	switch variable.Type {
+	case deploy.ConfigVariableTypeBool:
+		cmd.Flags().Bool(flagName, false, usage)
+	case deploy.ConfigVariableTypeNumber:
+		cmd.Flags().Var(&numberFlag{}, flagName, usage)
+	case deploy.ConfigVariableTypeString:
+		cmd.Flags().String(flagName, "", usage)
+	default:
+		cmd.Flags().String(flagName, "", usage)
+	}
+	if f := cmd.Flags().Lookup(flagName); f != nil {
+		f.DefValue = ""
+	}
+	infraFlagToVarName[flagName] = name
+
+	return nil
+}
+
+func infrastructureVariableFlagUsage(variable deploy.ConfigVariableDefinition) string {
+	usage := strings.TrimSpace(variable.Description)
+	if strings.TrimSpace(usage) == "" {
+		usage = "Infrastructure variable"
+	}
+	if strings.TrimSpace(variable.DefaultDisplay) != "" {
+		usage += fmt.Sprintf(" (default: %s)", variable.DefaultDisplay)
+	}
+	if variable.Required {
+		usage += " (required)"
+	}
+
+	return usage
 }
 
 func resolveInfrastructureVariablesFromDeployment(

--- a/cmd/exasol/init.go
+++ b/cmd/exasol/init.go
@@ -178,13 +178,15 @@ func runInitForFreshDeployment(
 ) error {
 	err := deploy.InitDeployment(
 		cmd.Context(),
-		infraPreset,
-		installPreset,
-		infraVars,
-		installVars,
 		deployment,
-		!commonFlags.NoLauncherVersionCheck,
-		CurrentLauncherVersion,
+		deploy.InitOptions{
+			InfrastructurePreset: infraPreset,
+			InstallationPreset:   installPreset,
+			InfraVars:            infraVars,
+			InstallVars:          installVars,
+			VersionCheckEnabled:  !commonFlags.NoLauncherVersionCheck,
+			CurrentVersion:       CurrentLauncherVersion,
+		},
 	)
 	if err != nil {
 		return err

--- a/cmd/exasol/install.go
+++ b/cmd/exasol/install.go
@@ -146,13 +146,15 @@ func initializeInstall(
 
 	if err := deploy.InitDeployment(
 		cmd.Context(),
-		infraPreset,
-		installPreset,
-		infraVars,
-		installVars,
 		deployment,
-		!commonFlags.NoLauncherVersionCheck,
-		CurrentLauncherVersion,
+		deploy.InitOptions{
+			InfrastructurePreset: infraPreset,
+			InstallationPreset:   installPreset,
+			InfraVars:            infraVars,
+			InstallVars:          installVars,
+			VersionCheckEnabled:  !commonFlags.NoLauncherVersionCheck,
+			CurrentVersion:       CurrentLauncherVersion,
+		},
 	); err != nil {
 		return fmt.Errorf("initialization failed: %w", err)
 	}

--- a/cmd/exasol/install_variables.go
+++ b/cmd/exasol/install_variables.go
@@ -111,54 +111,84 @@ func registerInstallationVariableFlags(
 		if cmd == nil {
 			continue
 		}
-		if cmd.Annotations == nil {
-			cmd.Annotations = map[string]string{}
-		}
-		cmd.Annotations[installPresetLabelAnnotationKey] = label
-
-		for name, def := range vars {
-			if def == nil {
-				continue
-			}
-
-			flagName := strings.ReplaceAll(name, "_", "-")
-			if cmd.Flags().Lookup(flagName) != nil || cmd.InheritedFlags().Lookup(flagName) != nil {
-				return fmt.Errorf(
-					"installation variable flag name conflict: "+
-						"--%s is already defined (preset: %s)",
-					flagName,
-					label,
-				)
-			}
-
-			usage := strings.TrimSpace(def.Description)
-			if usage == "" {
-				usage = "Installation variable"
-			}
-			if def.Default != nil {
-				usage += fmt.Sprintf(" (default: %v)", def.Default)
-			}
-
-			effectiveType, err := def.EffectiveType()
-			if err != nil {
-				return fmt.Errorf("invalid definition of installation variable %q: %w", name, err)
-			}
-			switch effectiveType {
-			case "bool":
-				cmd.Flags().Bool(flagName, false, usage)
-			case "number":
-				cmd.Flags().Var(&numberFlag{}, flagName, usage)
-			default:
-				cmd.Flags().String(flagName, "", usage)
-			}
-			if f := cmd.Flags().Lookup(flagName); f != nil {
-				f.DefValue = ""
-			}
-			installFlagToVarName[flagName] = name
+		if err := registerInstallationVariableFlagsForCommand(cmd, vars, label); err != nil {
+			return err
 		}
 	}
 
 	return nil
+}
+
+func registerInstallationVariableFlagsForCommand(
+	cmd *cobra.Command,
+	vars map[string]*presets.VariableDef,
+	label string,
+) error {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations[installPresetLabelAnnotationKey] = label
+
+	for name, def := range vars {
+		if def == nil {
+			continue
+		}
+		if err := registerInstallationVariableFlag(cmd, name, def, label); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func registerInstallationVariableFlag(
+	cmd *cobra.Command,
+	name string,
+	def *presets.VariableDef,
+	label string,
+) error {
+	flagName := strings.ReplaceAll(name, "_", "-")
+	if cmd.Flags().Lookup(flagName) != nil || cmd.InheritedFlags().Lookup(flagName) != nil {
+		return fmt.Errorf(
+			"installation variable flag name conflict: "+
+				"--%s is already defined (preset: %s)",
+			flagName,
+			label,
+		)
+	}
+
+	usage := installationVariableFlagUsage(def)
+
+	effectiveType, err := def.EffectiveType()
+	if err != nil {
+		return fmt.Errorf("invalid definition of installation variable %q: %w", name, err)
+	}
+	switch effectiveType {
+	case "bool":
+		cmd.Flags().Bool(flagName, false, usage)
+	case "number":
+		cmd.Flags().Var(&numberFlag{}, flagName, usage)
+	default:
+		cmd.Flags().String(flagName, "", usage)
+	}
+	if f := cmd.Flags().Lookup(flagName); f != nil {
+		f.DefValue = ""
+	}
+	installFlagToVarName[flagName] = name
+
+	return nil
+}
+
+func installationVariableFlagUsage(def *presets.VariableDef) string {
+	usage := strings.TrimSpace(def.Description)
+	if usage == "" {
+		usage = "Installation variable"
+	}
+	if def.Default != nil {
+		usage += fmt.Sprintf(" (default: %v)", def.Default)
+	}
+
+	return usage
 }
 
 func resolveInstallationVariablesFromDeployment(

--- a/cmd/exasol/preset_help.go
+++ b/cmd/exasol/preset_help.go
@@ -17,77 +17,132 @@ func embeddedPresetCompatibilityMatrix() string {
 		return ""
 	}
 
-	infraManifests := map[string]*presets.InfrastructureManifest{}
-	for _, infraID := range infraIDs {
-		manifest, err := presets.ReadInfrastructureManifest(infraID)
-		if err != nil {
-			continue
-		}
-		infraManifests[infraID] = manifest
-	}
-
-	installManifests := map[string]*presets.InstallManifest{}
-	for _, installID := range installIDs {
-		manifest, err := presets.ReadInstallManifest(installID)
-		if err != nil {
-			continue
-		}
-		installManifests[installID] = manifest
-	}
-
+	infraManifests := readEmbeddedInfrastructureManifests(infraIDs)
+	installManifests := readEmbeddedInstallationManifests(installIDs)
 	if len(infraManifests) == 0 || len(installManifests) == 0 {
 		return ""
 	}
 
-	firstColumnWidth := len("infrastructure")
-	for infraID := range infraManifests {
-		if len(infraID) > firstColumnWidth {
-			firstColumnWidth = len(infraID)
-		}
-	}
-
 	const compatibleCell = "yes"
-	columnWidths := map[string]int{}
-	for installID := range installManifests {
-		width := len(installID)
-		if width < len(compatibleCell) {
-			width = len(compatibleCell)
-		}
-		columnWidths[installID] = width
+	ctx := compatibilityMatrixContext{
+		installIDs:       installIDs,
+		installManifests: installManifests,
+		columnWidths:     compatibilityMatrixColumnWidths(installManifests, compatibleCell),
+		firstColumnWidth: compatibilityMatrixFirstColumnWidth(infraManifests),
+		compatibleCell:   compatibleCell,
 	}
 
 	var builder strings.Builder
 	_, _ = builder.WriteString("Compatibility matrix (embedded presets):\n")
-	_, _ = builder.WriteString(fmt.Sprintf("  %-*s", firstColumnWidth, "infrastructure"))
-	for _, installID := range installIDs {
-		if _, ok := installManifests[installID]; !ok {
-			continue
-		}
-		_, _ = builder.WriteString(fmt.Sprintf("  %-*s", columnWidths[installID], installID))
-	}
-	_ = builder.WriteByte('\n')
+	writeCompatibilityMatrixHeader(&builder, ctx)
 
 	for _, infraID := range infraIDs {
 		infraManifest, ok := infraManifests[infraID]
 		if !ok {
 			continue
 		}
-		_, _ = builder.WriteString(fmt.Sprintf("  %-*s", firstColumnWidth, infraID))
-		for _, installID := range installIDs {
-			installManifest, ok := installManifests[installID]
-			if !ok {
-				continue
-			}
-			cell := "no"
-			if embeddedPresetPairCompatible(infraManifest, installManifest) {
-				cell = compatibleCell
-			}
-			_, _ = builder.WriteString(fmt.Sprintf("  %-*s", columnWidths[installID], cell))
-		}
-		_ = builder.WriteByte('\n')
+		writeCompatibilityMatrixRow(&builder, ctx, infraID, infraManifest)
 	}
 
 	return strings.TrimRight(builder.String(), "\n")
+}
+
+// compatibilityMatrixContext holds the rendering context shared by the
+// compatibility matrix's header and every row.
+type compatibilityMatrixContext struct {
+	installIDs       []string
+	installManifests map[string]*presets.InstallManifest
+	columnWidths     map[string]int
+	firstColumnWidth int
+	compatibleCell   string
+}
+
+func readEmbeddedInfrastructureManifests(
+	infraIDs []string,
+) map[string]*presets.InfrastructureManifest {
+	manifests := map[string]*presets.InfrastructureManifest{}
+	for _, infraID := range infraIDs {
+		manifest, err := presets.ReadInfrastructureManifest(infraID)
+		if err != nil {
+			continue
+		}
+		manifests[infraID] = manifest
+	}
+
+	return manifests
+}
+
+func readEmbeddedInstallationManifests(installIDs []string) map[string]*presets.InstallManifest {
+	manifests := map[string]*presets.InstallManifest{}
+	for _, installID := range installIDs {
+		manifest, err := presets.ReadInstallManifest(installID)
+		if err != nil {
+			continue
+		}
+		manifests[installID] = manifest
+	}
+
+	return manifests
+}
+
+func compatibilityMatrixFirstColumnWidth(
+	infraManifests map[string]*presets.InfrastructureManifest,
+) int {
+	width := len("infrastructure")
+	for infraID := range infraManifests {
+		if len(infraID) > width {
+			width = len(infraID)
+		}
+	}
+
+	return width
+}
+
+func compatibilityMatrixColumnWidths(
+	installManifests map[string]*presets.InstallManifest, compatibleCell string,
+) map[string]int {
+	widths := map[string]int{}
+	for installID := range installManifests {
+		width := len(installID)
+		if width < len(compatibleCell) {
+			width = len(compatibleCell)
+		}
+		widths[installID] = width
+	}
+
+	return widths
+}
+
+func writeCompatibilityMatrixHeader(builder *strings.Builder, ctx compatibilityMatrixContext) {
+	_, _ = fmt.Fprintf(builder, "  %-*s", ctx.firstColumnWidth, "infrastructure")
+	for _, installID := range ctx.installIDs {
+		if _, ok := ctx.installManifests[installID]; !ok {
+			continue
+		}
+		_, _ = fmt.Fprintf(builder, "  %-*s", ctx.columnWidths[installID], installID)
+	}
+	_ = builder.WriteByte('\n')
+}
+
+func writeCompatibilityMatrixRow(
+	builder *strings.Builder,
+	ctx compatibilityMatrixContext,
+	infraID string,
+	infraManifest *presets.InfrastructureManifest,
+) {
+	_, _ = fmt.Fprintf(builder, "  %-*s", ctx.firstColumnWidth, infraID)
+	for _, installID := range ctx.installIDs {
+		installManifest, ok := ctx.installManifests[installID]
+		if !ok {
+			continue
+		}
+		cell := "no"
+		if embeddedPresetPairCompatible(infraManifest, installManifest) {
+			cell = ctx.compatibleCell
+		}
+		_, _ = fmt.Fprintf(builder, "  %-*s", ctx.columnWidths[installID], cell)
+	}
+	_ = builder.WriteByte('\n')
 }
 
 func embeddedPresetPairCompatible(

--- a/cmd/exasol/version_test.go
+++ b/cmd/exasol/version_test.go
@@ -100,16 +100,8 @@ func TestFormatLatestVersionText_ReportsNewerEqualAndOlderVersions(t *testing.T)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			for _, expected := range test.expected {
-				if !strings.Contains(actual, expected) {
-					t.Fatalf("expected output to contain %q, got %q", expected, actual)
-				}
-			}
-			for _, unexpected := range test.unexpected {
-				if strings.Contains(actual, unexpected) {
-					t.Fatalf("expected output to not contain %q, got %q", unexpected, actual)
-				}
-			}
+			assertContainsAll(t, actual, test.expected)
+			assertContainsNone(t, actual, test.unexpected)
 		})
 	}
 }
@@ -156,6 +148,26 @@ func TestVersionCmdQueuesPrimaryOutputForTerminalFlush(t *testing.T) {
 	}
 	if stderr.String() != "" {
 		t.Fatalf("unexpected stderr: %q", stderr.String())
+	}
+}
+
+func assertContainsAll(t *testing.T, actual string, expected []string) {
+	t.Helper()
+
+	for _, e := range expected {
+		if !strings.Contains(actual, e) {
+			t.Fatalf("expected output to contain %q, got %q", e, actual)
+		}
+	}
+}
+
+func assertContainsNone(t *testing.T, actual string, unexpected []string) {
+	t.Helper()
+
+	for _, u := range unexpected {
+		if strings.Contains(actual, u) {
+			t.Fatalf("expected output to not contain %q, got %q", u, actual)
+		}
 	}
 }
 

--- a/internal/config/exasol_launcher_state_test.go
+++ b/internal/config/exasol_launcher_state_test.go
@@ -22,20 +22,57 @@ func expectNoErr(t *testing.T, err error) {
 	}
 }
 
+func expectPanic(t *testing.T, action func()) {
+	t.Helper()
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic for invalid workflow state, got none")
+		}
+	}()
+
+	action()
+}
+
+func mustChmod(t *testing.T, path string, mode os.FileMode) {
+	t.Helper()
+	if err := os.Chmod(path, mode); err != nil {
+		t.Fatalf("chmod dir failed: %v", err)
+	}
+}
+
+// assertWorkflowStateRoundtrip writes state to a fresh deployment dir, reads
+// it back, and checks that GetWorkflowState reports the same concrete type.
+func assertWorkflowStateRoundtrip[T any](t *testing.T, state T) {
+	t.Helper()
+	deployment := NewDeploymentDir(t.TempDir())
+
+	exasolState := &ExasolPersonalState{}
+	//nolint:errcheck,gosec,revive // error checked in subsequent read
+	exasolState.SetWorkflowStateAndWrite(state, deployment)
+
+	newExasolState, err := ReadExasolPersonalState(deployment)
+	if err != nil {
+		t.Fatalf("failed to read exasol personal state: %v", err)
+	}
+
+	workflowState, err := newExasolState.GetWorkflowState()
+	expectNoErr(t, err)
+
+	if _, ok := workflowState.(T); !ok {
+		t.Fatalf("expected %T, got %T", state, workflowState)
+	}
+}
+
 func TestWorkflowState(t *testing.T) {
 	t.Parallel()
 
 	t.Run("Invalid state panics", func(t *testing.T) {
 		t.Parallel()
-		defer func() {
-			if recover() == nil {
-				t.Fatal("expected panic for invalid workflow state, got none")
-			}
-		}()
-
 		exasolState := &ExasolPersonalState{}
-		//nolint:errcheck,gosec // intentionally testing panic behavior
-		exasolState.SetWorkflowState(struct{ X int }{X: 1})
+		expectPanic(t, func() {
+			//nolint:errcheck,gosec // intentionally testing panic behavior
+			exasolState.SetWorkflowState(struct{ X int }{X: 1})
+		})
 	})
 
 	t.Run("Write error (non-writable dir)", func(t *testing.T) {
@@ -43,9 +80,7 @@ func TestWorkflowState(t *testing.T) {
 		dir := t.TempDir()
 		deployment := NewDeploymentDir(dir)
 		//nolint:gosec // remove write bit to force writeConfig error
-		if err := os.Chmod(dir, 0o600); err != nil {
-			t.Fatalf("chmod dir failed: %v", err)
-		}
+		mustChmod(t, dir, 0o600)
 		//nolint:gosec
 		defer os.Chmod(dir, 0o700)
 
@@ -55,145 +90,37 @@ func TestWorkflowState(t *testing.T) {
 
 	t.Run("Initialized", func(t *testing.T) {
 		t.Parallel()
-		dir := t.TempDir()
-		deployment := NewDeploymentDir(dir)
-
-		exasolState := &ExasolPersonalState{}
-		//nolint:errcheck,gosec // error checked in subsequent read
-		exasolState.SetWorkflowStateAndWrite(&WorkflowStateInitialized{}, NewDeploymentDir(dir))
-
-		newExasolState, err := ReadExasolPersonalState(deployment)
-		if err != nil {
-			t.Fatalf("failed to read exasol personal state: %v", err)
-		}
-
-		workflowState, err := newExasolState.GetWorkflowState()
-
-		expectNoErr(t, err)
-		if _, ok := workflowState.(*WorkflowStateInitialized); !ok {
-			t.Fatalf("expected Initialized, got %T", workflowState)
-		}
+		assertWorkflowStateRoundtrip(t, &WorkflowStateInitialized{})
 	})
 
 	t.Run("OperationInProgress", func(t *testing.T) {
 		t.Parallel()
-		dir := t.TempDir()
-		deployment := NewDeploymentDir(dir)
-
-		exasolState := &ExasolPersonalState{}
-		//nolint:errcheck,gosec // error checked in subsequent read
-		exasolState.SetWorkflowStateAndWrite(
-			&WorkflowStateOperationInProgress{},
-			deployment,
-		)
-
-		newExasolState, err := ReadExasolPersonalState(deployment)
-		if err != nil {
-			t.Fatalf("failed to read exasol personal state: %v", err)
-		}
-
-		workflowState, err := newExasolState.GetWorkflowState()
-
-		expectNoErr(t, err)
-		if _, ok := workflowState.(*WorkflowStateOperationInProgress); !ok {
-			t.Fatalf("expected OperationInProgress, got %T", workflowState)
-		}
+		assertWorkflowStateRoundtrip(t, &WorkflowStateOperationInProgress{})
 	})
 
 	t.Run("Running", func(t *testing.T) {
 		t.Parallel()
-		dir := t.TempDir()
-		deployment := NewDeploymentDir(dir)
-
-		exasolState := &ExasolPersonalState{}
-		//nolint:errcheck,gosec // error checked in subsequent read
-		exasolState.SetWorkflowStateAndWrite(
-			&WorkflowStateRunning{},
-			deployment,
-		)
-
-		newExasolState, err := ReadExasolPersonalState(deployment)
-		if err != nil {
-			t.Fatalf("failed to read exasol personal state: %v", err)
-		}
-
-		workflowState, err := newExasolState.GetWorkflowState()
-
-		expectNoErr(t, err)
-		if _, ok := workflowState.(*WorkflowStateRunning); !ok {
-			t.Fatalf("expected Running, got %T", workflowState)
-		}
+		assertWorkflowStateRoundtrip(t, &WorkflowStateRunning{})
 	})
 
 	t.Run("Stopped", func(t *testing.T) {
 		t.Parallel()
-		dir := t.TempDir()
-		deployment := NewDeploymentDir(dir)
-
-		exasolState := &ExasolPersonalState{}
-		//nolint:errcheck,gosec // error checked in subsequent read
-		exasolState.SetWorkflowStateAndWrite(&WorkflowStateStopped{}, NewDeploymentDir(dir))
-
-		newExasolState, err := ReadExasolPersonalState(deployment)
-		if err != nil {
-			t.Fatalf("failed to read exasol personal state: %v", err)
-		}
-
-		workflowState, err := newExasolState.GetWorkflowState()
-
-		expectNoErr(t, err)
-		if _, ok := workflowState.(*WorkflowStateStopped); !ok {
-			t.Fatalf("expected Stopped, got %T", workflowState)
-		}
+		assertWorkflowStateRoundtrip(t, &WorkflowStateStopped{})
 	})
 
 	t.Run("Interrupted", func(t *testing.T) {
 		t.Parallel()
-		dir := t.TempDir()
-		deployment := NewDeploymentDir(dir)
-
-		exasolState := &ExasolPersonalState{}
-		//nolint:errcheck,gosec // error checked in subsequent read
-		exasolState.SetWorkflowStateAndWrite(&WorkflowStateInterrupted{
+		assertWorkflowStateRoundtrip(t, &WorkflowStateInterrupted{
 			Error:                      "e",
 			InterruptedDuringOperation: StopOperation,
-		}, NewDeploymentDir(dir))
-
-		newExasolState, err := ReadExasolPersonalState(deployment)
-		if err != nil {
-			t.Fatalf("failed to read exasol personal state: %v", err)
-		}
-
-		workflowState, err := newExasolState.GetWorkflowState()
-
-		expectNoErr(t, err)
-		if _, ok := workflowState.(*WorkflowStateInterrupted); !ok {
-			t.Fatalf("expected Interrupted, got %T", workflowState)
-		}
+		})
 	})
 
 	t.Run("DeploymentFailed", func(t *testing.T) {
 		t.Parallel()
-		dir := t.TempDir()
-		deployment := NewDeploymentDir(dir)
-
-		exasolState := &ExasolPersonalState{}
-		//nolint:errcheck,gosec // error checked in subsequent read
-		exasolState.SetWorkflowStateAndWrite(&WorkflowStateDeploymentFailed{
+		assertWorkflowStateRoundtrip(t, &WorkflowStateDeploymentFailed{
 			Error: "f",
-		}, NewDeploymentDir(dir))
-
-		newExasolState, err := ReadExasolPersonalState(deployment)
-		if err != nil {
-			t.Fatalf("failed to read exasol personal state: %v", err)
-		}
-
-		workflowState, err := newExasolState.GetWorkflowState()
-
-		expectNoErr(t, err)
-		if _, ok := workflowState.(*WorkflowStateDeploymentFailed); !ok {
-			t.Fatalf("expected DeploymentFailed, got %T", workflowState)
-		}
+		})
 	})
 
 	t.Run("Missing file returns error", func(t *testing.T) {
@@ -218,9 +145,6 @@ func TestWorkflowState(t *testing.T) {
 		}
 
 		_, err = newExasolState.GetWorkflowState()
-		if err == nil {
-			t.Fatal("expected ErrNoWorkflowStateSet, got nil")
-		}
 		if !errors.Is(err, ErrNoWorkflowStateSet) {
 			t.Fatalf("expected ErrNoWorkflowStateSet, got: %v", err)
 		}

--- a/internal/connect/shell.go
+++ b/internal/connect/shell.go
@@ -135,56 +135,104 @@ func findStatementTerminator(sql string, from int) (terminator, bool) {
 	return findSemicolonTerminator(sql, from)
 }
 
+// quoteCommentState tracks which quoted-string or comment span the scanner is
+// currently inside, so ';' terminators found inside them are ignored.
+type quoteCommentState struct {
+	inSingleQuotes bool
+	inDoubleQuotes bool
+	inLineComment  bool
+	inBlockComment bool
+}
+
 func findSemicolonTerminator(sql string, from int) (terminator, bool) {
-	var inSingleQuotes, inDoubleQuotes, inLineComment, inBlockComment bool
+	var state quoteCommentState
 
 	for charIndex := from; charIndex < len(sql); charIndex++ {
 		switch {
-		case inLineComment:
-			if sql[charIndex] == '\n' {
-				inLineComment = false
-			}
-		case inBlockComment:
-			if sql[charIndex] == '*' && charIndex+1 < len(sql) && sql[charIndex+1] == '/' {
-				inBlockComment = false
-				charIndex++
-			}
-		case inSingleQuotes:
-			if sql[charIndex] == '\'' && charIndex+1 < len(sql) && sql[charIndex+1] == '\'' {
-				charIndex++
-			} else if sql[charIndex] == '\'' {
-				inSingleQuotes = false
-			}
-		case inDoubleQuotes:
-			if sql[charIndex] == '"' && charIndex+1 < len(sql) && sql[charIndex+1] == '"' {
-				charIndex++
-			} else if sql[charIndex] == '"' {
-				inDoubleQuotes = false
-			}
+		case state.inLineComment:
+			charIndex += consumeLineComment(&state, sql, charIndex)
+		case state.inBlockComment:
+			charIndex += consumeBlockComment(&state, sql, charIndex)
+		case state.inSingleQuotes:
+			charIndex += consumeSingleQuote(&state, sql, charIndex)
+		case state.inDoubleQuotes:
+			charIndex += consumeDoubleQuote(&state, sql, charIndex)
 		default:
-			switch sql[charIndex] {
-			case '\'':
-				inSingleQuotes = true
-			case '"':
-				inDoubleQuotes = true
-			case '-':
-				if charIndex+1 < len(sql) && sql[charIndex+1] == '-' {
-					inLineComment = true
-					charIndex++
-				}
-			case '/':
-				if charIndex+1 < len(sql) && sql[charIndex+1] == '*' {
-					inBlockComment = true
-					charIndex++
-				}
-			case ';':
-				return terminator{statementEnd: charIndex, nextStart: charIndex + 1}, true
-			default:
+			term, found, skip := consumeDefault(&state, sql, charIndex)
+			if found {
+				return term, true
 			}
+			charIndex += skip
 		}
 	}
 
 	return terminator{}, false
+}
+
+func consumeLineComment(state *quoteCommentState, sql string, charIndex int) int {
+	if sql[charIndex] == '\n' {
+		state.inLineComment = false
+	}
+
+	return 0
+}
+
+func consumeBlockComment(state *quoteCommentState, sql string, charIndex int) int {
+	if sql[charIndex] == '*' && charIndex+1 < len(sql) && sql[charIndex+1] == '/' {
+		state.inBlockComment = false
+
+		return 1
+	}
+
+	return 0
+}
+
+func consumeSingleQuote(state *quoteCommentState, sql string, charIndex int) int {
+	if sql[charIndex] == '\'' && charIndex+1 < len(sql) && sql[charIndex+1] == '\'' {
+		return 1
+	}
+	if sql[charIndex] == '\'' {
+		state.inSingleQuotes = false
+	}
+
+	return 0
+}
+
+func consumeDoubleQuote(state *quoteCommentState, sql string, charIndex int) int {
+	if sql[charIndex] == '"' && charIndex+1 < len(sql) && sql[charIndex+1] == '"' {
+		return 1
+	}
+	if sql[charIndex] == '"' {
+		state.inDoubleQuotes = false
+	}
+
+	return 0
+}
+
+func consumeDefault(state *quoteCommentState, sql string, charIndex int) (terminator, bool, int) {
+	switch sql[charIndex] {
+	case '\'':
+		state.inSingleQuotes = true
+	case '"':
+		state.inDoubleQuotes = true
+	case '-':
+		if charIndex+1 < len(sql) && sql[charIndex+1] == '-' {
+			state.inLineComment = true
+
+			return terminator{}, false, 1
+		}
+	case '/':
+		if charIndex+1 < len(sql) && sql[charIndex+1] == '*' {
+			state.inBlockComment = true
+
+			return terminator{}, false, 1
+		}
+	case ';':
+		return terminator{statementEnd: charIndex, nextStart: charIndex + 1}, true, 0
+	default:
+	}
+
+	return terminator{}, false, 0
 }
 
 // SCRIPT and FUNCTION bodies may contain ';', so they terminate on '/' instead.

--- a/internal/deploy/connection_instructions_test.go
+++ b/internal/deploy/connection_instructions_test.go
@@ -69,13 +69,14 @@ func initDeploymentForInfoTest(t *testing.T, deployment config.DeploymentDir) {
 
 	err := InitDeployment(
 		context.Background(),
-		PresetRef{Name: presets.DefaultInfrastructure},
-		PresetRef{Name: presets.DefaultInstallation},
-		map[string]string{},
-		map[string]string{},
 		deployment,
-		false,
-		"0.0.0",
+		InitOptions{
+			InfrastructurePreset: PresetRef{Name: presets.DefaultInfrastructure},
+			InstallationPreset:   PresetRef{Name: presets.DefaultInstallation},
+			InfraVars:            map[string]string{},
+			InstallVars:          map[string]string{},
+			CurrentVersion:       "0.0.0",
+		},
 	)
 	if err != nil {
 		t.Fatalf("failed to initialize deployment: %v", err)

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -120,7 +120,6 @@ func WorkflowStatePermitsDeploy(
 	return newBlockedStateError(deployment, ErrUnexpectedDeploymentStatus)
 }
 
-//
 //nolint:revive
 func deployFromManifests(
 	ctx context.Context,
@@ -130,126 +129,160 @@ func deployFromManifests(
 ) error {
 	return withDeploymentExclusiveLock(ctx, deployment,
 		func(deployment config.DeploymentDir) error {
-			exasolState, err := config.ReadExasolPersonalState(deployment)
-			if err != nil {
-				slog.Error("failed to read exasol personal state")
-				return err
-			}
-
-			if err := WorkflowStatePermitsDeploy(exasolState, deployment); err != nil {
-				return err
-			}
-
-			// Set the workflowstate to deployment in-progress
-			err = exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateOperationInProgress{
-				Operation: config.DeployOperation,
-			}, deployment)
-			if err != nil {
-				slog.Error("failed to set workflow state to in-progress", "error", err.Error())
-			}
-
-			// Register signal handler for catching interruptions and set state
-			// in case of interruption
-			unregister, _ := util.RegisterOnceSignalHandler(func() {
-				slog.Warn("Deployment interrupted")
-				err = exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateInterrupted{
-					Error:                      "Deployment interrupted via signal",
-					InterruptedDuringOperation: config.DeployOperation,
-				}, deployment)
-				if err != nil {
-					slog.Error("failed to set workflow state to in-progress", "error", err.Error())
-				}
-			})
-
-			// Fallback cleanup
-			defer unregister()
-
-			// Manifest-driven execution
-			infrastructureManifest, err := config.ReadInfrastructureManifest(deployment)
-			if err != nil {
-				return err
-			}
-			backend, err := newDeploymentBackend(deployment, infrastructureManifest)
-			if err != nil {
-				return err
-			}
-
-			installManifest, err := config.ReadInstallManifest(deployment)
-			if err != nil {
-				return err
-			}
-
-			var externalCommandOutput io.Writer
-			if verbose {
-				externalCommandOutput = os.Stderr
-			}
-
-			if err := backend.Deploy(
-				ctx,
-				externalCommandOutput,
-				externalCommandOutput,
-				options,
-			); err != nil {
-				unregister()
-
-				deployErr := appendDeployFailureHint(deployment, err)
-				if stateErr := exasolState.SetWorkflowStateAndWrite(
-					&config.WorkflowStateDeploymentFailed{
-						Error: deployErr.Error(),
-					},
-					deployment,
-				); stateErr != nil {
-					slog.Warn("failed to persist deployment failure state", "error", stateErr)
-				}
-
-				return deployErr
-			}
-
-			// Installation phase (remoteExec tasks)
-			if err := runInstallSteps(ctx, deployment, installManifest,
-				externalCommandOutput, externalCommandOutput); err != nil {
-				unregister()
-				deployErr := appendDeployFailureHint(deployment, err)
-				if stateErr := exasolState.SetWorkflowStateAndWrite(
-					&config.WorkflowStateDeploymentFailed{
-						Error: deployErr.Error(),
-					},
-					deployment,
-				); stateErr != nil {
-					slog.Warn("failed to persist deployment failure state", "error", stateErr)
-				}
-
-				return deployErr
-			}
-
-			// Stop handling interrupts before committing success state
-			unregister()
-
-			err = exasolState.SetWorkflowStateAndWrite(
-				&config.WorkflowStateRunning{},
-				deployment,
-			)
-			if err != nil {
-				slog.Error("failed to write workflow state")
-				return err
-			}
-
-			reconcileCustomSLCsAfterStart(ctx, deployment)
-
-			connectionInstructions, err := getConnectionInstructionsTextUnsafe(ctx, deployment)
-			if err != nil {
-				slog.Error("failed to collect connection instructions")
-				return err
-			}
-			if err := writeConnectionInstructionsFile(deployment, connectionInstructions); err != nil {
-				slog.Error("failed to write connection instructions")
-				return err
-			}
-
-			slog.Info("Completed deploying")
-
-			return nil
+			return deployLocked(ctx, deployment, verbose, options)
 		})
+}
+
+func deployLocked(
+	ctx context.Context,
+	deployment config.DeploymentDir,
+	verbose bool,
+	options DeployOptions,
+) error {
+	exasolState, err := config.ReadExasolPersonalState(deployment)
+	if err != nil {
+		slog.Error("failed to read exasol personal state")
+		return err
+	}
+
+	if err := WorkflowStatePermitsDeploy(exasolState, deployment); err != nil {
+		return err
+	}
+
+	// Set the workflowstate to deployment in-progress
+	if err := exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateOperationInProgress{
+		Operation: config.DeployOperation,
+	}, deployment); err != nil {
+		slog.Error("failed to set workflow state to in-progress", "error", err.Error())
+	}
+
+	return runDeployBackend(ctx, exasolState, deployment, verbose, options)
+}
+
+// runDeployBackend registers the interruption signal handler, runs the
+// manifest-driven deploy and installation phases, and commits the final
+// state. It is split out from deployLocked so the signal-handler lifetime
+// (registered right before the backend calls, unregistered right after)
+// stays scoped to a single, easy-to-audit block.
+//
+//nolint:revive // verbose mirrors the command-level --verbose flag.
+func runDeployBackend(
+	ctx context.Context,
+	exasolState *config.ExasolPersonalState,
+	deployment config.DeploymentDir,
+	verbose bool,
+	options DeployOptions,
+) error {
+	// Register signal handler for catching interruptions and set state
+	// in case of interruption
+	unregister, _ := util.RegisterOnceSignalHandler(func() {
+		slog.Warn("Deployment interrupted")
+		if err := exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateInterrupted{
+			Error:                      "Deployment interrupted via signal",
+			InterruptedDuringOperation: config.DeployOperation,
+		}, deployment); err != nil {
+			slog.Error("failed to set workflow state to in-progress", "error", err.Error())
+		}
+	})
+
+	// Fallback cleanup
+	defer unregister()
+
+	// Manifest-driven execution
+	infrastructureManifest, err := config.ReadInfrastructureManifest(deployment)
+	if err != nil {
+		return err
+	}
+	backend, err := newDeploymentBackend(deployment, infrastructureManifest)
+	if err != nil {
+		return err
+	}
+
+	installManifest, err := config.ReadInstallManifest(deployment)
+	if err != nil {
+		return err
+	}
+
+	var externalCommandOutput io.Writer
+	if verbose {
+		externalCommandOutput = os.Stderr
+	}
+
+	if err := backend.Deploy(
+		ctx,
+		externalCommandOutput,
+		externalCommandOutput,
+		options,
+	); err != nil {
+		unregister()
+
+		return recordDeployFailure(exasolState, deployment, err)
+	}
+
+	// Installation phase (remoteExec tasks)
+	if err := runInstallSteps(ctx, deployment, installManifest,
+		externalCommandOutput, externalCommandOutput); err != nil {
+		unregister()
+
+		return recordDeployFailure(exasolState, deployment, err)
+	}
+
+	// Stop handling interrupts before committing success state
+	unregister()
+
+	return finalizeSuccessfulDeploy(ctx, exasolState, deployment)
+}
+
+// recordDeployFailure appends diagnostic hints to err and persists the
+// deployment-failed workflow state before returning the enriched error.
+func recordDeployFailure(
+	exasolState *config.ExasolPersonalState,
+	deployment config.DeploymentDir,
+	err error,
+) error {
+	deployErr := appendDeployFailureHint(deployment, err)
+	if stateErr := exasolState.SetWorkflowStateAndWrite(
+		&config.WorkflowStateDeploymentFailed{
+			Error: deployErr.Error(),
+		},
+		deployment,
+	); stateErr != nil {
+		slog.Warn("failed to persist deployment failure state", "error", stateErr)
+	}
+
+	return deployErr
+}
+
+// finalizeSuccessfulDeploy commits the running workflow state and writes the
+// connection instructions after a successful deploy and installation phase.
+func finalizeSuccessfulDeploy(
+	ctx context.Context,
+	exasolState *config.ExasolPersonalState,
+	deployment config.DeploymentDir,
+) error {
+	if err := exasolState.SetWorkflowStateAndWrite(
+		&config.WorkflowStateRunning{},
+		deployment,
+	); err != nil {
+		slog.Error("failed to write workflow state")
+		return err
+	}
+
+	reconcileCustomSLCsAfterStart(ctx, deployment)
+
+	connectionInstructions, err := getConnectionInstructionsTextUnsafe(ctx, deployment)
+	if err != nil {
+		slog.Error("failed to collect connection instructions")
+		return err
+	}
+	if err := writeConnectionInstructionsFile(deployment, connectionInstructions); err != nil {
+		slog.Error("failed to write connection instructions")
+		return err
+	}
+
+	slog.Info("Completed deploying")
+
+	return nil
 }
 
 type nodeLookupImpl struct {

--- a/internal/deploy/deploymentControl.go
+++ b/internal/deploy/deploymentControl.go
@@ -168,7 +168,6 @@ func markOperationInterrupted(
 	return operationErr
 }
 
-//
 //nolint:revive
 func Start(
 	ctx context.Context,
@@ -178,101 +177,7 @@ func Start(
 ) error {
 	err := withDeploymentExclusiveLock(ctx, deployment,
 		func(deployment config.DeploymentDir) error {
-			exasolState, err := config.ReadExasolPersonalState(deployment)
-			if err != nil {
-				return err
-			}
-
-			if err := reconcileLocalVMState(ctx, exasolState, deployment); err != nil {
-				return err
-			}
-
-			decision, err := workflowStatePermitsStart(ctx, exasolState, deployment)
-			if err != nil {
-				return util.LoggedError(err, "run `status` for more information")
-			}
-			if !decision.shouldRun {
-				logLifecycleGuidance(decision.guidance)
-				if decision.showConnectionInstructions {
-					return nil
-				}
-
-				return ErrLifecycleActionSkipped
-			}
-
-			slog.Info("starting deployment. this may take a few minutes")
-
-			// Set the workflowstate to start operation in-progress
-			err = exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateOperationInProgress{
-				Operation: config.StartOperation,
-			}, deployment)
-			if err != nil {
-				slog.Error("failed to set workflow state to in-progress", "error", err.Error())
-			}
-
-			// Register signal handler for catching interruptions and set state
-			// in case of interruption
-			unregister, _ := util.RegisterOnceSignalHandler(func() {
-				slog.Warn("Start Operation interrupted")
-				_ = exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateInterrupted{
-					Error:                      "Start Operation interrupted via signal",
-					InterruptedDuringOperation: config.StartOperation,
-				}, deployment)
-			})
-
-			// Fallback cleanup
-			defer unregister()
-
-			manifest, err := config.ReadInfrastructureManifest(deployment)
-			if err != nil {
-				return err
-			}
-			backend, err := newDeploymentBackend(deployment, manifest)
-			if err != nil {
-				return err
-			}
-
-			var externalCommandOutput io.Writer
-			if verbose {
-				externalCommandOutput = os.Stderr
-			}
-
-			if err := backend.Start(
-				ctx,
-				externalCommandOutput,
-				externalCommandOutput,
-				waitTimeoutSeconds,
-			); err != nil {
-				unregister()
-
-				return markOperationInterrupted(exasolState, deployment, config.StartOperation, err)
-			}
-
-			// Stop handling interrupts before committing final running state
-			unregister()
-
-			err = exasolState.SetWorkflowStateAndWrite(
-				&config.WorkflowStateRunning{}, deployment,
-			)
-			if err != nil {
-				slog.Error("failed to set workflow state", "error", err.Error())
-			}
-
-			reconcileCustomSLCsAfterStart(ctx, deployment)
-
-			slog.Info("database is ready to accept connections")
-
-			slog.Warn(
-				"parameters such as instance IP, DNS name may have changed. " +
-					"Printing the connection instructions",
-			)
-
-			connectionInstructions, err := getConnectionInstructionsTextUnsafe(ctx, deployment)
-			if err != nil {
-				return err
-			}
-
-			return writeConnectionInstructionsFile(deployment, connectionInstructions)
+			return startLocked(ctx, deployment, verbose, waitTimeoutSeconds)
 		})
 	if errors.Is(err, ErrDeploymentDirectoryLocked) {
 		slog.Warn(err.Error())
@@ -280,6 +185,124 @@ func Start(
 	}
 
 	return err
+}
+
+func startLocked(
+	ctx context.Context,
+	deployment config.DeploymentDir,
+	verbose bool,
+	waitTimeoutSeconds int,
+) error {
+	exasolState, err := config.ReadExasolPersonalState(deployment)
+	if err != nil {
+		return err
+	}
+
+	if err := reconcileLocalVMState(ctx, exasolState, deployment); err != nil {
+		return err
+	}
+
+	decision, err := workflowStatePermitsStart(ctx, exasolState, deployment)
+	if err != nil {
+		return util.LoggedError(err, "run `status` for more information")
+	}
+	if !decision.shouldRun {
+		logLifecycleGuidance(decision.guidance)
+		if decision.showConnectionInstructions {
+			return nil
+		}
+
+		return ErrLifecycleActionSkipped
+	}
+
+	slog.Info("starting deployment. this may take a few minutes")
+
+	// Set the workflowstate to start operation in-progress
+	if err := exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateOperationInProgress{
+		Operation: config.StartOperation,
+	}, deployment); err != nil {
+		slog.Error("failed to set workflow state to in-progress", "error", err.Error())
+	}
+
+	return runStartBackend(ctx, exasolState, deployment, verbose, waitTimeoutSeconds)
+}
+
+// runStartBackend registers the interruption signal handler, invokes the
+// backend's start operation, and commits the final running state. It is
+// split out from startLocked so the signal-handler lifetime (registered
+// right before the backend call, unregistered right after) stays scoped
+// to a single, easy-to-audit block.
+//
+//nolint:revive // verbose mirrors the command-level --verbose flag.
+func runStartBackend(
+	ctx context.Context,
+	exasolState *config.ExasolPersonalState,
+	deployment config.DeploymentDir,
+	verbose bool,
+	waitTimeoutSeconds int,
+) error {
+	// Register signal handler for catching interruptions and set state
+	// in case of interruption
+	unregister, _ := util.RegisterOnceSignalHandler(func() {
+		slog.Warn("Start Operation interrupted")
+		_ = exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateInterrupted{
+			Error:                      "Start Operation interrupted via signal",
+			InterruptedDuringOperation: config.StartOperation,
+		}, deployment)
+	})
+
+	// Fallback cleanup
+	defer unregister()
+
+	manifest, err := config.ReadInfrastructureManifest(deployment)
+	if err != nil {
+		return err
+	}
+	backend, err := newDeploymentBackend(deployment, manifest)
+	if err != nil {
+		return err
+	}
+
+	var externalCommandOutput io.Writer
+	if verbose {
+		externalCommandOutput = os.Stderr
+	}
+
+	if err := backend.Start(
+		ctx,
+		externalCommandOutput,
+		externalCommandOutput,
+		waitTimeoutSeconds,
+	); err != nil {
+		unregister()
+
+		return markOperationInterrupted(exasolState, deployment, config.StartOperation, err)
+	}
+
+	// Stop handling interrupts before committing final running state
+	unregister()
+
+	if err := exasolState.SetWorkflowStateAndWrite(
+		&config.WorkflowStateRunning{}, deployment,
+	); err != nil {
+		slog.Error("failed to set workflow state", "error", err.Error())
+	}
+
+	reconcileCustomSLCsAfterStart(ctx, deployment)
+
+	slog.Info("database is ready to accept connections")
+
+	slog.Warn(
+		"parameters such as instance IP, DNS name may have changed. " +
+			"Printing the connection instructions",
+	)
+
+	connectionInstructions, err := getConnectionInstructionsTextUnsafe(ctx, deployment)
+	if err != nil {
+		return err
+	}
+
+	return writeConnectionInstructionsFile(deployment, connectionInstructions)
 }
 
 func workflowStatePermitsStop(

--- a/internal/deploy/destroy.go
+++ b/internal/deploy/destroy.go
@@ -18,80 +18,97 @@ import (
 func Destroy(ctx context.Context, deployment config.DeploymentDir, verbose bool) error {
 	if err := withDeploymentExclusiveLock(ctx, deployment,
 		func(deployment config.DeploymentDir) error {
-			slog.Info("Destroying deployment and releasing all resources")
-
-			exasolState, err := config.ReadExasolPersonalState(deployment)
-			if err != nil {
-				return err
-			}
-
-			// Set the workflowstate to destroy in-progress
-			err = exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateOperationInProgress{
-				Operation: config.DestroyOperation,
-			}, deployment)
-			if err != nil {
-				slog.Error("failed to set workflow state to in-progress", "error", err.Error())
-			}
-
-			// Register signal handler for catching interruptions and set state
-			// in case of interruption
-			unregister, _ := util.RegisterOnceSignalHandler(func() {
-				slog.Warn("Destroy interrupted")
-				_ = exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateInterrupted{
-					Error:                      "Destroy interrupted via signal",
-					InterruptedDuringOperation: config.DestroyOperation,
-				}, deployment)
-			})
-
-			defer unregister()
-
-			manifest, err := config.ReadInfrastructureManifest(deployment)
-			if err != nil {
-				return markDestroyInterrupted(exasolState, deployment, err)
-			}
-			backend, err := newDeploymentBackend(deployment, manifest)
-			if err != nil {
-				return markDestroyInterrupted(exasolState, deployment, err)
-			}
-
-			var externalCommandStandardOut io.Writer
-			if verbose {
-				externalCommandStandardOut = os.Stderr
-			}
-
-			if err := backend.Destroy(
-				ctx,
-				externalCommandStandardOut,
-				externalCommandStandardOut,
-			); err != nil {
-				unregister()
-
-				return markDestroyInterrupted(exasolState, deployment, err)
-			}
-
-			// Stop handling interrupts before committing final initialized state
-			unregister()
-
-			// Returning to the initialized state is required so that `deploy` can be run again.
-			err = exasolState.SetWorkflowStateAndWrite(
-				&config.WorkflowStateInitialized{},
-				deployment,
-			)
-			if err != nil {
-				return err
-			}
-
-			err = os.Remove(deployment.ConnectionInstructionsPath())
-			if err != nil {
-				slog.Debug(fmt.Sprintf("failed to remove connection instructions file: %v", err))
-			}
-
-			slog.Info("Successfully destroyed deployment and released all resources")
-
-			return nil
+			return destroyLocked(ctx, deployment, verbose)
 		}); err != nil {
 		return err
 	}
+
+	return nil
+}
+
+func destroyLocked(ctx context.Context, deployment config.DeploymentDir, verbose bool) error {
+	slog.Info("Destroying deployment and releasing all resources")
+
+	exasolState, err := config.ReadExasolPersonalState(deployment)
+	if err != nil {
+		return err
+	}
+
+	// Set the workflowstate to destroy in-progress
+	if err := exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateOperationInProgress{
+		Operation: config.DestroyOperation,
+	}, deployment); err != nil {
+		slog.Error("failed to set workflow state to in-progress", "error", err.Error())
+	}
+
+	return runDestroyBackend(ctx, exasolState, deployment, verbose)
+}
+
+// runDestroyBackend registers the interruption signal handler, invokes the
+// backend's destroy operation, and commits the final initialized state. It is
+// split out from destroyLocked so the signal-handler lifetime (registered
+// right before the backend call, unregistered right after) stays scoped
+// to a single, easy-to-audit block.
+//
+//nolint:revive // verbose mirrors the command-level --verbose flag.
+func runDestroyBackend(
+	ctx context.Context,
+	exasolState *config.ExasolPersonalState,
+	deployment config.DeploymentDir,
+	verbose bool,
+) error {
+	// Register signal handler for catching interruptions and set state
+	// in case of interruption
+	unregister, _ := util.RegisterOnceSignalHandler(func() {
+		slog.Warn("Destroy interrupted")
+		_ = exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateInterrupted{
+			Error:                      "Destroy interrupted via signal",
+			InterruptedDuringOperation: config.DestroyOperation,
+		}, deployment)
+	})
+
+	defer unregister()
+
+	manifest, err := config.ReadInfrastructureManifest(deployment)
+	if err != nil {
+		return markDestroyInterrupted(exasolState, deployment, err)
+	}
+	backend, err := newDeploymentBackend(deployment, manifest)
+	if err != nil {
+		return markDestroyInterrupted(exasolState, deployment, err)
+	}
+
+	var externalCommandStandardOut io.Writer
+	if verbose {
+		externalCommandStandardOut = os.Stderr
+	}
+
+	if err := backend.Destroy(
+		ctx,
+		externalCommandStandardOut,
+		externalCommandStandardOut,
+	); err != nil {
+		unregister()
+
+		return markDestroyInterrupted(exasolState, deployment, err)
+	}
+
+	// Stop handling interrupts before committing final initialized state
+	unregister()
+
+	// Returning to the initialized state is required so that `deploy` can be run again.
+	if err := exasolState.SetWorkflowStateAndWrite(
+		&config.WorkflowStateInitialized{},
+		deployment,
+	); err != nil {
+		return err
+	}
+
+	if err := os.Remove(deployment.ConnectionInstructionsPath()); err != nil {
+		slog.Debug(fmt.Sprintf("failed to remove connection instructions file: %v", err))
+	}
+
+	slog.Info("Successfully destroyed deployment and released all resources")
 
 	return nil
 }

--- a/internal/deploy/init.go
+++ b/internal/deploy/init.go
@@ -66,35 +66,65 @@ var (
 	)
 )
 
+// InitOptions bundles the preset selection, variable overrides, and version-check
+// metadata needed to initialize a deployment directory.
+type InitOptions struct {
+	InfrastructurePreset PresetRef
+	InstallationPreset   PresetRef
+	InfraVars            map[string]string
+	InstallVars          map[string]string
+	VersionCheckEnabled  bool
+	CurrentVersion       string
+}
+
 // InitDeployment initializes a new deployment directory by extracting presets and
 // creating the variables file based on the infrastructure manifest.
-//
-//nolint:revive // versionCheckEnabled is a user-controlled flag, not internal control coupling
 func InitDeployment(
 	ctx context.Context,
-	infrastructurePreset PresetRef,
-	installationPreset PresetRef,
-	infraVars map[string]string,
-	installVars map[string]string,
 	deployment config.DeploymentDir,
-	versionCheckEnabled bool,
-	currentVersion string,
+	options InitOptions,
 ) error {
 	// Do an initial update version check if permitted
-	if versionCheckEnabled {
-		_, _, _ = CheckLatestVersionUpdate(ctx, currentVersion, deployment)
+	if options.VersionCheckEnabled {
+		_, _, _ = CheckLatestVersionUpdate(ctx, options.CurrentVersion, deployment)
 	}
 
-	// Proactively validate the preset selection to produce friendly errors.
-	slog.Info("validating presets")
-	if err := ValidatePresetSelection(infrastructurePreset, installationPreset); err != nil {
+	if err := validateInitRequest(ctx, deployment, options); err != nil {
 		return err
 	}
-	infrastructureManifest, err := readInfrastructureManifestFromPreset(infrastructurePreset)
+
+	if err := ensureDeploymentDirReady(deployment); err != nil {
+		return err
+	}
+
+	// Lock the deployment directory with exclusive access
+	return withDeploymentExclusiveLock(ctx, deployment,
+		func(deployment config.DeploymentDir) error {
+			return initializeDeploymentLocked(ctx, deployment, options)
+		})
+}
+
+// validateInitRequest proactively validates the preset selection and target
+// environment to produce friendly errors before any state is mutated.
+func validateInitRequest(
+	ctx context.Context,
+	deployment config.DeploymentDir,
+	options InitOptions,
+) error {
+	slog.Info("validating presets")
+	if err := ValidatePresetSelection(
+		options.InfrastructurePreset,
+		options.InstallationPreset,
+	); err != nil {
+		return err
+	}
+	infrastructureManifest, err := readInfrastructureManifestFromPreset(
+		options.InfrastructurePreset,
+	)
 	if err != nil {
 		return fmt.Errorf(
 			"failed to load infrastructure preset %q: %w",
-			presetLabel(infrastructurePreset),
+			presetLabel(options.InfrastructurePreset),
 			err,
 		)
 	}
@@ -105,12 +135,16 @@ func InitDeployment(
 	if err := backend.ValidateEnvironment(); err != nil {
 		return err
 	}
-	if err := validateLocalInitMemory(ctx, infrastructureManifest, infraVars); err != nil {
-		return err
-	}
 
-	// Init only creates fresh deployment state. Existing deployment orchestration
-	// belongs to the command layer.
+	return validateLocalInitMemory(ctx, infrastructureManifest, options.InfraVars)
+}
+
+// ensureDeploymentDirReady makes sure the deployment directory has no prior
+// exasol-personal state and exists as an empty directory.
+//
+// Init only creates fresh deployment state. Existing deployment orchestration
+// belongs to the command layer.
+func ensureDeploymentDirReady(deployment config.DeploymentDir) error {
 	initialized, err := config.HasExasolPersonalStateFile(deployment)
 	if err != nil {
 		slog.Error("failed to check deployment directory initialization")
@@ -120,85 +154,86 @@ func InitDeployment(
 		return ErrDeploymentDirectoryNotEmpty
 	}
 
-	// Make sure the directory exists and is empty
-	if err = util.EnsureDir(deployment.Root()); err != nil {
+	if err := util.EnsureDir(deployment.Root()); err != nil {
 		return err
 	}
 
-	if err = ensureDirectoryIsEmpty(deployment); err != nil {
+	return ensureDirectoryIsEmpty(deployment)
+}
+
+func initializeDeploymentLocked(
+	ctx context.Context,
+	deployment config.DeploymentDir,
+	options InitOptions,
+) error {
+	deploymentId, err := GenerateDeploymentId()
+	if err != nil {
+		return fmt.Errorf("failed to generate deployment id: %w", err)
+	}
+	clusterIdentity := ComputeClusterIdentity(
+		deploymentId,
+		options.InfrastructurePreset,
+		options.InstallationPreset,
+	)
+
+	// Copy the presets into the deployment directory
+	if err := extractPresets(
+		options.InfrastructurePreset,
+		options.InstallationPreset,
+		deployment,
+	); err != nil {
 		return err
 	}
 
-	// Lock the deployment directory with exclusive access
-	return withDeploymentExclusiveLock(ctx, deployment,
-		func(deployment config.DeploymentDir) error {
-			deploymentId, err := GenerateDeploymentId()
-			if err != nil {
-				return fmt.Errorf("failed to generate deployment id: %w", err)
-			}
-			clusterIdentity := ComputeClusterIdentity(
-				deploymentId,
-				infrastructurePreset,
-				installationPreset,
-			)
+	slog.Debug("Initializing deployment state")
+	exasolState := newInitializedState(
+		options.VersionCheckEnabled,
+		options.CurrentVersion,
+		deploymentId,
+		clusterIdentity,
+		time.Now().UTC(),
+		options.InfrastructurePreset,
+		options.InstallationPreset,
+	)
+	infraManifest, _, err := readExtractedManifests(deployment)
+	if err != nil {
+		return err
+	}
+	backend, err := newDeploymentBackend(deployment, infraManifest)
+	if err != nil {
+		return err
+	}
+	if err := backend.SetupWorkspace(ctx); err != nil {
+		return err
+	}
+	if err := writeDeploymentConfiguration(
+		ctx,
+		deployment,
+		exasolState,
+		newDeploymentConfigurationFromRaw(options.InfraVars, options.InstallVars),
+	); err != nil {
+		return err
+	}
 
-			// Copy the presets into the deployment directory
-			err = extractPresets(infrastructurePreset, installationPreset, deployment)
-			if err != nil {
-				return err
-			}
+	if err := exasolState.SetWorkflowStateAndWrite(
+		&config.WorkflowStateInitialized{},
+		deployment,
+	); err != nil {
+		return err
+	}
+	if err := config.WriteDeploymentVersionMarker(deployment, options.CurrentVersion); err != nil {
+		return err
+	}
 
-			slog.Debug("Initializing deployment state")
-			exasolState := newInitializedState(
-				versionCheckEnabled,
-				currentVersion,
-				deploymentId,
-				clusterIdentity,
-				time.Now().UTC(),
-				infrastructurePreset,
-				installationPreset,
-			)
-			infraManifest, _, err := readExtractedManifests(deployment)
-			if err != nil {
-				return err
-			}
-			backend, err := newDeploymentBackend(deployment, infraManifest)
-			if err != nil {
-				return err
-			}
-			if err := backend.SetupWorkspace(ctx); err != nil {
-				return err
-			}
-			if err := writeDeploymentConfiguration(
-				ctx,
-				deployment,
-				exasolState,
-				newDeploymentConfigurationFromRaw(infraVars, installVars),
-			); err != nil {
-				return err
-			}
+	slog.Info(
+		"successfully initialized deployment",
+		"infrastructure",
+		presetLabel(options.InfrastructurePreset),
+		"installation",
+		presetLabel(options.InstallationPreset),
+	)
 
-			err = exasolState.SetWorkflowStateAndWrite(
-				&config.WorkflowStateInitialized{},
-				deployment,
-			)
-			if err != nil {
-				return err
-			}
-			if err := config.WriteDeploymentVersionMarker(deployment, currentVersion); err != nil {
-				return err
-			}
-
-			slog.Info(
-				"successfully initialized deployment",
-				"infrastructure",
-				presetLabel(infrastructurePreset),
-				"installation",
-				presetLabel(installationPreset),
-			)
-
-			return nil
-		})
+	return nil
 }
 
 // extractPresets writes infrastructure, installation,

--- a/internal/deploy/init_test.go
+++ b/internal/deploy/init_test.go
@@ -27,27 +27,41 @@ func TestInitDeployment_CreatesTfVarsWhenTofuConfigured(t *testing.T) {
 	// When the deployment is intialized
 	err := InitDeployment(
 		context.Background(),
-		PresetRef{Name: presets.DefaultInfrastructure},
-		PresetRef{Name: presets.DefaultInstallation},
-		map[string]string{"cluster_size": "2"},
-		map[string]string{},
 		deployment,
-		false,
-		"0.0.0",
+		InitOptions{
+			InfrastructurePreset: PresetRef{Name: presets.DefaultInfrastructure},
+			InstallationPreset:   PresetRef{Name: presets.DefaultInstallation},
+			InfraVars:            map[string]string{"cluster_size": "2"},
+			InstallVars:          map[string]string{},
+			CurrentVersion:       "0.0.0",
+		},
 	)
 	if err != nil {
 		t.Fatalf("InitDeployment failed: %v", err)
 	}
 
-	// Then: workflow state exists and is readable
+	assertInitializedDeploymentState(t, deployment, "0.0.0")
+	assertTfVarsFile(t, deployment)
+	assertInstallationVariablesFile(t, deployment)
+}
+
+// assertInitializedDeploymentState asserts that the persisted workflow state,
+// preset identities, and version marker reflect a freshly initialized deployment.
+func assertInitializedDeploymentState(
+	t *testing.T,
+	deployment config.DeploymentDir,
+	wantVersion string,
+) {
+	t.Helper()
+
 	state, err := config.ReadExasolPersonalState(deployment)
 	if err != nil {
 		t.Fatalf("expected workflow state to be readable, got error: %v", err)
 	}
-	if state.DeploymentVersion != "0.0.0" {
+	if state.DeploymentVersion != wantVersion {
 		t.Fatalf(
 			"expected deployment version to be persisted as %q, got %q",
-			"0.0.0",
+			wantVersion,
 			state.DeploymentVersion,
 		)
 	}
@@ -74,8 +88,8 @@ func TestInitDeployment_CreatesTfVarsWhenTofuConfigured(t *testing.T) {
 	} else if !ok {
 		t.Fatalf("expected deployment version marker %q to exist",
 			config.DeploymentVersionMarkerFileName)
-	} else if ver != "0.0.0" {
-		t.Fatalf("expected deployment version marker to be %q, got %q", "0.0.0", ver)
+	} else if ver != wantVersion {
+		t.Fatalf("expected deployment version marker to be %q, got %q", wantVersion, ver)
 	}
 	workflowState, err := state.GetWorkflowState()
 	if err != nil {
@@ -84,8 +98,13 @@ func TestInitDeployment_CreatesTfVarsWhenTofuConfigured(t *testing.T) {
 	if _, ok := workflowState.(*config.WorkflowStateInitialized); !ok {
 		t.Fatalf("expected Initialized workflow state, got %T", workflowState)
 	}
+}
 
-	// Then: tfvars file exists at default path (per manifest)
+// assertTfVarsFile asserts that the tfvars file exists at the manifest-defined
+// default path and contains the expected cluster and preset directory values.
+func assertTfVarsFile(t *testing.T, deployment config.DeploymentDir) {
+	t.Helper()
+
 	tfvarsPath := filepath.Join(deployment.InfrastructureDir(), tofu.DefaultVarsOutput)
 	data, err := os.ReadFile(tfvarsPath)
 	if err != nil {
@@ -133,8 +152,13 @@ func TestInitDeployment_CreatesTfVarsWhenTofuConfigured(t *testing.T) {
 	if filepath.IsAbs(installDir) {
 		t.Fatalf("expected installation_preset_dir to stay relative, got %q", installDir)
 	}
+}
 
-	// Then: installation variables file exists at the manifest-defined path.
+// assertInstallationVariablesFile asserts that the installation variables file
+// exists at the manifest-defined path and carries the launcher-governed keys.
+func assertInstallationVariablesFile(t *testing.T, deployment config.DeploymentDir) {
+	t.Helper()
+
 	const installationVarsRelPath = "files/etc/exasol_launcher/installation.json"
 
 	installVarsPath := filepath.Join(
@@ -171,13 +195,14 @@ func TestInitDeployment_CreatesDeploymentDir(t *testing.T) {
 	// When
 	err := InitDeployment(
 		context.Background(),
-		PresetRef{Name: presets.DefaultInfrastructure},
-		PresetRef{Name: presets.DefaultInstallation},
-		map[string]string{},
-		map[string]string{},
 		deployment,
-		false,
-		"",
+		InitOptions{
+			InfrastructurePreset: PresetRef{Name: presets.DefaultInfrastructure},
+			InstallationPreset:   PresetRef{Name: presets.DefaultInstallation},
+			InfraVars:            map[string]string{},
+			InstallVars:          map[string]string{},
+			CurrentVersion:       "",
+		},
 	)
 	// Then
 	if err != nil {
@@ -230,13 +255,14 @@ func TestInitDeployment_ErrWhenDirNotEmpty(t *testing.T) {
 	// When
 	err := InitDeployment(
 		context.Background(),
-		PresetRef{Name: presets.DefaultInfrastructure},
-		PresetRef{Name: presets.DefaultInstallation},
-		map[string]string{},
-		map[string]string{},
 		deployment,
-		false,
-		"",
+		InitOptions{
+			InfrastructurePreset: PresetRef{Name: presets.DefaultInfrastructure},
+			InstallationPreset:   PresetRef{Name: presets.DefaultInstallation},
+			InfraVars:            map[string]string{},
+			InstallVars:          map[string]string{},
+			CurrentVersion:       "",
+		},
 	)
 
 	// Then

--- a/internal/deploy/installation_variables.go
+++ b/internal/deploy/installation_variables.go
@@ -35,15 +35,9 @@ func writeInstallationVariablesFile(
 		return nil
 	}
 
-	// Resolve and validate output path (must stay within installDir).
-	outPath := filepath.Join(installDir, filepath.Clean(outputRel))
-	installDirClean := filepath.Clean(installDir)
-	if !strings.HasPrefix(outPath, installDirClean+string(os.PathSeparator)) &&
-		outPath != installDirClean {
-		return fmt.Errorf(
-			"installation variables outputFile escapes installation directory: %q",
-			outputRel,
-		)
+	outPath, err := resolveInstallationVariablesOutputPath(installDir, outputRel)
+	if err != nil {
+		return err
 	}
 
 	resolved := map[string]any{}
@@ -53,7 +47,35 @@ func writeInstallationVariablesFile(
 	// Host-side scheduled checks reuse the same endpoint selection as launcher checks.
 	resolved["version_check_url"] = versionCheckURL
 
-	// Apply defaults from manifest.
+	if err := applyInstallationVariableDefaults(resolved, spec); err != nil {
+		return err
+	}
+	if err := applyInstallationVariableOverrides(resolved, spec, overrides); err != nil {
+		return err
+	}
+
+	return writeResolvedInstallationVariables(outPath, resolved)
+}
+
+// resolveInstallationVariablesOutputPath resolves the manifest-declared output path
+// and validates it stays within installDir.
+func resolveInstallationVariablesOutputPath(installDir, outputRel string) (string, error) {
+	outPath := filepath.Join(installDir, filepath.Clean(outputRel))
+	installDirClean := filepath.Clean(installDir)
+	if !strings.HasPrefix(outPath, installDirClean+string(os.PathSeparator)) &&
+		outPath != installDirClean {
+		return "", fmt.Errorf(
+			"installation variables outputFile escapes installation directory: %q",
+			outputRel,
+		)
+	}
+
+	return outPath, nil
+}
+
+// applyInstallationVariableDefaults fills resolved with the manifest-declared defaults,
+// skipping launcher-governed keys that must not be overridden by presets.
+func applyInstallationVariableDefaults(resolved map[string]any, spec *presets.Variables) error {
 	for name, def := range spec.Vars {
 		name = strings.TrimSpace(name)
 		if name == "" || def == nil {
@@ -70,7 +92,16 @@ func writeInstallationVariablesFile(
 		resolved[name] = value
 	}
 
-	// Apply CLI overrides.
+	return nil
+}
+
+// applyInstallationVariableOverrides layers CLI-provided overrides on top of resolved,
+// skipping launcher-governed and unknown variable names.
+func applyInstallationVariableOverrides(
+	resolved map[string]any,
+	spec *presets.Variables,
+	overrides map[string]string,
+) error {
 	for name, raw := range overrides {
 		name = strings.TrimSpace(name)
 		if name == "" {
@@ -96,6 +127,10 @@ func writeInstallationVariablesFile(
 		resolved[name] = val
 	}
 
+	return nil
+}
+
+func writeResolvedInstallationVariables(outPath string, resolved map[string]any) error {
 	if err := os.MkdirAll(filepath.Dir(outPath), installVariablesFolderPermissions); err != nil {
 		return fmt.Errorf("failed to create installation variables output directory: %w", err)
 	}

--- a/internal/deploy/preset_identity_test.go
+++ b/internal/deploy/preset_identity_test.go
@@ -83,13 +83,14 @@ func initializedDeploymentOrFail(t *testing.T) config.DeploymentDir {
 	deployment := config.NewDeploymentDir(t.TempDir())
 	if err := InitDeployment(
 		context.Background(),
-		PresetRef{Name: presets.DefaultInfrastructure},
-		PresetRef{Name: presets.DefaultInstallation},
-		map[string]string{},
-		map[string]string{},
 		deployment,
-		false,
-		"0.0.0",
+		InitOptions{
+			InfrastructurePreset: PresetRef{Name: presets.DefaultInfrastructure},
+			InstallationPreset:   PresetRef{Name: presets.DefaultInstallation},
+			InfraVars:            map[string]string{},
+			InstallVars:          map[string]string{},
+			CurrentVersion:       "0.0.0",
+		},
 	); err != nil {
 		t.Fatalf("init failed: %v", err)
 	}

--- a/internal/deploy/preset_validation_test.go
+++ b/internal/deploy/preset_validation_test.go
@@ -58,13 +58,14 @@ install: []
 	// When
 	err := InitDeployment(
 		context.Background(),
-		PresetRef{Path: infrastructureDir},
-		PresetRef{Path: installationDir},
-		map[string]string{},
-		map[string]string{},
 		config.NewDeploymentDir(deploymentDir),
-		false,
-		"0.0.0",
+		InitOptions{
+			InfrastructurePreset: PresetRef{Path: infrastructureDir},
+			InstallationPreset:   PresetRef{Path: installationDir},
+			InfraVars:            map[string]string{},
+			InstallVars:          map[string]string{},
+			CurrentVersion:       "0.0.0",
+		},
 	)
 
 	// Then
@@ -99,13 +100,14 @@ func TestInitDeployment_RejectsUnsupportedLocalPlatformBeforeMutation(t *testing
 	// When
 	err := InitDeployment(
 		context.Background(),
-		PresetRef{Name: "local"},
-		PresetRef{Name: "local"},
-		map[string]string{},
-		map[string]string{},
 		config.NewDeploymentDir(deploymentDir),
-		false,
-		"0.0.0",
+		InitOptions{
+			InfrastructurePreset: PresetRef{Name: "local"},
+			InstallationPreset:   PresetRef{Name: "local"},
+			InfraVars:            map[string]string{},
+			InstallVars:          map[string]string{},
+			CurrentVersion:       "0.0.0",
+		},
 	)
 
 	// Then

--- a/internal/deploy/reconfiguration_test.go
+++ b/internal/deploy/reconfiguration_test.go
@@ -27,13 +27,14 @@ func TestEnsureDeploymentPresetIdentityMatches_RejectsDifferentPreset(t *testing
 	deployment := config.NewDeploymentDir(t.TempDir())
 	if err := InitDeployment(
 		context.Background(),
-		PresetRef{Name: presets.DefaultInfrastructure},
-		PresetRef{Name: presets.DefaultInstallation},
-		map[string]string{},
-		map[string]string{},
 		deployment,
-		false,
-		"0.0.0",
+		InitOptions{
+			InfrastructurePreset: PresetRef{Name: presets.DefaultInfrastructure},
+			InstallationPreset:   PresetRef{Name: presets.DefaultInstallation},
+			InfraVars:            map[string]string{},
+			InstallVars:          map[string]string{},
+			CurrentVersion:       "0.0.0",
+		},
 	); err != nil {
 		t.Fatalf("initial init failed: %v", err)
 	}
@@ -58,13 +59,14 @@ func TestSetDeploymentConfiguration_UpdatesVariablesAndPreservesStateFiles(t *te
 	deployment := config.NewDeploymentDir(t.TempDir())
 	if err := InitDeployment(
 		context.Background(),
-		PresetRef{Name: presets.DefaultInfrastructure},
-		PresetRef{Name: presets.DefaultInstallation},
-		map[string]string{"cluster_size": "2"},
-		map[string]string{},
 		deployment,
-		false,
-		"0.0.0",
+		InitOptions{
+			InfrastructurePreset: PresetRef{Name: presets.DefaultInfrastructure},
+			InstallationPreset:   PresetRef{Name: presets.DefaultInstallation},
+			InfraVars:            map[string]string{"cluster_size": "2"},
+			InstallVars:          map[string]string{},
+			CurrentVersion:       "0.0.0",
+		},
 	); err != nil {
 		t.Fatalf("init failed: %v", err)
 	}
@@ -119,13 +121,14 @@ func TestSetDeploymentConfiguration_PreservesDeploymentCreatedAt(t *testing.T) {
 	deployment := config.NewDeploymentDir(t.TempDir())
 	if err := InitDeployment(
 		context.Background(),
-		PresetRef{Name: presets.DefaultInfrastructure},
-		PresetRef{Name: presets.DefaultInstallation},
-		map[string]string{"cluster_size": "2"},
-		map[string]string{},
 		deployment,
-		false,
-		"0.0.0",
+		InitOptions{
+			InfrastructurePreset: PresetRef{Name: presets.DefaultInfrastructure},
+			InstallationPreset:   PresetRef{Name: presets.DefaultInstallation},
+			InfraVars:            map[string]string{"cluster_size": "2"},
+			InstallVars:          map[string]string{},
+			CurrentVersion:       "0.0.0",
+		},
 	); err != nil {
 		t.Fatalf("init failed: %v", err)
 	}

--- a/internal/directorymutex/directorymutex.go
+++ b/internal/directorymutex/directorymutex.go
@@ -273,49 +273,54 @@ func (m *DirectoryMutex) tryRelease(mode lockMode) (bool, error) {
 
 	switch mode {
 	case modeExclusive:
-		if marker.mode != modeExclusive {
-			return false, ErrLockStateChanged
-		}
-		if err := os.Remove(marker.path); err != nil {
-			if os.IsNotExist(err) {
-				return false, errWouldBlock
-			}
-
-			return false, err
-		}
-
-		return true, nil
+		return m.tryReleaseExclusive(marker)
 	case modeShared:
-		if marker.mode != modeShared {
-			return false, ErrLockStateChanged
-		}
-
-		if marker.count == 1 {
-			if err := os.Remove(marker.path); err != nil {
-				if os.IsNotExist(err) {
-					return false, errWouldBlock
-				}
-
-				return false, err
-			}
-
-			return true, nil
-		}
-
-		nextName := sharedMarkerName(marker.count - 1)
-		nextPath := filepath.Join(m.path, nextName)
-		if err := os.Rename(marker.path, nextPath); err != nil {
-			if os.IsNotExist(err) || os.IsExist(err) {
-				return false, errWouldBlock
-			}
-
-			return false, err
-		}
-
-		return true, nil
+		return m.tryReleaseShared(marker)
 	default:
 		return false, fmt.Errorf("unsupported lock mode: %d", mode)
 	}
+}
+
+func (*DirectoryMutex) tryReleaseExclusive(marker *markerInfo) (bool, error) {
+	if marker.mode != modeExclusive {
+		return false, ErrLockStateChanged
+	}
+
+	return removeMarkerFile(marker.path)
+}
+
+func (m *DirectoryMutex) tryReleaseShared(marker *markerInfo) (bool, error) {
+	if marker.mode != modeShared {
+		return false, ErrLockStateChanged
+	}
+
+	if marker.count == 1 {
+		return removeMarkerFile(marker.path)
+	}
+
+	nextName := sharedMarkerName(marker.count - 1)
+	nextPath := filepath.Join(m.path, nextName)
+	if err := os.Rename(marker.path, nextPath); err != nil {
+		if os.IsNotExist(err) || os.IsExist(err) {
+			return false, errWouldBlock
+		}
+
+		return false, err
+	}
+
+	return true, nil
+}
+
+func removeMarkerFile(path string) (bool, error) {
+	if err := os.Remove(path); err != nil {
+		if os.IsNotExist(err) {
+			return false, errWouldBlock
+		}
+
+		return false, err
+	}
+
+	return true, nil
 }
 
 func (m *DirectoryMutex) createMarker(name string) (bool, error) {

--- a/internal/directorymutex/directorymutex_test.go
+++ b/internal/directorymutex/directorymutex_test.go
@@ -300,20 +300,7 @@ func TestSharedLockStressLeavesUnlocked(t *testing.T) {
 		go func() {
 			defer waitGroup.Done()
 			<-start
-
-			for range iterations {
-				ctx, cancel := context.WithTimeout(context.Background(), acquireTimeout)
-				err := mutex.AcquireShared(ctx)
-				cancel()
-				if err != nil {
-					errCh <- err
-					return
-				}
-				if err := mutex.ReleaseShared(context.Background()); err != nil {
-					errCh <- err
-					return
-				}
-			}
+			acquireReleaseSharedRepeatedly(mutex, iterations, acquireTimeout, errCh)
 		}()
 	}
 	close(start)
@@ -333,6 +320,27 @@ func TestSharedLockStressLeavesUnlocked(t *testing.T) {
 	}
 	if status.Locked {
 		t.Fatalf("expected unlocked status, got %+v", status)
+	}
+}
+
+func acquireReleaseSharedRepeatedly(
+	mutex *DirectoryMutex,
+	iterations int,
+	acquireTimeout time.Duration,
+	errCh chan<- error,
+) {
+	for range iterations {
+		ctx, cancel := context.WithTimeout(context.Background(), acquireTimeout)
+		err := mutex.AcquireShared(ctx)
+		cancel()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		if err := mutex.ReleaseShared(context.Background()); err != nil {
+			errCh <- err
+			return
+		}
 	}
 }
 

--- a/internal/runtimeartifacts/git_source.go
+++ b/internal/runtimeartifacts/git_source.go
@@ -177,42 +177,63 @@ func getRefName(
 	}
 
 	if ref == "" {
-		// Resolve remote HEAD to the actual default branch so the clone
-		// produces a proper branch checkout with remote-tracking refs.
-		for _, r := range remoteRefs {
-			if r.Name() == plumbing.HEAD && r.Type() == plumbing.SymbolicReference {
-				target := r.Target()
-				for _, br := range remoteRefs {
-					if br.Name() == target {
-						return target, br.Hash(), nil
-					}
-				}
-
-				return "", plumbing.ZeroHash, fmt.Errorf(
-					"remote HEAD points to %q which does not exist in %s",
-					target,
-					repoURL,
-				)
-			}
-		}
-
-		return "", plumbing.ZeroHash, fmt.Errorf("no HEAD reference found for %s", repoURL)
+		return resolveHeadRef(remoteRefs, repoURL)
 	}
 
 	if isFullCommitSHA(ref) {
-		targetHash := plumbing.NewHash(ref)
-		for _, r := range remoteRefs {
-			if r.Type() == plumbing.SymbolicReference {
-				continue
-			}
-			if r.Hash() == targetHash {
-				return r.Name(), targetHash, nil
-			}
-		}
-		// No named ref points to this SHA; full-depth clone required.
-		return "", targetHash, nil
+		return resolveCommitSHARef(remoteRefs, ref)
 	}
 
+	return resolveNamedRef(remoteRefs, ref, repoURL)
+}
+
+// resolveHeadRef resolves remote HEAD to the actual default branch so the
+// clone produces a proper branch checkout with remote-tracking refs.
+func resolveHeadRef(
+	remoteRefs []*plumbing.Reference,
+	repoURL string,
+) (plumbing.ReferenceName, plumbing.Hash, error) {
+	for _, r := range remoteRefs {
+		if r.Name() == plumbing.HEAD && r.Type() == plumbing.SymbolicReference {
+			target := r.Target()
+			for _, br := range remoteRefs {
+				if br.Name() == target {
+					return target, br.Hash(), nil
+				}
+			}
+
+			return "", plumbing.ZeroHash, fmt.Errorf(
+				"remote HEAD points to %q which does not exist in %s",
+				target,
+				repoURL,
+			)
+		}
+	}
+
+	return "", plumbing.ZeroHash, fmt.Errorf("no HEAD reference found for %s", repoURL)
+}
+
+func resolveCommitSHARef(
+	remoteRefs []*plumbing.Reference,
+	ref string,
+) (plumbing.ReferenceName, plumbing.Hash, error) {
+	targetHash := plumbing.NewHash(ref)
+	for _, r := range remoteRefs {
+		if r.Type() == plumbing.SymbolicReference {
+			continue
+		}
+		if r.Hash() == targetHash {
+			return r.Name(), targetHash, nil
+		}
+	}
+	// No named ref points to this SHA; full-depth clone required.
+	return "", targetHash, nil
+}
+
+func resolveNamedRef(
+	remoteRefs []*plumbing.Reference,
+	ref, repoURL string,
+) (plumbing.ReferenceName, plumbing.Hash, error) {
 	for _, r := range remoteRefs {
 		if r.Type() == plumbing.SymbolicReference {
 			continue

--- a/internal/runtimeartifacts/manager_test.go
+++ b/internal/runtimeartifacts/manager_test.go
@@ -842,30 +842,7 @@ func writeTarGzMultiFixture(
 	}
 	sort.Strings(keys)
 	for _, entryName := range keys {
-		entry := entries[entryName]
-		if entry.IsDir || strings.HasSuffix(entryName, "/") {
-			if err := tarWriter.WriteHeader(&tar.Header{
-				Name:     entryName,
-				Mode:     entry.Mode,
-				Typeflag: tar.TypeDir,
-			}); err != nil {
-				t.Fatalf("failed to write tar directory header: %v", err)
-			}
-
-			continue
-		}
-
-		if err := tarWriter.WriteHeader(&tar.Header{
-			Name:     entryName,
-			Mode:     entry.Mode,
-			Size:     int64(len(entry.Content)),
-			Typeflag: tar.TypeReg,
-		}); err != nil {
-			t.Fatalf("failed to write tar header: %v", err)
-		}
-		if _, err := tarWriter.Write([]byte(entry.Content)); err != nil {
-			t.Fatalf("failed to write tar payload: %v", err)
-		}
+		writeTarGzFixtureEntry(t, tarWriter, entryName, entries[entryName])
 	}
 	if err := tarWriter.Close(); err != nil {
 		t.Fatalf("failed to close tar writer: %v", err)
@@ -878,6 +855,39 @@ func writeTarGzMultiFixture(
 	}
 
 	return path
+}
+
+func writeTarGzFixtureEntry(
+	t *testing.T,
+	tarWriter *tar.Writer,
+	entryName string,
+	entry tarFixtureEntry,
+) {
+	t.Helper()
+
+	if entry.IsDir || strings.HasSuffix(entryName, "/") {
+		if err := tarWriter.WriteHeader(&tar.Header{
+			Name:     entryName,
+			Mode:     entry.Mode,
+			Typeflag: tar.TypeDir,
+		}); err != nil {
+			t.Fatalf("failed to write tar directory header: %v", err)
+		}
+
+		return
+	}
+
+	if err := tarWriter.WriteHeader(&tar.Header{
+		Name:     entryName,
+		Mode:     entry.Mode,
+		Size:     int64(len(entry.Content)),
+		Typeflag: tar.TypeReg,
+	}); err != nil {
+		t.Fatalf("failed to write tar header: %v", err)
+	}
+	if _, err := tarWriter.Write([]byte(entry.Content)); err != nil {
+		t.Fatalf("failed to write tar payload: %v", err)
+	}
 }
 
 func writeZipFixture(t *testing.T, dir, name string, entries map[string]string) string {

--- a/internal/runtimeartifacts/targz_extractor.go
+++ b/internal/runtimeartifacts/targz_extractor.go
@@ -6,6 +6,7 @@ package runtimeartifacts
 import (
 	"archive/tar"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -40,59 +41,19 @@ func (*TarGzExtractor) Extract(srcPath, dstPath string) error {
 	extracted := false
 	for {
 		hdr, err := tarReader.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {
 			return err
 		}
 
-		cleanName := filepath.Clean(filepath.FromSlash(hdr.Name))
-		if cleanName == "." || cleanName == ".." ||
-			strings.HasPrefix(cleanName, ".."+string(filepath.Separator)) ||
-			filepath.IsAbs(cleanName) {
-			return fmt.Errorf(
-				"refusing to extract archive entry %q outside %s",
-				hdr.Name,
-				dstPath,
-			)
+		ok, err := extractTarEntry(tarReader, hdr, dstPath)
+		if err != nil {
+			return err
 		}
-
-		targetPath := filepath.Join(dstPath, cleanName)
-		mode := os.FileMode(hdr.Mode).Perm()
-
-		switch hdr.Typeflag {
-		case tar.TypeDir:
-			if err := os.MkdirAll(targetPath, mode); err != nil {
-				return err
-			}
-			if err := os.Chmod(targetPath, mode); err != nil {
-				return err
-			}
+		if ok {
 			extracted = true
-		case tar.TypeReg:
-			if err := os.MkdirAll(filepath.Dir(targetPath), dirPerm); err != nil {
-				return err
-			}
-
-			out, err := os.OpenFile(targetPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
-			if err != nil {
-				return err
-			}
-			// #nosec G110 -- archive contents are trusted runtime artifacts.
-			if _, err := io.Copy(out, tarReader); err != nil {
-				_ = out.Close()
-				return err
-			}
-			if err := out.Close(); err != nil {
-				return err
-			}
-			if err := os.Chmod(targetPath, mode); err != nil {
-				return err
-			}
-			extracted = true
-		default:
-			continue
 		}
 	}
 
@@ -101,4 +62,71 @@ func (*TarGzExtractor) Extract(srcPath, dstPath string) error {
 	}
 
 	return nil
+}
+
+// extractTarEntry extracts a single tar entry under dstPath and reports
+// whether it produced an extractable file or directory.
+func extractTarEntry(tarReader *tar.Reader, hdr *tar.Header, dstPath string) (bool, error) {
+	targetPath, err := sanitizeTarEntryPath(dstPath, hdr.Name)
+	if err != nil {
+		return false, err
+	}
+
+	mode := os.FileMode(hdr.Mode).Perm()
+
+	switch hdr.Typeflag {
+	case tar.TypeDir:
+		if err := os.MkdirAll(targetPath, mode); err != nil {
+			return false, err
+		}
+		if err := os.Chmod(targetPath, mode); err != nil {
+			return false, err
+		}
+
+		return true, nil
+	case tar.TypeReg:
+		if err := writeTarRegularFile(tarReader, targetPath, mode); err != nil {
+			return false, err
+		}
+
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+func sanitizeTarEntryPath(dstPath, name string) (string, error) {
+	cleanName := filepath.Clean(filepath.FromSlash(name))
+	if cleanName == "." || cleanName == ".." ||
+		strings.HasPrefix(cleanName, ".."+string(filepath.Separator)) ||
+		filepath.IsAbs(cleanName) {
+		return "", fmt.Errorf(
+			"refusing to extract archive entry %q outside %s",
+			name,
+			dstPath,
+		)
+	}
+
+	return filepath.Join(dstPath, cleanName), nil
+}
+
+func writeTarRegularFile(tarReader *tar.Reader, targetPath string, mode os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(targetPath), dirPerm); err != nil {
+		return err
+	}
+
+	out, err := os.OpenFile(targetPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+	// #nosec G110 -- archive contents are trusted runtime artifacts.
+	if _, err := io.Copy(out, tarReader); err != nil {
+		_ = out.Close()
+		return err
+	}
+	if err := out.Close(); err != nil {
+		return err
+	}
+
+	return os.Chmod(targetPath, mode)
 }

--- a/internal/runtimeartifacts/zip_extractor.go
+++ b/internal/runtimeartifacts/zip_extractor.go
@@ -31,58 +31,13 @@ func (*ZipExtractor) Extract(srcPath, dstPath string) error {
 
 	extracted := false
 	for _, zipEntry := range zipReader.File {
-		cleanName := filepath.Clean(filepath.FromSlash(zipEntry.Name))
-		if cleanName == "." || cleanName == ".." ||
-			strings.HasPrefix(cleanName, ".."+string(filepath.Separator)) ||
-			filepath.IsAbs(cleanName) {
-			return fmt.Errorf(
-				"refusing to extract archive entry %q outside %s",
-				zipEntry.Name,
-				dstPath,
-			)
+		ok, err := extractZipEntry(zipEntry, dstPath)
+		if err != nil {
+			return err
 		}
-
-		targetPath := filepath.Join(dstPath, cleanName)
-		mode := zipEntry.Mode().Perm()
-		if mode == 0 {
-			mode = 0o644
-		}
-
-		if zipEntry.FileInfo().IsDir() {
-			if err := os.MkdirAll(targetPath, mode); err != nil {
-				return err
-			}
+		if ok {
 			extracted = true
-
-			continue
 		}
-
-		if err := os.MkdirAll(filepath.Dir(targetPath), dirPerm); err != nil {
-			return err
-		}
-
-		entryReader, err := zipEntry.Open()
-		if err != nil {
-			return err
-		}
-
-		out, err := os.OpenFile(targetPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
-		if err != nil {
-			_ = entryReader.Close()
-			return err
-		}
-		// #nosec G110 -- archive contents are trusted runtime artifacts.
-		if _, err := io.Copy(out, entryReader); err != nil {
-			_ = entryReader.Close()
-			_ = out.Close()
-
-			return err
-		}
-		_ = entryReader.Close()
-		if err := out.Close(); err != nil {
-			return err
-		}
-		extracted = true
 	}
 
 	if !extracted {
@@ -90,4 +45,74 @@ func (*ZipExtractor) Extract(srcPath, dstPath string) error {
 	}
 
 	return nil
+}
+
+// extractZipEntry extracts a single zip entry under dstPath and reports
+// whether it produced an extractable file or directory.
+func extractZipEntry(zipEntry *zip.File, dstPath string) (bool, error) {
+	targetPath, err := sanitizeZipEntryPath(dstPath, zipEntry.Name)
+	if err != nil {
+		return false, err
+	}
+
+	mode := zipEntry.Mode().Perm()
+	if mode == 0 {
+		mode = 0o644
+	}
+
+	if zipEntry.FileInfo().IsDir() {
+		if err := os.MkdirAll(targetPath, mode); err != nil {
+			return false, err
+		}
+
+		return true, nil
+	}
+
+	if err := writeZipRegularFile(zipEntry, targetPath, mode); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func sanitizeZipEntryPath(dstPath, name string) (string, error) {
+	cleanName := filepath.Clean(filepath.FromSlash(name))
+	if cleanName == "." || cleanName == ".." ||
+		strings.HasPrefix(cleanName, ".."+string(filepath.Separator)) ||
+		filepath.IsAbs(cleanName) {
+		return "", fmt.Errorf(
+			"refusing to extract archive entry %q outside %s",
+			name,
+			dstPath,
+		)
+	}
+
+	return filepath.Join(dstPath, cleanName), nil
+}
+
+func writeZipRegularFile(zipEntry *zip.File, targetPath string, mode os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(targetPath), dirPerm); err != nil {
+		return err
+	}
+
+	entryReader, err := zipEntry.Open()
+	if err != nil {
+		return err
+	}
+
+	out, err := os.OpenFile(targetPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		_ = entryReader.Close()
+		return err
+	}
+	// #nosec G110 -- archive contents are trusted runtime artifacts.
+	if _, err := io.Copy(out, entryReader); err != nil {
+		_ = entryReader.Close()
+		_ = out.Close()
+
+		return err
+	}
+	_ = entryReader.Close()
+
+	return out.Close()
 }

--- a/internal/task_runner/regex_logger.go
+++ b/internal/task_runner/regex_logger.go
@@ -51,11 +51,7 @@ func (w *regexLogger) Write(data []byte) (int, error) {
 			tmpCount, err := w.lineBuffer.Write(data)
 			count += tmpCount
 
-			if err != nil {
-				return count, err
-			}
-
-			break
+			return count, err
 		}
 
 		tmpCount, err := w.lineBuffer.Write(data[:idx+1])
@@ -65,30 +61,7 @@ func (w *regexLogger) Write(data []byte) (int, error) {
 			return count, err
 		}
 
-		for _, pattern := range w.patterns {
-			matches := pattern.CompiledRegex.FindSubmatch(w.lineBuffer.Bytes())
-			if matches != nil {
-				// Replace placeholders in message with captured groups
-				// $0 = full match, $1 = first group, $2 = second group, etc.
-				logMsg := []byte(pattern.Message)
-				for i, match := range matches {
-					placeholder := "$" + string(rune('0'+i))
-					matchStr := string(bytes.TrimRight(match, "\n\r"))
-					logMsg = bytes.ReplaceAll(logMsg, []byte(placeholder), []byte(matchStr))
-				}
-
-				// Add node prefix if set
-				if w.nodePrefix != "" {
-					logMsg = append([]byte(w.nodePrefix), logMsg...)
-				}
-
-				if pattern.LogAsError {
-					slog.Error(string(logMsg))
-				} else {
-					slog.Info(string(logMsg))
-				}
-			}
-		}
+		w.logMatchingPatterns()
 
 		w.lineBuffer.Reset()
 		data = data[idx+1:]
@@ -97,6 +70,40 @@ func (w *regexLogger) Write(data []byte) (int, error) {
 			panic("expected remaining bytes to decrease")
 		}
 	}
+}
 
-	return count, nil
+// logMatchingPatterns runs every pattern against the current line buffer and
+// logs a message for each one that matches.
+func (w *regexLogger) logMatchingPatterns() {
+	for _, pattern := range w.patterns {
+		matches := pattern.CompiledRegex.FindSubmatch(w.lineBuffer.Bytes())
+		if matches == nil {
+			continue
+		}
+
+		w.logMatch(pattern, matches)
+	}
+}
+
+// logMatch renders a pattern's message template against the captured groups
+// and emits it at the configured log level.
+func (w *regexLogger) logMatch(pattern *presets.RegexLog, matches [][]byte) {
+	// Replace placeholders in message with captured groups
+	// $0 = full match, $1 = first group, $2 = second group, etc.
+	logMsg := []byte(pattern.Message)
+	for i, match := range matches {
+		placeholder := "$" + string(rune('0'+i))
+		matchStr := string(bytes.TrimRight(match, "\n\r"))
+		logMsg = bytes.ReplaceAll(logMsg, []byte(placeholder), []byte(matchStr))
+	}
+
+	if w.nodePrefix != "" {
+		logMsg = append([]byte(w.nodePrefix), logMsg...)
+	}
+
+	if pattern.LogAsError {
+		slog.Error(string(logMsg))
+	} else {
+		slog.Info(string(logMsg))
+	}
 }

--- a/internal/task_runner/task_runner_test.go
+++ b/internal/task_runner/task_runner_test.go
@@ -102,121 +102,138 @@ func TestRunRemoteScript(t *testing.T) {
 	t.Parallel()
 	slog.SetLogLoggerLevel(slog.LevelInfo)
 
-	type testArgs struct {
+	testCases := []struct {
+		name     string
 		parallel bool
-	}
-
-	testCases := []testArgs{
-		{
-			parallel: true,
-		},
-		{
-			parallel: false,
-		},
+	}{
+		{name: "parallel", parallel: true},
+		{name: "sequential", parallel: false},
 	}
 
 	for _, testCase := range testCases {
-		localCommandRunner := mocks.NewLocalCommandRunnerMock()
-		remoteScriptRunner := mocks.NewRemoteScriptRunnerMock()
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			runRemoteScriptAndVerifyOrdering(t, testCase.parallel)
+		})
+	}
+}
 
-		nodeLookupMock := mocks.NewNodeLookupMock(mocks.NewNodeLookupDirectory(5))
+//nolint:revive // parallel selects which table-driven test case runs, not internal control coupling.
+func runRemoteScriptAndVerifyOrdering(t *testing.T, parallel bool) {
+	t.Helper()
 
-		taskRunner := task_runner.NewTaskRunner(
-			localCommandRunner,
-			remoteScriptRunner,
-			nodeLookupMock,
-		)
+	localCommandRunner := mocks.NewLocalCommandRunnerMock()
+	remoteScriptRunner := mocks.NewRemoteScriptRunnerMock()
 
-		fakeDeploymentDir := t.TempDir()
-		scriptFilePath := filepath.Join(fakeDeploymentDir, "script.sh")
-		mocks.NewUniqueFile(scriptFilePath)
-		deployment := config.NewDeploymentDir(fakeDeploymentDir)
+	nodeLookupMock := mocks.NewNodeLookupMock(mocks.NewNodeLookupDirectory(5))
 
-		tasks := []config.Task{
-			{
-				RemoteExec: &presets.RemoteExecTask{
-					Description:       "test task",
-					Filename:          scriptFilePath,
-					ExecuteInParallel: testCase.parallel,
-					Node:              "*",
-				},
+	taskRunner := task_runner.NewTaskRunner(
+		localCommandRunner,
+		remoteScriptRunner,
+		nodeLookupMock,
+	)
+
+	fakeDeploymentDir := t.TempDir()
+	scriptFilePath := filepath.Join(fakeDeploymentDir, "script.sh")
+	mocks.NewUniqueFile(scriptFilePath)
+	deployment := config.NewDeploymentDir(fakeDeploymentDir)
+
+	tasks := []config.Task{
+		{
+			RemoteExec: &presets.RemoteExecTask{
+				Description:       "test task",
+				Filename:          scriptFilePath,
+				ExecuteInParallel: parallel,
+				Node:              "*",
 			},
-		}
+		},
+	}
 
-		slog.Debug("pre availableNodes", "nodes", nodeLookupMock.Directory)
-		err := taskRunner.RunTasks(t.Context(), tasks, deployment, nil, nil)
+	slog.Debug("pre availableNodes", "nodes", nodeLookupMock.Directory)
+	err := taskRunner.RunTasks(t.Context(), tasks, deployment, nil, nil)
 
-		require.NoError(t, err, "RunTasks should succeed")
+	require.NoError(t, err, "RunTasks should succeed")
 
-		require.Len(
-			t,
-			remoteScriptRunner.RunScriptCalls, len(nodeLookupMock.Directory),
-			"expected script to run on all nodes",
-		)
+	require.Len(
+		t,
+		remoteScriptRunner.RunScriptCalls, len(nodeLookupMock.Directory),
+		"expected script to run on all nodes",
+	)
 
-		startStopMap := map[int64]string{}
+	startStopMap := matchCallsToNodes(
+		t, nodeLookupMock.Directory, remoteScriptRunner.RunScriptCalls,
+	)
 
-		availableNodes := make([]task_runner.RunScriptNode, len(nodeLookupMock.Directory))
+	err = verifyStartStopOrdering(startStopMap)
+	if parallel {
+		require.ErrorIs(t, err, errInterleavedTasks)
+	} else {
+		require.NoError(t, err)
+	}
+}
 
-		for idx, node := range nodeLookupMock.Directory {
-			connectionOptions := *node.ConnectionOptions
-			availableNodes[idx] = task_runner.RunScriptNode{
-				Name:              node.Name,
-				ConnectionOptions: &connectionOptions,
-			}
-		}
+// matchCallsToNodes pairs each recorded RunScript call with the node it targeted
+// (by connection host) and returns a map of each call's start/stop timestamp to
+// whether it marks a "start" or "stop". It fails the test if any node was not
+// matched to exactly one call.
+func matchCallsToNodes(
+	t *testing.T,
+	nodes []task_runner.RunScriptNode,
+	calls []mocks.RemoteScriptRunnerMockRunScriptCall,
+) map[int64]string {
+	t.Helper()
 
-		slog.Debug("post availableNodes", "nodes", nodeLookupMock.Directory)
+	availableNodes := make([]task_runner.RunScriptNode, len(nodes))
 
-		slog.Debug("availableNodes", "nodes", availableNodes)
-		for _, call := range remoteScriptRunner.RunScriptCalls {
-			for idx, node := range availableNodes {
-				if node.ConnectionOptions.Host == call.ConnectionOptions.Host {
-					availableNodes = append(availableNodes[0:idx], availableNodes[idx+1:]...)
-					startStopMap[call.Start.UnixMicro()] = "start"
-					startStopMap[call.Stop.UnixMicro()] = "stop"
-				}
-			}
-		}
-
-		// All nodes should have been matched above and filtered out.
-		require.Empty(t, availableNodes, "found unmatched nodes")
-
-		startStopMapKeys := []int64{}
-		for key := range startStopMap {
-			startStopMapKeys = append(startStopMapKeys, key)
-		}
-
-		slices.Sort(startStopMapKeys)
-
-		errInterleavedTasks := errors.New("tasks were interleaved")
-		tasksNotInterleaved := func() error {
-			for idx, key := range startStopMapKeys {
-				if idx%2 == 0 {
-					if startStopMap[key] != "start" {
-						return errInterleavedTasks
-					}
-				} else {
-					if startStopMap[key] != "stop" {
-						return errInterleavedTasks
-					}
-				}
-			}
-
-			return nil
-		}
-
-		if testCase.parallel {
-			require.ErrorIs(
-				t,
-				tasksNotInterleaved(),
-				errInterleavedTasks,
-			)
-		} else {
-			require.NoError(
-				t,
-				tasksNotInterleaved(),
-			)
+	for idx, node := range nodes {
+		connectionOptions := *node.ConnectionOptions
+		availableNodes[idx] = task_runner.RunScriptNode{
+			Name:              node.Name,
+			ConnectionOptions: &connectionOptions,
 		}
 	}
+
+	startStopMap := map[int64]string{}
+
+	for _, call := range calls {
+		for idx, node := range availableNodes {
+			if node.ConnectionOptions.Host != call.ConnectionOptions.Host {
+				continue
+			}
+
+			availableNodes = append(availableNodes[0:idx], availableNodes[idx+1:]...)
+			startStopMap[call.Start.UnixMicro()] = "start"
+			startStopMap[call.Stop.UnixMicro()] = "stop"
+		}
+	}
+
+	require.Empty(t, availableNodes, "found unmatched nodes")
+
+	return startStopMap
+}
+
+var errInterleavedTasks = errors.New("tasks were interleaved")
+
+// verifyStartStopOrdering checks that sorted timestamps alternate strictly
+// between "start" and "stop", which only holds when tasks ran sequentially.
+func verifyStartStopOrdering(startStopMap map[int64]string) error {
+	startStopMapKeys := make([]int64, 0, len(startStopMap))
+	for key := range startStopMap {
+		startStopMapKeys = append(startStopMapKeys, key)
+	}
+
+	slices.Sort(startStopMapKeys)
+
+	for idx, key := range startStopMapKeys {
+		want := "start"
+		if idx%2 != 0 {
+			want = "stop"
+		}
+
+		if startStopMap[key] != want {
+			return errInterleavedTasks
+		}
+	}
+
+	return nil
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,8 +1,11 @@
 sonar.projectKey=com.exasol:exasol-personal
 sonar.organization=exasol
 sonar.sources=.
-sonar.exclusions=**/*_test.go,**/*_mocks.go,tests/**/*.py
+sonar.exclusions=**/*_test.go,**/*_mocks.go,tests/**/*.py,images/**
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go,**/*_mocks.go,tests/**/*.py
 sonar.go.coverage.reportPaths=./coverage-unit.out,./coverage-integration-linux/coverage-integration.out,./coverage-integration-windows/coverage-integration.out
 sonar.coverage.exclusions=**/*_test.go,tests/**/*.py,tools/**,**/typesfakes/**
+sonar.python.version=3.13
+sonar.terraform.provider.aws.version=6.35.0
+sonar.terraform.provider.azure.version=4.63.0

--- a/tools/cleanup/cmd/cleanup/cleanup_show.go
+++ b/tools/cleanup/cmd/cleanup/cleanup_show.go
@@ -151,41 +151,38 @@ func loadCleanupShowResult(
 	return result, nil
 }
 
+func firstResourceAttr(attr map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if v, ok := attr[key]; ok {
+			return fmt.Sprintf("%v", v)
+		}
+	}
+
+	return "-"
+}
+
+func resourceShowRow(resource shared.ResourceMeta) []string {
+	owner := resource.Tags["Owner"]
+	if owner == "" {
+		owner = "-"
+	}
+
+	return []string{
+		string(resource.Ref.Type),
+		resource.Ref.ID,
+		owner,
+		firstResourceAttr(resource.Attr, "launchTime", "createTime", "lastModified"),
+		firstResourceAttr(resource.Attr, "state"),
+		resource.Ref.ARN,
+	}
+}
+
 func renderCleanupShowResult(cmd *cobra.Command, resolved cleanupResolved, details *shared.DeploymentDetails) {
 	renderResolved(cmd.OutOrStdout(), resolved)
 	renderTypesFilter(cmd.OutOrStdout(), cleanupShowOpts.Types)
 	rows := make([][]string, 0, len(details.Resources))
 	for _, resource := range details.Resources {
-		owner := resource.Tags["Owner"]
-		if owner == "" {
-			owner = "-"
-		}
-		when := "-"
-		if v, ok := resource.Attr["launchTime"]; ok {
-			when = fmt.Sprintf("%v", v)
-		}
-		if when == "-" {
-			if v, ok := resource.Attr["createTime"]; ok {
-				when = fmt.Sprintf("%v", v)
-			}
-		}
-		if when == "-" {
-			if v, ok := resource.Attr["lastModified"]; ok {
-				when = fmt.Sprintf("%v", v)
-			}
-		}
-		state := "-"
-		if v, ok := resource.Attr["state"]; ok {
-			state = fmt.Sprintf("%v", v)
-		}
-		rows = append(rows, []string{
-			string(resource.Ref.Type),
-			resource.Ref.ID,
-			owner,
-			when,
-			state,
-			resource.Ref.ARN,
-		})
+		rows = append(rows, resourceShowRow(resource))
 	}
 	if len(rows) > 0 {
 		renderTable(

--- a/tools/cleanup/pkg/cleanup/providers/aws/collect.go
+++ b/tools/cleanup/pkg/cleanup/providers/aws/collect.go
@@ -61,10 +61,19 @@ func PreferEarlier(base time.Time, candidate *time.Time) time.Time {
 	return base
 }
 
+// detailsAccumulator carries the in-progress DeploymentDetails plus the
+// cross-phase state (earliest timestamp, EC2 presence/state flags) that
+// CollectDeploymentDetails' phases need to share.
+type detailsAccumulator struct {
+	details    *DeploymentDetails
+	earliest   *time.Time
+	hasEC2     bool
+	hasActive  bool
+	hasStopped bool
+}
+
 // CollectDeploymentDetails enumerates resources for a single deployment
 // and enriches attributes and summary.
-// function aggregates multiple AWS resources and states; split would harm cohesion.
-// nolint: gocyclo, maintidx
 func CollectDeploymentDetails(
 	ctx context.Context,
 	region string,
@@ -80,17 +89,55 @@ func CollectDeploymentDetails(
 	s3Client := s3.NewFromConfig(cfg)
 	iamClient := iam.NewFromConfig(cfg)
 
-	details := &DeploymentDetails{
-		Summary: DeploymentSummary{
-			ID:        deploymentID,
-			Provider:  "aws",
-			Region:    region,
-			Owner:     "",
-			CreatedAt: time.Time{},
-			State:     StateUnknown,
+	acc := &detailsAccumulator{
+		details: &DeploymentDetails{
+			Summary: DeploymentSummary{
+				ID:        deploymentID,
+				Provider:  "aws",
+				Region:    region,
+				Owner:     "",
+				CreatedAt: time.Time{},
+				State:     StateUnknown,
+			},
 		},
 	}
 
+	if err := discoverTaggedResources(ctx, client, region, deploymentID, acc); err != nil {
+		return nil, err
+	}
+	acc.details.Summary.Resources = len(acc.details.Resources)
+
+	// IAM discovery: roles and instance profiles are global and not returned by
+	// Resource Groups Tagging API in regional queries. Discover via IAM API and tags.
+	// Filter for Deployment=<deploymentID> tag on roles and instance profiles.
+	discoverIAMRoles(ctx, iamClient, region, deploymentID, acc)
+	discoverIAMInstanceProfiles(ctx, iamClient, region, deploymentID, acc)
+
+	// Update resource count after IAM discovery
+	acc.details.Summary.Resources = len(acc.details.Resources)
+
+	enrichResourcesByType(ctx, ec2Client, ssmClient, s3Client, acc)
+
+	// Apply earliest resource time only if it's earlier than tag-based CreatedAt
+	acc.details.Summary.CreatedAt = PreferEarlier(acc.details.Summary.CreatedAt, acc.earliest)
+	if acc.details.Summary.Owner == "" {
+		acc.details.Summary.Owner = "-"
+	}
+	deriveDetailsState(acc)
+
+	return acc.details, nil
+}
+
+// discoverTaggedResources paginates the Resource Groups Tagging API for all
+// resources tagged with Deployment=<deploymentID>, recording each as a
+// ResourceMeta and deriving the summary owner/createdAt from tags.
+func discoverTaggedResources(
+	ctx context.Context,
+	client *rgt.Client,
+	region string,
+	deploymentID string,
+	acc *detailsAccumulator,
+) error {
 	paginationToken := ""
 	for {
 		input := &rgt.GetResourcesInput{
@@ -104,235 +151,196 @@ func CollectDeploymentDetails(
 		}
 		out, err := client.GetResources(ctx, input)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		for _, mapping := range out.ResourceTagMappingList {
-			arn := awsString(mapping.ResourceARN)
-			rType, rID := classifyARN(arn)
-			// Do NOT skip unclassified: include in output
-			// so resource counts match discover and users can see raw entries
-			meta := ResourceMeta{
-				Ref:  ResourceRef{ARN: arn, Type: rType, Region: region, ID: rID},
-				Tags: tagsToMap(mapping.Tags),
-				Attr: map[string]any{},
-			}
-			details.Resources = append(details.Resources, meta)
-			if details.Summary.Owner == "" {
-				if o := meta.Tags["Owner"]; o != "" {
-					details.Summary.Owner = o
-				}
-			}
-			// CreatedAt tag wins first
-			details.Summary.CreatedAt = UpdateCreatedAtFromTag(
-				details.Summary.CreatedAt,
-				meta.Tags["CreatedAt"],
-			)
+			recordTaggedResource(mapping, region, acc)
 		}
 		if out.PaginationToken == nil || *out.PaginationToken == "" {
 			break
 		}
 		paginationToken = *out.PaginationToken
 	}
-	details.Summary.Resources = len(details.Resources)
 
-	// IAM discovery: roles and instance profiles are global and not returned by
-	// Resource Groups Tagging API in regional queries. Discover via IAM API and tags.
-	// Filter for Deployment=<deploymentID> tag on roles and instance profiles.
-	//nolint:nestif // acceptable nested flow for paging and tag checks
-	{
-		slog.Debug("Starting IAM discovery", "deploymentID", deploymentID)
-		// List roles
-		var marker *string
-		rolesChecked := 0
-		for {
-			out, err := iamClient.ListRoles(ctx, &iam.ListRolesInput{Marker: marker})
-			if err != nil {
-				slog.Debug("IAM list roles failed", "error", err)
-				break
-			}
-			rolesChecked += len(out.Roles)
-			for _, role := range out.Roles {
-				// Fetch role tags and check Deployment match
-				tagsOut, tErr := iamClient.ListRoleTags(ctx, &iam.ListRoleTagsInput{RoleName: role.RoleName})
-				if tErr == nil {
-					hasTag := hasIAMDeploymentTag(tagsOut.Tags, deploymentID)
-					hasName := role.RoleName != nil && strings.Contains(*role.RoleName, deploymentID)
-					if hasTag || hasName {
-						slog.Debug("IAM role matched", "name", awsString(role.RoleName), "hasTag", hasTag, "hasName", hasName)
-						meta := ResourceMeta{
-							Ref: ResourceRef{
-								ARN:    awsString(role.Arn),
-								Type:   ResourceIAMRole,
-								Region: region,
-								ID:     awsString(role.RoleName),
-							},
-							Tags: iamTagsToMap(tagsOut.Tags),
-							Attr: map[string]any{},
-						}
-						if role.CreateDate != nil {
-							meta.Attr["createTime"] = *role.CreateDate
-						}
-						details.Resources = append(details.Resources, meta)
-					}
-				}
-			}
-			if out.IsTruncated && out.Marker != nil {
-				marker = out.Marker
-			} else {
-				break
-			}
-		}
-		slog.Debug("IAM role discovery complete", "rolesChecked", rolesChecked)
+	return nil
+}
 
-		// List instance profiles
-		marker = nil
-		for {
-			out, err := iamClient.ListInstanceProfiles(ctx, &iam.ListInstanceProfilesInput{Marker: marker})
-			if err != nil {
-				slog.Debug("IAM list instance profiles failed", "error", err)
-				break
-			}
-			for _, prof := range out.InstanceProfiles {
-				tagsOut, tErr := iamClient.ListInstanceProfileTags(ctx, &iam.ListInstanceProfileTagsInput{InstanceProfileName: prof.InstanceProfileName})
-				if tErr == nil {
-					if hasIAMDeploymentTag(tagsOut.Tags, deploymentID) || (prof.InstanceProfileName != nil && strings.Contains(*prof.InstanceProfileName, deploymentID)) {
-						meta := ResourceMeta{
-							Ref: ResourceRef{
-								ARN:    awsString(prof.Arn),
-								Type:   ResourceIAMInstProf,
-								Region: region,
-								ID:     awsString(prof.InstanceProfileName),
-							},
-							Tags: iamTagsToMap(tagsOut.Tags),
-							Attr: map[string]any{},
-						}
-						if prof.CreateDate != nil {
-							meta.Attr["createTime"] = *prof.CreateDate
-						}
-						details.Resources = append(details.Resources, meta)
-					}
-				}
-			}
-			if out.IsTruncated && out.Marker != nil {
-				marker = out.Marker
-			} else {
-				break
-			}
+// recordTaggedResource records a single tagged-resource mapping as a
+// ResourceMeta and folds its Owner/CreatedAt tags into the summary.
+func recordTaggedResource(mapping rgttypes.ResourceTagMapping, region string, acc *detailsAccumulator) {
+	arn := awsString(mapping.ResourceARN)
+	rType, rID := classifyARN(arn)
+	// Do NOT skip unclassified: include in output
+	// so resource counts match discover and users can see raw entries
+	meta := ResourceMeta{
+		Ref:  ResourceRef{ARN: arn, Type: rType, Region: region, ID: rID},
+		Tags: tagsToMap(mapping.Tags),
+		Attr: map[string]any{},
+	}
+	acc.details.Resources = append(acc.details.Resources, meta)
+	if acc.details.Summary.Owner == "" {
+		if o := meta.Tags["Owner"]; o != "" {
+			acc.details.Summary.Owner = o
 		}
 	}
+	// CreatedAt tag wins first
+	acc.details.Summary.CreatedAt = UpdateCreatedAtFromTag(
+		acc.details.Summary.CreatedAt,
+		meta.Tags["CreatedAt"],
+	)
+}
 
-	// Update resource count after IAM discovery
-	details.Summary.Resources = len(details.Resources)
+// discoverIAMRoles finds IAM roles matching deploymentID by tag or name.
+// IAM is global and not covered by the regional Resource Groups Tagging API query.
+func discoverIAMRoles(
+	ctx context.Context,
+	iamClient *iam.Client,
+	region string,
+	deploymentID string,
+	acc *detailsAccumulator,
+) {
+	slog.Debug("Starting IAM discovery", "deploymentID", deploymentID)
+	var marker *string
+	rolesChecked := 0
+	for {
+		out, err := iamClient.ListRoles(ctx, &iam.ListRolesInput{Marker: marker})
+		if err != nil {
+			slog.Debug("IAM list roles failed", "error", err)
+			break
+		}
+		rolesChecked += len(out.Roles)
+		for _, role := range out.Roles {
+			recordIAMRoleIfMatching(ctx, iamClient, region, deploymentID, role, acc)
+		}
+		if out.IsTruncated && out.Marker != nil {
+			marker = out.Marker
+		} else {
+			break
+		}
+	}
+	slog.Debug("IAM role discovery complete", "rolesChecked", rolesChecked)
+}
 
-	// Enrichment and state derivation
-	var earliest *time.Time
-	hasEC2 := false
-	hasActive := false
-	hasStopped := false
-	for i := range details.Resources {
-		meta := &details.Resources[i]
+// recordIAMRoleIfMatching fetches a role's tags and records it as a
+// ResourceMeta if it's tagged or named for the deployment.
+func recordIAMRoleIfMatching(
+	ctx context.Context,
+	iamClient *iam.Client,
+	region string,
+	deploymentID string,
+	role iamtypes.Role,
+	acc *detailsAccumulator,
+) {
+	// Fetch role tags and check Deployment match
+	tagsOut, tErr := iamClient.ListRoleTags(ctx, &iam.ListRoleTagsInput{RoleName: role.RoleName})
+	if tErr != nil {
+		return
+	}
+	hasTag := hasIAMDeploymentTag(tagsOut.Tags, deploymentID)
+	hasName := role.RoleName != nil && strings.Contains(*role.RoleName, deploymentID)
+	if !hasTag && !hasName {
+		return
+	}
+	slog.Debug("IAM role matched", "name", awsString(role.RoleName), "hasTag", hasTag, "hasName", hasName)
+	meta := ResourceMeta{
+		Ref: ResourceRef{
+			ARN:    awsString(role.Arn),
+			Type:   ResourceIAMRole,
+			Region: region,
+			ID:     awsString(role.RoleName),
+		},
+		Tags: iamTagsToMap(tagsOut.Tags),
+		Attr: map[string]any{},
+	}
+	if role.CreateDate != nil {
+		meta.Attr["createTime"] = *role.CreateDate
+	}
+	acc.details.Resources = append(acc.details.Resources, meta)
+}
+
+// discoverIAMInstanceProfiles finds IAM instance profiles matching
+// deploymentID by tag or name, mirroring discoverIAMRoles.
+func discoverIAMInstanceProfiles(
+	ctx context.Context,
+	iamClient *iam.Client,
+	region string,
+	deploymentID string,
+	acc *detailsAccumulator,
+) {
+	var marker *string
+	for {
+		out, err := iamClient.ListInstanceProfiles(ctx, &iam.ListInstanceProfilesInput{Marker: marker})
+		if err != nil {
+			slog.Debug("IAM list instance profiles failed", "error", err)
+			break
+		}
+		for _, prof := range out.InstanceProfiles {
+			recordIAMInstanceProfileIfMatching(ctx, iamClient, region, deploymentID, prof, acc)
+		}
+		if out.IsTruncated && out.Marker != nil {
+			marker = out.Marker
+		} else {
+			break
+		}
+	}
+}
+
+// recordIAMInstanceProfileIfMatching fetches an instance profile's tags and
+// records it as a ResourceMeta if it's tagged or named for the deployment.
+func recordIAMInstanceProfileIfMatching(
+	ctx context.Context,
+	iamClient *iam.Client,
+	region string,
+	deploymentID string,
+	prof iamtypes.InstanceProfile,
+	acc *detailsAccumulator,
+) {
+	tagsOut, tErr := iamClient.ListInstanceProfileTags(ctx, &iam.ListInstanceProfileTagsInput{InstanceProfileName: prof.InstanceProfileName})
+	if tErr != nil {
+		return
+	}
+	if !hasIAMDeploymentTag(tagsOut.Tags, deploymentID) &&
+		!(prof.InstanceProfileName != nil && strings.Contains(*prof.InstanceProfileName, deploymentID)) {
+		return
+	}
+	meta := ResourceMeta{
+		Ref: ResourceRef{
+			ARN:    awsString(prof.Arn),
+			Type:   ResourceIAMInstProf,
+			Region: region,
+			ID:     awsString(prof.InstanceProfileName),
+		},
+		Tags: iamTagsToMap(tagsOut.Tags),
+		Attr: map[string]any{},
+	}
+	if prof.CreateDate != nil {
+		meta.Attr["createTime"] = *prof.CreateDate
+	}
+	acc.details.Resources = append(acc.details.Resources, meta)
+}
+
+// enrichResourcesByType dispatches each discovered resource to its
+// type-specific enrichment, tracking cross-resource state in acc.
+func enrichResourcesByType(
+	ctx context.Context,
+	ec2Client *ec2.Client,
+	ssmClient *ssm.Client,
+	s3Client *s3.Client,
+	acc *detailsAccumulator,
+) {
+	for i := range acc.details.Resources {
+		meta := &acc.details.Resources[i]
 		switch meta.Ref.Type {
 		case ResourceIAMRole, ResourceIAMInstProf:
-			// Basic presence and created time already recorded; mark state
-			if _, ok := meta.Attr["state"]; !ok {
-				meta.Attr["state"] = "present"
-			}
-			if ct, ok := meta.Attr["createTime"].(time.Time); ok {
-				earliest = preferPtrEarlier(earliest, &ct)
-			}
+			enrichIAMResource(meta, acc)
 		case ResourceEC2Instance:
-			hasEC2 = true
-			out, err := ec2Client.DescribeInstances(
-				ctx,
-				&ec2.DescribeInstancesInput{InstanceIds: []string{meta.Ref.ID}},
-			)
-			if err == nil {
-				for _, res := range out.Reservations {
-					for _, inst := range res.Instances {
-						if inst.LaunchTime != nil {
-							meta.Attr["launchTime"] = *inst.LaunchTime
-							earliest = preferPtrEarlier(earliest, inst.LaunchTime)
-						}
-						st := ec2StateToSimple(inst.State)
-						meta.Attr["state"] = st
-						switch st {
-						case StateActive, StateProvisioning:
-							hasActive = true
-						case StateStopped:
-							hasStopped = true
-						default:
-							// no-op
-						}
-					}
-				}
-			} else {
-				slog.Debug("describe instance failed", "id", meta.Ref.ID, "error", err)
-				if _, ok := meta.Attr["state"]; !ok {
-					meta.Attr["state"] = StateUnknown
-				}
-			}
+			enrichEC2Instance(ctx, ec2Client, meta, acc)
 		case ResourceEBSVolume:
-			out, err := ec2Client.DescribeVolumes(
-				ctx,
-				&ec2.DescribeVolumesInput{VolumeIds: []string{meta.Ref.ID}},
-			)
-			if err == nil {
-				for _, volume := range out.Volumes {
-					if volume.CreateTime != nil {
-						meta.Attr["createTime"] = *volume.CreateTime
-						earliest = preferPtrEarlier(earliest, volume.CreateTime)
-					}
-					if volume.State != "" {
-						meta.Attr["state"] = string(volume.State)
-					}
-				}
-			} else {
-				slog.Debug("describe volume failed", "id", meta.Ref.ID, "error", err)
-				if _, ok := meta.Attr["state"]; !ok {
-					meta.Attr["state"] = StateUnknown
-				}
-			}
+			enrichEBSVolume(ctx, ec2Client, meta, acc)
 		case ResourceSSMParam:
-			out, err := ssmClient.DescribeParameters(
-				ctx,
-				&ssm.DescribeParametersInput{
-					Filters: []ssmtypes.ParametersFilter{
-						{Key: ssmtypes.ParametersFilterKeyName, Values: []string{meta.Ref.ID}},
-					},
-				},
-			)
-			if err == nil {
-				for _, p := range out.Parameters {
-					if p.LastModifiedDate != nil {
-						meta.Attr["lastModified"] = *p.LastModifiedDate
-						earliest = preferPtrEarlier(earliest, p.LastModifiedDate)
-					}
-				}
-				if _, ok := meta.Attr["state"]; !ok {
-					meta.Attr["state"] = "present"
-				}
-			} else {
-				slog.Debug("describe parameter failed", "name", meta.Ref.ID, "error", err)
-				if _, ok := meta.Attr["state"]; !ok {
-					meta.Attr["state"] = StateUnknown
-				}
-			}
+			enrichSSMParam(ctx, ssmClient, meta, acc)
 		case ResourceS3Bucket:
-			vOut, err := s3Client.GetBucketVersioning(
-				ctx,
-				&s3.GetBucketVersioningInput{Bucket: aws.String(meta.Ref.ID)},
-			)
-			if err == nil {
-				if vOut.Status != "" {
-					meta.Attr["versioning"] = string(vOut.Status)
-				}
-				meta.Attr["state"] = "present"
-			} else {
-				slog.Debug("get bucket versioning failed", "bucket", meta.Ref.ID, "error", err)
-				if _, ok := meta.Attr["state"]; !ok {
-					meta.Attr["state"] = StateUnknown
-				}
-			}
+			enrichS3Bucket(ctx, s3Client, meta)
 		case ResourceEC2KeyPair,
 			ResourceInternetGW,
 			ResourceRouteTable,
@@ -343,33 +351,179 @@ func CollectDeploymentDetails(
 			// no enrichment required here; handled by delete phase or not applicable
 		}
 	}
-	// Apply earliest resource time only if it's earlier than tag-based CreatedAt
-	details.Summary.CreatedAt = PreferEarlier(details.Summary.CreatedAt, earliest)
-	if details.Summary.Owner == "" {
-		details.Summary.Owner = "-"
+}
+
+// enrichIAMResource marks presence/state for an IAM role or instance profile
+// and folds its already-recorded createTime into the earliest timestamp.
+func enrichIAMResource(meta *ResourceMeta, acc *detailsAccumulator) {
+	// Basic presence and created time already recorded; mark state
+	if _, ok := meta.Attr["state"]; !ok {
+		meta.Attr["state"] = "present"
 	}
-	if hasEC2 {
+	if ct, ok := meta.Attr["createTime"].(time.Time); ok {
+		acc.earliest = preferPtrEarlier(acc.earliest, &ct)
+	}
+}
+
+// enrichEC2Instance describes an EC2 instance and records its launch time and state.
+func enrichEC2Instance(
+	ctx context.Context,
+	ec2Client *ec2.Client,
+	meta *ResourceMeta,
+	acc *detailsAccumulator,
+) {
+	acc.hasEC2 = true
+	out, err := ec2Client.DescribeInstances(
+		ctx,
+		&ec2.DescribeInstancesInput{InstanceIds: []string{meta.Ref.ID}},
+	)
+	if err != nil {
+		slog.Debug("describe instance failed", "id", meta.Ref.ID, "error", err)
+		if _, ok := meta.Attr["state"]; !ok {
+			meta.Attr["state"] = StateUnknown
+		}
+
+		return
+	}
+	for _, res := range out.Reservations {
+		for _, inst := range res.Instances {
+			if inst.LaunchTime != nil {
+				meta.Attr["launchTime"] = *inst.LaunchTime
+				acc.earliest = preferPtrEarlier(acc.earliest, inst.LaunchTime)
+			}
+			st := ec2StateToSimple(inst.State)
+			meta.Attr["state"] = st
+			switch st {
+			case StateActive, StateProvisioning:
+				acc.hasActive = true
+			case StateStopped:
+				acc.hasStopped = true
+			default:
+				// no-op
+			}
+		}
+	}
+}
+
+// enrichEBSVolume describes an EBS volume and records its creation time and state.
+func enrichEBSVolume(
+	ctx context.Context,
+	ec2Client *ec2.Client,
+	meta *ResourceMeta,
+	acc *detailsAccumulator,
+) {
+	out, err := ec2Client.DescribeVolumes(
+		ctx,
+		&ec2.DescribeVolumesInput{VolumeIds: []string{meta.Ref.ID}},
+	)
+	if err != nil {
+		slog.Debug("describe volume failed", "id", meta.Ref.ID, "error", err)
+		if _, ok := meta.Attr["state"]; !ok {
+			meta.Attr["state"] = StateUnknown
+		}
+
+		return
+	}
+	for _, volume := range out.Volumes {
+		if volume.CreateTime != nil {
+			meta.Attr["createTime"] = *volume.CreateTime
+			acc.earliest = preferPtrEarlier(acc.earliest, volume.CreateTime)
+		}
+		if volume.State != "" {
+			meta.Attr["state"] = string(volume.State)
+		}
+	}
+}
+
+// enrichSSMParam describes an SSM parameter and records its last-modified time.
+func enrichSSMParam(
+	ctx context.Context,
+	ssmClient *ssm.Client,
+	meta *ResourceMeta,
+	acc *detailsAccumulator,
+) {
+	out, err := ssmClient.DescribeParameters(
+		ctx,
+		&ssm.DescribeParametersInput{
+			Filters: []ssmtypes.ParametersFilter{
+				{Key: ssmtypes.ParametersFilterKeyName, Values: []string{meta.Ref.ID}},
+			},
+		},
+	)
+	if err != nil {
+		slog.Debug("describe parameter failed", "name", meta.Ref.ID, "error", err)
+		if _, ok := meta.Attr["state"]; !ok {
+			meta.Attr["state"] = StateUnknown
+		}
+
+		return
+	}
+	for _, p := range out.Parameters {
+		if p.LastModifiedDate != nil {
+			meta.Attr["lastModified"] = *p.LastModifiedDate
+			acc.earliest = preferPtrEarlier(acc.earliest, p.LastModifiedDate)
+		}
+	}
+	if _, ok := meta.Attr["state"]; !ok {
+		meta.Attr["state"] = "present"
+	}
+}
+
+// enrichS3Bucket records an S3 bucket's versioning status.
+func enrichS3Bucket(
+	ctx context.Context,
+	s3Client *s3.Client,
+	meta *ResourceMeta,
+) {
+	vOut, err := s3Client.GetBucketVersioning(
+		ctx,
+		&s3.GetBucketVersioningInput{Bucket: aws.String(meta.Ref.ID)},
+	)
+	if err != nil {
+		slog.Debug("get bucket versioning failed", "bucket", meta.Ref.ID, "error", err)
+		if _, ok := meta.Attr["state"]; !ok {
+			meta.Attr["state"] = StateUnknown
+		}
+
+		return
+	}
+	if vOut.Status != "" {
+		meta.Attr["versioning"] = string(vOut.Status)
+	}
+	meta.Attr["state"] = "present"
+}
+
+// deriveDetailsState determines the deployment state from the discovered and enriched resources.
+func deriveDetailsState(acc *detailsAccumulator) {
+	if acc.hasEC2 {
 		switch {
-		case hasActive:
-			details.Summary.State = StateActive
-		case hasStopped:
-			details.Summary.State = StateStopped
-		case details.Summary.Resources > 0:
-			details.Summary.State = StateTerminated
+		case acc.hasActive:
+			acc.details.Summary.State = StateActive
+		case acc.hasStopped:
+			acc.details.Summary.State = StateStopped
+		case acc.details.Summary.Resources > 0:
+			acc.details.Summary.State = StateTerminated
 		default:
 			// no-op
 		}
-	} else if details.Summary.Resources > 0 {
-		details.Summary.State = "orphaned"
+	} else if acc.details.Summary.Resources > 0 {
+		acc.details.Summary.State = "orphaned"
 	}
+}
 
-	return details, nil
+// summariesAccumulator carries the in-progress deployment summaries plus the
+// resource-ID buckets that CollectDeploymentSummaries' later enrichment
+// phases need.
+type summariesAccumulator struct {
+	summaries   map[string]*DeploymentSummary
+	instanceIDs map[string][]string
+	volumeIDs   map[string][]string
+	ssmNames    map[string][]string
+	processed   map[string]struct{}
 }
 
 // CollectDeploymentSummaries discovers deployments across the account/region with filters,
 // deriving CreatedAt and state using shared precedence rules.
-// function coordinates cross-service summarization; refactor would reduce clarity.
-// nolint: gocyclo, maintidx
 func CollectDeploymentSummaries(
 	ctx context.Context,
 	region string,
@@ -383,160 +537,210 @@ func CollectDeploymentSummaries(
 	client := rgt.NewFromConfig(cfg)
 	ec2Client := ec2.NewFromConfig(cfg)
 
-	summaries := map[string]*DeploymentSummary{}
-	instanceIDs := map[string][]string{}
-	volumeIDs := map[string][]string{}
-	ssmNames := map[string][]string{}
-	processed := map[string]struct{}{}
-
-	// Helper: compile strict deployment tag regex once
+	acc := &summariesAccumulator{
+		summaries:   map[string]*DeploymentSummary{},
+		instanceIDs: map[string][]string{},
+		volumeIDs:   map[string][]string{},
+		ssmNames:    map[string][]string{},
+		processed:   map[string]struct{}{},
+	}
+	// compile strict deployment tag regex once
 	deploymentIDRegex := regexp.MustCompile(`^exasol-[a-f0-9]{8}$`)
 
-	// Helper to process resources for given tag filters
-	processWithFilters := func(tagFilters []rgttypes.TagFilter) error {
-		paginationToken := ""
-		for {
-			input := &rgt.GetResourcesInput{
-				TagFilters:       tagFilters,
-				ResourcesPerPage: aws.Int32(resourcesPerPage),
-			}
-			if paginationToken != "" {
-				input.PaginationToken = aws.String(paginationToken)
-			}
-			out, err := client.GetResources(ctx, input)
-			if err != nil {
-				return err
-			}
-			for _, mapping := range out.ResourceTagMappingList {
-				deploymentID := tagValue(mapping.Tags, "Deployment")
-				// Applies to both modern and legacy deployments: ensure the
-				// deployment tag matches the strict format.
-				if !deploymentIDRegex.MatchString(deploymentID) {
-					continue
-				}
-
-				ownerTag := tagValue(mapping.Tags, "Owner")
-				if !ownerMatchesFilter(ownerTag, ownerFilter) {
-					continue
-				}
-				arn := awsString(mapping.ResourceARN)
-				if _, seen := processed[arn]; seen {
-					continue
-				}
-				processed[arn] = struct{}{}
-				reg := parseRegionFromARN(arn)
-				if reg == "" {
-					reg = region
-				}
-				sum := summaries[deploymentID]
-				if sum == nil {
-					sum = &DeploymentSummary{
-						ID:        deploymentID,
-						Provider:  "aws",
-						Region:    reg,
-						Owner:     ownerTag,
-						CreatedAt: time.Time{},
-						State:     "unknown",
-					}
-					summaries[deploymentID] = sum
-				} else if sum.Owner == "" {
-					sum.Owner = ownerTag
-				}
-				// CreatedAt tag wins first
-				sum.CreatedAt = UpdateCreatedAtFromTag(
-					sum.CreatedAt,
-					tagValue(mapping.Tags, "CreatedAt"),
-				)
-				sum.Resources++
-				rType, rID := classifyARN(arn)
-				switch rType {
-				case ResourceEC2Instance:
-					if rID != "" {
-						instanceIDs[deploymentID] = append(instanceIDs[deploymentID], rID)
-					}
-				case ResourceEBSVolume:
-					if rID != "" {
-						volumeIDs[deploymentID] = append(volumeIDs[deploymentID], rID)
-					}
-				case ResourceSSMParam:
-					if rID != "" {
-						ssmNames[deploymentID] = append(ssmNames[deploymentID], rID)
-					}
-				case ResourceEC2KeyPair,
-					ResourceInternetGW,
-					ResourceRouteTable,
-					ResourceSecurityGrp,
-					ResourceSubnet,
-					ResourceVPC,
-					ResourceS3Bucket:
-				default:
-					// ignore other resource types for summaries aggregation here
-				}
-			}
-			if out.PaginationToken == nil || *out.PaginationToken == "" {
-				break
-			}
-			paginationToken = *out.PaginationToken
-		}
-		return nil
-	}
-
+	var tagFilters []rgttypes.TagFilter
 	if legacy {
 		// Legacy mode: Only discover via Deployment tag presence (ignore Project tag)
-		if err := processWithFilters([]rgttypes.TagFilter{{Key: aws.String("Deployment")}}); err != nil {
-			return nil, err
-		}
+		tagFilters = []rgttypes.TagFilter{{Key: aws.String("Deployment")}}
 	} else {
 		// Default: Require Project tag to be exasol-personal
-		if err := processWithFilters([]rgttypes.TagFilter{{Key: aws.String("Project"), Values: []string{"exasol-personal"}}}); err != nil {
-			return nil, err
-		}
+		tagFilters = []rgttypes.TagFilter{{Key: aws.String("Project"), Values: []string{"exasol-personal"}}}
+	}
+	if err := discoverTaggedSummaries(ctx, client, region, tagFilters, deploymentIDRegex, ownerFilter, acc); err != nil {
+		return nil, err
 	}
 
-	// EC2 enrichment for state + earliest
-	for depID, ids := range instanceIDs {
-		out, err := ec2Client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{InstanceIds: ids})
-		if err != nil {
-			slog.Debug("instance describe failed", "deployment", depID, "error", err)
-			continue
+	enrichSummariesFromEC2(ctx, ec2Client, acc)
+	applyEBSFallbackCreatedAt(ctx, ec2Client, acc)
+	applySSMFallbackCreatedAt(ctx, cfg, acc)
+	markOrphanedSummaries(acc)
+
+	return summariesSliceFromMap(acc.summaries), nil
+}
+
+// discoverTaggedSummaries paginates the Resource Groups Tagging API for the
+// given tag filters, registering/updating a DeploymentSummary per matching
+// deployment and bucketing resource IDs by type for later enrichment.
+func discoverTaggedSummaries(
+	ctx context.Context,
+	client *rgt.Client,
+	region string,
+	tagFilters []rgttypes.TagFilter,
+	deploymentIDRegex *regexp.Regexp,
+	ownerFilter string,
+	acc *summariesAccumulator,
+) error {
+	paginationToken := ""
+	for {
+		input := &rgt.GetResourcesInput{
+			TagFilters:       tagFilters,
+			ResourcesPerPage: aws.Int32(resourcesPerPage),
 		}
-		var earliest *time.Time
-		hasActive := false
-		hasStopped := false
-		foundAny := false
-		for _, res := range out.Reservations {
-			for _, inst := range res.Instances {
-				foundAny = true
-				earliest = preferPtrEarlier(earliest, inst.LaunchTime)
-				switch ec2StateToSimple(inst.State) {
-				case StateActive, StateProvisioning:
-					hasActive = true
-				case StateStopped:
-					hasStopped = true
-				default:
-					// no update
-				}
+		if paginationToken != "" {
+			input.PaginationToken = aws.String(paginationToken)
+		}
+		out, err := client.GetResources(ctx, input)
+		if err != nil {
+			return err
+		}
+		for _, mapping := range out.ResourceTagMappingList {
+			recordTaggedSummaryResource(mapping, region, deploymentIDRegex, ownerFilter, acc)
+		}
+		if out.PaginationToken == nil || *out.PaginationToken == "" {
+			break
+		}
+		paginationToken = *out.PaginationToken
+	}
+
+	return nil
+}
+
+// recordTaggedSummaryResource filters a single tagged resource mapping by
+// deployment-ID format and owner, dedupes it by ARN, updates or creates the
+// deployment's summary, and buckets the resource ID by type.
+func recordTaggedSummaryResource(
+	mapping rgttypes.ResourceTagMapping,
+	region string,
+	deploymentIDRegex *regexp.Regexp,
+	ownerFilter string,
+	acc *summariesAccumulator,
+) {
+	deploymentID := tagValue(mapping.Tags, "Deployment")
+	// Applies to both modern and legacy deployments: ensure the
+	// deployment tag matches the strict format.
+	if !deploymentIDRegex.MatchString(deploymentID) {
+		return
+	}
+
+	ownerTag := tagValue(mapping.Tags, "Owner")
+	if !ownerMatchesFilter(ownerTag, ownerFilter) {
+		return
+	}
+	arn := awsString(mapping.ResourceARN)
+	if _, seen := acc.processed[arn]; seen {
+		return
+	}
+	acc.processed[arn] = struct{}{}
+	reg := parseRegionFromARN(arn)
+	if reg == "" {
+		reg = region
+	}
+	sum := acc.summaries[deploymentID]
+	if sum == nil {
+		sum = &DeploymentSummary{
+			ID:        deploymentID,
+			Provider:  "aws",
+			Region:    reg,
+			Owner:     ownerTag,
+			CreatedAt: time.Time{},
+			State:     "unknown",
+		}
+		acc.summaries[deploymentID] = sum
+	} else if sum.Owner == "" {
+		sum.Owner = ownerTag
+	}
+	// CreatedAt tag wins first
+	sum.CreatedAt = UpdateCreatedAtFromTag(
+		sum.CreatedAt,
+		tagValue(mapping.Tags, "CreatedAt"),
+	)
+	sum.Resources++
+	rType, rID := classifyARN(arn)
+	switch rType {
+	case ResourceEC2Instance:
+		if rID != "" {
+			acc.instanceIDs[deploymentID] = append(acc.instanceIDs[deploymentID], rID)
+		}
+	case ResourceEBSVolume:
+		if rID != "" {
+			acc.volumeIDs[deploymentID] = append(acc.volumeIDs[deploymentID], rID)
+		}
+	case ResourceSSMParam:
+		if rID != "" {
+			acc.ssmNames[deploymentID] = append(acc.ssmNames[deploymentID], rID)
+		}
+	case ResourceEC2KeyPair,
+		ResourceInternetGW,
+		ResourceRouteTable,
+		ResourceSecurityGrp,
+		ResourceSubnet,
+		ResourceVPC,
+		ResourceS3Bucket:
+	default:
+		// ignore other resource types for summaries aggregation here
+	}
+}
+
+// enrichSummariesFromEC2 describes every collected EC2 instance per
+// deployment and derives the deployment's CreatedAt and lifecycle state.
+func enrichSummariesFromEC2(ctx context.Context, ec2Client *ec2.Client, acc *summariesAccumulator) {
+	for depID, ids := range acc.instanceIDs {
+		enrichSummaryFromEC2Instances(ctx, ec2Client, depID, ids, acc)
+	}
+}
+
+// enrichSummaryFromEC2Instances describes one deployment's EC2 instances and
+// derives its CreatedAt and lifecycle state from the results.
+func enrichSummaryFromEC2Instances(
+	ctx context.Context,
+	ec2Client *ec2.Client,
+	depID string,
+	ids []string,
+	acc *summariesAccumulator,
+) {
+	out, err := ec2Client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{InstanceIds: ids})
+	if err != nil {
+		slog.Debug("instance describe failed", "deployment", depID, "error", err)
+		return
+	}
+	var earliest *time.Time
+	hasActive := false
+	hasStopped := false
+	foundAny := false
+	for _, res := range out.Reservations {
+		for _, inst := range res.Instances {
+			foundAny = true
+			earliest = preferPtrEarlier(earliest, inst.LaunchTime)
+			switch ec2StateToSimple(inst.State) {
+			case StateActive, StateProvisioning:
+				hasActive = true
+			case StateStopped:
+				hasStopped = true
+			default:
+				// no update
 			}
 		}
-		if earliest != nil {
-			s := summaries[depID]
-			s.CreatedAt = PreferEarlier(s.CreatedAt, earliest)
-		}
-		switch {
-		case hasActive:
-			summaries[depID].State = StateActive
-		case hasStopped:
-			summaries[depID].State = StateStopped
-		case !foundAny:
-			summaries[depID].State = StateTerminated
-		default:
-			// no update
-		}
 	}
+	if earliest != nil {
+		s := acc.summaries[depID]
+		s.CreatedAt = PreferEarlier(s.CreatedAt, earliest)
+	}
+	switch {
+	case hasActive:
+		acc.summaries[depID].State = StateActive
+	case hasStopped:
+		acc.summaries[depID].State = StateStopped
+	case !foundAny:
+		acc.summaries[depID].State = StateTerminated
+	default:
+		// no update
+	}
+}
 
-	// EBS fallback for CreatedAt
-	for depID, ids := range volumeIDs {
-		sum := summaries[depID]
+// applyEBSFallbackCreatedAt fills in a deployment's CreatedAt from its EBS
+// volumes when no earlier source has already set it.
+func applyEBSFallbackCreatedAt(ctx context.Context, ec2Client *ec2.Client, acc *summariesAccumulator) {
+	for depID, ids := range acc.volumeIDs {
+		sum := acc.summaries[depID]
 		if sum == nil {
 			continue
 		}
@@ -555,53 +759,63 @@ func CollectDeploymentSummaries(
 			sum.CreatedAt = PreferEarlier(sum.CreatedAt, earliest)
 		}
 	}
+}
 
-	// SSM fallback for CreatedAt
-	if len(ssmNames) > 0 {
-		ssmClient := ssm.NewFromConfig(cfg)
-		for depID, names := range ssmNames {
-			sum := summaries[depID]
-			if sum == nil || !sum.CreatedAt.IsZero() {
-				continue
-			}
-			out, err := ssmClient.DescribeParameters(
-				ctx,
-				&ssm.DescribeParametersInput{
-					Filters: []ssmtypes.ParametersFilter{
-						{Key: ssmtypes.ParametersFilterKeyName, Values: names},
-					},
+// applySSMFallbackCreatedAt fills in a deployment's CreatedAt from its SSM
+// parameters when no earlier source has already set it.
+func applySSMFallbackCreatedAt(ctx context.Context, cfg aws.Config, acc *summariesAccumulator) {
+	if len(acc.ssmNames) == 0 {
+		return
+	}
+	ssmClient := ssm.NewFromConfig(cfg)
+	for depID, names := range acc.ssmNames {
+		sum := acc.summaries[depID]
+		if sum == nil || !sum.CreatedAt.IsZero() {
+			continue
+		}
+		out, err := ssmClient.DescribeParameters(
+			ctx,
+			&ssm.DescribeParametersInput{
+				Filters: []ssmtypes.ParametersFilter{
+					{Key: ssmtypes.ParametersFilterKeyName, Values: names},
 				},
-			)
-			if err != nil {
-				continue
-			}
-			var earliest *time.Time
-			for _, p := range out.Parameters {
-				earliest = preferPtrEarlier(earliest, p.LastModifiedDate)
-			}
-			if earliest != nil {
-				sum.CreatedAt = PreferEarlier(sum.CreatedAt, earliest)
-			}
+			},
+		)
+		if err != nil {
+			continue
+		}
+		var earliest *time.Time
+		for _, p := range out.Parameters {
+			earliest = preferPtrEarlier(earliest, p.LastModifiedDate)
+		}
+		if earliest != nil {
+			sum.CreatedAt = PreferEarlier(sum.CreatedAt, earliest)
 		}
 	}
+}
 
-	// Mark orphaned
-	for depID, sum := range summaries {
+// markOrphanedSummaries flags deployments with resources but no EC2
+// instances (and otherwise-unknown state) as orphaned.
+func markOrphanedSummaries(acc *summariesAccumulator) {
+	for depID, sum := range acc.summaries {
 		if sum.Resources > 0 {
-			if _, ok := instanceIDs[depID]; !ok {
+			if _, ok := acc.instanceIDs[depID]; !ok {
 				if sum.State == StateUnknown {
 					sum.State = "orphaned"
 				}
 			}
 		}
 	}
+}
 
+// summariesSliceFromMap converts the discovered deployment map into a slice.
+func summariesSliceFromMap(summaries map[string]*DeploymentSummary) []DeploymentSummary {
 	result := make([]DeploymentSummary, 0, len(summaries))
 	for _, s := range summaries {
 		result = append(result, *s)
 	}
 
-	return result, nil
+	return result
 }
 
 // preferPtrEarlier returns the earlier non-nil pointer, else existing.

--- a/tools/cleanup/pkg/cleanup/providers/aws/handlers.go
+++ b/tools/cleanup/pkg/cleanup/providers/aws/handlers.go
@@ -109,18 +109,61 @@ func (h *ec2VolumeHandler) Delete(ctx context.Context, ref ResourceRef) error {
 	return err
 }
 
+// deleteRouteInputFor builds the DeleteRoute input addressing the route's
+// destination, reporting false when the route has no destination we can target.
+func deleteRouteInputFor(
+	routeTableID *string,
+	route ec2types.Route,
+) (*ec2svc.DeleteRouteInput, bool) {
+	input := &ec2svc.DeleteRouteInput{RouteTableId: routeTableID}
+	switch {
+	case route.DestinationCidrBlock != nil:
+		input.DestinationCidrBlock = route.DestinationCidrBlock
+	case route.DestinationIpv6CidrBlock != nil:
+		input.DestinationIpv6CidrBlock = route.DestinationIpv6CidrBlock
+	case route.DestinationPrefixListId != nil:
+		input.DestinationPrefixListId = route.DestinationPrefixListId
+	default:
+		return nil, false
+	}
+
+	return input, true
+}
+
 type ec2InternetGatewayHandler struct{ client *ec2svc.Client }
 
 func (h *ec2InternetGatewayHandler) Delete(ctx context.Context, ref ResourceRef) error {
-	// Describe attachments to detach
-	out, err := h.client.DescribeInternetGateways(
-		ctx,
-		&ec2svc.DescribeInternetGatewaysInput{InternetGatewayIds: []string{ref.ID}},
-	)
+	vpcs, err := h.attachedVPCs(ctx, ref.ID)
 	if err != nil {
 		return err
 	}
-	// Track VPCs to clean up routes referencing the IGW
+	// Proactively delete routes targeting IGW before detaching,
+	// as some accounts block detachment while routes exist
+	if err := h.deleteRoutesReferencingGateway(ctx, ref.ID, vpcs); err != nil {
+		return err
+	}
+	if err := h.detachFromVPCs(ctx, ref.ID, vpcs); err != nil {
+		return err
+	}
+	h.waitForGatewayDetachment(ctx, ref.ID)
+	// (routes were removed before detach)
+
+	return h.retryDeleteInternetGateway(ctx, ref.ID)
+}
+
+// attachedVPCs describes the gateway attachments and returns the VPCs whose
+// routes reference the IGW and from which it has to be detached.
+func (h *ec2InternetGatewayHandler) attachedVPCs(
+	ctx context.Context,
+	gatewayID string,
+) ([]string, error) {
+	out, err := h.client.DescribeInternetGateways(
+		ctx,
+		&ec2svc.DescribeInternetGatewaysInput{InternetGatewayIds: []string{gatewayID}},
+	)
+	if err != nil {
+		return nil, err
+	}
 	var vpcs []string
 	for _, gw := range out.InternetGateways {
 		for _, att := range gw.Attachments {
@@ -129,8 +172,17 @@ func (h *ec2InternetGatewayHandler) Delete(ctx context.Context, ref ResourceRef)
 			}
 		}
 	}
-	// Proactively delete routes targeting IGW before detaching,
-	// as some accounts block detachment while routes exist
+
+	return vpcs, nil
+}
+
+// deleteRoutesReferencingGateway removes routes targeting the IGW from every
+// route table of the given VPCs.
+func (h *ec2InternetGatewayHandler) deleteRoutesReferencingGateway(
+	ctx context.Context,
+	gatewayID string,
+	vpcs []string,
+) error {
 	for _, vpcID := range vpcs {
 		rtOut, rErr := h.client.DescribeRouteTables(ctx, &ec2svc.DescribeRouteTablesInput{
 			Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
@@ -138,81 +190,127 @@ func (h *ec2InternetGatewayHandler) Delete(ctx context.Context, ref ResourceRef)
 		if rErr != nil {
 			return rErr
 		}
-		for _, rt := range rtOut.RouteTables {
-			for _, route := range rt.Routes {
-				if route.GatewayId != nil && *route.GatewayId == ref.ID && rt.RouteTableId != nil {
-					input := &ec2svc.DeleteRouteInput{RouteTableId: rt.RouteTableId}
-					switch {
-					case route.DestinationCidrBlock != nil:
-						input.DestinationCidrBlock = route.DestinationCidrBlock
-					case route.DestinationIpv6CidrBlock != nil:
-						input.DestinationIpv6CidrBlock = route.DestinationIpv6CidrBlock
-					case route.DestinationPrefixListId != nil:
-						input.DestinationPrefixListId = route.DestinationPrefixListId
-					default:
-						continue
-					}
-					if _, drErr := h.client.DeleteRoute(ctx, input); drErr != nil {
-						return drErr
-					}
-				}
+		if err := h.deleteGatewayRoutes(ctx, gatewayID, rtOut.RouteTables); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// deleteGatewayRoutes deletes every route of the given tables whose target is
+// the IGW.
+func (h *ec2InternetGatewayHandler) deleteGatewayRoutes(
+	ctx context.Context,
+	gatewayID string,
+	tables []ec2types.RouteTable,
+) error {
+	for _, rt := range tables {
+		for _, route := range rt.Routes {
+			if route.GatewayId == nil || *route.GatewayId != gatewayID || rt.RouteTableId == nil {
+				continue
+			}
+			input, ok := deleteRouteInputFor(rt.RouteTableId, route)
+			if !ok {
+				continue
+			}
+			if _, drErr := h.client.DeleteRoute(ctx, input); drErr != nil {
+				return drErr
 			}
 		}
 	}
-	// Now detach IGW from each VPC
+
+	return nil
+}
+
+// detachFromVPCs detaches the IGW from each VPC it is attached to.
+func (h *ec2InternetGatewayHandler) detachFromVPCs(
+	ctx context.Context,
+	gatewayID string,
+	vpcs []string,
+) error {
 	for _, vpcID := range vpcs {
-		// Retry detachment as it may fail if there are still network interfaces being released
-		var detachErr error
-		for i := 0; i < 10; i++ {
-			_, detachErr = h.client.DetachInternetGateway(
-				ctx,
-				&ec2svc.DetachInternetGatewayInput{
-					InternetGatewayId: aws.String(ref.ID),
-					VpcId:             aws.String(vpcID),
-				},
-			)
-			if detachErr == nil {
-				break
-			}
-			if !strings.Contains(detachErr.Error(), "DependencyViolation") {
-				return detachErr
-			}
-			time.Sleep(2 * time.Second)
+		if err := h.detachFromVPC(ctx, gatewayID, vpcID); err != nil {
+			return err
 		}
-		if detachErr != nil {
+	}
+
+	return nil
+}
+
+// detachFromVPC retries detachment as it may fail if there are still network
+// interfaces being released.
+func (h *ec2InternetGatewayHandler) detachFromVPC(
+	ctx context.Context,
+	gatewayID string,
+	vpcID string,
+) error {
+	var detachErr error
+	for i := 0; i < 10; i++ {
+		_, detachErr = h.client.DetachInternetGateway(
+			ctx,
+			&ec2svc.DetachInternetGatewayInput{
+				InternetGatewayId: aws.String(gatewayID),
+				VpcId:             aws.String(vpcID),
+			},
+		)
+		if detachErr == nil {
+			break
+		}
+		if !strings.Contains(detachErr.Error(), "DependencyViolation") {
 			return detachErr
 		}
+		time.Sleep(2 * time.Second)
 	}
-	// Wait briefly until attachments reflect detachment
+
+	return detachErr
+}
+
+// waitForGatewayDetachment waits briefly until attachments reflect detachment.
+func (h *ec2InternetGatewayHandler) waitForGatewayDetachment(
+	ctx context.Context,
+	gatewayID string,
+) {
 	for range 5 {
 		time.Sleep(1 * time.Second)
 		check, cErr := h.client.DescribeInternetGateways(
 			ctx,
-			&ec2svc.DescribeInternetGatewaysInput{InternetGatewayIds: []string{ref.ID}},
+			&ec2svc.DescribeInternetGatewaysInput{InternetGatewayIds: []string{gatewayID}},
 		)
 		if cErr != nil {
 			break
 		}
-		allDetached := true
-		for _, gw := range check.InternetGateways {
-			for _, att := range gw.Attachments {
-				if att.State == ec2types.AttachmentStatusAttached {
-					allDetached = false
-					break
-				}
-			}
-		}
-		if allDetached {
+		if allAttachmentsDetached(check.InternetGateways) {
 			break
 		}
 	}
-	// (routes were removed before detach)
-	// Retry delete IGW a few times to overcome eventual consistency
+}
+
+// allAttachmentsDetached reports whether none of the gateways still has an
+// attached attachment.
+func allAttachmentsDetached(gateways []ec2types.InternetGateway) bool {
+	for _, gw := range gateways {
+		for _, att := range gw.Attachments {
+			if att.State == ec2types.AttachmentStatusAttached {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// retryDeleteInternetGateway retries the delete a few times to overcome
+// eventual consistency.
+func (h *ec2InternetGatewayHandler) retryDeleteInternetGateway(
+	ctx context.Context,
+	gatewayID string,
+) error {
 	var lastErr error
 	for range igwDeleteRetries {
 		_, derr := h.client.DeleteInternetGateway(
 			ctx,
-			&ec2svc.DeleteInternetGatewayInput{InternetGatewayId: aws.String(ref.ID)},
+			&ec2svc.DeleteInternetGatewayInput{InternetGatewayId: aws.String(gatewayID)},
 		)
 		if derr == nil {
 			return nil
@@ -234,38 +332,20 @@ func (h *ec2VpcEndpointHandler) Delete(ctx context.Context, ref ResourceRef) err
 	// For gateway endpoints (e.g., S3), routes reference the endpoint id in route.GatewayId.
 	// Clean any routes in the VPC that target this endpoint id.
 	// First, find the VPC of the endpoint to scope route tables.
-	desc, err := h.client.DescribeVpcEndpoints(ctx, &ec2svc.DescribeVpcEndpointsInput{
-		VpcEndpointIds: []string{ref.ID},
-	})
+	vpcID, missing, err := h.endpointVPC(ctx, ref.ID)
 	if err != nil {
-		// If not found, treat as success
-		if strings.Contains(err.Error(), "VpcEndpointIdNotFound") ||
-			strings.Contains(err.Error(), errInvalidVpcEndpointIDNotFound) {
-			return nil
-		}
 		return err
 	}
-	var vpcID string
-	for _, ep := range desc.VpcEndpoints {
-		if ep.VpcId != nil {
-			vpcID = *ep.VpcId
-			break
-		}
+	if missing {
+		return nil
 	}
 	// Try deleting the endpoint first. For gateway endpoints (S3) AWS manages
 	// the route table entries and will remove them when the endpoint is deleted.
 	// Deleting the endpoint first avoids errors like
 	// "cannot remove VPC endpoint route ..." when attempting to delete routes
 	// manually.
-	_, delErr := h.client.DeleteVpcEndpoints(ctx, &ec2svc.DeleteVpcEndpointsInput{
-		VpcEndpointIds: []string{ref.ID},
-	})
+	delErr := h.deleteEndpoint(ctx, ref.ID)
 	if delErr == nil {
-		return nil
-	}
-	// Treat not found as success
-	if strings.Contains(delErr.Error(), errInvalidVpcEndpointIDNotFound) ||
-		strings.Contains(delErr.Error(), "VpcEndpointIdNotFound") {
 		return nil
 	}
 
@@ -273,53 +353,111 @@ func (h *ec2VpcEndpointHandler) Delete(ctx context.Context, ref ResourceRef) err
 	// lingering route table entries referencing the endpoint, then retry
 	// deletion. Some accounts may allow manual route removal as a fallback.
 	if vpcID != "" {
-		rtOut, rErr := h.client.DescribeRouteTables(ctx, &ec2svc.DescribeRouteTablesInput{
-			Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
-		})
-		if rErr == nil {
-			for _, rt := range rtOut.RouteTables {
-				for _, route := range rt.Routes {
-					if route.GatewayId != nil && *route.GatewayId == ref.ID && rt.RouteTableId != nil {
-						input := &ec2svc.DeleteRouteInput{RouteTableId: rt.RouteTableId}
-						switch {
-						case route.DestinationCidrBlock != nil:
-							input.DestinationCidrBlock = route.DestinationCidrBlock
-						case route.DestinationIpv6CidrBlock != nil:
-							input.DestinationIpv6CidrBlock = route.DestinationIpv6CidrBlock
-						case route.DestinationPrefixListId != nil:
-							input.DestinationPrefixListId = route.DestinationPrefixListId
-						default:
-							continue
-						}
-						if _, drErr := h.client.DeleteRoute(ctx, input); drErr != nil {
-							// If AWS rejects manual route deletion for endpoint-managed
-							// routes, ignore and continue; we'll retry endpoint delete
-							// below.
-							if strings.Contains(drErr.Error(), "cannot remove VPC endpoint route") {
-								continue
-							}
-							return drErr
-						}
-					}
-				}
+		if rErr := h.removeRoutesReferencingEndpoint(ctx, ref.ID, vpcID); rErr != nil {
+			return rErr
+		}
+	}
+
+	// Retry deleting the endpoint once after attempting manual route cleanup.
+	// Prefer returning the original delete error if retry failed too.
+	if h.deleteEndpoint(ctx, ref.ID) != nil {
+		return delErr
+	}
+
+	return nil
+}
+
+// isVpcEndpointNotFound reports whether the error says the endpoint is gone,
+// which cleanup treats as success.
+func isVpcEndpointNotFound(err error) bool {
+	return strings.Contains(err.Error(), errInvalidVpcEndpointIDNotFound) ||
+		strings.Contains(err.Error(), "VpcEndpointIdNotFound")
+}
+
+// endpointVPC returns the VPC of the endpoint used to scope route tables, and
+// reports missing when the endpoint no longer exists.
+func (h *ec2VpcEndpointHandler) endpointVPC(
+	ctx context.Context,
+	endpointID string,
+) (vpcID string, missing bool, err error) {
+	desc, err := h.client.DescribeVpcEndpoints(ctx, &ec2svc.DescribeVpcEndpointsInput{
+		VpcEndpointIds: []string{endpointID},
+	})
+	if err != nil {
+		// If not found, treat as success
+		if isVpcEndpointNotFound(err) {
+			return "", true, nil
+		}
+		return "", false, err
+	}
+	for _, ep := range desc.VpcEndpoints {
+		if ep.VpcId != nil {
+			return *ep.VpcId, false, nil
+		}
+	}
+
+	return "", false, nil
+}
+
+// deleteEndpoint deletes the endpoint, treating not found as success.
+func (h *ec2VpcEndpointHandler) deleteEndpoint(ctx context.Context, endpointID string) error {
+	_, err := h.client.DeleteVpcEndpoints(ctx, &ec2svc.DeleteVpcEndpointsInput{
+		VpcEndpointIds: []string{endpointID},
+	})
+	if err != nil && isVpcEndpointNotFound(err) {
+		return nil
+	}
+
+	return err
+}
+
+// removeRoutesReferencingEndpoint deletes lingering route table entries in the
+// VPC that target the endpoint. Route tables that cannot be described are
+// skipped so the caller can still retry the endpoint deletion.
+func (h *ec2VpcEndpointHandler) removeRoutesReferencingEndpoint(
+	ctx context.Context,
+	endpointID string,
+	vpcID string,
+) error {
+	rtOut, rErr := h.client.DescribeRouteTables(ctx, &ec2svc.DescribeRouteTablesInput{
+		Filters: []ec2types.Filter{{Name: aws.String("vpc-id"), Values: []string{vpcID}}},
+	})
+	if rErr != nil {
+		return nil
+	}
+	for _, rt := range rtOut.RouteTables {
+		for _, route := range rt.Routes {
+			if route.GatewayId == nil || *route.GatewayId != endpointID || rt.RouteTableId == nil {
+				continue
+			}
+			if err := h.removeRouteToEndpoint(ctx, rt.RouteTableId, route); err != nil {
+				return err
 			}
 		}
 	}
 
-	// Retry deleting the endpoint once after attempting manual route cleanup
-	_, retryErr := h.client.DeleteVpcEndpoints(ctx, &ec2svc.DeleteVpcEndpointsInput{
-		VpcEndpointIds: []string{ref.ID},
-	})
-	if retryErr != nil {
-		if strings.Contains(retryErr.Error(), errInvalidVpcEndpointIDNotFound) ||
-			strings.Contains(retryErr.Error(), "VpcEndpointIdNotFound") {
+	return nil
+}
+
+// removeRouteToEndpoint deletes a single route targeting the endpoint.
+func (h *ec2VpcEndpointHandler) removeRouteToEndpoint(
+	ctx context.Context,
+	routeTableID *string,
+	route ec2types.Route,
+) error {
+	input, ok := deleteRouteInputFor(routeTableID, route)
+	if !ok {
+		return nil
+	}
+	if _, drErr := h.client.DeleteRoute(ctx, input); drErr != nil {
+		// If AWS rejects manual route deletion for endpoint-managed
+		// routes, ignore and continue; we'll retry endpoint delete
+		// below.
+		if strings.Contains(drErr.Error(), "cannot remove VPC endpoint route") {
 			return nil
 		}
-	}
 
-	// Prefer returning the original delete error if retry failed too.
-	if retryErr != nil {
-		return delErr
+		return drErr
 	}
 
 	return nil
@@ -509,81 +647,101 @@ type s3BucketHandler struct{ client *s3svc.Client }
 
 func (h *s3BucketHandler) Delete(ctx context.Context, ref ResourceRef) error {
 	bucket := ref.ID
+
 	// Try to delete all object versions first (handles versioned buckets)
-	// List object versions
+	if err := h.deleteObjectVersions(ctx, bucket); err != nil {
+		return err
+	}
+	// Non-versioned objects
+	if err := h.deleteCurrentObjects(ctx, bucket); err != nil {
+		return err
+	}
+
+	return h.deleteBucketItself(ctx, bucket)
+}
+
+// deleteObjectVersions empties a versioned bucket by batch-deleting every
+// object version and delete marker. A list failure is treated as "nothing to
+// delete here" so Delete still proceeds to the other cleanup phases.
+func (h *s3BucketHandler) deleteObjectVersions(ctx context.Context, bucket string) error {
 	listVers, err := h.client.ListObjectVersions(
 		ctx,
 		&s3svc.ListObjectVersionsInput{Bucket: aws.String(bucket)},
 	)
-	// nolint:nestif // nested flow is acceptable for batch deletions
-	if err == nil {
-		// Collect all keys + versionIds including delete markers
-		toDelete := make([]s3types.ObjectIdentifier, 0)
-		for _, v := range listVers.Versions {
-			if v.Key != nil && v.VersionId != nil {
-				toDelete = append(
-					toDelete,
-					s3types.ObjectIdentifier{Key: v.Key, VersionId: v.VersionId},
-				)
-			}
-		}
-		for _, d := range listVers.DeleteMarkers {
-			if d.Key != nil && d.VersionId != nil {
-				toDelete = append(
-					toDelete,
-					s3types.ObjectIdentifier{Key: d.Key, VersionId: d.VersionId},
-				)
-			}
-		}
-		if len(toDelete) > 0 {
-			// batch delete in chunks of 1000 per AWS limits
-			for item := 0; item < len(toDelete); item += s3BatchDeleteSize {
-				end := item + s3BatchDeleteSize
-				if end > len(toDelete) {
-					end = len(toDelete)
-				}
-				_, derr := h.client.DeleteObjects(ctx, &s3svc.DeleteObjectsInput{
-					Bucket: aws.String(bucket),
-					Delete: &s3types.Delete{Objects: toDelete[item:end], Quiet: aws.Bool(true)},
-				})
-				if derr != nil {
-					return derr
-				}
-			}
-		}
-	}
-	// Non-versioned objects
-	list, err := h.client.ListObjectsV2(ctx, &s3svc.ListObjectsV2Input{Bucket: aws.String(bucket)})
-	// nolint:nestif // nested flow is acceptable for batch deletions
-	if err == nil {
-		objs := make([]s3types.ObjectIdentifier, 0)
-		for _, o := range list.Contents {
-			if o.Key != nil {
-				objs = append(objs, s3types.ObjectIdentifier{Key: o.Key})
-			}
-		}
-		if len(objs) > 0 {
-			for item := 0; item < len(objs); item += s3BatchDeleteSize {
-				end := item + s3BatchDeleteSize
-				if end > len(objs) {
-					end = len(objs)
-				}
-				_, derr := h.client.DeleteObjects(ctx, &s3svc.DeleteObjectsInput{
-					Bucket: aws.String(bucket),
-					Delete: &s3types.Delete{Objects: objs[item:end], Quiet: aws.Bool(true)},
-				})
-				if derr != nil {
-					return derr
-				}
-			}
-		}
-	}
-	// Attempt bucket delete
-	_, err = h.client.DeleteBucket(ctx, &s3svc.DeleteBucketInput{Bucket: aws.String(bucket)})
 	if err != nil {
-		if strings.Contains(err.Error(), "NoSuchBucket") {
-			return nil
+		return nil
+	}
+
+	// Collect all keys + versionIds including delete markers
+	toDelete := make([]s3types.ObjectIdentifier, 0)
+	for _, v := range listVers.Versions {
+		if v.Key != nil && v.VersionId != nil {
+			toDelete = append(
+				toDelete,
+				s3types.ObjectIdentifier{Key: v.Key, VersionId: v.VersionId},
+			)
 		}
+	}
+	for _, d := range listVers.DeleteMarkers {
+		if d.Key != nil && d.VersionId != nil {
+			toDelete = append(
+				toDelete,
+				s3types.ObjectIdentifier{Key: d.Key, VersionId: d.VersionId},
+			)
+		}
+	}
+
+	return h.batchDeleteObjects(ctx, bucket, toDelete)
+}
+
+// deleteCurrentObjects empties a non-versioned bucket's current objects. A
+// list failure is treated as "nothing to delete here" so Delete still
+// proceeds to the bucket-delete phase.
+func (h *s3BucketHandler) deleteCurrentObjects(ctx context.Context, bucket string) error {
+	list, err := h.client.ListObjectsV2(ctx, &s3svc.ListObjectsV2Input{Bucket: aws.String(bucket)})
+	if err != nil {
+		return nil
+	}
+
+	objs := make([]s3types.ObjectIdentifier, 0)
+	for _, o := range list.Contents {
+		if o.Key != nil {
+			objs = append(objs, s3types.ObjectIdentifier{Key: o.Key})
+		}
+	}
+
+	return h.batchDeleteObjects(ctx, bucket, objs)
+}
+
+// batchDeleteObjects deletes the given objects in chunks of s3BatchDeleteSize
+// per AWS's DeleteObjects limit.
+func (h *s3BucketHandler) batchDeleteObjects(
+	ctx context.Context,
+	bucket string,
+	objects []s3types.ObjectIdentifier,
+) error {
+	for item := 0; item < len(objects); item += s3BatchDeleteSize {
+		end := item + s3BatchDeleteSize
+		if end > len(objects) {
+			end = len(objects)
+		}
+		_, derr := h.client.DeleteObjects(ctx, &s3svc.DeleteObjectsInput{
+			Bucket: aws.String(bucket),
+			Delete: &s3types.Delete{Objects: objects[item:end], Quiet: aws.Bool(true)},
+		})
+		if derr != nil {
+			return derr
+		}
+	}
+
+	return nil
+}
+
+// deleteBucketItself deletes the bucket, treating NoSuchBucket as success.
+func (h *s3BucketHandler) deleteBucketItself(ctx context.Context, bucket string) error {
+	_, err := h.client.DeleteBucket(ctx, &s3svc.DeleteBucketInput{Bucket: aws.String(bucket)})
+	if err != nil && strings.Contains(err.Error(), "NoSuchBucket") {
+		return nil
 	}
 
 	return err

--- a/tools/cleanup/pkg/cleanup/providers/exoscale/collect.go
+++ b/tools/cleanup/pkg/cleanup/providers/exoscale/collect.go
@@ -77,6 +77,16 @@ func getZoneEndpoint(zone string) (v3.Endpoint, error) {
 	}
 }
 
+// detailsAccumulator carries the mutable state that the per-resource-type
+// discovery phases of CollectDeploymentDetails contribute to.
+type detailsAccumulator struct {
+	details      *DeploymentDetails
+	earliest     *time.Time
+	hasInstances bool
+	hasActive    bool
+	hasStopped   bool
+}
+
 // CollectDeploymentDetails enumerates resources for a single deployment in Exoscale
 func CollectDeploymentDetails(
 	ctx context.Context,
@@ -88,339 +98,467 @@ func CollectDeploymentDetails(
 		return nil, err
 	}
 
-	details := &DeploymentDetails{
-		Summary: DeploymentSummary{
-			ID:        deploymentID,
-			Provider:  "exoscale",
-			Region:    zone,
-			Owner:     "",
-			CreatedAt: time.Time{},
-			State:     StateUnknown,
+	acc := &detailsAccumulator{
+		details: &DeploymentDetails{
+			Summary: DeploymentSummary{
+				ID:        deploymentID,
+				Provider:  "exoscale",
+				Region:    zone,
+				Owner:     "",
+				CreatedAt: time.Time{},
+				State:     StateUnknown,
+			},
 		},
 	}
 
-	var earliest *time.Time
-	hasInstances := false
-	hasActive := false
-	hasStopped := false
+	collectInstanceDetails(ctx, client, zone, deploymentID, acc)
+	collectBlockStorageVolumeDetails(ctx, client, zone, deploymentID, acc)
+	collectPrivateNetworkDetails(ctx, client, zone, deploymentID, acc)
+	collectSecurityGroupDetails(ctx, client, zone, deploymentID, acc)
+	collectSSHKeyDetails(ctx, client, zone, deploymentID, acc)
+	collectIAMRoleDetails(ctx, client, zone, deploymentID, acc)
+	collectIAMAPIKeyDetails(ctx, client, zone, deploymentID, acc)
+	collectSOSBucketDetails(ctx, zone, deploymentID, acc)
 
-	// Discover compute instances by label
+	applyDetailsSummaryTotals(acc)
+	deriveDetailsSummaryState(acc)
+	applyOwnerFallback(&acc.details.Summary)
+
+	return acc.details, nil
+}
+
+// collectInstanceDetails discovers compute instances by label
+func collectInstanceDetails(
+	ctx context.Context,
+	client *v3.Client,
+	zone string,
+	deploymentID string,
+	acc *detailsAccumulator,
+) {
 	instancesResp, err := client.ListInstances(ctx)
 	if err != nil {
 		slog.Debug("list instances failed", "error", err)
-	} else if instancesResp != nil && instancesResp.Instances != nil {
-		for _, inst := range instancesResp.Instances {
-			// inst.ID is v3.UUID which is a string type
-			if inst.ID == "" {
-				continue
-			}
-			instID := inst.ID
-
-			// Get full instance to access all fields
-			fullInst, err := client.GetInstance(ctx, instID)
-			if err != nil {
-				slog.Debug("failed to get instance details", "error", err)
-				continue
-			}
-
-			nameStr := fullInst.Name
-			labels := fullInst.Labels
-			slog.Info("discovered instance", "id", instID, "name", nameStr, "labels", labels, "deploymentID", deploymentID)
-
-			if !matchesDeployment(&nameStr, labels, deploymentID) {
-				continue
-			}
-
-			hasInstances = true
-			stateStr := string(fullInst.State)
-			state := instanceStateToSimple(&stateStr)
-
-			typeID := ""
-			if fullInst.InstanceType != nil {
-				typeID = string(fullInst.InstanceType.ID)
-			}
-
-			instIDStr := string(instID)
-
-			meta := ResourceMeta{
-				Ref: ResourceRef{
-					ARN:    instanceARN(zone, instIDStr),
-					Type:   ResourceComputeInstance,
-					Region: zone,
-					ID:     instIDStr,
-				},
-				Tags: labels,
-				Attr: map[string]any{
-					"name":  nameStr,
-					"state": state,
-					"type":  typeID,
-				},
-			}
-
-			if !fullInst.CreatedAT.IsZero() {
-				meta.Attr["createdAt"] = fullInst.CreatedAT
-				earliest = preferEarlier(earliest, &fullInst.CreatedAT)
-			}
-
-			if owner, ok := labels["owner"]; ok && owner != "" {
-				details.Summary.Owner = owner
-			}
-
-			switch state {
-			case StateActive:
-				hasActive = true
-			case StateStopped:
-				hasStopped = true
-			}
-
-			details.Resources = append(details.Resources, meta)
-		}
+		return
 	}
 
-	// Block storage volumes
+	if instancesResp == nil || instancesResp.Instances == nil {
+		return
+	}
+
+	for _, inst := range instancesResp.Instances {
+		collectInstanceDetail(ctx, client, zone, deploymentID, inst, acc)
+	}
+}
+
+// collectInstanceDetail records a single compute instance if it belongs to the deployment
+func collectInstanceDetail(
+	ctx context.Context,
+	client *v3.Client,
+	zone string,
+	deploymentID string,
+	inst v3.ListInstancesResponseInstances,
+	acc *detailsAccumulator,
+) {
+	// inst.ID is v3.UUID which is a string type
+	if inst.ID == "" {
+		return
+	}
+	instID := inst.ID
+
+	// Get full instance to access all fields
+	fullInst, err := client.GetInstance(ctx, instID)
+	if err != nil {
+		slog.Debug("failed to get instance details", "error", err)
+		return
+	}
+
+	nameStr := fullInst.Name
+	labels := fullInst.Labels
+	slog.Info("discovered instance", "id", instID, "name", nameStr, "labels", labels, "deploymentID", deploymentID)
+
+	if !matchesDeployment(&nameStr, labels, deploymentID) {
+		return
+	}
+
+	acc.hasInstances = true
+	stateStr := string(fullInst.State)
+	state := instanceStateToSimple(&stateStr)
+
+	typeID := ""
+	if fullInst.InstanceType != nil {
+		typeID = string(fullInst.InstanceType.ID)
+	}
+
+	instIDStr := string(instID)
+
+	meta := ResourceMeta{
+		Ref: ResourceRef{
+			ARN:    instanceARN(zone, instIDStr),
+			Type:   ResourceComputeInstance,
+			Region: zone,
+			ID:     instIDStr,
+		},
+		Tags: labels,
+		Attr: map[string]any{
+			"name":  nameStr,
+			"state": state,
+			"type":  typeID,
+		},
+	}
+
+	if !fullInst.CreatedAT.IsZero() {
+		meta.Attr["createdAt"] = fullInst.CreatedAT
+		acc.earliest = preferEarlier(acc.earliest, &fullInst.CreatedAT)
+	}
+
+	if owner, ok := labels["owner"]; ok && owner != "" {
+		acc.details.Summary.Owner = owner
+	}
+
+	switch state {
+	case StateActive:
+		acc.hasActive = true
+	case StateStopped:
+		acc.hasStopped = true
+	}
+
+	acc.details.Resources = append(acc.details.Resources, meta)
+}
+
+// collectBlockStorageVolumeDetails discovers block storage volumes by label
+func collectBlockStorageVolumeDetails(
+	ctx context.Context,
+	client *v3.Client,
+	zone string,
+	deploymentID string,
+	acc *detailsAccumulator,
+) {
 	volumesResp, err := client.ListBlockStorageVolumes(ctx)
 	if err != nil {
 		slog.Debug("list block storage volumes failed", "error", err)
-	} else if volumesResp != nil && volumesResp.BlockStorageVolumes != nil {
-		for _, vol := range volumesResp.BlockStorageVolumes {
-			labels := vol.Labels
-
-			if !matchesDeploymentLabels(labels, deploymentID) {
-				continue
-			}
-
-			volID := string(vol.ID)
-			volName := vol.Name
-			stateStr := string(vol.State)
-			state := blockStorageStateToSimple(stateStr)
-
-			meta := ResourceMeta{
-				Ref: ResourceRef{
-					ARN:    volumeARN(zone, volID),
-					Type:   ResourceBlockVolume,
-					Region: zone,
-					ID:     volID,
-				},
-				Tags: labels,
-				Attr: map[string]any{
-					"name":  volName,
-					"state": state,
-					"size":  vol.Size,
-				},
-			}
-
-			if !vol.CreatedAT.IsZero() {
-				meta.Attr["createdAt"] = vol.CreatedAT
-				earliest = preferEarlier(earliest, &vol.CreatedAT)
-			}
-
-			details.Resources = append(details.Resources, meta)
-		}
+		return
 	}
 
-	// Discover private networks by label
+	if volumesResp == nil || volumesResp.BlockStorageVolumes == nil {
+		return
+	}
+
+	for _, vol := range volumesResp.BlockStorageVolumes {
+		labels := vol.Labels
+
+		if !matchesDeploymentLabels(labels, deploymentID) {
+			continue
+		}
+
+		volID := string(vol.ID)
+		volName := vol.Name
+		stateStr := string(vol.State)
+		state := blockStorageStateToSimple(stateStr)
+
+		meta := ResourceMeta{
+			Ref: ResourceRef{
+				ARN:    volumeARN(zone, volID),
+				Type:   ResourceBlockVolume,
+				Region: zone,
+				ID:     volID,
+			},
+			Tags: labels,
+			Attr: map[string]any{
+				"name":  volName,
+				"state": state,
+				"size":  vol.Size,
+			},
+		}
+
+		if !vol.CreatedAT.IsZero() {
+			meta.Attr["createdAt"] = vol.CreatedAT
+			acc.earliest = preferEarlier(acc.earliest, &vol.CreatedAT)
+		}
+
+		acc.details.Resources = append(acc.details.Resources, meta)
+	}
+}
+
+// collectPrivateNetworkDetails discovers private networks by label
+func collectPrivateNetworkDetails(
+	ctx context.Context,
+	client *v3.Client,
+	zone string,
+	deploymentID string,
+	acc *detailsAccumulator,
+) {
 	networksResp, err := client.ListPrivateNetworks(ctx)
 	if err != nil {
 		slog.Debug("list private networks failed", "error", err)
-	} else if networksResp != nil && networksResp.PrivateNetworks != nil {
-		for _, net := range networksResp.PrivateNetworks {
-			nameStr := net.Name
-			labels := net.Labels
-
-			if !matchesDeployment(&nameStr, labels, deploymentID) {
-				continue
-			}
-
-			netID := string(net.ID)
-
-			meta := ResourceMeta{
-				Ref: ResourceRef{
-					ARN:    networkARN(zone, netID),
-					Type:   ResourcePrivateNetwork,
-					Region: zone,
-					ID:     netID,
-				},
-				Tags: labels,
-				Attr: map[string]any{
-					"name": nameStr,
-				},
-			}
-
-			details.Resources = append(details.Resources, meta)
-		}
+		return
 	}
 
-	// Discover security groups by name pattern
+	if networksResp == nil || networksResp.PrivateNetworks == nil {
+		return
+	}
+
+	for _, net := range networksResp.PrivateNetworks {
+		nameStr := net.Name
+		labels := net.Labels
+
+		if !matchesDeployment(&nameStr, labels, deploymentID) {
+			continue
+		}
+
+		netID := string(net.ID)
+
+		meta := ResourceMeta{
+			Ref: ResourceRef{
+				ARN:    networkARN(zone, netID),
+				Type:   ResourcePrivateNetwork,
+				Region: zone,
+				ID:     netID,
+			},
+			Tags: labels,
+			Attr: map[string]any{
+				"name": nameStr,
+			},
+		}
+
+		acc.details.Resources = append(acc.details.Resources, meta)
+	}
+}
+
+// collectSecurityGroupDetails discovers security groups by name pattern
+func collectSecurityGroupDetails(
+	ctx context.Context,
+	client *v3.Client,
+	zone string,
+	deploymentID string,
+	acc *detailsAccumulator,
+) {
 	securityGroupsResp, err := client.ListSecurityGroups(ctx)
 	if err != nil {
 		slog.Debug("list security groups failed", "error", err)
-	} else if securityGroupsResp != nil && securityGroupsResp.SecurityGroups != nil {
-		for _, sg := range securityGroupsResp.SecurityGroups {
-			nameStr := sg.Name
-
-			if !matchesDeploymentName(&nameStr, deploymentID) {
-				continue
-			}
-
-			sgID := string(sg.ID)
-
-			meta := ResourceMeta{
-				Ref: ResourceRef{
-					ARN:    securityGroupARN(zone, sgID),
-					Type:   ResourceSecurityGroup,
-					Region: zone,
-					ID:     sgID,
-				},
-				Tags: map[string]string{},
-				Attr: map[string]any{
-					"name": nameStr,
-				},
-			}
-
-			details.Resources = append(details.Resources, meta)
-		}
+		return
 	}
 
-	// Discover SSH keys by name pattern
+	if securityGroupsResp == nil || securityGroupsResp.SecurityGroups == nil {
+		return
+	}
+
+	for _, sg := range securityGroupsResp.SecurityGroups {
+		nameStr := sg.Name
+
+		if !matchesDeploymentName(&nameStr, deploymentID) {
+			continue
+		}
+
+		sgID := string(sg.ID)
+
+		meta := ResourceMeta{
+			Ref: ResourceRef{
+				ARN:    securityGroupARN(zone, sgID),
+				Type:   ResourceSecurityGroup,
+				Region: zone,
+				ID:     sgID,
+			},
+			Tags: map[string]string{},
+			Attr: map[string]any{
+				"name": nameStr,
+			},
+		}
+
+		acc.details.Resources = append(acc.details.Resources, meta)
+	}
+}
+
+// collectSSHKeyDetails discovers SSH keys by name pattern
+func collectSSHKeyDetails(
+	ctx context.Context,
+	client *v3.Client,
+	zone string,
+	deploymentID string,
+	acc *detailsAccumulator,
+) {
 	sshKeysResp, err := client.ListSSHKeys(ctx)
 	if err != nil {
 		slog.Debug("list ssh keys failed", "error", err)
-	} else if sshKeysResp != nil && sshKeysResp.SSHKeys != nil {
-		for _, key := range sshKeysResp.SSHKeys {
-			nameStr := key.Name
-
-			if !matchesDeploymentName(&nameStr, deploymentID) {
-				continue
-			}
-
-			meta := ResourceMeta{
-				Ref: ResourceRef{
-					ARN:    sshKeyARN(zone, nameStr),
-					Type:   ResourceSSHKey,
-					Region: zone,
-					ID:     nameStr,
-				},
-				Tags: map[string]string{},
-				Attr: map[string]any{
-					"name": nameStr,
-				},
-			}
-
-			details.Resources = append(details.Resources, meta)
-		}
+		return
 	}
 
-	// Discover IAM roles by label
+	if sshKeysResp == nil || sshKeysResp.SSHKeys == nil {
+		return
+	}
+
+	for _, key := range sshKeysResp.SSHKeys {
+		nameStr := key.Name
+
+		if !matchesDeploymentName(&nameStr, deploymentID) {
+			continue
+		}
+
+		meta := ResourceMeta{
+			Ref: ResourceRef{
+				ARN:    sshKeyARN(zone, nameStr),
+				Type:   ResourceSSHKey,
+				Region: zone,
+				ID:     nameStr,
+			},
+			Tags: map[string]string{},
+			Attr: map[string]any{
+				"name": nameStr,
+			},
+		}
+
+		acc.details.Resources = append(acc.details.Resources, meta)
+	}
+}
+
+// collectIAMRoleDetails discovers IAM roles by label
+func collectIAMRoleDetails(
+	ctx context.Context,
+	client *v3.Client,
+	zone string,
+	deploymentID string,
+	acc *detailsAccumulator,
+) {
 	iamRolesResp, err := client.ListIAMRoles(ctx)
 	if err != nil {
 		slog.Debug("list iam roles failed", "error", err)
-	} else if iamRolesResp != nil && iamRolesResp.IAMRoles != nil {
-		for _, role := range iamRolesResp.IAMRoles {
-			nameStr := role.Name
-			labels := role.Labels
-
-			if !matchesDeployment(&nameStr, labels, deploymentID) {
-				continue
-			}
-
-			roleID := string(role.ID)
-
-			meta := ResourceMeta{
-				Ref: ResourceRef{
-					ARN:    iamRoleARN(roleID),
-					Type:   ResourceIAMRole,
-					Region: zone,
-					ID:     roleID,
-				},
-				Tags: labels,
-				Attr: map[string]any{
-					"name": nameStr,
-				},
-			}
-
-			details.Resources = append(details.Resources, meta)
-		}
+		return
 	}
 
-	// Discover IAM API keys
+	if iamRolesResp == nil || iamRolesResp.IAMRoles == nil {
+		return
+	}
+
+	for _, role := range iamRolesResp.IAMRoles {
+		nameStr := role.Name
+		labels := role.Labels
+
+		if !matchesDeployment(&nameStr, labels, deploymentID) {
+			continue
+		}
+
+		roleID := string(role.ID)
+
+		meta := ResourceMeta{
+			Ref: ResourceRef{
+				ARN:    iamRoleARN(roleID),
+				Type:   ResourceIAMRole,
+				Region: zone,
+				ID:     roleID,
+			},
+			Tags: labels,
+			Attr: map[string]any{
+				"name": nameStr,
+			},
+		}
+
+		acc.details.Resources = append(acc.details.Resources, meta)
+	}
+}
+
+// collectIAMAPIKeyDetails discovers IAM API keys by name pattern
+func collectIAMAPIKeyDetails(
+	ctx context.Context,
+	client *v3.Client,
+	zone string,
+	deploymentID string,
+	acc *detailsAccumulator,
+) {
 	apiKeysResp, err := client.ListAPIKeys(ctx)
 	if err != nil {
 		slog.Debug("list iam api keys failed", "error", err)
-	} else if apiKeysResp != nil && apiKeysResp.APIKeys != nil {
-		for _, key := range apiKeysResp.APIKeys {
-			nameStr := key.Name
-
-			if !matchesDeploymentName(&nameStr, deploymentID) {
-				continue
-			}
-
-			keyStr := key.Key
-
-			meta := ResourceMeta{
-				Ref: ResourceRef{
-					ARN:    iamAPIKeyARN(keyStr),
-					Type:   ResourceIAMAPIKey,
-					Region: zone,
-					ID:     keyStr,
-				},
-				Tags: map[string]string{},
-				Attr: map[string]any{
-					"name": nameStr,
-				},
-			}
-
-			details.Resources = append(details.Resources, meta)
-		}
+		return
 	}
 
-	// Discover SOS buckets by name pattern
+	if apiKeysResp == nil || apiKeysResp.APIKeys == nil {
+		return
+	}
+
+	for _, key := range apiKeysResp.APIKeys {
+		nameStr := key.Name
+
+		if !matchesDeploymentName(&nameStr, deploymentID) {
+			continue
+		}
+
+		keyStr := key.Key
+
+		meta := ResourceMeta{
+			Ref: ResourceRef{
+				ARN:    iamAPIKeyARN(keyStr),
+				Type:   ResourceIAMAPIKey,
+				Region: zone,
+				ID:     keyStr,
+			},
+			Tags: map[string]string{},
+			Attr: map[string]any{
+				"name": nameStr,
+			},
+		}
+
+		acc.details.Resources = append(acc.details.Resources, meta)
+	}
+}
+
+// collectSOSBucketDetails discovers SOS buckets by name pattern
+func collectSOSBucketDetails(
+	ctx context.Context,
+	zone string,
+	deploymentID string,
+	acc *detailsAccumulator,
+) {
 	sosBuckets, err := listSOSBuckets(ctx, zone, deploymentID)
 	if err != nil {
 		slog.Debug("list sos buckets failed", "error", err)
-	} else {
-		for _, bucket := range sosBuckets {
-			meta := ResourceMeta{
-				Ref: ResourceRef{
-					ARN:    sosBucketARN(zone, bucket),
-					Type:   ResourceSOSBucket,
-					Region: zone,
-					ID:     bucket,
-				},
-				Tags: map[string]string{},
-				Attr: map[string]any{
-					"name": bucket,
-				},
-			}
+		return
+	}
 
-			details.Resources = append(details.Resources, meta)
+	for _, bucket := range sosBuckets {
+		meta := ResourceMeta{
+			Ref: ResourceRef{
+				ARN:    sosBucketARN(zone, bucket),
+				Type:   ResourceSOSBucket,
+				Region: zone,
+				ID:     bucket,
+			},
+			Tags: map[string]string{},
+			Attr: map[string]any{
+				"name": bucket,
+			},
 		}
-	}
 
-	// Update summary
-	details.Summary.Resources = len(details.Resources)
-	if earliest != nil {
-		details.Summary.CreatedAt = *earliest
+		acc.details.Resources = append(acc.details.Resources, meta)
 	}
+}
 
-	// Determine state
-	if hasInstances {
+// applyDetailsSummaryTotals updates the summary resource count and creation time
+func applyDetailsSummaryTotals(acc *detailsAccumulator) {
+	acc.details.Summary.Resources = len(acc.details.Resources)
+	if acc.earliest != nil {
+		acc.details.Summary.CreatedAt = *acc.earliest
+	}
+}
+
+// deriveDetailsSummaryState determines the deployment state from the discovered resources
+func deriveDetailsSummaryState(acc *detailsAccumulator) {
+	if acc.hasInstances {
 		switch {
-		case hasActive:
-			details.Summary.State = StateActive
-		case hasStopped:
-			details.Summary.State = StateStopped
-		case details.Summary.Resources > 0:
-			details.Summary.State = StateTerminated
+		case acc.hasActive:
+			acc.details.Summary.State = StateActive
+		case acc.hasStopped:
+			acc.details.Summary.State = StateStopped
+		case acc.details.Summary.Resources > 0:
+			acc.details.Summary.State = StateTerminated
 		}
-	} else if details.Summary.Resources > 0 {
-		details.Summary.State = "orphaned"
+	} else if acc.details.Summary.Resources > 0 {
+		acc.details.Summary.State = "orphaned"
 	}
+}
 
-	if details.Summary.Owner == "" {
-		details.Summary.Owner = "-"
+// applyOwnerFallback substitutes a placeholder for an unknown owner
+func applyOwnerFallback(summary *DeploymentSummary) {
+	if summary.Owner == "" {
+		summary.Owner = "-"
 	}
-
-	return details, nil
 }
 
 // CollectDeploymentSummaries discovers deployments across the Exoscale zone
@@ -437,181 +575,267 @@ func CollectDeploymentSummaries(
 
 	summaries := make(map[string]*DeploymentSummary)
 
-	// Helper to get or create deployment summary entry
-	getOrCreateSummary := func(depID, owner string, createdAt time.Time) *DeploymentSummary {
-		if sum, ok := summaries[depID]; ok {
-			return sum
-		}
-		sum := &DeploymentSummary{
-			ID:        depID,
-			Provider:  "exoscale",
-			Region:    zone,
-			Owner:     owner,
-			CreatedAt: createdAt,
-			State:     StateUnknown,
-		}
-		summaries[depID] = sum
-		return sum
-	}
-
 	// Phase 1: Discover deployments from resources with deployment_id labels
 	// These are the authoritative sources for deployment existence
-
-	// Discover from compute instances
-	instancesResp, err := client.ListInstances(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list instances: %w", err)
+	if err := discoverSummariesFromInstances(ctx, client, zone, ownerFilter, summaries); err != nil {
+		return nil, err
 	}
-
-	if instancesResp != nil && instancesResp.Instances != nil {
-		for _, inst := range instancesResp.Instances {
-			depID, ok := inst.Labels["deployment_id"]
-			if !ok || depID == "" {
-				continue
-			}
-
-			owner := inst.Labels["owner"]
-			if !ownerMatchesFilter(owner, ownerFilter) {
-				continue
-			}
-
-			sum := getOrCreateSummary(depID, owner, inst.CreatedAT)
-			sum.Resources++
-
-			if !inst.CreatedAT.IsZero() && (sum.CreatedAt.IsZero() || inst.CreatedAT.Before(sum.CreatedAt)) {
-				sum.CreatedAt = inst.CreatedAT
-			}
-
-			stateStr := string(inst.State)
-			state := instanceStateToSimple(&stateStr)
-			switch state {
-			case StateActive:
-				if sum.State != StateActive {
-					sum.State = StateActive
-				}
-			case StateStopped:
-				if sum.State != StateActive {
-					sum.State = StateStopped
-				}
-			}
-		}
-	}
-
-	// Discover from block storage volumes
-	volumesResp, _ := client.ListBlockStorageVolumes(ctx)
-	if volumesResp != nil && volumesResp.BlockStorageVolumes != nil {
-		for _, vol := range volumesResp.BlockStorageVolumes {
-			depID, ok := vol.Labels["deployment_id"]
-			if !ok || depID == "" {
-				continue
-			}
-
-			owner := vol.Labels["owner"]
-			if !ownerMatchesFilter(owner, ownerFilter) {
-				continue
-			}
-
-			sum := getOrCreateSummary(depID, owner, vol.CreatedAT)
-			sum.Resources++
-
-			if !vol.CreatedAT.IsZero() && (sum.CreatedAt.IsZero() || vol.CreatedAT.Before(sum.CreatedAt)) {
-				sum.CreatedAt = vol.CreatedAT
-			}
-		}
-	}
-
-	// Discover from private networks
-	networksResp, _ := client.ListPrivateNetworks(ctx)
-	if networksResp != nil && networksResp.PrivateNetworks != nil {
-		for _, net := range networksResp.PrivateNetworks {
-			depID, ok := net.Labels["deployment_id"]
-			if !ok || depID == "" {
-				continue
-			}
-
-			owner := net.Labels["owner"]
-			if !ownerMatchesFilter(owner, ownerFilter) {
-				continue
-			}
-
-			sum := getOrCreateSummary(depID, owner, time.Time{})
-			sum.Resources++
-		}
-	}
+	discoverSummariesFromVolumes(ctx, client, zone, ownerFilter, summaries)
+	discoverSummariesFromPrivateNetworks(ctx, client, zone, ownerFilter, summaries)
 
 	// Phase 2: Count other resources only if their deployment already exists
 	// These resources don't have deployment_id labels, so we only count them
+	countSecurityGroupsIntoSummaries(ctx, client, summaries)
+	countSSHKeysIntoSummaries(ctx, client, summaries)
+	countIAMRolesIntoSummaries(ctx, client, summaries)
+	countAPIKeysIntoSummaries(ctx, client, summaries)
+	countSOSBucketsIntoSummaries(ctx, zone, summaries)
 
+	return summariesToSlice(summaries), nil
+}
+
+// getOrCreateSummary returns the existing deployment summary entry or registers a new one
+func getOrCreateSummary(
+	summaries map[string]*DeploymentSummary,
+	zone string,
+	depID string,
+	owner string,
+	createdAt time.Time,
+) *DeploymentSummary {
+	if sum, ok := summaries[depID]; ok {
+		return sum
+	}
+	sum := &DeploymentSummary{
+		ID:        depID,
+		Provider:  "exoscale",
+		Region:    zone,
+		Owner:     owner,
+		CreatedAt: createdAt,
+		State:     StateUnknown,
+	}
+	summaries[depID] = sum
+	return sum
+}
+
+// discoverSummariesFromInstances discovers deployments from compute instances
+func discoverSummariesFromInstances(
+	ctx context.Context,
+	client *v3.Client,
+	zone string,
+	ownerFilter string,
+	summaries map[string]*DeploymentSummary,
+) error {
+	instancesResp, err := client.ListInstances(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list instances: %w", err)
+	}
+
+	if instancesResp == nil || instancesResp.Instances == nil {
+		return nil
+	}
+
+	for _, inst := range instancesResp.Instances {
+		depID, ok := inst.Labels["deployment_id"]
+		if !ok || depID == "" {
+			continue
+		}
+
+		owner := inst.Labels["owner"]
+		if !ownerMatchesFilter(owner, ownerFilter) {
+			continue
+		}
+
+		sum := getOrCreateSummary(summaries, zone, depID, owner, inst.CreatedAT)
+		sum.Resources++
+
+		applyEarlierCreatedAt(sum, inst.CreatedAT)
+		applyInstanceStateToSummary(sum, inst.State)
+	}
+
+	return nil
+}
+
+// applyEarlierCreatedAt keeps the earliest known creation time on the summary
+func applyEarlierCreatedAt(sum *DeploymentSummary, createdAt time.Time) {
+	if !createdAt.IsZero() && (sum.CreatedAt.IsZero() || createdAt.Before(sum.CreatedAt)) {
+		sum.CreatedAt = createdAt
+	}
+}
+
+// applyInstanceStateToSummary promotes the summary state based on an instance state
+func applyInstanceStateToSummary(sum *DeploymentSummary, instanceState v3.InstanceState) {
+	stateStr := string(instanceState)
+	state := instanceStateToSimple(&stateStr)
+	switch state {
+	case StateActive:
+		if sum.State != StateActive {
+			sum.State = StateActive
+		}
+	case StateStopped:
+		if sum.State != StateActive {
+			sum.State = StateStopped
+		}
+	}
+}
+
+// discoverSummariesFromVolumes discovers deployments from block storage volumes
+func discoverSummariesFromVolumes(
+	ctx context.Context,
+	client *v3.Client,
+	zone string,
+	ownerFilter string,
+	summaries map[string]*DeploymentSummary,
+) {
+	volumesResp, _ := client.ListBlockStorageVolumes(ctx)
+	if volumesResp == nil || volumesResp.BlockStorageVolumes == nil {
+		return
+	}
+
+	for _, vol := range volumesResp.BlockStorageVolumes {
+		depID, ok := vol.Labels["deployment_id"]
+		if !ok || depID == "" {
+			continue
+		}
+
+		owner := vol.Labels["owner"]
+		if !ownerMatchesFilter(owner, ownerFilter) {
+			continue
+		}
+
+		sum := getOrCreateSummary(summaries, zone, depID, owner, vol.CreatedAT)
+		sum.Resources++
+
+		applyEarlierCreatedAt(sum, vol.CreatedAT)
+	}
+}
+
+// discoverSummariesFromPrivateNetworks discovers deployments from private networks
+func discoverSummariesFromPrivateNetworks(
+	ctx context.Context,
+	client *v3.Client,
+	zone string,
+	ownerFilter string,
+	summaries map[string]*DeploymentSummary,
+) {
+	networksResp, _ := client.ListPrivateNetworks(ctx)
+	if networksResp == nil || networksResp.PrivateNetworks == nil {
+		return
+	}
+
+	for _, net := range networksResp.PrivateNetworks {
+		depID, ok := net.Labels["deployment_id"]
+		if !ok || depID == "" {
+			continue
+		}
+
+		owner := net.Labels["owner"]
+		if !ownerMatchesFilter(owner, ownerFilter) {
+			continue
+		}
+
+		sum := getOrCreateSummary(summaries, zone, depID, owner, time.Time{})
+		sum.Resources++
+	}
+}
+
+// countResourceForMatchingSummary counts a resource against the first already-discovered
+// deployment whose ID matches the resource name
+func countResourceForMatchingSummary(summaries map[string]*DeploymentSummary, name string) {
+	for depID, sum := range summaries {
+		if matchesDeploymentName(&name, depID) {
+			sum.Resources++
+			break
+		}
+	}
+}
+
+// countSecurityGroupsIntoSummaries counts security groups of known deployments
+func countSecurityGroupsIntoSummaries(
+	ctx context.Context,
+	client *v3.Client,
+	summaries map[string]*DeploymentSummary,
+) {
 	securityGroupsResp, _ := client.ListSecurityGroups(ctx)
-	if securityGroupsResp != nil && securityGroupsResp.SecurityGroups != nil {
-		for _, sg := range securityGroupsResp.SecurityGroups {
-			// Only count if deployment already discovered
-			for depID, sum := range summaries {
-				if matchesDeploymentName(&sg.Name, depID) {
-					sum.Resources++
-					break
-				}
-			}
-		}
+	if securityGroupsResp == nil || securityGroupsResp.SecurityGroups == nil {
+		return
 	}
 
+	for _, sg := range securityGroupsResp.SecurityGroups {
+		countResourceForMatchingSummary(summaries, sg.Name)
+	}
+}
+
+// countSSHKeysIntoSummaries counts SSH keys of known deployments
+func countSSHKeysIntoSummaries(
+	ctx context.Context,
+	client *v3.Client,
+	summaries map[string]*DeploymentSummary,
+) {
 	sshKeysResp, _ := client.ListSSHKeys(ctx)
-	if sshKeysResp != nil && sshKeysResp.SSHKeys != nil {
-		for _, key := range sshKeysResp.SSHKeys {
-			// Only count if deployment already discovered
-			for depID, sum := range summaries {
-				if matchesDeploymentName(&key.Name, depID) {
-					sum.Resources++
-					break
-				}
-			}
-		}
+	if sshKeysResp == nil || sshKeysResp.SSHKeys == nil {
+		return
 	}
 
+	for _, key := range sshKeysResp.SSHKeys {
+		countResourceForMatchingSummary(summaries, key.Name)
+	}
+}
+
+// countIAMRolesIntoSummaries counts IAM roles of known deployments
+func countIAMRolesIntoSummaries(
+	ctx context.Context,
+	client *v3.Client,
+	summaries map[string]*DeploymentSummary,
+) {
 	iamRolesResp, _ := client.ListIAMRoles(ctx)
-	if iamRolesResp != nil && iamRolesResp.IAMRoles != nil {
-		for _, role := range iamRolesResp.IAMRoles {
-			// Only count if deployment already discovered
-			for depID, sum := range summaries {
-				if matchesDeploymentName(&role.Name, depID) {
-					sum.Resources++
-					break
-				}
-			}
-		}
+	if iamRolesResp == nil || iamRolesResp.IAMRoles == nil {
+		return
 	}
 
+	for _, role := range iamRolesResp.IAMRoles {
+		countResourceForMatchingSummary(summaries, role.Name)
+	}
+}
+
+// countAPIKeysIntoSummaries counts IAM API keys of known deployments
+func countAPIKeysIntoSummaries(
+	ctx context.Context,
+	client *v3.Client,
+	summaries map[string]*DeploymentSummary,
+) {
 	apiKeysResp, _ := client.ListAPIKeys(ctx)
-	if apiKeysResp != nil && apiKeysResp.APIKeys != nil {
-		for _, key := range apiKeysResp.APIKeys {
-			// Only count if deployment already discovered
-			for depID, sum := range summaries {
-				if matchesDeploymentName(&key.Name, depID) {
-					sum.Resources++
-					break
-				}
-			}
-		}
+	if apiKeysResp == nil || apiKeysResp.APIKeys == nil {
+		return
 	}
 
-	// SOS buckets
+	for _, key := range apiKeysResp.APIKeys {
+		countResourceForMatchingSummary(summaries, key.Name)
+	}
+}
+
+// countSOSBucketsIntoSummaries counts SOS buckets of known deployments
+func countSOSBucketsIntoSummaries(
+	ctx context.Context,
+	zone string,
+	summaries map[string]*DeploymentSummary,
+) {
 	for depID := range summaries {
 		buckets, _ := listSOSBuckets(ctx, zone, depID)
 		if sum, ok := summaries[depID]; ok {
 			sum.Resources += len(buckets)
 		}
 	}
+}
 
-	// Convert map to slice
+// summariesToSlice converts the discovered deployment map into the returned slice
+func summariesToSlice(summaries map[string]*DeploymentSummary) []DeploymentSummary {
 	result := make([]DeploymentSummary, 0, len(summaries))
 	for _, s := range summaries {
-		if s.Owner == "" {
-			s.Owner = "-"
-		}
+		applyOwnerFallback(s)
 		result = append(result, *s)
 	}
 
-	return result, nil
+	return result
 }
 
 // Helper functions

--- a/tools/cleanup/pkg/cleanup/providers/stackit/collect.go
+++ b/tools/cleanup/pkg/cleanup/providers/stackit/collect.go
@@ -90,151 +90,314 @@ func CollectResources(ctx context.Context, projectId, region string, deploymentI
 		return nil, err
 	}
 
+	servers, err := collectServers(ctx, iaasClient, projectId, region, deploymentId)
+	if err != nil {
+		return nil, err
+	}
+	resources = append(resources, servers...)
+
+	volumes, err := collectVolumes(ctx, iaasClient, projectId, region, deploymentId)
+	if err != nil {
+		return nil, err
+	}
+	resources = append(resources, volumes...)
+
+	networks, err := collectNetworks(ctx, iaasClient, projectId, region, deploymentId)
+	if err != nil {
+		return nil, err
+	}
+	resources = append(resources, networks...)
+
+	securityGroups, err := collectSecurityGroups(ctx, iaasClient, projectId, region, deploymentId)
+	if err != nil {
+		return nil, err
+	}
+	resources = append(resources, securityGroups...)
+
+	publicIPs, err := collectPublicIPs(ctx, iaasClient, projectId, region, deploymentId)
+	if err != nil {
+		return nil, err
+	}
+	resources = append(resources, publicIPs...)
+
+	buckets, err := collectBuckets(ctx, objectStorageClient, projectId, region, deploymentId)
+	if err != nil {
+		return nil, err
+	}
+	resources = append(resources, buckets...)
+
+	accessKeys, err := collectAccessKeys(ctx, objectStorageClient, projectId, region, deploymentId)
+	if err != nil {
+		return nil, err
+	}
+	resources = append(resources, accessKeys...)
+
+	credentialsGroups, err := collectCredentialsGroups(ctx, objectStorageClient, projectId, region, deploymentId)
+	if err != nil {
+		return nil, err
+	}
+	resources = append(resources, credentialsGroups...)
+
+	return resources, nil
+}
+
+func collectServers(
+	ctx context.Context,
+	iaasClient *iaas.APIClient,
+	projectId, region string,
+	deploymentId *string,
+) ([]ResourceMeta, error) {
 	serversResp, err := iaasClient.DefaultAPI.ListServers(ctx, projectId, region).Execute()
 	if err != nil {
 		slog.Debug("list servers failed", "error", err)
-	} else {
-		for _, server := range serversResp.GetItems() {
-			meta, err := ResourceMetaFromServer(server, projectId, region)
-			if err != nil {
-				return nil, err
-			}
 
-			if isDeployment(meta, deploymentId) {
-				resources = append(resources, *meta)
-			}
+		return nil, nil
+	}
+
+	resources := []ResourceMeta{}
+	for _, server := range serversResp.GetItems() {
+		meta, err := ResourceMetaFromServer(server, projectId, region)
+		if err != nil {
+			return nil, err
+		}
+
+		if isDeployment(meta, deploymentId) {
+			resources = append(resources, *meta)
 		}
 	}
 
+	return resources, nil
+}
+
+func collectVolumes(
+	ctx context.Context,
+	iaasClient *iaas.APIClient,
+	projectId, region string,
+	deploymentId *string,
+) ([]ResourceMeta, error) {
 	volumesResp, err := iaasClient.DefaultAPI.ListVolumes(ctx, projectId, region).Execute()
 	if err != nil {
 		slog.Debug("list volumes failed", "error", err)
-	} else {
-		for _, vol := range volumesResp.GetItems() {
-			meta, err := ResourceMetaFromVolume(vol, projectId, region)
-			if err != nil {
-				return nil, err
-			}
 
-			if isDeployment(meta, deploymentId) {
-				resources = append(resources, *meta)
-			}
+		return nil, nil
+	}
+
+	resources := []ResourceMeta{}
+	for _, vol := range volumesResp.GetItems() {
+		meta, err := ResourceMetaFromVolume(vol, projectId, region)
+		if err != nil {
+			return nil, err
+		}
+
+		if isDeployment(meta, deploymentId) {
+			resources = append(resources, *meta)
 		}
 	}
 
+	return resources, nil
+}
+
+// collectNetworks also collects the network interfaces of every listed network,
+// so that the network listing is only requested once.
+func collectNetworks(
+	ctx context.Context,
+	iaasClient *iaas.APIClient,
+	projectId, region string,
+	deploymentId *string,
+) ([]ResourceMeta, error) {
 	networksResp, err := iaasClient.DefaultAPI.ListNetworks(ctx, projectId, region).Execute()
 	if err != nil {
 		slog.Debug("list private networks failed", "error", err)
-	} else {
-		for _, net := range networksResp.GetItems() {
-			meta, err := ResourceMetaFromNetwork(net, projectId, region)
-			if err != nil {
-				return nil, err
-			}
 
-			if isDeployment(meta, deploymentId) {
-				resources = append(resources, *meta)
-			}
+		return nil, nil
+	}
+
+	resources := []ResourceMeta{}
+	for _, net := range networksResp.GetItems() {
+		meta, err := ResourceMetaFromNetwork(net, projectId, region)
+		if err != nil {
+			return nil, err
 		}
 
-		for _, net := range networksResp.GetItems() {
-			nicsResp, err := iaasClient.DefaultAPI.ListNics(ctx, projectId, region, net.GetId()).Execute()
-			if err != nil {
-				slog.Debug("list network interfaces failed", "network_id", net.GetId(), "error", err)
-				continue
-			}
-
-			for _, nic := range nicsResp.GetItems() {
-				meta, err := ResourceMetaFromNIC(nic, projectId, region)
-				if err != nil {
-					return nil, err
-				}
-
-				if isDeployment(meta, deploymentId) {
-					resources = append(resources, *meta)
-				}
-			}
+		if isDeployment(meta, deploymentId) {
+			resources = append(resources, *meta)
 		}
 	}
 
+	for _, net := range networksResp.GetItems() {
+		nics, err := collectNetworkInterfaces(ctx, iaasClient, projectId, region, net.GetId(), deploymentId)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, nics...)
+	}
+
+	return resources, nil
+}
+
+func collectNetworkInterfaces(
+	ctx context.Context,
+	iaasClient *iaas.APIClient,
+	projectId, region, networkId string,
+	deploymentId *string,
+) ([]ResourceMeta, error) {
+	nicsResp, err := iaasClient.DefaultAPI.ListNics(ctx, projectId, region, networkId).Execute()
+	if err != nil {
+		slog.Debug("list network interfaces failed", "network_id", networkId, "error", err)
+
+		return nil, nil
+	}
+
+	resources := []ResourceMeta{}
+	for _, nic := range nicsResp.GetItems() {
+		meta, err := ResourceMetaFromNIC(nic, projectId, region)
+		if err != nil {
+			return nil, err
+		}
+
+		if isDeployment(meta, deploymentId) {
+			resources = append(resources, *meta)
+		}
+	}
+
+	return resources, nil
+}
+
+func collectSecurityGroups(
+	ctx context.Context,
+	iaasClient *iaas.APIClient,
+	projectId, region string,
+	deploymentId *string,
+) ([]ResourceMeta, error) {
 	securityGroupsResp, err := iaasClient.DefaultAPI.ListSecurityGroups(ctx, projectId, region).Execute()
 	if err != nil {
 		slog.Debug("list security groups failed", "error", err)
-	} else {
-		for _, sg := range securityGroupsResp.GetItems() {
-			meta, err := ResourceMetaFromSecurityGroup(sg, projectId, region)
-			if err != nil {
-				return nil, err
-			}
 
-			if isDeployment(meta, deploymentId) {
-				resources = append(resources, *meta)
-			}
+		return nil, nil
+	}
+
+	resources := []ResourceMeta{}
+	for _, sg := range securityGroupsResp.GetItems() {
+		meta, err := ResourceMetaFromSecurityGroup(sg, projectId, region)
+		if err != nil {
+			return nil, err
+		}
+
+		if isDeployment(meta, deploymentId) {
+			resources = append(resources, *meta)
 		}
 	}
 
+	return resources, nil
+}
+
+func collectPublicIPs(
+	ctx context.Context,
+	iaasClient *iaas.APIClient,
+	projectId, region string,
+	deploymentId *string,
+) ([]ResourceMeta, error) {
 	publicIPsResp, err := iaasClient.DefaultAPI.ListPublicIPs(ctx, projectId, region).Execute()
 	if err != nil {
 		slog.Debug("list public IPs failed", "error", err)
-	} else {
-		for _, publicIP := range publicIPsResp.GetItems() {
-			meta, err := ResourceMetaFromPublicIP(publicIP, projectId, region)
-			if err != nil {
-				return nil, err
-			}
 
-			if isDeployment(meta, deploymentId) {
-				resources = append(resources, *meta)
-			}
+		return nil, nil
+	}
+
+	resources := []ResourceMeta{}
+	for _, publicIP := range publicIPsResp.GetItems() {
+		meta, err := ResourceMetaFromPublicIP(publicIP, projectId, region)
+		if err != nil {
+			return nil, err
+		}
+
+		if isDeployment(meta, deploymentId) {
+			resources = append(resources, *meta)
 		}
 	}
 
-	// Discover buckets by name pattern
+	return resources, nil
+}
+
+// collectBuckets discovers buckets by name pattern
+func collectBuckets(
+	ctx context.Context,
+	objectStorageClient *objectstorage.APIClient,
+	projectId, region string,
+	deploymentId *string,
+) ([]ResourceMeta, error) {
 	bucketsResp, err := objectStorageClient.DefaultAPI.ListBuckets(ctx, projectId, region).Execute()
 	if err != nil {
 		slog.Debug("list object storage buckets failed", "error", err)
-	} else {
-		for _, bucket := range bucketsResp.GetBuckets() {
-			meta, err := ResourceMetaFromBucket(bucket, projectId, region)
-			if err != nil {
-				return nil, err
-			}
 
-			if isDeployment(meta, deploymentId) {
-				resources = append(resources, *meta)
-			}
+		return nil, nil
+	}
+
+	resources := []ResourceMeta{}
+	for _, bucket := range bucketsResp.GetBuckets() {
+		meta, err := ResourceMetaFromBucket(bucket, projectId, region)
+		if err != nil {
+			return nil, err
+		}
+
+		if isDeployment(meta, deploymentId) {
+			resources = append(resources, *meta)
 		}
 	}
 
+	return resources, nil
+}
+
+func collectAccessKeys(
+	ctx context.Context,
+	objectStorageClient *objectstorage.APIClient,
+	projectId, region string,
+	deploymentId *string,
+) ([]ResourceMeta, error) {
 	credsResp, err := objectStorageClient.DefaultAPI.ListAccessKeys(ctx, projectId, region).Execute()
 	if err != nil {
 		slog.Debug("list object storage credentials failed", "error", err)
-	} else {
-		for _, cred := range credsResp.GetAccessKeys() {
-			meta, err := ResourceMetaFromAccessKey(cred, projectId, region)
-			if err != nil {
-				return nil, err
-			}
 
-			if isDeployment(meta, deploymentId) {
-				resources = append(resources, *meta)
-			}
+		return nil, nil
+	}
+
+	resources := []ResourceMeta{}
+	for _, cred := range credsResp.GetAccessKeys() {
+		meta, err := ResourceMetaFromAccessKey(cred, projectId, region)
+		if err != nil {
+			return nil, err
+		}
+
+		if isDeployment(meta, deploymentId) {
+			resources = append(resources, *meta)
 		}
 	}
 
+	return resources, nil
+}
+
+func collectCredentialsGroups(
+	ctx context.Context,
+	objectStorageClient *objectstorage.APIClient,
+	projectId, region string,
+	deploymentId *string,
+) ([]ResourceMeta, error) {
 	cgResp, err := objectStorageClient.DefaultAPI.ListCredentialsGroups(ctx, projectId, region).Execute()
 	if err != nil {
 		slog.Debug("list object storage credentials group failed", "error", err)
-	} else {
-		for _, cg := range cgResp.GetCredentialsGroups() {
-			meta, err := ResourceMetaFromCredentialsGroup(cg, projectId, region)
-			if err != nil {
-				return nil, err
-			}
 
-			if isDeployment(meta, deploymentId) {
-				resources = append(resources, *meta)
-			}
+		return nil, nil
+	}
+
+	resources := []ResourceMeta{}
+	for _, cg := range cgResp.GetCredentialsGroups() {
+		meta, err := ResourceMetaFromCredentialsGroup(cg, projectId, region)
+		if err != nil {
+			return nil, err
+		}
+
+		if isDeployment(meta, deploymentId) {
+			resources = append(resources, *meta)
 		}
 	}
 

--- a/tools/cleanup/pkg/cleanup/providers/stackit/collect.go
+++ b/tools/cleanup/pkg/cleanup/providers/stackit/collect.go
@@ -296,6 +296,70 @@ func CollectDeploymentSummaries(
 
 // Helper functions
 
+type deploymentAccumulator struct {
+	owner           string
+	earliest        *time.Time
+	hasInstances    bool
+	hasActive       bool
+	hasProvisioning bool
+	hasStopped      bool
+}
+
+func (acc *deploymentAccumulator) observe(meta ResourceMeta) {
+	if acc.owner == "" {
+		acc.owner = firstNonEmpty(meta.Tags["Owner"], meta.Tags["owner"])
+	}
+
+	if meta.Ref.Type == ResourceServer {
+		acc.observeServer(meta)
+	}
+
+	if createdAt, ok := meta.Attr["createdAt"].(time.Time); ok && !createdAt.IsZero() {
+		acc.earliest = preferEarlierTime(acc.earliest, createdAt)
+	}
+}
+
+func (acc *deploymentAccumulator) observeServer(meta ResourceMeta) {
+	acc.hasInstances = true
+
+	state, ok := meta.Attr["state"].(string)
+	if !ok {
+		return
+	}
+
+	switch state {
+	case StateActive:
+		acc.hasActive = true
+	case StateProvisioning:
+		acc.hasProvisioning = true
+	case StateStopped:
+		acc.hasStopped = true
+	}
+}
+
+func deploymentState(acc deploymentAccumulator, resourceCount int) string {
+	if !acc.hasInstances {
+		if resourceCount > 0 {
+			return "orphaned"
+		}
+
+		return StateUnknown
+	}
+
+	switch {
+	case acc.hasActive:
+		return StateActive
+	case acc.hasProvisioning:
+		return StateProvisioning
+	case acc.hasStopped:
+		return StateStopped
+	case resourceCount > 0:
+		return StateTerminated
+	default:
+		return StateUnknown
+	}
+}
+
 func summarizeDeploymentResources(
 	deploymentID string,
 	region string,
@@ -311,56 +375,17 @@ func summarizeDeploymentResources(
 		Resources: len(resources),
 	}
 
-	var earliest *time.Time
-	hasInstances := false
-	hasActive := false
-	hasProvisioning := false
-	hasStopped := false
-
+	acc := deploymentAccumulator{}
 	for _, meta := range resources {
-		if summary.Owner == "" {
-			if owner := firstNonEmpty(meta.Tags["Owner"], meta.Tags["owner"]); owner != "" {
-				summary.Owner = owner
-			}
-		}
-
-		if meta.Ref.Type == ResourceServer {
-			hasInstances = true
-			if state, ok := meta.Attr["state"].(string); ok {
-				switch state {
-				case StateActive:
-					hasActive = true
-				case StateProvisioning:
-					hasProvisioning = true
-				case StateStopped:
-					hasStopped = true
-				}
-			}
-		}
-
-		if createdAt, ok := meta.Attr["createdAt"].(time.Time); ok && !createdAt.IsZero() {
-			earliest = preferEarlierTime(earliest, createdAt)
-		}
+		acc.observe(meta)
 	}
 
-	if earliest != nil {
-		summary.CreatedAt = *earliest
+	if acc.earliest != nil {
+		summary.CreatedAt = *acc.earliest
 	}
 
-	if hasInstances {
-		switch {
-		case hasActive:
-			summary.State = StateActive
-		case hasProvisioning:
-			summary.State = StateProvisioning
-		case hasStopped:
-			summary.State = StateStopped
-		case summary.Resources > 0:
-			summary.State = StateTerminated
-		}
-	} else if summary.Resources > 0 {
-		summary.State = "orphaned"
-	}
+	summary.Owner = acc.owner
+	summary.State = deploymentState(acc, summary.Resources)
 
 	if summary.Owner == "" {
 		summary.Owner = "-"

--- a/tools/cleanup/pkg/cleanup/providers/stackit/objectstorage_s3.go
+++ b/tools/cleanup/pkg/cleanup/providers/stackit/objectstorage_s3.go
@@ -91,6 +91,41 @@ func temporaryObjectStorageCredentialsGroupName(now time.Time) string {
 	return name[:stackitTempBucketCredsMaxNameLength]
 }
 
+func s3ObjectIdentifiers(contents []s3types.Object) []s3types.ObjectIdentifier {
+	objects := make([]s3types.ObjectIdentifier, 0, len(contents))
+	for _, object := range contents {
+		if object.Key != nil {
+			objects = append(objects, s3types.ObjectIdentifier{Key: object.Key})
+		}
+	}
+
+	return objects
+}
+
+func deleteObjectStorageObjects(
+	ctx context.Context,
+	client *s3.Client,
+	bucket string,
+	objects []s3types.ObjectIdentifier,
+) error {
+	for start := 0; start < len(objects); start += s3BatchDeleteSize {
+		end := start + s3BatchDeleteSize
+		if end > len(objects) {
+			end = len(objects)
+		}
+
+		_, err := client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+			Bucket: awssdk.String(bucket),
+			Delete: &s3types.Delete{Objects: objects[start:end], Quiet: awssdk.Bool(true)},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to delete bucket objects: %w", err)
+		}
+	}
+
+	return nil
+}
+
 func emptyObjectStorageBucket(ctx context.Context, client *s3.Client, bucket string) error {
 	continuationToken := (*string)(nil)
 	for {
@@ -107,26 +142,8 @@ func emptyObjectStorageBucket(ctx context.Context, client *s3.Client, bucket str
 			return fmt.Errorf("failed to list bucket objects: %w", err)
 		}
 
-		objects := make([]s3types.ObjectIdentifier, 0, len(listResp.Contents))
-		for _, object := range listResp.Contents {
-			if object.Key != nil {
-				objects = append(objects, s3types.ObjectIdentifier{Key: object.Key})
-			}
-		}
-
-		for start := 0; start < len(objects); start += s3BatchDeleteSize {
-			end := start + s3BatchDeleteSize
-			if end > len(objects) {
-				end = len(objects)
-			}
-
-			_, err := client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
-				Bucket: awssdk.String(bucket),
-				Delete: &s3types.Delete{Objects: objects[start:end], Quiet: awssdk.Bool(true)},
-			})
-			if err != nil {
-				return fmt.Errorf("failed to delete bucket objects: %w", err)
-			}
+		if err := deleteObjectStorageObjects(ctx, client, bucket, s3ObjectIdentifiers(listResp.Contents)); err != nil {
+			return err
 		}
 
 		if !awssdk.ToBool(listResp.IsTruncated) || listResp.NextContinuationToken == nil {


### PR DESCRIPTION
## Description

Continues the SonarCloud cleanup started in #257: hardens S3/blob bucket policies and Azure disk network access, enforces HTTPS on curl downloads, extracts helpers across 12 functions/files to reduce cognitive complexity (including the high-complexity AWS/Exoscale/STACKIT cleanup-tool collectors and handlers), tunes SonarCloud scanner configuration to remove analysis warnings, and fixes deployment tests running coverage-instrumented binaries without `GOCOVERDIR` set. No deployed behavior changes.

## Related Issue

SPOT-32039

## Type of Change

- [x] `fix`: Bug fix
- [x] `refactor`: Code refactoring
- [x] `chore`: Maintenance tasks

## Changes Made

- Hardened S3/blob bucket policies (deny non-HTTPS transport) on the AWS and STACKIT presets, and tightened the AWS bootstrap bucket's public-access-block settings. Exoscale SOS rejects the AWS bucket-policy JSON grammar (validates against its own, undocumented IAM v3 policy spec instead), so no policy-level restriction was added there; transport is still HTTPS-only in practice via the hardcoded SOS endpoint
- Disabled unnecessary public network access on the Azure managed data disk
- Enforced HTTPS protocol (`--proto '=https'`) on curl downloads in the installer script and the CodeSignTool GitHub Action
- Extracted helpers across `cmd/exasol` (also bundling `writeCompatibilityMatrixRow`'s 8 parameters into a context struct to fix a too-many-parameters finding), `runtimeartifacts`, `directorymutex`, `task_runner`, `connect`/launcher-state, and `deploy` (also bundling `InitDeployment`'s 8 parameters into an options struct) to reduce cognitive complexity
- Extracted helpers in the cleanup tool's `aws`, `exoscale`, and `stackit` providers to reduce cognitive complexity in the highest-complexity flagged functions (up to 162)
- Configured `sonar.python.version` and `sonar.terraform.provider.{aws,azure}.version`, and excluded `images/**` from analysis, to remove SonarCloud scanner configuration warnings
- Set `GOCOVERDIR` for the `tests-deployment*` Taskfile tasks: the launcher binary is always built with `-cover` in CI, and without `GOCOVERDIR` it printed a warning on every invocation that broke tests asserting exact output (e.g. `test_connect_table_width`)

## Testing

- [x] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

`task all` passes on this branch (lint, build, `go test -race ./...`, and integration tests). The `tools/cleanup` module (a separate `go.mod`) was additionally verified on its own with `go build`, `go vet`, `go test`, and `golangci-lint`. Deployment tests were run against real AWS, Azure, Exoscale, and local infrastructure via CI; the Exoscale bucket-policy issue and the `GOCOVERDIR` warning were both caught and fixed this way.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [ ] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [ ] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

No CHANGELOG entry — these are internal security-hardening, maintainability, and test-infrastructure changes with no user-visible CLI, deployment, or compatibility impact.

The cleanup tool's provider refactors (`aws/collect.go`, `aws/handlers.go`, `exoscale/collect.go`, `stackit/collect.go`) touch destructive cloud-resource-deletion code with near-zero existing test coverage. Each was a purely mechanical extract-method transformation with no logic changes, verified by manual line-by-line comparison against the pre-refactor code rather than by new tests.