### PR TITLE
feat(ai-lab): add opt-in AI Lab capability via --with-ai-lab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Notable user-facing changes to Exasol Personal are documented here.
 
 ### Added
 
+- Added the Exasol AI Lab as an opt-in add-on for cloud deployments: `exasol install <cloud> --with-ai-lab` runs the [Exasol AI Lab](https://github.com/exasol/ai-lab) JupyterLab container on the database host, pre-configured to connect to the database and BucketFS so notebooks work with no manual setup.
+
+  The AI Lab is served over HTTPS (using the deployment's certificate) on a dedicated port (default `49494`, configurable with `--ai-lab-port`), restricted by `--allowed-cidr` and protected by a generated Jupyter password. `exasol info` shows the AI Lab URL; the Jupyter and config-store passwords are stored in `secrets.json`. Currently available on cloud deployments only.
+
+  Example: `exasol install aws --with-ai-lab`
+
 - Added `exasol slc custom install` and `exasol slc custom update` to manage user-supplied (custom) script language containers in local deployments, for languages the official catalog does not ship — for example a Python container with extra packages. Custom containers are removed with the existing `exasol slc remove <alias>`, which handles both official and custom containers.
 
   The container is given as `--source`, which takes either a local tarball or an `https` URL, together with the `--alias` used in `CREATE <alias> SCALAR SCRIPT` and the `--language` it provides.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,3 +8,42 @@ content.
 
 @AGENTS.md
 @CONTRIBUTING.md
+
+## Gotchas
+
+### `exasol install` reuses an already-initialized deployment dir
+
+`exasol install` does **not** re-extract the binary's `//go:embed` installation
+assets if the target deployment directory is already initialized. It logs
+*"deployment directory is already initialized with the requested presets"* and
+runs the preset files already extracted into
+`~/.exasol/personal/deployments/<name>/installation/`.
+
+Consequence: after editing an embedded asset (e.g.
+`assets/installation/ubuntu/files/opt/exasol_launcher/scripts/installAiLab.sh`)
+and rebuilding the CLI, a plain `install` into an existing deployment dir still
+runs the **old** script. To validate changes to embedded installation assets
+end-to-end on a real deployment, re-initialize first:
+
+```bash
+exasol destroy --remove   # or `exasol remove` if resources are already gone
+exasol install <preset>   # now the updated assets are extracted
+```
+
+(Confirmed empirically: a fresh `--with-ai-lab` deploy ran a stale
+`installAiLab.sh` because the default deployment dir was already initialized.)
+
+## Building
+
+Preferred: `task build` (Taskfile `build` target) — produces `bin/exasol`.
+
+If `task` is not installed, the equivalent is:
+
+```bash
+go run ./tools/localrunner placeholder \
+  -target assets/localruntimebin/generated/darwin/arm64/mac-runner-aarch64  # go:embed placeholder
+go generate ./...
+version=$(git describe --tags --abbrev=0)
+CGO_ENABLED=0 go build -o bin/exasol -trimpath -gcflags=all=-l \
+  -ldflags "-s -w -X main.CurrentLauncherVersion=${version:1}" ./cmd/exasol
+```

--- a/README.md
+++ b/README.md
@@ -307,6 +307,20 @@ Your browser may show a security warning when connecting to Exasol Admin because
 
 Currently, Exasol Admin is only available on cloud deployments.
 
+## 🤖 AI Lab
+
+The [Exasol AI Lab](https://github.com/exasol/ai-lab) is a ready-to-use JupyterLab environment for data science and AI work against your database. You can have it installed and pre-wired automatically on the same infrastructure as your database — **one flag, zero manual configuration**:
+
+```bash
+exasol install aws --with-ai-lab
+```
+
+When enabled, the launcher runs the `exasol/ai-lab` container alongside the database and pre-configures its connection to the Exasol database and BucketFS, so notebooks work with no manual setup. After installation, `exasol info` prints the AI Lab URL; the Jupyter and config-store passwords are stored in `secrets.json`.
+
+Currently, AI Lab is available on cloud deployments only.
+
+See [doc/ai_lab.md](doc/ai_lab.md) for the architecture, the port/firewall details, and how the connection is pre-wired.
+
 ## 🔒 Connect using SSH
 
 To connect with SSH to your deployment use one of the following commands:

--- a/assets/infrastructure/aws/cloudinit.tf
+++ b/assets/infrastructure/aws/cloudinit.tf
@@ -97,8 +97,22 @@ locals {
     }
     postInstall = {
       # postInstall hooks run on the *access node (n11) only*
-      scripts = var.s3_archive_enabled ? ["/opt/exasol_launcher/scripts/aws_registerS3ArchiveVolume.sh"] : []
+      scripts = concat(
+        var.s3_archive_enabled ? ["/opt/exasol_launcher/scripts/aws_registerS3ArchiveVolume.sh"] : [],
+        var.with_ai_lab ? ["/opt/exasol_launcher/scripts/installAiLab.sh"] : []
+      )
     }
+
+    # AI Lab settings consumed by the installAiLab.sh post-install hook. Emitted
+    # only when AI Lab is requested, so a plain deployment carries no AI Lab
+    # block in its cloud-init user-data.
+    aiLab = var.with_ai_lab ? {
+      enabled            = true
+      port               = var.ai_lab_port
+      scsPasswordB64     = base64encode(random_password.ai_lab_scs[0].result)
+      jupyterPasswordB64 = base64encode(random_password.ai_lab_jupyter[0].result)
+      bfsPasswordB64     = base64encode(random_password.ai_lab_bfs[0].result)
+    } : null
 
     # Cloud-provider specific values needed by optional infra hooks.
     aws = {

--- a/assets/infrastructure/aws/infrastructure.yaml
+++ b/assets/infrastructure/aws/infrastructure.yaml
@@ -5,6 +5,7 @@ backend: tofu
 compatibility:
   provides:
     - admin-ui
+    - ai-lab
     - remote-exec
 
 tofu:

--- a/assets/infrastructure/aws/outputs.tf
+++ b/assets/infrastructure/aws/outputs.tf
@@ -32,6 +32,9 @@ locals {
         username                   = "admin"
         insecureSkipCertValidation = true
       }
+      aiLab = var.with_ai_lab ? {
+        url = "https://${values(data.aws_instance.nodes)[0].public_dns}:${var.ai_lab_port}"
+      } : null
       username       = "sys"
       sshCommand     = "ssh -i ${local.key_file_relative_path} ubuntu@${values(data.aws_instance.nodes)[0].public_dns} -p 22"
       sshPort        = "22"
@@ -61,12 +64,19 @@ locals {
       }
     }
   }
-  deployment_secrets = {
-    adminUiUsername = "admin"
-    adminUiPassword = local.adminui_password_final
-    dbUsername      = "sys"
-    dbPassword      = local.db_password_final
-  }
+  deployment_secrets = merge(
+    {
+      adminUiUsername = "admin"
+      adminUiPassword = local.adminui_password_final
+      dbUsername      = "sys"
+      dbPassword      = local.db_password_final
+    },
+    var.with_ai_lab ? {
+      aiLabScsPassword     = random_password.ai_lab_scs[0].result
+      aiLabJupyterPassword = random_password.ai_lab_jupyter[0].result
+      aiLabBfsPassword     = random_password.ai_lab_bfs[0].result
+    } : {}
+  )
 }
 
 output "deployment_info" {

--- a/assets/infrastructure/aws/secrets.tf
+++ b/assets/infrastructure/aws/secrets.tf
@@ -14,6 +14,38 @@ resource "random_password" "adminui" {
   min_numeric = 1
 }
 
+# AI Lab secure-configuration-storage (SCS) master password.
+# Only created when AI Lab is requested, so a plain deployment carries no AI Lab
+# secrets in state or cloud-init.
+resource "random_password" "ai_lab_scs" {
+  count       = var.with_ai_lab ? 1 : 0
+  length      = 16
+  special     = false
+  min_upper   = 1
+  min_lower   = 1
+  min_numeric = 1
+}
+
+# AI Lab Jupyter access password.
+resource "random_password" "ai_lab_jupyter" {
+  count       = var.with_ai_lab ? 1 : 0
+  length      = 16
+  special     = false
+  min_upper   = 1
+  min_lower   = 1
+  min_numeric = 1
+}
+
+# AI Lab BucketFS bucket read/write password.
+resource "random_password" "ai_lab_bfs" {
+  count       = var.with_ai_lab ? 1 : 0
+  length      = 16
+  special     = false
+  min_upper   = 1
+  min_lower   = 1
+  min_numeric = 1
+}
+
 resource "tls_private_key" "tls_ca_key" {
   algorithm   = "ECDSA"
   ecdsa_curve = "P256"

--- a/assets/infrastructure/aws/security.tf
+++ b/assets/infrastructure/aws/security.tf
@@ -33,6 +33,19 @@ resource "aws_security_group" "exasol_instance" {
     }
   }
 
+  # AI Lab (Jupyter) access, only when AI Lab is installed.
+  dynamic "ingress" {
+    for_each = var.with_ai_lab ? { (var.ai_lab_port) = "Exasol AI Lab (Jupyter)" } : {}
+
+    content {
+      from_port   = ingress.key
+      to_port     = ingress.key
+      protocol    = "tcp"
+      cidr_blocks = [var.allowed_cidr]
+      description = ingress.value
+    }
+  }
+
   # Allow all outbound traffic
   egress {
     from_port   = 0

--- a/assets/infrastructure/aws/variables_public.tf
+++ b/assets/infrastructure/aws/variables_public.tf
@@ -49,3 +49,15 @@ variable "s3_archive_enabled" {
   type        = bool
   default     = true
 }
+
+variable "with_ai_lab" {
+  description = "Install the Exasol AI Lab (Jupyter) container alongside the database, pre-configured to connect to the database and BucketFS."
+  type        = bool
+  default     = false
+}
+
+variable "ai_lab_port" {
+  description = "Port on which the AI Lab Jupyter server is exposed."
+  type        = number
+  default     = 49494
+}

--- a/assets/installation/ubuntu/cloudconf/static.yaml
+++ b/assets/installation/ubuntu/cloudconf/static.yaml
@@ -10,6 +10,9 @@ packages:
   - net-tools
   - jq
   - uidmap
+  # Container runtime for the optional AI Lab container (installed on all nodes;
+  # only used on n11 when AI Lab is enabled).
+  - podman
 
 runcmd:
   - "echo 'EXASOL-INSTALL-SUBSTEP: System package installation and updates completed'"

--- a/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/installAiLab.sh
+++ b/assets/installation/ubuntu/files/opt/exasol_launcher/scripts/installAiLab.sh
@@ -1,0 +1,362 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+# installAiLab.sh - install and pre-configure the Exasol AI Lab container.
+#
+# This is a cloud-agnostic post-install hook (registered by the infrastructure
+# preset in postInstall.scripts). It runs on the access node (n11) only, after
+# the database is ready, as the unprivileged 'ubuntu' user (see
+# exasol_launcher_post_install.service, User=ubuntu). It:
+#   1. Runs the official exasol/ai-lab container via rootless Podman,
+#      publishing the configured AI Lab port.
+#   2. Seeds the AI Lab Secure Configuration Storage (SCS) with the database and
+#      BucketFS connection parameters so notebooks connect with no manual setup.
+#   3. Installs a Podman Quadlet unit (+ user lingering) so the container is
+#      restarted on reboot and across deployment stop/start.
+#
+# Settings are read from infrastructure.json (the `aiLab` block) and the DB
+# password from `dbPasswordB64`.
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+# shellcheck source=./logging.sh
+source "${SCRIPT_DIR}/logging.sh"
+# shellcheck source=./config.sh
+source "${SCRIPT_DIR}/config.sh"
+# shellcheck source=./shared_post_install.sh
+source "${SCRIPT_DIR}/shared_post_install.sh" # provides C4_PATH
+
+readonly AILAB_IMAGE="docker.io/exasol/ai-lab:latest"
+readonly AILAB_CONTAINER="exasol-ai-lab"
+readonly AILAB_VOLUME="exasol-ai-lab-notebooks"
+# Jupyter always listens on 49494 inside the container.
+readonly AILAB_CONTAINER_PORT=49494
+# The SCS file the AI Lab notebooks load from the notebooks directory by default.
+readonly AILAB_SCS_FILE="/home/jupyter/notebooks/ai_lab_secure_configuration_storage.sqlite"
+# The notebook-connector library lives in the JupyterLab virtualenv, not the
+# system python, so the SCS must be seeded with that interpreter.
+readonly AILAB_PYTHON="/home/jupyter/jupyterenv/bin/python3"
+# Default database schema pre-created so notebooks are ready to use without
+# running the main configuration notebook.
+readonly AILAB_DB_SCHEMA="AI_LAB"
+# Dedicated BucketFS bucket pre-created for AI Lab, in the default BucketFS service.
+readonly AILAB_BFS_BUCKET="ailab_bucket"
+readonly AILAB_BFS_SERVICE="bfsdefault"
+# BucketFS HTTP auth user for write access on Exasol.
+readonly AILAB_BFS_USER="w"
+
+# Use -r (not -e): `jq -e` exits non-zero when the resolved value is false/null,
+# which under `set -e` would abort here before the graceful skip below.
+enabled="$(infra_jq -r '.aiLab.enabled // false')"
+if [[ "${enabled}" != "true" ]]; then
+  log_substep_info "AI Lab disabled; skipping installation"
+  exit 0
+fi
+
+log_step_info "Installing Exasol AI Lab"
+
+ai_lab_port="$(infra_jq -er '.aiLab.port')"
+jupyter_password="$(infra_jq -er '.aiLab.jupyterPasswordB64' | base64 -d)"
+scs_password="$(infra_jq -er '.aiLab.scsPasswordB64' | base64 -d)"
+db_password="$(infra_jq -er '.dbPasswordB64' | base64 -d)"
+# BucketFS bucket password. confd bucket_add and the SCS / BucketFS HTTP auth
+# both take it in plain text; bucket_add stores it base64-encoded internally.
+bfs_password="$(infra_jq -er '.aiLab.bfsPasswordB64' | base64 -d)"
+# TLS: reuse the deployment's self-signed server cert + key (the same one COS
+# uses for the Admin UI, injected via infrastructure.json) so Jupyter is served
+# over HTTPS instead of plaintext HTTP.
+tls_cert="$(infra_jq -er '.tlsCert')"
+tls_key="$(infra_jq -er '.tlsKey')"
+
+# This script runs as the unprivileged 'ubuntu' user, so Podman runs rootless
+# directly (no runuser). This hook runs from a systemd service with no user
+# login session, so enable lingering first: that creates the per-user runtime
+# directory (/run/user/<uid>) that rootless Podman requires. Do this before any
+# Podman call so it works on a fresh boot, not only when a session already exists.
+if ! sudo -n loginctl enable-linger "$(id -un)" 2>/dev/null; then
+  log_substep_info "Warning: could not enable user lingering; rootless Podman may be unavailable"
+fi
+XDG_RUNTIME_DIR="/run/user/$(id -u)"
+export XDG_RUNTIME_DIR
+for _ in $(seq 1 10); do
+  [[ -d "${XDG_RUNTIME_DIR}" ]] && break
+  sleep 1
+done
+
+# Podman on Ubuntu 22.04 requires fully-qualified image names by default and
+# refuses short names like "exasol/script-language-container:..." with "no
+# unqualified-search registries defined". The AI Lab exaslct/SLC build uses
+# short names pulled from docker.io, so configure docker.io as the default
+# search registry for the ubuntu user. The user-level file takes precedence
+# over /etc/containers/registries.conf without needing sudo.
+log_substep_info "Configuring Podman unqualified-search registries"
+mkdir -p "${HOME:-/home/ubuntu}/.config/containers"
+printf 'unqualified-search-registries = ["docker.io"]\n' \
+  > "${HOME:-/home/ubuntu}/.config/containers/registries.conf"
+
+# Enable the Podman Docker-compatible API socket so tools inside the AI Lab
+# container that use the Docker SDK (e.g. exaslct / Script Language Container
+# export) can reach it at /var/run/docker.sock. The socket is mounted into the
+# container below. Without this, the AI Lab export_as_is notebook fails with
+# "No such file or directory" when the Docker client looks for the socket.
+#
+# This is the documented limitation of the containerized AI Lab: by default it
+# "does not allow creating Script Language Containers (SLCs)" because the
+# container has no Docker daemon, and the sanctioned workaround is to mount the
+# daemon socket. See:
+#   https://github.com/exasol/ai-lab/blob/main/doc/user_guide/docker/docker-usage.md
+# The Podman-specific steps here (this socket, the registries.conf above, and
+# the DockerRegistryImageChecker patch below) adapt that Docker-oriented
+# workaround to the rootless Podman runtime we use on the host.
+#
+# The socket is created mode 0660 root-owned by default. When bind-mounted into
+# the rootless container, the host 'ubuntu' uid/gid is remapped to the
+# container's root, so the AI Lab's non-root 'jupyter' user (which actually runs
+# exaslct) cannot access it and the Docker client fails with PermissionError.
+# A drop-in sets SocketMode=0666 so that on a clean boot the socket is created
+# world-accessible. But podman.socket may already be active (started early via
+# user lingering) before the drop-in is read, in which case it keeps its
+# original 0660 mode for this session. So we ALSO chmod the live socket
+# explicitly below: the drop-in covers subsequent reboots, the chmod covers
+# install time. The chmod must run before the container mounts the socket.
+#
+# Security note: mode 0666 looks broad but is NOT world-exposed in practice. The
+# socket lives under ${XDG_RUNTIME_DIR} (/run/user/<uid>), which systemd-logind
+# creates mode 0700 owned by this user. No other host user can traverse that
+# directory, so the only principals that can reach the API socket are this user
+# (and its rootless subuids — i.e. the single-purpose AI Lab container's own
+# root/ubuntu/jupyter). Tighter group-based schemes don't help here: under
+# rootless userns the host owner/group remap to the container's root, the socket
+# inode is recreated on every reboot (so a chgrp would not persist), and a
+# usable container-visible group cannot be produced from the host side. Given
+# the 0700 parent and the single-user appliance model, 0666 is the simplest
+# robust choice. See exasol/ai-lab#535.
+log_substep_info "Enabling Podman Docker-compatible API socket"
+socket_dropin_dir="${HOME:-/home/ubuntu}/.config/systemd/user/podman.socket.d"
+mkdir -p "${socket_dropin_dir}"
+printf '[Socket]\nSocketMode=0666\n' > "${socket_dropin_dir}/mode.conf"
+XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR}" systemctl --user daemon-reload
+XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR}" systemctl --user enable --now podman.socket
+podman_sock="${XDG_RUNTIME_DIR}/podman/podman.sock"
+for _ in $(seq 1 15); do
+  [[ -S "${podman_sock}" ]] && break
+  sleep 1
+done
+# Make the live socket accessible to the container's non-root jupyter user
+# regardless of when the unit first created it (see comment above).
+chmod 666 "${podman_sock}" 2>/dev/null || true
+
+# Write the deployment TLS cert + key to a private host dir, mounted read-only
+# into the container below so Jupyter can serve HTTPS with them. Same cert the
+# Admin UI uses, so the trust story is identical (self-signed → browser warns,
+# user accepts, mirroring the Admin UI).
+#
+# Permissions: the AI Lab image runs Jupyter as the non-root 'jupyter' user,
+# which its entrypoint adds to group 0 (root). Under rootless userns the mounted
+# files' owner and group both remap to container-root (0:0), so the files must
+# be group-readable (0640) for Jupyter to read them — owner-only (0600) leaves
+# Jupyter unable to load the cert and it silently fails to start the HTTPS
+# listener. 0640 keeps the private key unreadable by other unprivileged host
+# users while letting the container's group-0 Jupyter read it.
+log_substep_info "Writing deployment TLS cert for the AI Lab"
+ailab_tls_dir="${HOME:-/home/ubuntu}/.config/exasol-ai-lab/tls"
+mkdir -p "${ailab_tls_dir}"
+(
+  umask 077
+  printf '%s\n' "${tls_cert}" > "${ailab_tls_dir}/cert.pem"
+  printf '%s\n' "${tls_key}" > "${ailab_tls_dir}/key.pem"
+)
+chmod 0640 "${ailab_tls_dir}/cert.pem" "${ailab_tls_dir}/key.pem"
+
+log_substep_info "Pulling AI Lab image ${AILAB_IMAGE}"
+podman pull "${AILAB_IMAGE}"
+
+# Recreate the container idempotently so re-running the hook is safe.
+podman rm -f "${AILAB_CONTAINER}" >/dev/null 2>&1 || true
+
+log_substep_info "Starting AI Lab container on port ${ai_lab_port}"
+# allow_host_loopback lets the rootless container reach the database and BucketFS
+# on the host (via host.containers.internal); slirp4netns blocks this by default.
+# Retry the first start: on a freshly-booted host the initial rootless run right
+# after the image pull can intermittently fail while the network/storage is set up.
+start_attempt=0
+until podman run \
+  --detach \
+  --name "${AILAB_CONTAINER}" \
+  --restart always \
+  --network slirp4netns:allow_host_loopback=true \
+  --env JUPYTER_PASSWORD="${jupyter_password}" \
+  --volume "${AILAB_VOLUME}:/home/jupyter/notebooks" \
+  --volume "${XDG_RUNTIME_DIR}/podman/podman.sock:/var/run/docker.sock:Z" \
+  --volume "${ailab_tls_dir}:/etc/exasol-ai-lab/tls:ro,Z" \
+  --publish "${ai_lab_port}:${AILAB_CONTAINER_PORT}" \
+  "${AILAB_IMAGE}"; do
+  start_attempt=$((start_attempt + 1))
+  if [[ "${start_attempt}" -ge 3 ]]; then
+    log_error "Failed to start AI Lab container after ${start_attempt} attempts"
+    exit 1
+  fi
+  log_substep_info "AI Lab container start failed; retrying (attempt ${start_attempt})"
+  podman rm -f "${AILAB_CONTAINER}" >/dev/null 2>&1 || true
+  sleep 3
+done
+
+# Wait for the container to be running and the JupyterLab python (used for
+# seeding) to be invocable before exec'ing into it.
+log_substep_info "Waiting for the AI Lab container to be ready"
+for _ in $(seq 1 30); do
+  if podman exec --user jupyter "${AILAB_CONTAINER}" test -x "${AILAB_PYTHON}" 2>/dev/null; then
+    break
+  fi
+  sleep 2
+done
+
+log_substep_info "Ensuring BucketFS bucket '${AILAB_BFS_BUCKET}' exists"
+# Create a dedicated bucket for AI Lab in the default BucketFS service if it does
+# not already exist. confd_client runs inside the COS container, reached via c4
+# connect (same pattern as the archive-volume hook). bucket_add takes the
+# read/write passwords in plain text (it stores them base64-encoded), so we pass
+# the same plain-text password the SCS uses; params go as JSON to stay safe
+# regardless of password punctuation.
+PLAY_ID="$("${C4_PATH}" config -e .play.id)"
+{
+  printf 'BUCKET=%q\n' "${AILAB_BFS_BUCKET}"
+  printf 'BFS=%q\n' "${AILAB_BFS_SERVICE}"
+  printf 'PW=%q\n' "${bfs_password}"
+  cat <<'CONNECTEOF'
+set -Eeuo pipefail
+if confd_client -c bucketfs_info -a "bucketfs_name: ${BFS}" -j \
+  | jq -e --arg b "${BUCKET}" '.buckets[$b] // empty' >/dev/null 2>&1; then
+  echo "Bucket ${BUCKET} already exists; leaving it unchanged"
+else
+  PARAMS=$(jq -nc --arg b "${BUCKET}" --arg s "${BFS}" --arg p "${PW}" \
+    '{bucket_name:$b,bucketfs_name:$s,public:true,read_password:$p,write_password:$p}')
+  confd_client -c bucket_add -A "${PARAMS}"
+fi
+CONNECTEOF
+} | "${C4_PATH}" connect -s cos -i "${PLAY_ID}"
+
+log_substep_info "Pre-seeding AI Lab connection configuration (SCS)"
+# The database and BucketFS run on the host; from a rootless container the host
+# is reachable via host.containers.internal. Exasol Personal uses a self-signed
+# certificate, so certificate validation is disabled (cert_vld=false).
+# Run as the 'jupyter' user (the image's default user is 'ubuntu'), so the SCS is
+# owned by and readable from the JupyterLab environment. -i forwards the heredoc
+# to python's stdin.
+podman exec -i --user jupyter \
+  --env SCS_PASSWORD="${scs_password}" \
+  --env DB_PASSWORD="${db_password}" \
+  --env DB_SCHEMA="${AILAB_DB_SCHEMA}" \
+  --env BFS_SERVICE="${AILAB_BFS_SERVICE}" \
+  --env BFS_BUCKET="${AILAB_BFS_BUCKET}" \
+  --env BFS_USER="${AILAB_BFS_USER}" \
+  --env BFS_PASSWORD="${bfs_password}" \
+  "${AILAB_CONTAINER}" "${AILAB_PYTHON}" - "${AILAB_SCS_FILE}" <<'PY'
+import os
+import sys
+
+from pathlib import Path
+from exasol.nb_connector.secret_store import Secrets
+from exasol.nb_connector.ai_lab_config import AILabConfig as K, StorageBackend
+from exasol.nb_connector.connections import open_pyexasol_connection
+
+scs = Secrets(Path(sys.argv[1]), master_password=os.environ["SCS_PASSWORD"])
+
+# Database connection (on-prem, external DB on the same host).
+scs.save(K.storage_backend, StorageBackend.onprem.name)
+scs.save(K.use_itde, "False")
+scs.save(K.db_host_name, "host.containers.internal")
+scs.save(K.db_port, "8563")
+scs.save(K.db_user, "sys")
+scs.save(K.db_password, os.environ["DB_PASSWORD"])
+scs.save(K.db_encryption, "True")
+scs.save(K.cert_vld, "False")
+scs.save(K.db_schema, os.environ["DB_SCHEMA"])
+
+# BucketFS connection (default service is HTTPS on 2581, so encryption is on).
+scs.save(K.bfs_host_name, "host.containers.internal")
+scs.save(K.bfs_port, "2581")
+scs.save(K.bfs_service, os.environ["BFS_SERVICE"])
+scs.save(K.bfs_bucket, os.environ["BFS_BUCKET"])
+scs.save(K.bfs_user, os.environ["BFS_USER"])
+scs.save(K.bfs_password, os.environ["BFS_PASSWORD"])
+scs.save(K.bfs_encryption, "True")
+
+# Pre-create the database schema so notebooks are ready to use without running
+# the main configuration notebook (this mirrors its "Create DB schema" step).
+with open_pyexasol_connection(scs, compression=True) as con:
+    con.execute(f'CREATE SCHEMA IF NOT EXISTS "{os.environ["DB_SCHEMA"]}"')
+PY
+
+log_substep_info "Patching exasol_integration_test_docker_environment for Podman compatibility"
+# DockerRegistryImageChecker.handle_log_line raises on any unknown status, but
+# Podman emits "Already exists" for locally-cached layers during a registry pull
+# check (real Docker does too). The unpatched code crashes the SLC export step
+# in the export_as_is notebook. Return None instead of raising so the checker
+# can continue and correctly determine whether the image is in the registry.
+# Done before the systemd handover below so it runs while the container is
+# definitely up from 'podman run', independent of systemd unit activation.
+podman exec -i --user root "${AILAB_CONTAINER}" python3 - <<'PATCHPY'
+import glob
+import sys
+
+# Version-agnostic glob (python3.*): an upstream image Python bump must not make
+# a hardcoded path raise and abort the install under set -e. Skip cleanly if the
+# file is absent (e.g. a future image where the checker no longer exists).
+matches = glob.glob(
+    "/home/jupyter/jupyterenv/lib/python3.*/site-packages"
+    "/exasol_integration_test_docker_environment/lib/docker/images/create"
+    "/utils/docker_registry_image_checker.py"
+)
+if not matches:
+    print("docker_registry_image_checker.py not found — skipping patch")
+    sys.exit(0)
+old = '        raise Exception(f"Unexpected log line: {log_line}")'
+new = '        return None  # unknown status (e.g. "Already exists") — not an error'
+for path in matches:
+    with open(path) as fh:
+        src = fh.read()
+    if old in src:
+        with open(path, "w") as fh:
+            fh.write(src.replace(old, new))
+        print(f"Patched {path}")
+    else:
+        print(f"Already patched or pattern not found — {path}")
+PATCHPY
+
+log_substep_info "Configuring Jupyter to serve HTTPS"
+# Point Jupyter at the mounted deployment cert so it serves HTTPS rather than
+# plaintext HTTP (the published port is reachable from allowed_cidr, so the
+# login password must not cross the network in the clear). The config file is
+# read at every Jupyter start, and the systemd restart below re-launches Jupyter
+# with TLS on. Set both ServerApp (Jupyter Server 2+) and NotebookApp (older)
+# keys for cross-version safety.
+podman exec -i --user jupyter "${AILAB_CONTAINER}" \
+  bash -lc 'mkdir -p "${HOME}/.jupyter" && cat > "${HOME}/.jupyter/jupyter_server_config.py"' <<'JPYCFG'
+c.ServerApp.certfile = "/etc/exasol-ai-lab/tls/cert.pem"
+c.ServerApp.keyfile = "/etc/exasol-ai-lab/tls/key.pem"
+c.NotebookApp.certfile = "/etc/exasol-ai-lab/tls/cert.pem"
+c.NotebookApp.keyfile = "/etc/exasol-ai-lab/tls/key.pem"
+JPYCFG
+
+log_substep_info "Configuring AI Lab to restart on reboot"
+# Ubuntu 22.04 ships Podman 3.4.4 which predates Quadlet (4.4+). Use
+# podman generate systemd to create a plain systemd user service instead.
+systemd_user_dir="${HOME:-/home/ubuntu}/.config/systemd/user"
+mkdir -p "${systemd_user_dir}"
+podman generate systemd \
+  --name "${AILAB_CONTAINER}" \
+  --restart-policy always \
+  > "${systemd_user_dir}/container-${AILAB_CONTAINER}.service"
+
+log_substep_info "Activating AI Lab systemd unit"
+# The generated unit's ExecStart runs 'podman start <name>'. If the container is
+# still running from the 'podman run' above, systemd's start/notify handshake
+# fails ("did not take the steps required by its unit configuration") and, under
+# 'set -e', aborts the whole post-install. Stop the container first so systemd
+# cleanly starts and owns it. The container's writable layer (the patch above)
+# and its mounts/volume are preserved across stop/start.
+podman stop "${AILAB_CONTAINER}" >/dev/null 2>&1 || true
+XDG_RUNTIME_DIR="/run/user/$(id -u)" systemctl --user daemon-reload
+XDG_RUNTIME_DIR="/run/user/$(id -u)" systemctl --user enable --now "container-${AILAB_CONTAINER}"
+
+log_step_info "Exasol AI Lab installation completed"

--- a/doc/ai_lab.md
+++ b/doc/ai_lab.md
@@ -1,0 +1,57 @@
+# AI Lab
+
+The [Exasol AI Lab](https://github.com/exasol/ai-lab) is a ready-to-use JupyterLab environment for data science and AI work against your database. Exasol Personal can install and pre-wire it automatically on the same infrastructure as your database — **one flag, zero manual configuration**.
+
+Currently, AI Lab is available on **cloud deployments only** — it is not offered for local deployments because the UDFs and BucketFS it relies on are not available locally.
+
+## Install
+
+Install AI Lab together with the database by adding `--with-ai-lab`:
+
+```bash
+exasol install aws --with-ai-lab
+```
+
+When enabled, the launcher:
+
+- runs the `exasol/ai-lab` container (via rootless Podman) on the database host,
+- pre-configures its connection to the Exasol database and BucketFS, so notebooks work with **no manual configuration**,
+- exposes the AI Lab port (default `49494`, configurable with `--ai-lab-port`) over **HTTPS** through the deployment's firewall, restricted by `--allowed-cidr` and protected by a generated Jupyter password.
+
+## Reaching it
+
+After installation, `exasol info` prints the AI Lab URL (`https://…`). The Jupyter password and the config-store master password are stored in `secrets.json` in the deployment directory (the same place as the database credentials) — they are not printed to the terminal.
+
+Jupyter is served over HTTPS using the deployment's self-signed certificate — the same certificate the Admin UI uses. Your browser will warn about the certificate on first connection; accept the warning and continue.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    user["Data scientist<br/>(browser)"]
+    cli["exasol CLI"]
+
+    subgraph host["Cloud instance (e.g. AWS EC2)"]
+        direction TB
+        ailab["AI Lab (Jupyter)"]
+        db[("Exasol DB + BucketFS")]
+        ailab -->|"pre-seeded SCS"| db
+    end
+
+    cli -->|"--with-ai-lab"| host
+    user -->|"port 49494"| ailab
+```
+
+The AI Lab container runs **as a sidecar next to the Exasol database on the same instance**, under rootless Podman. At install time the launcher:
+
+- opens a dedicated security-group ingress rule for the AI Lab port, and
+- injects the database and BucketFS credentials into the container's **Secure Configuration Storage (SCS)** — so every notebook can connect to the database and BucketFS immediately, over `host.containers.internal`, without any additional setup.
+
+## Security
+
+Jupyter is served over HTTPS, so the login password and session are encrypted in transit. The Jupyter and config-store passwords are generated per deployment and stored only in `secrets.json`.
+
+Still restrict `--allowed-cidr` to a trusted range (or reach the AI Lab through an SSH tunnel) rather than leaving it open. Two reasons beyond the login itself:
+
+- The notebook is pre-wired to the database with the `sys` credentials, so notebook access is effectively database access.
+- To let notebooks build Script Language Containers, the host's container engine socket is mounted into the AI Lab container (the upstream-documented mechanism). That means code running in a notebook can drive the host's rootless Podman — so treat notebook access as equivalent to access to the host's unprivileged `ubuntu` user, and protect it accordingly.

--- a/doc/presets.md
+++ b/doc/presets.md
@@ -369,3 +369,13 @@ If the manifest is missing, the launcher reports an error before attempting any 
 | `does not contain the expected ... manifest` | The resolved directory lacks the manifest file | Confirm the repository or archive root contains `infrastructure.yaml` / `installation.yaml` |
 | `resource path must be a directory or a supported archive file` | `file://` URI points to a plain file | Use a directory or `.tar.gz` / `.tgz` / `.zip` archive |
 | `@ref syntax ... is only valid on git source URLs` | `@suffix` appended to a non-git URL | Remove the `@ref` or use a `.git` URL |
+
+## Adding AI Lab to another infrastructure preset
+
+The cloud-agnostic AI Lab installer lives once in the installation preset (`assets/installation/ubuntu/files/opt/exasol_launcher/scripts/installAiLab.sh`, plus the `podman` package in `cloudconf`). An infrastructure preset opts in by replicating the three provider-specific bits already present in the AWS preset:
+
+1. **Declare the capability** — add `ai-lab` to `compatibility.provides` in `infrastructure.yaml`.
+2. **Expose the port** — add a firewall/security-group ingress rule for `var.ai_lab_port`, gated on `var.with_ai_lab` and restricted to `var.allowed_cidr` (the rule is provider-specific; there is no shared abstraction).
+3. **Wire variables, secrets, metadata, and the hook** — add the `with_ai_lab` and `ai_lab_port` variables; generate `random_password` resources for the SCS and Jupyter passwords and emit them into `secrets.json` (`aiLabScsPassword`/`aiLabJupyterPassword`) when enabled; emit the `aiLab` connection object into `deployment.json`; and in `cloudinit.tf` inject the `aiLab` block (`enabled`, `port`, base64 passwords) into `infrastructure.json` and register `installAiLab.sh` in `postInstall.scripts`.
+
+The enablement is an **infrastructure** variable (not an installation variable) because it must be known at Terraform plan time to conditionally create the firewall rule, secrets, outputs, and hook registration.

--- a/internal/config/connection_info.go
+++ b/internal/config/connection_info.go
@@ -20,6 +20,7 @@ type ConnectionInfo struct {
 	DBPort                     int
 	UIPort                     int
 	AdminUI                    *DeploymentAdminUI
+	AILab                      *DeploymentAILab
 	Username                   string
 	CertFingerprint            string
 	InsecureSkipCertValidation bool
@@ -82,6 +83,7 @@ func (info *DeploymentInfo) ConnectionInfo(deployment DeploymentDir) (*Connectio
 		DBPort:                     info.Connection.DBPort,
 		UIPort:                     info.Connection.UIPort,
 		AdminUI:                    cloneDeploymentAdminUI(info.Connection.AdminUI),
+		AILab:                      cloneDeploymentAILab(info.Connection.AILab),
 		Username:                   username,
 		CertFingerprint:            certFingerPrint,
 		InsecureSkipCertValidation: info.Connection.InsecureSkipCertValidation,
@@ -102,6 +104,17 @@ func cloneDeploymentAdminUI(adminUI *DeploymentAdminUI) *DeploymentAdminUI {
 	clone.URL = strings.TrimSpace(clone.URL)
 	clone.Username = strings.TrimSpace(clone.Username)
 	clone.CertFingerprint = strings.TrimSpace(clone.CertFingerprint)
+
+	return &clone
+}
+
+func cloneDeploymentAILab(aiLab *DeploymentAILab) *DeploymentAILab {
+	if aiLab == nil || strings.TrimSpace(aiLab.URL) == "" {
+		return nil
+	}
+
+	clone := *aiLab
+	clone.URL = strings.TrimSpace(clone.URL)
 
 	return &clone
 }

--- a/internal/config/connection_info_test.go
+++ b/internal/config/connection_info_test.go
@@ -160,6 +160,61 @@ func TestResolveConnectionInfo_AllowsMissingAdminUIMetadata(t *testing.T) {
 	}
 }
 
+func TestResolveConnectionInfo_UsesAILabMetadata(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	deployment := NewDeploymentDir(t.TempDir())
+	writeConnectionInfoTestFiles(t, deployment, &DeploymentInfo{
+		DeploymentId: "dep-1",
+		Connection: &DeploymentConnection{
+			Host:   "example.local",
+			DBPort: 8563,
+			AILab: &DeploymentAILab{
+				URL: " http://example.local:49494 ",
+			},
+		},
+	})
+
+	// When
+	info, err := ResolveConnectionInfo(deployment)
+	// Then
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if info.AILab == nil {
+		t.Fatal("expected AI Lab metadata")
+	}
+	if info.AILab.URL != "http://example.local:49494" {
+		t.Fatalf("expected trimmed AI Lab URL, got %q", info.AILab.URL)
+	}
+}
+
+func TestResolveConnectionInfo_AllowsMissingAILabMetadata(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	deployment := NewDeploymentDir(t.TempDir())
+	writeConnectionInfoTestFiles(t, deployment, &DeploymentInfo{
+		DeploymentId: "dep-1",
+		Connection: &DeploymentConnection{
+			Host:   "example.local",
+			DBPort: 8563,
+			AILab:  &DeploymentAILab{URL: "   "},
+		},
+	})
+
+	// When
+	info, err := ResolveConnectionInfo(deployment)
+	// Then
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if info.AILab != nil {
+		t.Fatalf("expected no AI Lab metadata for blank URL, got %#v", info.AILab)
+	}
+}
+
 func TestResolveConnectionInfo_UsesExplicitConnectionCertFingerprint(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/node_details.go
+++ b/internal/config/node_details.go
@@ -72,6 +72,7 @@ type DeploymentConnection struct {
 	DBPort                     int                `json:"dbPort,omitempty"`
 	UIPort                     int                `json:"uiPort,omitempty"`
 	AdminUI                    *DeploymentAdminUI `json:"adminUi,omitempty"`
+	AILab                      *DeploymentAILab   `json:"aiLab,omitempty"`
 	Username                   string             `json:"username,omitempty"`
 	CertFingerprint            string             `json:"certFingerprint,omitempty"`
 	InsecureSkipCertValidation bool               `json:"insecureSkipCertValidation,omitempty"`
@@ -85,6 +86,13 @@ type DeploymentAdminUI struct {
 	Username                   string `json:"username,omitempty"`
 	CertFingerprint            string `json:"certFingerprint,omitempty"`
 	InsecureSkipCertValidation bool   `json:"insecureSkipCertValidation,omitempty"`
+}
+
+// DeploymentAILab holds resolved connection metadata for an optional Exasol AI
+// Lab installed alongside the database. It is present only when the deployment's
+// infrastructure exposes AI Lab.
+type DeploymentAILab struct {
+	URL string `json:"url,omitempty"`
 }
 
 type (

--- a/internal/config/secrets.go
+++ b/internal/config/secrets.go
@@ -13,8 +13,11 @@ import (
 const secretsFileName = "secrets.json"
 
 type Secrets struct {
-	DbPassword      string `json:"dbPassword"`
-	AdminUiPassword string `json:"adminUiPassword,omitempty"`
+	DbPassword           string `json:"dbPassword"`
+	AdminUiPassword      string `json:"adminUiPassword,omitempty"`
+	AiLabScsPassword     string `json:"aiLabScsPassword,omitempty"`
+	AiLabJupyterPassword string `json:"aiLabJupyterPassword,omitempty"`
+	AiLabBfsPassword     string `json:"aiLabBfsPassword,omitempty"`
 }
 
 func SecretsFilePath(deployment DeploymentDir) (string, error) {

--- a/internal/deploy/connection_instructions.tmpl
+++ b/internal/deploy/connection_instructions.tmpl
@@ -49,6 +49,17 @@ To connect using the CLI:
 {{- end }}
 
 {{ end -}}
+{{ if .HasAILab -}}
+=== How to open the AI Lab ===
+  URL: {{ .AILab.URL }}
+{{- if .AILabSecured }}
+  Jupyter password: <stored in {{ .SecretsFilePath }}>
+  Config-store master password: <stored in {{ .SecretsFilePath }}>
+{{- end }}
+  Certificate Validation: accept the self-signed certificate if necessary
+  The database and BucketFS connections are pre-configured.
+
+{{ end -}}
 {{ if .ShellSupported }}{{ if .IsLocalBackend }}
 === Host Shell Instructions ===
   Local endpoint: {{ .DisplayHostname }}

--- a/internal/deploy/connection_instructions_test.go
+++ b/internal/deploy/connection_instructions_test.go
@@ -215,3 +215,72 @@ func TestRenderConnectionInstructionsText_IncludesAdminUIWhenMetadataPresent(t *
 		}
 	}
 }
+
+func TestRenderConnectionInstructionsText_OmitsAILabWhenMetadataMissing(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	report := &DeploymentInfoReport{
+		DeploymentDir:   "/deployment",
+		DeploymentID:    "test-deployment",
+		DeploymentState: StatusRunning,
+		Connection: &ConnectionDetails{
+			DisplayHost:     "db.example.local",
+			DBPort:          8563,
+			Username:        "sys",
+			SecretsFilePath: "/deployment/secrets.json",
+		},
+	}
+
+	// When
+	content, err := RenderConnectionInstructionsText(report)
+	// Then
+	if err != nil {
+		t.Fatalf("expected report to render: %v", err)
+	}
+	if strings.Contains(content, "AI Lab") {
+		t.Fatalf("expected AI Lab instructions to be omitted, got %q", content)
+	}
+	if !strings.Contains(content, "exasol connect") {
+		t.Fatalf("expected SQL instructions to be preserved, got %q", content)
+	}
+}
+
+func TestRenderConnectionInstructionsText_IncludesAILabWhenMetadataPresent(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	report := &DeploymentInfoReport{
+		DeploymentDir:   "/deployment",
+		DeploymentID:    "test-deployment",
+		DeploymentState: StatusRunning,
+		Connection: &ConnectionDetails{
+			DisplayHost:     "db.example.local",
+			DBPort:          8563,
+			Username:        "sys",
+			SecretsFilePath: "/deployment/secrets.json",
+			AILab: &config.DeploymentAILab{
+				URL: "http://ai.example.local:49494",
+			},
+			AILabSecured: true,
+		},
+	}
+
+	// When
+	content, err := RenderConnectionInstructionsText(report)
+	// Then
+	if err != nil {
+		t.Fatalf("expected report to render: %v", err)
+	}
+	for _, expected := range []string{
+		"How to open the AI Lab",
+		"http://ai.example.local:49494",
+		"Jupyter password: <stored in /deployment/secrets.json>",
+		"Config-store master password: <stored in /deployment/secrets.json>",
+		"pre-configured",
+	} {
+		if !strings.Contains(content, expected) {
+			t.Fatalf("expected instructions to contain %q, got %q", expected, content)
+		}
+	}
+}

--- a/internal/deploy/info.go
+++ b/internal/deploy/info.go
@@ -16,6 +16,7 @@ type ConnectionDetails struct {
 	DisplayHost     string                    `json:"displayHost,omitempty"`
 	DBPort          int                       `json:"dbPort,omitempty"`
 	AdminUI         *config.DeploymentAdminUI `json:"adminUi,omitempty"`
+	AILab           *config.DeploymentAILab   `json:"aiLab,omitempty"`
 	Username        string                    `json:"username,omitempty"`
 	CertFingerprint string                    `json:"certFingerprint,omitempty"`
 	InsecureSkipTLS bool                      `json:"insecureSkipCertValidation,omitempty"`
@@ -25,6 +26,7 @@ type ConnectionDetails struct {
 	SSHPort         string                    `json:"sshPort,omitempty"`
 	ShellSupported  bool                      `json:"shellSupported,omitempty"`
 	AdminUISecured  bool                      `json:"-"`
+	AILabSecured    bool                      `json:"-"`
 }
 
 type DeploymentInfoReport struct {
@@ -62,6 +64,10 @@ func (details *ConnectionDetails) HasAdminUI() bool {
 	return details != nil && details.AdminUI != nil && details.AdminUI.URL != ""
 }
 
+func (details *ConnectionDetails) HasAILab() bool {
+	return details != nil && details.AILab != nil && details.AILab.URL != ""
+}
+
 func readConnectionDetails(deployment config.DeploymentDir) (*ConnectionDetails, error) {
 	deploymentInfo, err := config.ReadDeploymentInfo(deployment)
 	if err != nil {
@@ -83,6 +89,7 @@ func readConnectionDetails(deployment config.DeploymentDir) (*ConnectionDetails,
 		PublicIp:        connectionInfo.PublicIP,
 		DBPort:          connectionInfo.DBPort,
 		AdminUI:         connectionInfo.AdminUI,
+		AILab:           connectionInfo.AILab,
 		SSHCommand:      connectionInfo.SSHCommand,
 		SSHPort:         connectionInfo.SSHPort,
 		Username:        connectionInfo.Username,
@@ -91,6 +98,7 @@ func readConnectionDetails(deployment config.DeploymentDir) (*ConnectionDetails,
 		SecretsFilePath: connectionInfo.SecretsFilePath,
 		ShellSupported:  connectionInfo.ShellSupported,
 		AdminUISecured:  secrets.AdminUiPassword != "",
+		AILabSecured:    secrets.AiLabJupyterPassword != "",
 	}, nil
 }
 

--- a/internal/presets/infrastructure_manifest_test.go
+++ b/internal/presets/infrastructure_manifest_test.go
@@ -50,6 +50,40 @@ func TestBuiltInLocalPresetDoesNotDeclareAdminUICapability(t *testing.T) {
 	}
 }
 
+func TestBuiltInAwsPresetDeclaresAILabCapability(t *testing.T) {
+	t.Parallel()
+
+	// Given / When
+	manifest, err := ReadInfrastructureManifest("aws")
+	// Then
+	if err != nil {
+		t.Fatalf("failed to read aws infrastructure manifest: %v", err)
+	}
+	if !slices.Contains(manifest.ProvidedCapabilities(), "ai-lab") {
+		t.Fatalf(
+			"expected aws preset to provide ai-lab, got %#v",
+			manifest.ProvidedCapabilities(),
+		)
+	}
+}
+
+func TestBuiltInLocalPresetDoesNotDeclareAILabCapability(t *testing.T) {
+	t.Parallel()
+
+	// Given / When
+	manifest, err := ReadInfrastructureManifest("local")
+	// Then
+	if err != nil {
+		t.Fatalf("failed to read local infrastructure manifest: %v", err)
+	}
+	if slices.Contains(manifest.ProvidedCapabilities(), "ai-lab") {
+		t.Fatalf(
+			"expected local preset not to provide ai-lab, got %#v",
+			manifest.ProvidedCapabilities(),
+		)
+	}
+}
+
 func TestBuiltInCloudPresetsEmitAdminUIMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/openspec/changes/add-ai-lab-capability/.openspec.yaml
+++ b/openspec/changes/add-ai-lab-capability/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-18

--- a/openspec/changes/add-ai-lab-capability/design.md
+++ b/openspec/changes/add-ai-lab-capability/design.md
@@ -1,0 +1,68 @@
+## Context
+
+Exasol Personal provisions a single compute instance (on AWS: an Ubuntu 22.04 `r6i.xlarge`) that runs the Exasol database inside a rootless container managed by **C4** (`c4 host play`, `CCC_PLAY_ROOTLESS=true`). The host installs only a small package set (`wget curl tar net-tools jq uidmap`); **Podman is not installed by default**, and C4 manages the database container through its own bundled runtime.
+
+The Exasol **AI Lab** ships as an official container image (`exasol/ai-lab`) running JupyterLab on port **49494** as the non-root user `jupyter`, with notebooks/config under `/home/jupyter/notebooks`. It connects to an *external* Exasol database (our case — the DB is already on the box). Its connection settings live in a **Secure Configuration Storage (SCS)** — an encrypted SQLCipher file accessed via the `exasol-notebook-connector` Python library (`exasol.nb_connector.secret_store.Secrets` + the `AILabConfig` key enum), and unlocked with a master password.
+
+This change adds AI Lab as an opt-in, pre-wired companion to the database. It deliberately follows the existing **`admin-ui-access`** capability pattern: presets declare support via `compatibility.provides`, the backend writes optional connection metadata to `deployment.json`, connection instructions render conditionally, and the local backend omits it.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One-command, zero-config AI Lab co-located with the database on supporting cloud infrastructure.
+- Pre-seed DB + BucketFS connection so notebooks work immediately with no manual setup.
+- Reachable via a URL (exposed port) protected by a password and the existing address allow-list.
+- Reproducible behavior consistent with how the launcher already exposes the Admin UI.
+
+**Non-Goals:**
+- AI Lab on local deployments (deferred — UDFs and BucketFS are unavailable locally; the capability is shaped so local can opt in later with no consumer changes).
+- AI Lab's integrated Docker-DB and Script-Language-Container build features (they require docker-socket/privileged access; out of scope — we always use the external DB).
+- Multi-user / JupyterHub deployment.
+- Pinning/reproducing a specific AI Lab image version (decision: track latest).
+
+## Decisions
+
+### Install trigger: `--with-ai-lab` now; standalone command deferred
+`exasol install <preset> --with-ai-lab` covers the greenfield path and is delivered in this change. Alternative (default-on) was rejected — every deployment would pay the shared-instance resource cost and gain an exposed service unconditionally.
+
+The originally-planned standalone `exasol ai-lab install` (adding AI Lab to an already-running deployment) is **deferred to a follow-up change**. It is not mechanical: cloud-init and the `postInstall` hook run only on first boot, so re-applying Terraform with `with_ai_lab=true` would add the security-group rule and generate secrets but would **not** re-run `installAiLab.sh` on the already-booted host, nor would the host's `infrastructure.json` contain the `aiLab` block. The follow-up will choose among:
+1. **Reconfigure + remote-exec** — flip `with_ai_lab`, `tofu apply` (SG rule + secrets + metadata), then deliver the AI Lab settings to the host and run `installAiLab.sh` over SSH via the launcher's remote-exec path. Most faithful; reuses the install script.
+2. **Documented reconfigure recipe** — no new command; users add AI Lab via the existing reconfigure flow.
+3. **(chosen for now)** ship the `--with-ai-lab` path and track the command separately.
+
+### Container runtime: install Podman on the host
+Since Podman is not present, the installation assets add the `podman` package (rootless prerequisites like `uidmap` already exist). We run AI Lab as a **separate rootless Podman container**, independent of C4's database container. Alternative (reuse C4) was rejected: C4 is purpose-built for the database cluster, not arbitrary side containers.
+
+### Installation mechanism: shared OS-preset script + per-cloud hook registration
+The AI Lab install **script lives in the installation (OS) preset** (`assets/installation/ubuntu/`, alongside `installExasol.sh`/`runInfraHookScripts.sh`) so it is cloud-agnostic and written once. Each **infrastructure preset** opts in by registering that script in its `postInstall.scripts` hook (run on n11 after the database is ready, via `runInfraHookScripts.sh`) and injecting the AI Lab settings/secrets through its own `cloudinit.tf`. The script pulls the image, sets the Jupyter password, seeds the SCS, and installs a Podman Quadlet/systemd unit with `loginctl enable-linger` so the container survives reboots and `stop`/`start`. Rationale: keeps the OS-level mechanics in one place and reuses the established, declarative extension point rather than inventing new install plumbing.
+
+### Connectivity: container → database/BucketFS on the same host
+AI Lab reaches the DB at the host over Podman's `host.containers.internal` (fallback: the node's private address), DB port `8563`, BucketFS port `2581`. The launcher seeds the SCS keys via the notebook-connector library: `db_host_name`, `db_port`, `db_user`, `db_password`, `db_encryption=True`, `cert_vld=False` (Exasol Personal uses a self-signed cert), `storage_backend=onprem`, `use_itde=False`, plus the `bfs_*` BucketFS keys.
+
+### Secrets: auto-generate, store in `secrets.json`, reference (don't print) in instructions
+The SCS master password and Jupyter password are generated as OpenTofu `random_password` outputs and written into `secrets.json` (mirroring `dbPassword`/`adminUiPassword`), with matching fields added to `config.Secrets`. Connection instructions show the AI Lab **URL** and point the user to `secrets.json` for the passwords — they are **not** echoed to the terminal, exactly as the DB and Admin UI passwords are handled today (`connection_instructions.go` prints `Password: <stored in …/secrets.json>`). This achieves "no manual config": the user never has to invent or type connection details — the pre-seeded SCS carries them, and the master/Jupyter passwords are waiting in `secrets.json`.
+
+### Network exposure: dedicated security-group ingress, gated by `allowed_cidr`
+A new ingress rule opens the AI Lab port (subject to the existing `allowed_cidr`), alongside the Jupyter password gate. The ingress rule is provider-specific (AWS security group ≠ Azure NSG ≠ Exoscale/STACKIT), so it lives in each infrastructure preset; there is no shared "open a port" abstraction. Mirrors how 8443/8563 are exposed today. Alternative (SSH-tunnel-only) was rejected per product intent ("expose the port so the user can connect"), but the tunnel remains available for users who lock `allowed_cidr` down.
+
+### Capability shape: new `ai-lab-access`, modeled on `admin-ui-access`
+Optional `deployment.json` metadata object, conditional connection instructions, local backend omits it. Keeps the launcher's "infrastructure provides X → metadata → instructions" pattern consistent.
+
+## Risks / Trade-offs
+
+- **Resource contention on the shared instance** → AI Lab recommends ~2 cores / 8 GiB; the DB is the heavy tenant on a 4 vCPU / 32 GiB `r6i.xlarge`. Mitigation: opt-in only; document bumping `--instance-type` for heavier ML work.
+- **Larger attack surface (exposed port + two stored secrets)** → Mitigation: gate behind `allowed_cidr`, require the Jupyter password, store secrets with the existing secrets model; document tunnel-only as the hardened option.
+- **Tracking `latest` makes deployments non-reproducible / an upstream change could break installs** → Accepted per decision; mitigation: surface the resolved image digest/version in diagnostics and keep the image reference overridable.
+- **Installing Podman outside C4's control could perturb the rootless setup** → Mitigation: run AI Lab in a distinct rootless tree; validate on a live deployment that it does not interfere with the database container.
+- **Master password stored at rest** → Accepted trade-off for zero-config; same posture as the existing DB password in the deployment's secrets.
+
+## Migration Plan
+
+Additive and opt-in: existing deployments are unaffected until a user passes `--with-ai-lab` or runs `exasol ai-lab install`. Rollback = remove the AI Lab container/unit and the security-group rule; the database deployment is untouched. No `deployment.json` migration needed (the AI Lab object is optional and absent for existing deployments).
+
+## Open Questions
+
+- Exact reachable DB/BucketFS endpoint from a rootless Podman container on the host (`host.containers.internal` vs private IP; whether 8563/2581 are bound on a container-reachable address) — to confirm on a live deployment.
+- The SCS file name/location the current AI Lab notebooks expect by default, so the pre-seeded file is picked up without notebook edits.
+- Whether `exasol ai-lab install` should also have an uninstall/teardown counterpart in this change or a follow-up.
+- Generalization to other cloud presets (Azure/Exoscale/STACKIT): AWS is implemented now; others opt in by adding `ai-lab` to `compatibility.provides` plus their own ingress rule.

--- a/openspec/changes/add-ai-lab-capability/proposal.md
+++ b/openspec/changes/add-ai-lab-capability/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+Exasol Personal users who want to do data science / AI work against their database currently have to find, install, and manually wire up a notebook environment themselves — installing a container runtime, running the Exasol AI Lab image, and hand-entering database and BucketFS connection details. This is exactly the friction Exasol Personal exists to remove. Because a cloud deployment already provisions a capable compute instance running the database, we can co-locate the AI Lab there and pre-wire it, so users get a ready-to-use Jupyter environment connected to their data with zero configuration.
+
+## What Changes
+
+- Add an optional **Exasol AI Lab** installation that runs the official `exasol/ai-lab` container (via Podman) on the same infrastructure (e.g. the AWS EC2 instance) that hosts the Exasol database.
+- Make AI Lab installation **opt-in** via a `--with-ai-lab` flag on `exasol install`. (A standalone `exasol ai-lab install` command to add AI Lab to an already-running deployment is **deferred to a follow-up change** — it requires a reconfigure + remote-exec flow that is out of scope here; see design.md.)
+- **Pre-configure** AI Lab so it connects to the local Exasol database and BucketFS automatically, with no manual configuration steps: the launcher seeds AI Lab's Secure Configuration Storage (SCS) with the resolved DB and BucketFS connection parameters.
+- **Auto-generate** the SCS master password and Jupyter password as OpenTofu `random_password` outputs and store them in `secrets.json`, alongside the existing `dbPassword`/`adminUiPassword` (mirroring how those secrets are handled today).
+- **Expose** the AI Lab (Jupyter) port through a dedicated security-group ingress rule, gated by the existing `allowed_cidr` restriction and protected by the Jupyter password.
+- **Print connection information** for AI Lab in `exasol info` / connection instructions — the AI Lab URL, with the Jupyter and SCS master passwords referenced via `secrets.json` rather than printed — shown only when AI Lab is present for that deployment.
+- Track the `exasol/ai-lab:latest` container image.
+- Restrict availability to infrastructure presets that declare support: AI Lab is offered on cloud presets only. **Local deployments do not get AI Lab** in this version because UDFs and BucketFS are not available locally; the capability is designed so local can be added later without spec changes to consumers.
+
+## Capabilities
+
+### New Capabilities
+- `ai-lab-access`: how the launcher optionally installs the Exasol AI Lab container alongside the database on supporting infrastructure, pre-configures its connection to the database and BucketFS, exposes and secures its port, and surfaces AI Lab connection information — while omitting it on infrastructure that does not support it (e.g. local).
+
+### Modified Capabilities
+<!-- None: no existing permanent spec covers AI Lab. The preset-declares-support, deployment.json connection metadata, and conditional connection-instructions behaviors are captured within the new ai-lab-access capability, consistent with how admin-ui-access is structured. -->
+
+## Impact
+
+The work divides along the existing preset boundary: the cloud-agnostic mechanics live once in the **installation (OS) preset**, and each **infrastructure preset** opts in with a small, provider-specific surface. AWS is the first infrastructure preset to opt in; Azure/Exoscale/STACKIT can follow later by adding the same three bits.
+
+- **Installation (OS) preset — shared across all clouds** (`assets/installation/ubuntu/`): install Podman; add a post-install hook **script** (alongside the existing shared scripts like `installExasol.sh` / `runInfraHookScripts.sh`) that pulls and runs the `exasol/ai-lab` container, sets the Jupyter password, generates the SCS master password, seeds the SCS with DB + BucketFS connection parameters, and registers a systemd/Podman unit (with user lingering) so AI Lab survives reboots and start/stop. This runs identically regardless of cloud.
+- **Infrastructure presets — per cloud, AWS first** (`assets/infrastructure/aws/`): the only inherently provider-specific pieces — (1) declare `ai-lab` in `compatibility.provides`; (2) add a security-group ingress rule for the AI Lab port gated by `allowed_cidr` (provider-specific: AWS SG ≠ Azure NSG ≠ Exoscale/STACKIT); (3) inject the AI Lab settings/secrets into the preset's `cloudinit.tf` and register the shared hook in `postInstall.scripts`. Other cloud presets opt in by adding these same three bits.
+- **CLI** (`cmd/exasol/`): add the `--with-ai-lab` flag to `install`; add an `exasol ai-lab install` command; extend connection-instructions/`info` output to include AI Lab access.
+- **Deployment metadata**: add an optional AI Lab connection object to `deployment.json`; generate the SCS master password and Jupyter password as OpenTofu `random_password` outputs and store them in `secrets.json` (mirroring `dbPassword`/`adminUiPassword`); add the corresponding fields to the `config.Secrets` struct.
+- **Backends** (`internal/deploy`): write AI Lab connection metadata when the infrastructure exposes it; omit it (e.g. for the local backend) otherwise.
+- **Variables**: infrastructure-preset variables `with_ai_lab` (enablement) and `ai_lab_port`. Enablement is an infrastructure variable rather than an installation-preset variable because it must be known at Terraform plan time (to conditionally create the security-group rule, secrets, outputs, and hook registration); it is surfaced to the host via `infrastructure.json`. Both auto-surface as the `--with-ai-lab` / `--ai-lab-port` CLI flags.
+- **Documentation**: README and connection docs describe AI Lab, how to reach it, and its zero-config DB/BucketFS connection.
+- **External dependencies**: the `exasol/ai-lab` container image (pulled at deploy time) and the `podman` package on the host. No new Go dependencies.
+- **Security**: a new exposed port and two generated secrets (Jupyter + SCS master passwords) stored in `secrets.json`; the port is gated by `allowed_cidr` and the secrets follow the existing storage model. Connection instructions show the AI Lab URL and point to `secrets.json` for the passwords rather than printing them.

--- a/openspec/changes/add-ai-lab-capability/specs/ai-lab-access/spec.md
+++ b/openspec/changes/add-ai-lab-capability/specs/ai-lab-access/spec.md
@@ -1,0 +1,113 @@
+## ADDED Requirements
+
+### Requirement: Infrastructure presets declare AI Lab support
+The system SHALL allow infrastructure presets to declare that they support running the Exasol AI Lab on the deployment's infrastructure through an `ai-lab` provided capability.
+
+#### Scenario: Preset advertises AI Lab support
+- **WHEN** an infrastructure preset includes `ai-lab` in `compatibility.provides`
+- **THEN** the launcher treats that preset as capable of installing and exposing AI Lab for its deployments
+
+#### Scenario: Preset omits AI Lab support
+- **WHEN** an infrastructure preset does not include `ai-lab` in `compatibility.provides`
+- **THEN** the launcher does not offer AI Lab installation for deployments using that preset
+
+#### Scenario: Local deployment does not support AI Lab
+- **WHEN** a deployment uses the Exasol Local infrastructure
+- **THEN** AI Lab is not available, because UDFs and BucketFS required by AI Lab are not available locally
+
+### Requirement: AI Lab installation is opt-in
+The system SHALL install AI Lab only when the user explicitly requests it, and SHALL NOT install it by default.
+
+#### Scenario: Request AI Lab during install
+- **WHEN** a user runs `exasol install` for a supporting preset with the `--with-ai-lab` flag
+- **THEN** the launcher installs the database and additionally installs AI Lab on the same infrastructure
+
+#### Scenario: Install without requesting AI Lab
+- **WHEN** a user runs `exasol install` without `--with-ai-lab`
+- **THEN** the launcher deploys only the database and does not install AI Lab
+
+#### Scenario: Request AI Lab on an unsupported preset
+- **WHEN** a user targets a preset whose infrastructure does not provide the `ai-lab` capability
+- **THEN** the `--with-ai-lab` option is not offered for that preset, so AI Lab cannot be requested for it
+
+### Requirement: AI Lab runs as a container alongside the database
+The system SHALL run AI Lab as the official Exasol AI Lab container, managed by Podman, on the same infrastructure that hosts the database.
+
+#### Scenario: AI Lab container is started on the database host
+- **WHEN** AI Lab installation runs for a supporting deployment
+- **THEN** the launcher runs the Exasol AI Lab container using Podman on the host that runs the database
+
+#### Scenario: AI Lab uses the latest published image
+- **WHEN** the launcher installs the AI Lab container
+- **THEN** it uses the latest published `exasol/ai-lab` container image
+
+#### Scenario: AI Lab persists across restarts
+- **WHEN** the host running AI Lab is stopped and started, or the deployment is stopped and started
+- **THEN** AI Lab becomes available again without re-running installation
+
+### Requirement: AI Lab is pre-configured to connect to the database and BucketFS
+The system SHALL pre-configure AI Lab so that it connects to the deployment's Exasol database and BucketFS automatically, requiring no manual configuration steps from the user.
+
+#### Scenario: Database connection is pre-seeded
+- **WHEN** AI Lab is installed for a deployment
+- **THEN** AI Lab's secure configuration is seeded with the database connection parameters (host, port, user, password, and encryption/certificate settings appropriate for the deployment) so notebooks can connect without manual entry
+
+#### Scenario: BucketFS connection is pre-seeded
+- **WHEN** AI Lab is installed for a deployment
+- **THEN** a dedicated BucketFS bucket is created for AI Lab if it does not already exist, with a generated write password, and AI Lab's secure configuration is seeded with that bucket's name, user, and password so notebooks can use BucketFS without manual entry
+
+#### Scenario: Database schema is pre-created
+- **WHEN** AI Lab is installed for a deployment
+- **THEN** a default database schema is created (if absent) and recorded in AI Lab's configuration, so notebooks are ready to use without running the main configuration notebook
+
+#### Scenario: Self-signed certificate is handled
+- **WHEN** the deployment's database or BucketFS presents a self-signed certificate
+- **THEN** the pre-seeded AI Lab configuration connects successfully without requiring the user to disable certificate validation manually
+
+### Requirement: AI Lab secrets are generated and stored
+The system SHALL generate the secrets required to secure and unlock AI Lab and store them with the deployment's secrets.
+
+#### Scenario: Master password is generated and stored
+- **WHEN** AI Lab is installed for a deployment
+- **THEN** the launcher generates the AI Lab secure-configuration master password and stores it in the deployment's `secrets.json`, alongside the existing database and Admin UI secrets
+
+#### Scenario: Jupyter password is generated and stored
+- **WHEN** AI Lab is installed for a deployment
+- **THEN** the launcher sets a Jupyter access password for the AI Lab container and stores it in the deployment's `secrets.json`
+
+### Requirement: AI Lab port is exposed and access-restricted
+The system SHALL expose the AI Lab Jupyter port through the deployment's network so the user can connect, restricted by the same address allow-list used for other deployment ports.
+
+#### Scenario: AI Lab port is reachable within the allow-list
+- **WHEN** a cloud deployment installs AI Lab
+- **THEN** the AI Lab port is opened for inbound access subject to the deployment's configured allowed address range
+
+#### Scenario: Access is protected by the Jupyter password
+- **WHEN** a client reaches the exposed AI Lab port
+- **THEN** access to the Jupyter environment requires the deployment's AI Lab Jupyter password
+
+### Requirement: Deployment metadata contains resolved AI Lab access
+The system SHALL represent AI Lab access as optional resolved connection metadata written by the active backend.
+
+#### Scenario: Backend exposes AI Lab
+- **WHEN** a backend creates or refreshes a deployment that has AI Lab installed
+- **THEN** `deployment.json` contains an AI Lab connection object with the URL that users can open for that concrete deployment
+
+#### Scenario: Backend does not expose AI Lab
+- **WHEN** a backend creates or refreshes a deployment that does not have AI Lab installed
+- **THEN** `deployment.json` omits the AI Lab connection object
+
+#### Scenario: Local backend does not expose AI Lab
+- **WHEN** the Exasol Local backend writes deployment metadata
+- **THEN** `deployment.json` omits AI Lab connection metadata
+
+### Requirement: Connection instructions conditionally show AI Lab
+The system SHALL show AI Lab connection instructions only when resolved AI Lab metadata is present.
+
+#### Scenario: AI Lab metadata is present
+- **WHEN** a running deployment has AI Lab metadata in `deployment.json`
+- **THEN** the connection instructions include the AI Lab URL and reference `secrets.json` for the Jupyter and secure-configuration master passwords, without printing the password values (consistent with how database and Admin UI passwords are surfaced)
+
+#### Scenario: AI Lab metadata is absent
+- **WHEN** a running deployment has no AI Lab metadata in `deployment.json`
+- **THEN** the connection instructions omit the AI Lab section while preserving the SQL connection instructions

--- a/openspec/changes/add-ai-lab-capability/tasks.md
+++ b/openspec/changes/add-ai-lab-capability/tasks.md
@@ -1,0 +1,56 @@
+## 1. Installation (OS) preset — shared across all clouds
+
+- [x] 1.1 Install the `podman` package on the host during preparation (in the `ubuntu` installation preset)
+- [x] 1.2 Add a post-install hook script (alongside the existing shared scripts, e.g. `installExasol.sh`/`runInfraHookScripts.sh`) that pulls the latest `exasol/ai-lab` image and runs it via Podman, publishing the AI Lab port and mounting a persistent notebooks volume
+- [x] 1.3 Set the Jupyter password on the container from the value injected by the infrastructure preset
+- [x] 1.4 Generate/seed the SCS: write the master password and the database connection parameters (host, port, user, password, encryption, `cert_vld=false`, `storage_backend=onprem`, `use_itde=false`) and the BucketFS parameters (`bfs_*`) using the notebook-connector configuration keys
+- [x] 1.5 Confirm the seeded SCS file name/location matches what the AI Lab notebooks load by default, and that connection works against the self-signed DB certificate — VERIFIED on AWS: SCS at `/home/jupyter/notebooks/ai_lab_secure_configuration_storage.sqlite` (owned by `jupyter`), `open_pyexasol_connection` returned `SELECT 1 → [(1,)]`, version `2026.1.0` with `cert_vld=false`. SCS filename updated from `ai_lab_config.db` to match `notebook-connector` `DEFAULT_FILE_NAME`. Verified compatible with `exasol/ai-lab:6.0.0` / `notebook-connector 3.0.0` (2026-06-24): no path or key changes affect our seeding.
+- [x] 1.6 Install a Podman Quadlet/systemd unit and enable user lingering so AI Lab restarts after reboot and survives deployment stop/start
+- [x] 1.7 Verify the AI Lab container does not interfere with the C4-managed database container (rootless isolation) — VERIFIED on AWS: AI Lab container runs rootless alongside the C4 DB container; DB stays queryable while AI Lab is up
+- [x] 1.8 Enablement flag (default off): realized as an **infrastructure** variable `with_ai_lab` (must be known at Terraform plan time) and surfaced to the host via `infrastructure.json` `aiLab.enabled`, rather than an installation-preset variable
+
+## 2. Infrastructure preset opt-in (AWS first)
+
+- [x] 2.1 Declare `ai-lab` in the AWS preset's `compatibility.provides`
+- [x] 2.2 Add an infrastructure-preset variable for the AI Lab port (default 49494), plus the `with_ai_lab` enablement variable
+- [x] 2.3 Add a security-group ingress rule for the AI Lab port, gated by `allowed_cidr` (conditional on `with_ai_lab`)
+- [x] 2.4 Generate the SCS master password and Jupyter password as OpenTofu `random_password` resources; output them into `secrets.json` (mirroring `dbPassword`/`adminUiPassword`)
+- [x] 2.5 Inject the AI Lab enablement, port, and secrets into the preset's `cloudinit.tf` and register the shared post-install hook in `postInstall.scripts`
+- [x] 2.6 Document the three opt-in bits so Azure/Exoscale/STACKIT can adopt AI Lab by replicating them (`doc/presets.md`)
+
+## 3. CLI surface
+
+- [x] 3.1 Add `--with-ai-lab` flag to `exasol install` (auto-generated from the `with_ai_lab` infrastructure variable; `--ai-lab-port` likewise)
+- [~] 3.2 `exasol ai-lab install` command for existing deployments — **deferred to a follow-up change** (needs a reconfigure + remote-exec flow; see design.md)
+- [~] 3.3 Wire both paths to the same install logic — **deferred** with 3.2; the install-time path is complete
+- [x] 3.4 Presets that do not provide `ai-lab` do not expose the `--with-ai-lab` flag, so AI Lab cannot be requested for them
+
+## 4. Secrets and deployment metadata
+
+- [x] 4.1 Add `aiLabScsPassword` and `aiLabJupyterPassword` (omitempty) to the `config.Secrets` struct and ensure they are read from `secrets.json`
+- [x] 4.2 Add an optional AI Lab connection object to `deployment.json` and write it from the active backend only when AI Lab is installed (Go side: `DeploymentAILab` struct + `DeploymentConnection.AILab` + clone/resolve into `ConnectionInfo`; write-side: AWS `outputs.tf` emits the `aiLab` connection object and the secrets when `with_ai_lab`)
+- [x] 4.3 Ensure the local backend (and any non-supporting infrastructure) omits AI Lab metadata (optional `aiLab` field; only populated when the infra writes it)
+
+## 5. Connection information output
+
+- [x] 5.1 Extend connection instructions / `exasol info` to show the AI Lab URL when AI Lab metadata is present, and point the user to `secrets.json` for the Jupyter and SCS master passwords (do not print the secrets), mirroring how the DB/Admin UI passwords are handled. Migrated from string-building to Go template (`connection_instructions.tmpl`) during rebase onto main (2026-06-24); `AILab`/`AILabSecured` fields added to `ConnectionDetails` in `info.go`.
+- [x] 5.2 Ensure the AI Lab section is omitted when no AI Lab metadata is present, preserving SQL connection instructions
+
+## 6. Tests
+
+- [x] 6.1 Unit tests for preset capability resolution (`ai-lab` provided by aws / not by local)
+- [x] 6.2 `--with-ai-lab` flag auto-generation verified (surfaces on `install aws`); `exasol ai-lab install` command wiring deferred with 3.2
+- [x] 6.3 Unit tests for AI Lab deployment-metadata read/write (resolve present / blank-URL omitted)
+- [x] 6.4 Unit tests for connection-instructions output with and without AI Lab metadata (URL shown, passwords referenced not printed)
+
+## 7. Documentation
+
+- [x] 7.1 Document AI Lab in the README: how to install it (`--with-ai-lab`), how to reach it, and its zero-config DB/BucketFS connection (the `exasol ai-lab install` path will be added with that command)
+- [x] 7.2 Document the new exposed port, the secrets stored in `secrets.json`, and the recommendation to restrict `allowed_cidr` / use a tunnel for hardened setups
+
+## 8. Verification
+
+- [x] 8.1 Manual verification on a live AWS deployment — VERIFIED: `--with-ai-lab` flowed to `with_ai_lab=true`; `deployment.json` carries the `aiLab` URL; `secrets.json` holds `aiLabJupyterPassword`/`aiLabScsPassword`; SG opens 49494 and Jupyter is reachable externally; notebooks connect to the DB via the pre-seeded SCS with no manual config. Two additional bugs found and fixed post-hackathon (2026-06-24): (1) `installAiLab.sh` wrote the Quadlet file but never called `daemon-reload`/`enable`, so systemd never activated the unit; (2) Ubuntu 22.04 ships Podman 3.4.4 which predates Quadlet (4.4+) — replaced with `podman generate systemd`. Systemd unit confirmed `active (running)` and enabled on the live deployment; Jupyter reachable at `http://ec2-63-180-230-185.eu-central-1.compute.amazonaws.com:49494`.
+- [x] 8.2 Manual verification that a deployment without `--with-ai-lab` shows no AI Lab section in `exasol info` and opens no AI Lab port
+- [x] 8.3 Verified the AI Lab SLC tooling (`script_languages_container/export_as_is.ipynb` → `slc.export()`) works under rootless Podman. Four Podman-vs-Docker compatibility fixes were required and are now baked into `installAiLab.sh` (2026-06-24/25): (1) exaslct uses the Docker SDK, which needs a daemon socket at `/var/run/docker.sock` — enable the Podman `podman.socket` user unit and bind-mount it into the container; (2) Podman rejects short image names (`exasol/script-language-container:...`) with "no unqualified-search registries defined" — write a user-level `~/.config/containers/registries.conf` with `unqualified-search-registries = ["docker.io"]`; (3) `DockerRegistryImageChecker.handle_log_line` in `exasol_integration_test_docker_environment` raises on Podman's `{"status":"Already exists"}` pull responses — patch it to return `None` (treat unknown statuses as non-errors); (4) the mounted socket is created mode 0660 root-owned and rootless userns remaps it to container-root, so the non-root `jupyter` user that runs exaslct gets `PermissionError` — a `podman.socket.d` drop-in sets `SocketMode=0666`. With these, the `export_as_is` notebook **pulls** the prebuilt SLC image from Docker Hub and completes (verified 2026-06-25 on a clean deploy with an unmodified flavor: 0 local builds, image fetched via `DockerPullImageTask`). Context: the upstream AI Lab docs document that the containerized AI Lab cannot create SLCs by default and that mounting the Docker daemon socket is the sanctioned workaround (https://github.com/exasol/ai-lab/blob/main/doc/user_guide/docker/docker-usage.md); these four fixes adapt that Docker-oriented workaround to our rootless Podman runtime.
+- [ ] 8.4 Known non-blocker (NOT an Exasol Personal / AI Lab integration issue): a **from-scratch** SLC build of the `template-Exasol-all-python-3.10` flavor (script-languages-release 11.1.1) fails because the flavor pins exact apt versions that Ubuntu has since removed from the jammy archive (`libssl-dev=3.0.2-0ubuntu1.21`, `curl=7.81.0-1ubuntu1.23`, `openjdk-11-jdk-headless=11.0.30+7-1ubuntu1~22.04`). **Scope clarified 2026-06-25:** this does NOT affect the default `export_as_is` notebook, which pulls the prebuilt release image from Docker Hub and never builds locally (see 8.3). It only bites flows that force a local rebuild — i.e. customizing a flavor or changing a build step (the "Customizing a flavor" notebook). It is environment-independent (reproduces on stock Docker too) and is upstream flavor staleness. Reported upstream: https://github.com/exasol/script-languages-release/issues/1489 — Torsten Kilias confirmed the exact pinning is intentional and that a newer SLC uses relaxed pinning (pinning only what is stable across an Ubuntu version) that AI Lab may adopt. We deliberately do not work around it in `installAiLab.sh`.

--- a/openspec/changes/add-ai-lab-notebook-tests/.openspec.yaml
+++ b/openspec/changes/add-ai-lab-notebook-tests/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-24

--- a/openspec/changes/add-ai-lab-notebook-tests/design.md
+++ b/openspec/changes/add-ai-lab-notebook-tests/design.md
@@ -1,0 +1,102 @@
+# Design — AI Lab notebook run-through test harness
+
+## Goal
+
+Execute the AI Lab's bundled notebooks top-to-bottom in a clean, deployment-faithful environment, with **no AWS deployment and no human reading tracebacks**, and produce a classified per-notebook report that can gate `exasol/ai-lab` and `notebook-connector` upgrades.
+
+## Why this is possible without AWS
+
+The AI Lab is just the `exasol/ai-lab` container plus a seeded Secure Configuration Storage (SCS). Nothing about running the notebooks requires AWS specifically — it requires (a) the container configured the way a real host configures it, and (b) a reachable Exasol database + BucketFS. Both can be produced locally:
+
+- The **container configuration** is fully captured by `installAiLab.sh` (Podman socket mount → `/var/run/docker.sock`, `~/.config/containers/registries.conf` with `docker.io`, the `DockerRegistryImageChecker` patch, the SCS seeding). The harness reuses these so it tests what we actually ship.
+- The **database** comes from the AI Lab's own **ITDE** (Integrated Test Docker Environment, a.k.a. docker-db), selected via the `use_itde` SCS key. This is the same mechanism the upstream `ai-lab` project uses to test itself — self-contained, no cloud.
+
+`papermill` runs a notebook non-interactively, parameterized, and surfaces the failing cell and traceback as structured output — which is precisely the "run-through + capture the error" loop, automated.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│ harness host (this WSL box, a dev machine, or a CI runner)     │
+│  - Docker or Podman                                            │
+│  - papermill (in a venv, or invoked inside the ai-lab image)   │
+│                                                                │
+│   1. start exasol/ai-lab container                             │
+│      • mount podman.sock → /var/run/docker.sock (if Podman)    │
+│      • write registries.conf (docker.io)                       │
+│      • apply DockerRegistryImageChecker patch                  │
+│   2. bring up ITDE / docker-db  ── use_itde=true ──┐           │
+│   3. seed SCS (same keys as installAiLab.sh)       │           │
+│   4. discover *.ipynb in the image                 ▼           │
+│   5. for each notebook: papermill execute  ──► Exasol docker-db│
+│   6. classify result, append to report                         │
+└──────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+                  report.{md,json}  (per-notebook status + cause)
+```
+
+### Two database modes
+
+| Mode | DB source | SCS keys | Use |
+|---|---|---|---|
+| **ITDE** (default for the harness) | docker-db started by the AI Lab | `use_itde=true`, `storage_backend=onprem` | CI / local; no cloud, no creds |
+| **External** (what we did manually) | a real `exasol install` deployment | `use_itde=false`, `db_host_name=host.containers.internal`, etc. (as `installAiLab.sh` seeds) | optional end-to-end check against a live deployment |
+
+The harness defaults to ITDE. External mode is a flag for an occasional full-fidelity run against a real deployment.
+
+## Execution & classification
+
+For each discovered notebook the harness runs `papermill <nb> <out> --kernel python3` (timeout per notebook) and maps the outcome:
+
+| Result | Meaning | Example trigger |
+|---|---|---|
+| `PASS` | All cells executed without error | — |
+| `FAIL (integration)` | Our host wiring is wrong | missing `/var/run/docker.sock`; short-name registry error; `DockerRegistryImageChecker` crash |
+| `FAIL (upstream)` | Defect in `ai-lab` / `notebook-connector` / a flavor | flavor apt pin removed (#1489); a broken notebook cell |
+| `SKIP (needs X)` | Requires an external secret/service we don't provide | Bedrock/SageMaker/OpenAI key, Hugging Face token, external S3 bucket |
+
+Classification is rule-based on the captured traceback (pattern table maintained alongside the harness), defaulting to `FAIL (integration)` when unmatched so we never hide a regression behind a vague skip. The three integration signatures we already know are seeded into the pattern table from day one.
+
+## Notebook coverage matrix
+
+Coverage is **discovered at runtime**, not hardcoded — the matrix below is the expected shape and the unattended-runnability call per category. (Exact filenames vary by image version; the `script_languages_container/` set is what we observed on `exasol/ai-lab:latest` this session.)
+
+| Category | Example notebooks | Unattended? | Needs |
+|---|---|---|---|
+| Getting started / configuration | main config / "configure the AI Lab" | ✅ (ITDE) | — |
+| Data access / BucketFS | bucketfs access, IMPORT/EXPORT | ✅ (ITDE) | — |
+| SLC — export / use | `script_languages_container/export_as_is`, `configure_slc_repository`, `test_slc`, `using_the_*` | ✅ (pulls prebuilt image from Docker Hub; verified 2026-06-25) | socket access (fixes in `installAiLab.sh`) |
+| SLC — customize / rebuild | `customize`, `advanced` | ⛔ blocked | forces a local SLC build → **#1489** (stale flavor apt pins) |
+| SQL / basic analytics | sql examples | ✅ (ITDE) | — |
+| Machine learning (in-DB) | sklearn / in-database training | ✅ (ITDE) likely; verify resources | possibly RAM |
+| Transformers / Hugging Face | `te_*` text-embedding/NLP | ⛔ SKIP by default | Hugging Face token; model downloads; RAM/GPU |
+| Cloud ML services | SageMaker Autopilot, Bedrock | ⛔ SKIP by default | AWS creds + cloud resources |
+| Cloud storage / external | external S3, cloud connections | ⛔ SKIP by default | cloud creds/buckets |
+
+The harness emits the **actual** matrix each run (discovered notebooks × result), so this table is a planning aid, not the source of truth.
+
+## Where it lives & how it's invoked
+
+- Tooling under `tests/ai_lab/` (Python; aligns with the existing `tests/` Python suite). A `task ai-lab:notebooks` target wraps it.
+- Default invocation: ITDE mode, run all discovered notebooks, write `report.md` + `report.json`, exit non-zero if any `FAIL (integration)` (upstream/skip do not fail the gate by default; configurable).
+- CI: a **manually-triggered / version-bump-triggered** GitHub Actions workflow, not part of the fast PR suite — a full run pulls images, starts ITDE, and (for SLC) compiles containers, so it is minutes-to-tens-of-minutes and resource-heavy.
+
+## Resource notes & honest limits
+
+- This dev box: 14 CPU / 15 GB / ~933 GB free, **no container runtime installed** — Docker/Podman must be installed to run locally. 15 GB is fine for ITDE + light notebooks; heavy ML notebooks and parallel SLC builds may need a larger target.
+- `export_as_is` **passes**: it pulls the prebuilt release image from Docker Hub (verified 2026-06-25 on a clean deploy with an unmodified flavor — 0 local builds), so #1489 does not affect it. Only notebooks that force a local rebuild (`customize` / `advanced`) will report `FAIL (upstream)` until #1489 is resolved; that is correct and informative, not a harness bug.
+- Credential-gated notebooks are intentionally `SKIP` — wiring real cloud/LLM creds into CI is a separate decision with its own security tradeoffs.
+- The harness validates **our integration and the notebooks' executability**, not model quality or numerical results.
+
+## Alternatives considered
+
+- **Keep testing against a real `exasol install` deployment.** Highest fidelity but slow, costs cloud money, needs SSH, and can't run in CI unattended. Kept as optional "external mode," not the default.
+- **Unit-test the SCS seeding only.** Cheap, but would not have caught any of the three integration bugs — they only appear when a notebook actually drives `exaslct`/Docker through the container. Rejected as insufficient.
+- **`nbconvert --execute` instead of `papermill`.** Works, but `papermill` gives cleaner per-cell error capture and parameterization (e.g. inject ITDE vs external). Minor preference.
+
+## Open questions
+
+1. Run `papermill` inside the AI Lab container (uses the image's exact `jupyterenv`) vs. from the host against the container's kernel — inside is more faithful; confirm during implementation.
+2. Should `FAIL (upstream)` block CI or just warn? Default: warn (so known-upstream breakage like #1489 doesn't red-wall the gate), with an allowlist of known-upstream issues.
+3. Pin the `exasol/ai-lab` image by digest per run for reproducibility, or always test `:latest` to catch upstream drift early? Likely both: a pinned gate + a scheduled `:latest` canary.

--- a/openspec/changes/add-ai-lab-notebook-tests/proposal.md
+++ b/openspec/changes/add-ai-lab-notebook-tests/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The `--with-ai-lab` capability installs the `exasol/ai-lab` container and pre-wires it to the database, but we have no automated way to confirm the shipped notebooks actually run against a real Exasol deployment. The only validation so far has been manual: deploy AWS, SSH into the host, run a notebook by hand, and read tracebacks off the screen. That loop is slow, expensive, human-in-the-loop, and easy to skip — and it is exactly how three Podman-vs-Docker integration bugs (missing `/var/run/docker.sock`, no unqualified-search registry, `DockerRegistryImageChecker` crashing on `"Already exists"`) and one upstream flavor-staleness issue (exasol/script-languages-release#1489) reached a live deployment before being noticed.
+
+Every one of those failures is deterministic and would have been caught by executing the notebooks top-to-bottom in a clean environment. We want a headless "run-through" test harness that does this automatically — without an AWS deployment and without a human copy-pasting errors — so that future `exasol/ai-lab` and `notebook-connector` bumps are validated before they ship.
+
+## What Changes
+
+- Add a **headless notebook test harness** that starts the AI Lab container configured exactly as `installAiLab.sh` configures it (Podman socket mount, `registries.conf`, the `DockerRegistryImageChecker` patch, seeded SCS), brings up a self-contained database, executes the bundled notebooks with `papermill`, and reports a per-notebook result.
+- Use the AI Lab's **integrated test database (ITDE / docker-db)** instead of a cloud deployment, so the harness runs locally or in CI with no AWS, no SSH, and no human in the loop.
+- **Discover** notebooks at runtime (glob `*.ipynb` in the image) rather than hardcoding a list, so coverage tracks whatever the image ships and new notebooks are not silently missed.
+- **Classify** each notebook result so failures are actionable, not just red/green: `PASS`, `FAIL (integration)` — our wiring is wrong, `FAIL (upstream)` — a defect in `ai-lab`/`notebook-connector`/a flavor, or `SKIP (needs <credential/resource>)` — requires an external secret or service we deliberately do not provide in the harness.
+- Provide a **notebook coverage matrix** (in design.md) recording, for each notebook category, whether it is runnable unattended, and if not, what it needs.
+- Optionally wire the harness into **CI** (GitHub Actions) as a regression gate that can be triggered on demand and on `ai-lab` / `notebook-connector` version bumps.
+
+This change adds **test/verification tooling only**. It does not change the `--with-ai-lab` runtime behavior, the installed artifacts, or any user-facing surface.
+
+## Capabilities
+
+### New Capabilities
+- `ai-lab-notebook-tests`: how the project headlessly executes the AI Lab's bundled notebooks against a self-contained database in a deployment-faithful container configuration, discovers notebooks automatically, and reports a classified per-notebook result suitable for use as a regression gate.
+
+### Modified Capabilities
+<!-- None. This is verification tooling for the existing ai-lab-access capability; it does not alter that capability's requirements. -->
+
+## Impact
+
+- **New test tooling** (location TBD in design, e.g. `tests/ai_lab/`): the papermill driver, the container/ITDE bring-up, the SCS seeding (reusing the same parameters as `installAiLab.sh`), the notebook-discovery + classification logic, and the report writer.
+- **CI** (optional, `tasks/` + `.github/`): a workflow that runs the harness; not part of the default fast test suite because a full run is heavy (image pulls, ITDE startup, and — for `export_as_is` — SLC image builds).
+- **No production code changes.** The harness consumes the same configuration that `installAiLab.sh` already applies; if anything, it documents that configuration as the single source of truth for "how a correct AI Lab host is set up."
+- **External dependencies (test-time only):** a container runtime (Docker or Podman) and `papermill`. Credential-gated notebooks remain out of scope and are reported as `SKIP` rather than failures.
+- **Known limits:** `export_as_is` currently fails on upstream flavor staleness (exasol/script-languages-release#1489) and will report `FAIL (upstream)` until that is fixed; heavy ML notebooks may exceed a small CI runner's resources and may be marked for a larger target.

--- a/openspec/changes/add-ai-lab-notebook-tests/specs/ai-lab-notebook-tests/spec.md
+++ b/openspec/changes/add-ai-lab-notebook-tests/specs/ai-lab-notebook-tests/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Headless notebook execution without a cloud deployment
+The system SHALL execute the AI Lab's bundled notebooks non-interactively against a self-contained Exasol database, without requiring a cloud deployment or interactive user input.
+
+#### Scenario: Run notebooks against the integrated test database
+- **WHEN** the harness runs in its default mode
+- **THEN** it starts the `exasol/ai-lab` container, brings up the integrated test database (ITDE), seeds the SCS, and executes the notebooks without any cloud provisioning or SSH access
+
+#### Scenario: Optional run against a live deployment
+- **WHEN** the harness is invoked in external mode against an existing `exasol install` deployment
+- **THEN** it seeds the SCS with that deployment's database and BucketFS parameters (as `installAiLab.sh` does) and executes the notebooks against the live database
+
+### Requirement: Deployment-faithful container configuration
+The harness SHALL configure the AI Lab container with the same settings that `installAiLab.sh` applies, so that it tests the behavior of a real deployment.
+
+#### Scenario: Podman host configuration is reproduced
+- **WHEN** the harness starts the AI Lab container on a Podman host
+- **THEN** it mounts the Podman API socket at `/var/run/docker.sock`, configures `docker.io` as an unqualified-search registry, and applies the `DockerRegistryImageChecker` compatibility patch
+
+### Requirement: Notebooks are discovered at runtime
+The system SHALL determine the set of notebooks to execute by discovering them in the image at runtime, rather than from a hardcoded list.
+
+#### Scenario: New notebook is picked up automatically
+- **WHEN** the AI Lab image contains a notebook not previously seen by the harness
+- **THEN** the harness discovers and executes it, and records it in the report
+
+### Requirement: Per-notebook results are classified
+The system SHALL report a result for each executed notebook classified as pass, integration failure, upstream failure, or skipped-needs-credential, including the failing cell and cause for failures.
+
+#### Scenario: Integration failure is attributed to our wiring
+- **WHEN** a notebook fails because of host/container configuration the launcher is responsible for
+- **THEN** the harness reports `FAIL (integration)` with the captured traceback
+
+#### Scenario: Upstream failure is attributed to a dependency
+- **WHEN** a notebook fails because of a defect in `ai-lab`, `notebook-connector`, or a flavor (e.g. stale flavor package pins)
+- **THEN** the harness reports `FAIL (upstream)` and references the known upstream issue when matched
+
+#### Scenario: Credential-gated notebook is skipped, not failed
+- **WHEN** a notebook requires an external credential or service the harness does not provide
+- **THEN** the harness reports `SKIP (needs <requirement>)` rather than a failure
+
+#### Scenario: Unrecognized failure is not hidden
+- **WHEN** a notebook fails with a traceback that matches no known pattern
+- **THEN** the harness defaults to `FAIL (integration)` so the regression is surfaced rather than silently skipped
+
+### Requirement: Usable as a regression gate
+The system SHALL produce a machine-readable report and an exit status suitable for gating dependency upgrades in CI.
+
+#### Scenario: Gate fails on integration regression
+- **WHEN** any notebook reports `FAIL (integration)`
+- **THEN** the harness exits non-zero
+
+#### Scenario: Known-upstream breakage does not red-wall the gate
+- **WHEN** the only failures are `FAIL (upstream)` entries on the known-issue allowlist
+- **THEN** the harness reports them as warnings and does not fail the gate by default

--- a/openspec/changes/add-ai-lab-notebook-tests/tasks.md
+++ b/openspec/changes/add-ai-lab-notebook-tests/tasks.md
@@ -1,0 +1,36 @@
+## 1. Harness foundation
+
+- [ ] 1.1 Choose harness location (`tests/ai_lab/`) and add a `task ai-lab:notebooks` target
+- [ ] 1.2 Container runtime bring-up: start `exasol/ai-lab` configured like `installAiLab.sh` (Podman socket mount → `/var/run/docker.sock`, `registries.conf` with `docker.io`, `DockerRegistryImageChecker` patch); support both Docker and Podman hosts
+- [ ] 1.3 Database bring-up in ITDE mode (`use_itde=true`); confirm the AI Lab can start and reach its docker-db
+- [ ] 1.4 SCS seeding helper reusing the exact keys from `installAiLab.sh` (DB + BucketFS params), parameterized for ITDE vs external mode
+
+## 2. Notebook discovery & execution
+
+- [ ] 2.1 Discover `*.ipynb` in the image at runtime (no hardcoded list); record the discovered set in the report
+- [ ] 2.2 Execute each notebook with `papermill` (per-notebook timeout); decide inside-container vs host-kernel execution (design open question 1)
+- [ ] 2.3 Capture failing cell + traceback as structured output
+
+## 3. Classification & reporting
+
+- [ ] 3.1 Rule-based classifier: `PASS` / `FAIL (integration)` / `FAIL (upstream)` / `SKIP (needs X)`; default unmatched → `FAIL (integration)`
+- [ ] 3.2 Seed the pattern table with the four known integration signatures (missing docker.sock, socket `PermissionError`, short-name registry, `Already exists`) and the known upstream signature (#1489 apt pin)
+- [ ] 3.3 Write `report.md` + `report.json` (discovered notebooks × result × cause)
+- [ ] 3.4 Exit codes: fail the gate on any `FAIL (integration)`; `FAIL (upstream)` warns by default with a known-issue allowlist (design open question 2)
+
+## 4. CI integration (optional)
+
+- [ ] 4.1 GitHub Actions workflow, manually-triggered + on `ai-lab`/`notebook-connector` version bump; not in the fast PR suite
+- [ ] 4.2 Decide image pinning strategy: pinned-digest gate + scheduled `:latest` canary (design open question 3)
+
+## 5. Validation
+
+- [ ] 5.1 Run the harness locally in ITDE mode; confirm light notebooks (config, BucketFS, SQL) report `PASS`
+- [ ] 5.2 Confirm `export_as_is` reports `PASS` (pulls the prebuilt image from Docker Hub, no local build); confirm a customize/rebuild notebook reports `FAIL (upstream)` linking #1489 (not `FAIL (integration)`)
+- [ ] 5.3 Confirm credential-gated notebooks report `SKIP (needs X)` with the specific missing requirement
+- [ ] 5.4 Regression check: temporarily revert one of the three `installAiLab.sh` fixes and confirm the harness flips the relevant notebook to `FAIL (integration)` with the right signature
+
+## 6. Documentation
+
+- [ ] 6.1 Document how to run the harness (local ITDE, external mode against a live deployment) and how to read the report
+- [ ] 6.2 Note resource expectations and known limits (heavy ML notebooks, SLC build cost, credential-gated skips)


### PR DESCRIPTION
## Description

Adds an opt-in **Exasol AI Lab** capability to cloud deployments. Passing `--with-ai-lab` to `exasol install` provisions and pre-wires the [`exasol/ai-lab`](https://github.com/exasol/ai-lab) JupyterLab container on the database host — one flag, zero manual configuration.

When enabled, the launcher:
- runs the `exasol/ai-lab` container (rootless Podman) alongside the database,
- pre-seeds its Secure Configuration Storage (SCS) with the DB and BucketFS connection so notebooks connect with no manual setup,
- serves Jupyter over **HTTPS** (using the deployment's self-signed certificate, the same one COS uses for the Admin UI) on a dedicated port (default `49494`, `--ai-lab-port`), gated by `--allowed-cidr` and protected by a generated Jupyter password,
- surfaces the AI Lab URL in `exasol info`; the Jupyter and config-store passwords go to `secrets.json` (never printed).

Enablement is an infrastructure variable (`with_ai_lab`, known at plan time), surfaced to the host via `infrastructure.json`. The `--with-ai-lab` / `--ai-lab-port` flags auto-generate from it and only appear on presets whose `compatibility.provides` includes `ai-lab` (AWS today). Cloud-only — local deployments lack the UDFs/BucketFS the AI Lab relies on. A standalone `exasol ai-lab install` for existing deployments is deferred to a follow-up (see the OpenSpec change).

## Related Issue

Fixes #<!-- no tracking issue in this repo; internal wishlist item. Related upstream issues (other repos): exasol/ai-lab#535 (rootless-Podman socket), exasol/script-languages-release#1489 (flavor pins) -->

## Type of Change

- [x] `feat`: New feature

## Changes Made

- **AWS preset** (`assets/infrastructure/aws/`): declare `ai-lab`; `with_ai_lab`/`ai_lab_port` vars; conditional security-group ingress gated by `allowed_cidr`; SCS/Jupyter/BucketFS `random_password` (count-gated, so plain deploys carry no AI Lab secrets); emit the `aiLab` connection object + secrets only when enabled; register the install hook.
- **Ubuntu install hook** (`installAiLab.sh`): run the container rootless; persist via a `podman generate systemd` unit; seed the SCS; create a dedicated BucketFS bucket + `AI_LAB` schema; **serve Jupyter over HTTPS** with the deployment cert; Podman↔Docker compatibility for the SLC export tooling (socket mount, `registries.conf`, `DockerRegistryImageChecker` patch).
- **Go** (`internal/`): `DeploymentAILab` metadata + secrets, resolved into `ConnectionInfo`; `exasol info` renders an AI Lab section (URL + secrets reference, self-signed-cert note).
- **Docs**: README section + `doc/ai_lab.md` (Mermaid architecture, security notes), `doc/presets.md` adoption bits, `CHANGELOG.md`.
- **OpenSpec**: `add-ai-lab-capability` (this change) and a design-only `add-ai-lab-notebook-tests` proposal.

## Testing

- [x] All existing tests pass (ran `go build ./...` and `go test ./internal/...`; `task`/`tofu` not available in my environment — relying on CI for `task all` / `tflint` / `terraform fmt`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

Verified end-to-end on live AWS deployments (`exasol install aws --with-ai-lab`), unattended from a clean deploy:
- `--with-ai-lab` flows to `with_ai_lab=true`; `deployment.json` carries the `aiLab` URL; `secrets.json` holds the generated passwords; the SG opens the port.
- **Jupyter reachable over HTTPS** externally (`https://<host>:49494` → 200, serving the deployment's `CN=exacluster.local` cert); plain HTTP on the port is refused.
- Notebooks connect to the DB/BucketFS via the pre-seeded SCS with no manual config; `export_as_is` pulls the prebuilt SLC image and completes.
- A deployment **without** `--with-ai-lab` shows no AI Lab section and opens no port.

## Checklist

- [x] Code follows the project's coding guidelines
- [ ] Ran `task fmt` and `task lint` (not installed locally — `gofmt -l` and `go vet` are clean; CI to run fmt/lint + tflint)
- [x] Updated documentation
- [x] Updated `CHANGELOG.md` for user-facing changes, including an example
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow Conventional Commits

## Additional Notes

- History is **5 self-contained commits** (each builds and tests pass independently) — suitable for a rebase merge; squash-merge is also fine.
- A prior security review flagged that Jupyter was served over plaintext HTTP on a port defaulting to `0.0.0.0/0`; this PR closes that by serving HTTPS with the deployment cert (matching the Admin UI). The container's mounted engine socket (needed for SLC builds) means notebook access is effectively host-`ubuntu`-level — documented in `doc/ai_lab.md`, and mitigated by `--allowed-cidr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
