### PR TITLE
docs: Add instructions how to use an agent to set up Exasol Personal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Notable user-facing changes to Exasol Personal are documented here.
 
 ### Added
 
+- Added an **Install with AI Agent** section to the README, showing the single `claude`/`codex` command that has an AI coding agent install the [Exasol agent skills](https://github.com/exasol-labs/exasol-agent-skills) and set up Exasol Personal.
+
 - Added `exasol slc custom install` and `exasol slc custom update` to manage user-supplied (custom) script language containers in local deployments, for languages the official catalog does not ship — for example a Python container with extra packages. Custom containers are removed with the existing `exasol slc remove <alias>`, which handles both official and custom containers.
 
   The container is given as `--source`, which takes either a local tarball or an `https` URL, together with the `--alias` used in `CREATE <alias> SCALAR SCRIPT` and the `--language` it provides.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,23 @@ To run UDFs locally, install a script language container — see **UDFs and Scri
 Prefer to run in your own cloud? See the **Deploy to the Cloud** section below.
 
 
+## 🤖 Install with AI Agent
+
+If you work with an AI coding agent, it can set up and run Exasol Personal for you. Exasol publishes [agent skills](https://github.com/exasol-labs/exasol-agent-skills) that teach agents how to deploy Exasol Personal, connect to it, load data, and write Exasol SQL.
+
+One command is enough — the agent installs the skills itself, then uses them:
+
+```bash
+# Claude Code
+claude "Install skills from https://github.com/exasol-labs/exasol-agent-skills/ and use these skills to set up Exasol Personal"
+
+# Codex
+codex "Install skills from https://github.com/exasol-labs/exasol-agent-skills/ and use these skills to set up Exasol Personal"
+```
+
+The agent takes it from there, including installing the launcher, and asks before it makes changes to your machine or cloud account.
+
+
 ## ☁️ Deploy to the Cloud
 
 Deploy Exasol Personal to your own cloud account when you need more scale or a shared instance. Supported providers: AWS, Azure, Exoscale, and STACKIT.


### PR DESCRIPTION
## Description

Adds an **Install with AI Agent** section to the README, right after Quick Start, for users who would rather have an AI coding agent set up Exasol Personal than run the launcher themselves.

The section is a single copy-pasteable command per agent. The prompt tells the agent to install the [Exasol agent skills](https://github.com/exasol-labs/exasol-agent-skills) itself, so there are no separate plugin-install or `install.sh` steps to document — and nothing to keep in sync with that repository's install instructions.

## Related Issue

None.

## Type of Change

- [x] `docs`: Documentation update

## Changes Made

- Added a `## 🤖 Install with AI Agent` section to `README.md` after **Quick Start**, with the one-line invocation for Claude Code and Codex:
  ```bash
  # Claude Code
  claude "Install skills from https://github.com/exasol-labs/exasol-agent-skills/ and use these skills to set up Exasol Personal"

  # Codex
  codex "Install skills from https://github.com/exasol-labs/exasol-agent-skills/ and use these skills to set up Exasol Personal"
  ```
- Noted that the agent handles the rest, including installing the launcher, and asks before changing the user's machine or cloud account.
- Added a `CHANGELOG.md` entry under `Unreleased` → `Added`.

## Testing

- [x] Manually tested the changes

### Test Details

Documentation-only change; no code paths touched. Verified the rendered section reads correctly in place after **Quick Start** and that the surrounding heading order is unchanged. The install commands were taken from the upstream `exasol-labs/exasol-agent-skills` README rather than written from memory.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Updated documentation (if applicable)
- [x] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

The claim that the agent also installs the launcher rests on the upstream Personal-setup skill covering that step — worth confirming against a clean machine before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
