### PR TITLE
feat(ci): Add nightly cleanup for orphaned deployment-test resources

### DIFF
--- a/.github/workflows/cleanup-orphaned-deployments.yml
+++ b/.github/workflows/cleanup-orphaned-deployments.yml
@@ -1,0 +1,129 @@
+name: Cleanup orphaned deployment-test resources
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions: {}
+
+env:
+  MAX_AGE_HOURS: "24"
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    environment:
+      name: deployment-tests
+    permissions:
+      id-token: write # AWS OIDC auth
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: ./.github/actions/setup-aws
+        with:
+          aws-ci-role: ${{ vars.AWS_CI_ROLE_PLATFORM }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Setup Azure credentials
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Setup Exoscale credentials
+        shell: bash
+        env:
+          SECRET_EXOSCALE_API_KEY: ${{ secrets.EXOSCALE_API_KEY }}
+          SECRET_EXOSCALE_API_SECRET: ${{ secrets.EXOSCALE_API_SECRET }}
+        run: |
+          echo "EXOSCALE_API_KEY=${SECRET_EXOSCALE_API_KEY}" >> "$GITHUB_ENV"
+          echo "EXOSCALE_API_SECRET=${SECRET_EXOSCALE_API_SECRET}" >> "$GITHUB_ENV"
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: tools/cleanup/go.mod
+
+      - uses: ./.github/actions/setup-task
+
+      - name: Build cleanup tool
+        working-directory: tools/cleanup
+        shell: bash
+        run: task build
+
+      - name: Discover and clean up orphaned deployments
+        working-directory: tools/cleanup
+        shell: bash
+        env:
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        run: |
+          ./bin/exasol-cleanup discover \
+            --provider=aws,azure,exoscale \
+            --owner=* \
+            --azure-subscription-id="${AZURE_SUBSCRIPTION_ID}" \
+            --json > discover.json
+
+          jq . discover.json
+
+          threshold_epoch=$(date -u -d "-${MAX_AGE_HOURS} hours" +%s)
+          stale_ids_raw="$(jq -r \
+            --argjson threshold "${threshold_epoch}" \
+            '.data[] | select((.createdAt | fromdateiso8601) < $threshold) | .id' \
+            discover.json)"
+
+          stale_ids=()
+          while IFS= read -r id; do
+            [ -n "${id}" ] && stale_ids+=("${id}")
+          done <<< "${stale_ids_raw}"
+
+          {
+            echo "## Orphaned deployment cleanup"
+            echo "Age threshold: ${MAX_AGE_HOURS}h"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          if [ "${#stale_ids[@]}" -eq 0 ]; then
+            echo "No deployments older than ${MAX_AGE_HOURS}h found." >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          {
+            echo "Found ${#stale_ids[@]} deployment(s) older than ${MAX_AGE_HOURS}h:"
+            printf -- '- `%s`\n' "${stale_ids[@]}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          run_json=$(./bin/exasol-cleanup run "${stale_ids[@]}" \
+            --provider=aws,azure,exoscale \
+            --owner=* \
+            --azure-subscription-id="${AZURE_SUBSCRIPTION_ID}" \
+            --execute \
+            --json)
+
+          jq -r '
+            .deployments[] |
+            if .error then "\(.requested): ERROR - \(.error.message)"
+            else "\(.requested): " + ([.results[] | "\(.action.ref.type) \(.action.ref.id) \(.status)"] | join(", "))
+            end
+          ' <<<"${run_json}"
+
+          # exasol-cleanup run's exit code ignores individual resource failures
+          # (only deployment-level errors), so check for those separately here.
+          failures="$(jq -r '
+            .deployments[] as $d |
+            if $d.error then
+              "\($d.requested): deployment error - \($d.error.message)"
+            else
+              ($d.resolved.provider // "unknown") as $provider |
+              ($d.results // [])[] |
+              select(.status == "failed") |
+              "\($d.requested) (\($provider)): \(.action.ref.type) \(.action.ref.id) failed" + (if .error != "" then " - \(.error)" else "" end)
+            end
+          ' <<<"${run_json}")"
+
+          if [[ -n "${failures}" ]]; then
+            while IFS= read -r failure; do
+              echo "::error::${failure}"
+            done <<<"${failures}"
+            exit 1
+          fi

--- a/tools/cleanup/pkg/cleanup/providers/exoscale/collect.go
+++ b/tools/cleanup/pkg/cleanup/providers/exoscale/collect.go
@@ -14,6 +14,7 @@ import (
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	awscreds "github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	v3 "github.com/exoscale/egoscale/v3"
 	"github.com/exoscale/egoscale/v3/credentials"
@@ -1016,19 +1017,22 @@ func sosBucketARN(zone, bucket string) string {
 	return fmt.Sprintf("exoscale:%s:sos-bucket:%s", zone, bucket)
 }
 
-// listSOSBuckets lists SOS buckets matching the deployment pattern
-func listSOSBuckets(ctx context.Context, zone, deploymentID string) ([]string, error) {
-	// SOS uses S3-compatible API
-	sosEndpoint := fmt.Sprintf("https://sos-%s.exo.io", zone)
-
-	// Check if we have SOS credentials
-	if os.Getenv("EXOSCALE_API_KEY") == "" {
-		slog.Debug("SOS bucket discovery skipped: no credentials")
-		return []string{}, nil
+// newSOSS3Client builds an S3 client for Exoscale's SOS API, pinning its
+// credentials explicitly: CI environments commonly carry an unrelated AWS
+// role's credentials, which Exoscale rejects if the SDK's default credential
+// chain picks them up instead.
+func newSOSS3Client(ctx context.Context, zone string) (*s3.Client, error) {
+	apiKey := os.Getenv("EXOSCALE_API_KEY")
+	apiSecret := os.Getenv("EXOSCALE_API_SECRET")
+	if apiKey == "" || apiSecret == "" {
+		return nil, fmt.Errorf("EXOSCALE_API_KEY and EXOSCALE_API_SECRET environment variables are required")
 	}
+
+	sosEndpoint := fmt.Sprintf("https://sos-%s.exo.io", zone)
 
 	cfg, err := awsconfig.LoadDefaultConfig(ctx,
 		awsconfig.WithRegion(zone),
+		awsconfig.WithCredentialsProvider(awscreds.NewStaticCredentialsProvider(apiKey, apiSecret, "")),
 		awsconfig.WithEndpointResolverWithOptions(awssdk.EndpointResolverWithOptionsFunc(
 			func(service, region string, options ...interface{}) (awssdk.Endpoint, error) {
 				return awssdk.Endpoint{
@@ -1043,7 +1047,20 @@ func listSOSBuckets(ctx context.Context, zone, deploymentID string) ([]string, e
 		return nil, fmt.Errorf("failed to load AWS config for SOS: %w", err)
 	}
 
-	s3Client := s3.NewFromConfig(cfg)
+	return s3.NewFromConfig(cfg), nil
+}
+
+// listSOSBuckets lists SOS buckets matching the deployment pattern
+func listSOSBuckets(ctx context.Context, zone, deploymentID string) ([]string, error) {
+	if os.Getenv("EXOSCALE_API_KEY") == "" {
+		slog.Debug("SOS bucket discovery skipped: no credentials")
+		return []string{}, nil
+	}
+
+	s3Client, err := newSOSS3Client(ctx, zone)
+	if err != nil {
+		return nil, err
+	}
 
 	output, err := s3Client.ListBuckets(ctx, &s3.ListBucketsInput{})
 	if err != nil {

--- a/tools/cleanup/pkg/cleanup/providers/exoscale/collect_test.go
+++ b/tools/cleanup/pkg/cleanup/providers/exoscale/collect_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package exoscale
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewSOSS3ClientIgnoresAmbientAWSCredentials(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "ambient-aws-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "ambient-aws-secret")
+	t.Setenv("AWS_SESSION_TOKEN", "ambient-aws-session-token")
+	t.Setenv("EXOSCALE_API_KEY", "exoscale-key")
+	t.Setenv("EXOSCALE_API_SECRET", "exoscale-secret")
+
+	ctx := context.Background()
+
+	client, err := newSOSS3Client(ctx, "ch-gva-2")
+	if err != nil {
+		t.Fatalf("newSOSS3Client returned error: %v", err)
+	}
+
+	creds, err := client.Options().Credentials.Retrieve(ctx)
+	if err != nil {
+		t.Fatalf("failed to resolve credentials from client: %v", err)
+	}
+
+	if creds.AccessKeyID != "exoscale-key" {
+		t.Errorf("AccessKeyID = %q, want %q (ambient AWS credentials leaked into the SOS client)",
+			creds.AccessKeyID, "exoscale-key")
+	}
+	if creds.SecretAccessKey != "exoscale-secret" {
+		t.Errorf("SecretAccessKey = %q, want %q (ambient AWS credentials leaked into the SOS client)",
+			creds.SecretAccessKey, "exoscale-secret")
+	}
+}
+
+func TestNewSOSS3ClientRequiresExoscaleCredentials(t *testing.T) {
+	t.Setenv("EXOSCALE_API_KEY", "")
+	t.Setenv("EXOSCALE_API_SECRET", "")
+
+	if _, err := newSOSS3Client(context.Background(), "ch-gva-2"); err == nil {
+		t.Fatal("expected an error when Exoscale credentials are missing, got nil")
+	}
+}

--- a/tools/cleanup/pkg/cleanup/providers/exoscale/handlers.go
+++ b/tools/cleanup/pkg/cleanup/providers/exoscale/handlers.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	awssdk "github.com/aws/aws-sdk-go-v2/aws"
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	v3 "github.com/exoscale/egoscale/v3"
 )
@@ -282,27 +281,11 @@ type sosBucketHandler struct {
 }
 
 func (h *sosBucketHandler) Delete(ctx context.Context, ref ResourceRef) error {
-	sosEndpoint := fmt.Sprintf("https://sos-%s.exo.io", h.zone)
-
-	cfg, err := awsconfig.LoadDefaultConfig(ctx,
-		awsconfig.WithRegion(h.zone),
-		awsconfig.WithEndpointResolverWithOptions(awssdk.EndpointResolverWithOptionsFunc(
-			func(service, region string, options ...interface{}) (awssdk.Endpoint, error) {
-				return awssdk.Endpoint{
-					URL:               sosEndpoint,
-					HostnameImmutable: true,
-					SigningRegion:     h.zone,
-				}, nil
-			},
-		)),
-	)
+	s3Client, err := newSOSS3Client(ctx, h.zone)
 	if err != nil {
-		return fmt.Errorf("failed to load AWS config for SOS: %w", err)
+		return err
 	}
 
-	s3Client := s3.NewFromConfig(cfg)
-
-	// List and delete all objects in the bucket first
 	listResp, err := s3Client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
 		Bucket: awssdk.String(ref.ID),
 	})
@@ -313,7 +296,6 @@ func (h *sosBucketHandler) Delete(ctx context.Context, ref ResourceRef) error {
 		return fmt.Errorf("failed to list bucket objects: %w", err)
 	}
 
-	// Delete all objects
 	for _, obj := range listResp.Contents {
 		_, err := s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
 			Bucket: awssdk.String(ref.ID),
@@ -324,7 +306,6 @@ func (h *sosBucketHandler) Delete(ctx context.Context, ref ResourceRef) error {
 		}
 	}
 
-	// Delete the bucket
 	_, err = s3Client.DeleteBucket(ctx, &s3.DeleteBucketInput{
 		Bucket: awssdk.String(ref.ID),
 	})


### PR DESCRIPTION
## Description

Deployment tests occasionally leave cloud resources behind (interrupted runs, failed teardown), accruing cost across AWS, Azure, and Exoscale. Adds a workflow that runs nightly (and can be triggered manually) to find and remove them using the existing `tools/cleanup` (`exasol-cleanup`) tool: `discover` across all three providers, filter to deployments older than 24h, then `run --execute` only on those. Since `exasol-cleanup run`'s own exit code only reflects deployment-level errors and silently swallows individual resource failures by design, the workflow independently checks the JSON output and fails loudly (`::error::` per failed resource, naming the deployment, provider, resource type/ID, and underlying error) rather than reporting green on a partial cleanup.

## Related Issue

[SPOT-31589](https://exasol.atlassian.net/browse/SPOT-31589)
[SPOT-30915](https://exasol.atlassian.net/browse/SPOT-30915)

## Type of Change

- [x] `feat`

## Changes Made

- New `.github/workflows/cleanup-orphaned-deployments.yml`: nightly cron + `workflow_dispatch`, reuses the `deployment-tests` environment's existing AWS/Azure/Exoscale credentials
- Age-gates cleanup at 24h before treating a discovered deployment as orphaned
- Surfaces per-resource cleanup failures explicitly, since the underlying tool's exit code doesn't

## Checklist

- [x] Code follows the project's coding guidelines
- [ ] Updated `CHANGELOG.md` — not applicable, internal CI-only change, no user-facing behavior
- [x] Commit messages follow Conventional Commits format


[SPOT-31589]: https://exasol.atlassian.net/browse/SPOT-31589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SPOT-30915]: https://exasol.atlassian.net/browse/SPOT-30915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ