### PR TITLE
fix: Install Podman on cloud hosts for Data Lakehouse Turbo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Notable user-facing changes to Exasol Personal are documented here.
 
 ### Fixed
 
+- Fixed Data Lakehouse Turbo activation failing on cloud deployments. Podman was missing from the deployment hosts, so activating the feature in the AdminUI hung on a spinner and reported `Activation status for database Exasol could not be retrieved`. Podman is now installed during cloud-init on all supported cloud providers (AWS, Azure, Exoscale, STACKIT).
+
 ### Breaking Changes
 
 - None.

--- a/assets/installation/ubuntu/cloudconf/static.yaml
+++ b/assets/installation/ubuntu/cloudconf/static.yaml
@@ -10,6 +10,7 @@ packages:
   - net-tools
   - jq
   - uidmap
+  - podman
 
 runcmd:
   - "echo 'EXASOL-INSTALL-SUBSTEP: System package installation and updates completed'"


### PR DESCRIPTION
## Description

Data Lakehouse Turbo could not be activated on Exasol Personal cloud deployments because Podman was not installed on the deployment hosts. Activating the feature in the AdminUI hung on a spinner and reported `Activation status for database Exasol could not be retrieved`.

Reported on AWS via L3-4379, but the cause was provider-independent: all supported cloud providers build their cloud-init from the same shared `ubuntu` installation preset, whose package list was missing `podman`. `uidmap` was already present for rootless container support — `podman` itself was the missing piece.

## Related Issue

SPOT-32133

## Type of Change

- [x] `fix`: Bug fix

## Changes Made

- Added `podman` to the package list in the shared `ubuntu` installation preset cloud-config, next to the existing `uidmap` rootless-container prerequisite.
- Added a `CHANGELOG.md` entry under `Unreleased` → `Fixed`.

## Testing

- [x] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [ ] Manually tested the changes

### Test Details

`task all` passes (114 passed, 1 skipped); `task lint` and `task lint-terraform` are clean.

No local suite exercises this change — the fix only manifests on a real cloud deployment, so verifying it end to end requires a provisioned deployment with an AdminUI. Deployment-level regression coverage for feature availability is deliberately out of scope here and is part of the wider Exasol Personal test coverage discussion.

One assumption worth a reviewer's eye: `podman` comes from Ubuntu's `universe` component, which is enabled by default on Ubuntu cloud images.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [x] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [ ] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

The AdminUI side of this — activation failure surfacing as an unretrievable status plus an indefinite spinner rather than an actionable error — is already tracked separately in SPOT-30695 (and SPOT-30699 for the deactivation equivalent). This PR only ensures the host prerequisite is present.
