### PR TITLE
feat: mount Java SLC at /exa/slc/current-java for JDBC virtual schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Notable user-facing changes to Exasol Personal are documented here.
 
 ### Added
 
+- Enabled Virtual Schema support in local deployments when the required adapter runtime and dependencies are installed.
+
 - Added `exasol slc custom install`, `update`, and `remove` to manage user-supplied (custom) script language containers in local deployments, for languages the official catalog does not ship — for example a Python container with extra packages.
 
   The container is given as `--source`, which takes either a local tarball or an `https` URL, together with the `--alias` used in `CREATE <alias> SCALAR SCRIPT` and the `--language` it provides.

--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ exasol slc remove python3
 
 The argument is a language alias as used in `CREATE ... SCRIPT`, matched case-insensitively. `exasol slc list` shows each container's flavor, its aliases, its version, and whether it is installed.
 
+Script language containers are also used by features that execute script language code, such as virtual schema adapter scripts. Install the SLC required by the adapter language before creating the adapter script. For JDBC-based virtual schemas on local deployments, see [Virtual schemas on local deployments](doc/virtual_schemas.md).
+
 Installing, updating, or removing an SLC restarts the local database so the change takes effect, which drops open connections and aborts running statements. The command asks for confirmation first; pass `--auto-approve` to skip the prompt (required for non-interactive use), or `--no-restart` to record the change and activate it on the next start.
 
 `exasol slc install`, `update`, and `remove` apply to local deployments only.
@@ -367,7 +369,7 @@ Where the database runs depends on the deployment type:
 Local deployments are intended for development and exploration and do not yet support every feature of a cloud deployment:
 
 - **UDFs** — supported, but no script language container is installed by default. Install one with `exasol slc install <language>` (see **UDFs and Script Language Containers** above); on cloud deployments UDFs work out of the box.
-- **Virtual schemas** — virtual schemas are not available yet (coming soon).
+- **Virtual schemas** — supported when the required adapter runtime and dependencies are installed. Depending on the adapter, this may require installing an SLC and staging adapter or driver files. See [Virtual schemas on local deployments](doc/virtual_schemas.md).
 - **Admin UI** — the Administration UI is not available yet (coming soon).
 - **Multi-node clusters** — a local deployment is a single VM on your machine by design and always runs as a single node.
 

--- a/doc/virtual_schemas.md
+++ b/doc/virtual_schemas.md
@@ -1,0 +1,204 @@
+# Virtual schemas on local deployments
+
+Virtual schemas let you query data that lives in another database as if it were a schema in
+Exasol. This document covers the setup that a **local deployment** needs before the standard
+Exasol virtual schema SQL flow works.
+
+Cloud deployments need none of this — they ship the standard script language containers and
+the usual driver locations, so follow the [Exasol virtual schema
+documentation](https://docs.exasol.com/db/latest/database_concepts/virtual_schemas.htm)
+directly.
+
+The SQL flow itself is unchanged from that documentation. Local deployments only need
+additional runtime and file setup, depending on the adapter you use.
+
+## Runtime prerequisite
+
+Local deployments ship without any script language container. Install the SLC required by
+the virtual schema adapter before creating its adapter script. For example, JDBC-based
+adapters are Java UDFs, and JDBC data transfer also needs a Java runtime:
+
+```bash
+exasol slc install java --no-restart
+```
+
+Use the corresponding language alias for adapters implemented in another supported language.
+If the adapter needs packages that are not in an official SLC, install a custom SLC as
+described in [UDFs and Script Language Containers](../README.md#-udfs-and-script-language-containers).
+
+The `--no-restart` option records the SLC and applies it on the next start. The steps below
+stage the adapter and driver files before that start, so the complete setup requires one
+restart. If the required SLC is already installed, skip this command.
+
+## Quick setup
+
+For a JDBC-based virtual schema, the complete local-deployment flow is:
+
+1. Install the required adapter SLC with `--no-restart`.
+2. Download the adapter and source-database JDBC driver.
+3. Copy both JARs into BucketFS.
+4. Register the JDBC driver under `/exa/jdbc/<DRIVERNAME>/`.
+5. Restart once with `exasol stop && exasol start`.
+6. Run the standard Exasol SQL to create the connection, adapter script, and virtual schema.
+
+The PostgreSQL example below gives the exact commands for each step.
+
+## JDBC adapter setup
+
+The rest of this guide uses a JDBC adapter as an example. A JDBC virtual schema needs three
+files: the virtual schema adapter JAR, the JDBC driver JAR for your source database, and a
+`settings.cfg` describing the driver. They live in two different places, because two
+different components read them.
+
+| File | Location inside the database container | Read by |
+| --- | --- | --- |
+| Adapter JAR + driver JAR | `/exa/bucketfs/<service>/<bucket>/<dir>/` | the adapter script, through `%jar /buckets/...` |
+| Driver JAR + `settings.cfg` | `/exa/jdbc/<DRIVERNAME>/` | the ETL layer, for `IMPORT`/`EXPORT` |
+
+The driver JAR is needed in both places: the adapter uses it on its own classpath to read
+metadata, and the ETL layer uses the registered copy to transfer data.
+
+> **Difference from the Exasol documentation.** Exasol's [Add JDBC
+> Driver](https://docs.exasol.com/db/latest/administration/on-premise/manage_drivers/add_jdbc_driver.htm)
+> page places the driver and `settings.cfg` in BucketFS under `drivers/jdbc`. Local
+> deployments use `/exa/jdbc/<DRIVERNAME>/` instead, which is where the local database looks
+> for JDBC driver configuration. Everything else on that page — the `settings.cfg` keys and
+> their meaning — applies unchanged.
+
+Any directory you create under `/exa/bucketfs` becomes a bucket, so you can use the same
+bucket and path names as the Exasol examples and keep your SQL identical to the
+documentation.
+
+## Connection details for local deployments
+
+The database runs inside a VM. `exasol shell host` opens a shell in that VM, and its SSH key
+and port are in the deployment directory, so you can copy files in with `scp`:
+
+```bash
+# Deployment directory paths
+KEY=./local/node_access.pem
+PORT=$(jq -r '.ports.ssh' ./local/runtime/vm-state.json)
+```
+
+Create the target directories, then copy the files in. The worked example below stages both
+the SLC and the JDBC files before restarting the deployment once.
+
+## Worked example: PostgreSQL JDBC adapter
+
+This example uses the [PostgreSQL virtual
+schema](https://github.com/exasol/postgresql-virtual-schema) adapter. Check its releases page
+and the [PostgreSQL JDBC driver](https://jdbc.postgresql.org/download/) site for current
+versions before downloading. The versions below are examples and may need to be updated.
+
+### 1. Download the adapter and driver
+
+```bash
+# Example versions; replace these with current releases when needed.
+ADAPTER_VERSION=4.0.0
+ADAPTER_JAR=virtual-schema-dist-14.0.2-postgresql-4.0.0.jar
+DRIVER_JAR=postgresql-42.7.13.jar
+
+curl -L -o "$ADAPTER_JAR" \
+  "https://github.com/exasol/postgresql-virtual-schema/releases/download/$ADAPTER_VERSION/$ADAPTER_JAR"
+curl -L -o "$DRIVER_JAR" "https://jdbc.postgresql.org/download/$DRIVER_JAR"
+```
+
+### 2. Copy both JARs into BucketFS
+
+```bash
+ssh -i "$KEY" -p "$PORT" root@127.0.0.1 \
+  'mkdir -p /var/lib/exa/bucketfs/bfsdefault/default/vs'
+
+scp -i "$KEY" -P "$PORT" \
+  "$ADAPTER_JAR" "$DRIVER_JAR" \
+  root@127.0.0.1:/var/lib/exa/bucketfs/bfsdefault/default/vs/
+```
+
+Inside the database, `/var/lib/exa` is `/exa`, and BucketFS contents are reachable under
+`/buckets`. So these files are addressed in SQL as
+`/buckets/bfsdefault/default/vs/<filename>`.
+
+### 3. Register the JDBC driver
+
+```bash
+ssh -i "$KEY" -p "$PORT" root@127.0.0.1 'mkdir -p /var/lib/exa/jdbc/POSTGRESQL'
+
+scp -i "$KEY" -P "$PORT" "$DRIVER_JAR" \
+  root@127.0.0.1:/var/lib/exa/jdbc/POSTGRESQL/
+
+ssh -i "$KEY" -p "$PORT" root@127.0.0.1 'cat > /var/lib/exa/jdbc/POSTGRESQL/settings.cfg <<CFG
+DRIVERNAME=POSTGRESQL
+PREFIX=jdbc:postgresql:
+DRIVERMAIN=org.postgresql.Driver
+FETCHSIZE=100000
+INSERTSIZE=-1
+JAR=postgresql-42.7.13.jar
+
+CFG'
+```
+
+`DRIVERNAME` is the name you use in `IMPORT ... DRIVER = '...'`. The file must end with an
+empty line. If you change either example variable, use the resulting filenames for `JAR`
+and the `%jar` lines in the adapter script below.
+
+### 4. Apply the setup
+
+```bash
+exasol stop && exasol start
+```
+
+This activates the SLC and makes the JDBC driver configuration available to the database.
+
+### 5. Create the connection and the virtual schema
+
+From here everything is standard Exasol SQL:
+
+```sql
+CREATE OR REPLACE CONNECTION POSTGRES_CONN
+  TO 'jdbc:postgresql://<host>:5432/<database>'
+  USER '<user>' IDENTIFIED BY '<password>';
+
+CREATE SCHEMA IF NOT EXISTS VS;
+
+CREATE OR REPLACE JAVA ADAPTER SCRIPT VS.POSTGRES_ADAPTER AS
+  %scriptclass com.exasol.adapter.RequestDispatcher;
+  %jar /buckets/bfsdefault/default/vs/virtual-schema-dist-14.0.2-postgresql-4.0.0.jar;
+  %jar /buckets/bfsdefault/default/vs/postgresql-42.7.13.jar;
+/
+
+CREATE VIRTUAL SCHEMA VS_POSTGRES
+  USING VS.POSTGRES_ADAPTER
+  WITH CONNECTION_NAME = 'POSTGRES_CONN'
+       SCHEMA_NAME = 'public';
+
+SELECT * FROM VS_POSTGRES.<table>;
+```
+
+Use `ALTER VIRTUAL SCHEMA VS_POSTGRES REFRESH` when the source schema changes.
+
+If the source database runs on your own machine rather than in the VM, use the VM's gateway
+address as `<host>` rather than `localhost`.
+
+## Other adapters and JDBC dialects
+
+For non-JDBC adapters, install the SLC required by the adapter and follow that adapter's
+installation documentation for its dependencies and script definition. The [Exasol virtual
+schema
+documentation](https://docs.exasol.com/db/latest/database_concepts/virtual_schemas.htm) lists
+the available adapters and their properties.
+
+The same file pattern applies to every JDBC-based dialect — Oracle, SQL Server, Snowflake,
+MySQL, BigQuery and the rest. Swap the adapter JAR, the driver JAR, and the `settings.cfg`
+values (`DRIVERNAME`, `PREFIX`, `DRIVERMAIN`, `JAR`) for your source database.
+
+## Troubleshooting
+
+**`ETL-1014: No default DRIVER registered`** — the driver is not registered. Check that
+`/exa/jdbc/<DRIVERNAME>/` contains both the JAR and `settings.cfg`, that `settings.cfg` ends
+with an empty line, and that you restarted the deployment.
+
+**Adapter script fails to find its class** — check the `%jar` paths resolve under `/buckets`
+and that the files were copied into the bucket directory.
+
+**No runtime errors during adapter execution or `IMPORT`** — confirm that the SLC required
+by the adapter is installed with `exasol slc list`. For JDBC adapters, this is the Java SLC.

--- a/internal/deploy/slc.go
+++ b/internal/deploy/slc.go
@@ -540,7 +540,7 @@ func localRunnerSlcArgs(deployment config.DeploymentDir) ([]string, error) {
 	total := len(state.InstalledSLCs) + len(state.InstalledCustomSLCs)
 	args := make([]string, 0, total*argsPerSLC)
 	for _, installed := range state.InstalledSLCs {
-		args = append(args, "--slc", installed.Image+"="+installed.Target)
+		args = appendOfficialSLCMountArgs(args, installed)
 	}
 	for _, custom := range state.InstalledCustomSLCs {
 		args = append(args,
@@ -550,6 +550,23 @@ func localRunnerSlcArgs(deployment config.DeploymentDir) ([]string, error) {
 	}
 
 	return args, nil
+}
+
+// Without this anchor JDBC IMPORT/EXPORT finds no JVM: etlJdbcJavaPath otherwise scans for a
+// directory name containing "_java_", which the flavor-named target (java-17) does not match.
+const currentJavaMountTarget = slc.SLCMountRoot + "/current-java"
+
+func appendOfficialSLCMountArgs(args []string, installed config.InstalledSLC) []string {
+	args = append(args, "--slc", installed.Image+"="+installed.Target)
+	if isJavaSLC(installed) {
+		args = append(args, "--slc", installed.Image+"="+currentJavaMountTarget)
+	}
+
+	return args
+}
+
+func isJavaSLC(installed config.InstalledSLC) bool {
+	return strings.EqualFold(installed.Language, "java")
 }
 
 // applySLCChange (re)starts the local database so a changed SLC set takes effect. Success

--- a/internal/deploy/slc.go
+++ b/internal/deploy/slc.go
@@ -566,7 +566,13 @@ func appendOfficialSLCMountArgs(args []string, installed config.InstalledSLC) []
 }
 
 func isJavaSLC(installed config.InstalledSLC) bool {
-	return strings.EqualFold(installed.Language, "java")
+	for _, alias := range installed.Aliases {
+		if strings.EqualFold(alias, "JAVA") {
+			return true
+		}
+	}
+
+	return false
 }
 
 // applySLCChange (re)starts the local database so a changed SLC set takes effect. Success

--- a/internal/deploy/slc_test.go
+++ b/internal/deploy/slc_test.go
@@ -178,12 +178,14 @@ func TestLocalRunnerSlcArgsFromState(t *testing.T) {
 				Flavor:   "python-3.12",
 				Image:    "docker.io/x:pytag",
 				Target:   "/exa/slc/python-3.12",
+				Aliases:  []string{"PYTHON3", "PYTHON312"},
 			},
 			{
 				Language: "java",
 				Flavor:   "java-17",
 				Image:    "docker.io/x:javatag",
 				Target:   "/exa/slc/java-17",
+				Aliases:  []string{"JAVA", "JAVA17"},
 			},
 		},
 	}

--- a/internal/deploy/slc_test.go
+++ b/internal/deploy/slc_test.go
@@ -169,25 +169,39 @@ func TestFindInstalledByImage(t *testing.T) {
 func TestLocalRunnerSlcArgsFromState(t *testing.T) {
 	t.Parallel()
 
+	// Given
 	deployment := config.NewDeploymentDir(t.TempDir())
 	state := &config.ExasolPersonalState{
 		InstalledSLCs: []config.InstalledSLC{
-			{Flavor: "python-3.12", Image: "docker.io/x:pytag", Target: "/exa/slc/python-3.12"},
-			{Flavor: "java-17", Image: "docker.io/x:javatag", Target: "/exa/slc/java-17"},
+			{
+				Language: "python",
+				Flavor:   "python-3.12",
+				Image:    "docker.io/x:pytag",
+				Target:   "/exa/slc/python-3.12",
+			},
+			{
+				Language: "java",
+				Flavor:   "java-17",
+				Image:    "docker.io/x:javatag",
+				Target:   "/exa/slc/java-17",
+			},
 		},
 	}
 	if err := config.WriteExasolPersonalState(state, deployment); err != nil {
 		t.Fatalf("failed to write state: %v", err)
 	}
 
+	// When
 	args, err := localRunnerSlcArgs(deployment)
 	if err != nil {
 		t.Fatalf("localRunnerSlcArgs error: %v", err)
 	}
 
+	// Then
 	want := []string{
 		"--slc", "docker.io/x:pytag=/exa/slc/python-3.12",
 		"--slc", "docker.io/x:javatag=/exa/slc/java-17",
+		"--slc", "docker.io/x:javatag=/exa/slc/current-java",
 	}
 	if len(args) != len(want) {
 		t.Fatalf("args = %v, want %v", args, want)


### PR DESCRIPTION
## Description

This PR updates local SLC mounting so Java SLC is also mounted at `/exa/slc/current-java`. This allows Exasol Personal local deployments to reuse the installed Java SLC for JDBC IMPORT/EXPORT runtime discovery, which is required for JDBC-based Virtual Schema flows.

## Related Issue

[SPOT-32084](https://exasol.atlassian.net/browse/SPOT-32084)

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [x] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Added an extra Java-only official SLC mount at `/exa/slc/current-java`.
- Updated unit test coverage for local runner SLC mount arguments.
- Updated CHANGELOG/README to describe Virtual Schema support in local deployments.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

Manual Testing done. Logs for reference - [VS_JDBC_Dev_Testing_Logs_SPOT-32084.txt](https://github.com/user-attachments/files/30992895/VS_JDBC_Dev_Testing_Logs_SPOT-32084.txt)

## Checklist

<!-- Mark completed items with an "x" -->

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

[SPOT-32084]: https://exasol.atlassian.net/browse/SPOT-32084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ