### PR TITLE
fix(build): Clear resource_path when embedding raw artifacts

### DIFF
--- a/tools/resourceembedder/main.go
+++ b/tools/resourceembedder/main.go
@@ -227,6 +227,15 @@ func (g *generator) resolveResourceEmbed(
 	rawDef := def
 	rawDef.Extract = false
 	rawDef.Embed = false
+	// resource_path names a path inside the extracted archive, so it is
+	// meaningless for the raw artifact fetched here: joining it onto a bare
+	// file would resolve to a path that cannot exist. Clear it alongside
+	// Extract, on a fresh map so the caller's definition stays untouched.
+	rawDef.Artifact = make(map[string]runtimeartifacts.ArtifactSpec, len(def.Artifact))
+	for platform, artifact := range def.Artifact {
+		artifact.ResourcePath = ""
+		rawDef.Artifact[platform] = artifact
+	}
 
 	rawPath, err := g.manager.Get(ctx, rawDef, resourceID)
 	if err != nil {

--- a/tools/resourceembedder/main_test.go
+++ b/tools/resourceembedder/main_test.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -288,5 +290,79 @@ func TestGeneratePlatform_CombinesMultipleResourcesIntoOneFile(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(outputDir, dataFile)); err != nil {
 			t.Fatalf("expected data file %s to exist, got %v", dataFile, err)
 		}
+	}
+}
+
+// zipContaining builds an in-memory zip archive holding a single named entry,
+// matching the shape of the real embedded resources: an archive that declares
+// extract: true plus a resource_path pointing at a file inside it.
+func zipContaining(t *testing.T, name string, content []byte) []byte {
+	t.Helper()
+
+	buffer := bytes.Buffer{}
+	writer := zip.NewWriter(&buffer)
+	entry, err := writer.Create(name)
+	if err != nil {
+		t.Fatalf("creating zip entry: %v", err)
+	}
+	if _, err := entry.Write(content); err != nil {
+		t.Fatalf("writing zip entry: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("closing zip: %v", err)
+	}
+
+	return buffer.Bytes()
+}
+
+// Embedding stages the raw archive, so the generator neutralizes extract and
+// the resource_path that goes with it. Leaving resource_path in place resolves
+// it against the downloaded file instead of an extracted directory, yielding a
+// path such as artifact.zip/launcher that cannot exist.
+func TestGeneratePlatform_EmbedsRawArchiveWhenResourcePathIsDeclared(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	inner := []byte("runner binary bytes")
+	archive := zipContaining(t, "launcher", inner)
+	server := newFixtureServer(t, "artifact.zip", archive)
+	def := runtimeartifacts.ResourceDefinition{
+		Extract: true,
+		Embed:   true,
+		Artifact: map[string]runtimeartifacts.ArtifactSpec{
+			"darwin/arm64": {
+				URL:          server.URL + "/artifact.zip",
+				Sha256:       sha256Hex(archive),
+				ResourcePath: "launcher",
+			},
+		},
+	}
+	spec := runtimeartifacts.ResourceSpec{"embed-extract-test": def}
+	outputDir := t.TempDir()
+	manager := runtimeartifacts.NewResourceManagerForPlatform(
+		spec, t.TempDir(), "darwin", "arm64",
+	)
+	g := &generator{manager: manager, outputDir: outputDir, goos: "darwin", goarch: "arm64"}
+
+	// When
+	err := g.generatePlatform(context.Background(), spec)
+
+	// Then
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	dataPath := filepath.Join(outputDir, "embed_extract_test_darwin_arm64.bin")
+	dataBytes, err := os.ReadFile(dataPath)
+	if err != nil {
+		t.Fatalf("expected embedded data file, got %v", err)
+	}
+	if !bytes.Equal(dataBytes, archive) {
+		t.Fatalf("expected the raw archive bytes, got %d bytes", len(dataBytes))
+	}
+
+	// The caller's definition must survive untouched: the generator clears
+	// resource_path on its own copy, not on the shared spec.
+	if got := spec["embed-extract-test"].Artifact["darwin/arm64"].ResourcePath; got != "launcher" {
+		t.Errorf("expected the spec's resource_path to be left alone, got %q", got)
 	}
 }


### PR DESCRIPTION
## Description

`task build` currently fails on darwin/arm64 during `go generate`:

```
Error: failed to generate embedded resource "exasol-local-runner" for darwin/arm64:
stat .../mac-launcher-aarch64.zip/launcher: not a directory
```

`resources.yaml` declares the local runner with both `extract: true` and `resource_path: launcher` — `launcher` being the binary inside the zip. The generator deliberately forces `Extract` and `Embed` to `false` so it always performs a real, checksum-verified fetch of the **raw** artifact whose bytes it embeds. It left `resource_path` in place, however, so the manager resolved it against the downloaded *file* rather than an extracted *directory*, producing `mac-launcher-aarch64.zip/launcher`. `os.Stat` on that returns `ENOTDIR`, which is not `os.ErrNotExist`, so the cache-verification path in `manager.go` surfaced it as a hard error instead of treating it as a miss.

Nothing is wrong with the artifact itself — the cached zip hashes to exactly the declared `a230ce33…`.

This combination was silently tolerated until `f769779` ("feat: support git fragment paths for remote presets") made `resource_path` apply uniformly regardless of source kind. Before that, `resource_path` was only joined when `def.Extract` was true, so the generator's contradictory definition — raw bytes wanted, yet `resource_path` pointing inside the archive — never resolved to an impossible path.

`resource_path` names a path inside the extracted archive, so it belongs with `extract`. The fix clears it alongside `Extract`/`Embed`, on a fresh artifact map since `rawDef := def` shallow-copies and would otherwise mutate the caller's shared spec.

I deliberately did **not** change the manager. `resolveEntry` is a pure path computation, called before the fetch for both cache lookup and entry building, so an `os.Stat`-based "is this root a directory?" guard there would be unreliable on a cold cache and would put filesystem state into a pure function. Telling directory-shaped sources (git clones, `file://` directories — the case `f769779` added) apart from file downloads would mean a real semantics change to recently-landed behavior. The generator is the component constructing the contradictory definition, so the fix belongs here.

## Related Issue

None.

## Type of Change

- [x] `fix`: Bug fix

## Changes Made

- `tools/resourceembedder/main.go`: clear `ResourcePath` on the generator's copy of the resource definition, alongside the existing `Extract`/`Embed` overrides, using a fresh `Artifact` map so the shared spec is not mutated.
- `tools/resourceembedder/main_test.go`: added `TestGeneratePlatform_EmbedsRawArchiveWhenResourcePathIsDeclared`, which mirrors the real `resources.yaml` shape (`extract: true` + `resource_path`) against a genuine in-memory zip, asserts the embedded bytes are the raw archive, and asserts the caller's spec keeps its `resource_path`.

## Testing

- [x] Manually tested the changes
- [x] Added new tests for new functionality

### Test Details

- `task build` now succeeds. The generator resolves to the raw zip as intended, and the resulting `./bin/exasol version` reports `2.2.0`.
- `go test ./tools/resourceembedder/...` passes.
- Confirmed the new test actually guards the regression: with the one-line fix stashed it fails with the same error seen in the build, `open .../artifact.zip/launcher: not a directory`.
- `task fmt` and `task lint` are clean (`0 issues`).
- Two failures remain in `internal/runtimeartifacts` (`TestFileSource_Fetch_BareFileReturnsRedirectPath`, `TestFileSource_Fetch_ArchiveReturnsRedirectPath`). They are pre-existing and unrelated — macOS resolves `TMPDIR` through the `/var` → `/private/var` symlink — and they fail identically with this change stashed.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Added/updated tests
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

No `CHANGELOG.md` entry: this fixes the contributor build only and changes no CLI behavior, deployment behavior, supported platforms, or user-visible errors.

The fix changes the artifact's cache key (`resource_path` feeds the identity hash), so the first build after this re-downloads the 165 MB runner once.

Possible follow-up, out of scope here: `Manager.resolveResolvedPath` will still fabricate an unstattable path for any caller that combines `Extract: false` with a `resource_path`. Rejecting that combination with a clear error would turn a confusing `ENOTDIR` into an actionable message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
