### PR TITLE
feat(cleanup): Select deployments by age, and sweep previous AWS regions

### DIFF
--- a/.github/workflows/cleanup-orphaned-deployments.yml
+++ b/.github/workflows/cleanup-orphaned-deployments.yml
@@ -7,26 +7,47 @@ on:
 
 permissions: {}
 
-env:
-  MAX_AGE_HOURS: "24"
-
 jobs:
   cleanup:
+    name: cleanup (${{ matrix.awsRegion }})
     runs-on: ubuntu-latest
     environment:
       name: deployment-tests
     permissions:
       id-token: write # AWS OIDC auth
       contents: read
+    strategy:
+      # One region per job: a failing region must not hold back the others, and
+      # a deployment matching two regions at once is rejected by the tool (AWS
+      # reports global resources such as IAM roles in us-east-1 regardless).
+      fail-fast: false
+      matrix:
+        # Previously used regions are swept too, since orphans outlive a region
+        # switch, but on a longer threshold. Add the outgoing region as a row
+        # whenever AWS_REGION changes.
+        include:
+          - providers: aws,azure,exoscale
+            awsRegion: ${{ vars.AWS_REGION }}
+            maxAgeHours: 24
+          - providers: aws
+            awsRegion: eu-west-1
+            maxAgeHours: 72
+          - providers: aws
+            awsRegion: eu-central-1
+            maxAgeHours: 72
+          - providers: aws
+            awsRegion: us-east-1
+            maxAgeHours: 72
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - uses: ./.github/actions/setup-aws
         with:
           aws-ci-role: ${{ vars.AWS_CI_ROLE_PLATFORM }}
-          aws-region: ${{ vars.AWS_REGION }}
+          aws-region: ${{ matrix.awsRegion }}
 
       - name: Setup Azure credentials
+        if: ${{ contains(matrix.providers, 'azure') }}
         uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -34,6 +55,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Setup Exoscale credentials
+        if: ${{ contains(matrix.providers, 'exoscale') }}
         shell: bash
         env:
           SECRET_EXOSCALE_API_KEY: ${{ secrets.EXOSCALE_API_KEY }}
@@ -53,77 +75,19 @@ jobs:
         shell: bash
         run: task build
 
-      - name: Discover and clean up orphaned deployments
+      - name: Clean up orphaned deployments
         working-directory: tools/cleanup
         shell: bash
         env:
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          PROVIDERS: ${{ matrix.providers }}
+          CLEANUP_AWS_REGION: ${{ matrix.awsRegion }}
+          MAX_AGE_HOURS: ${{ matrix.maxAgeHours }}
         run: |
-          ./bin/exasol-cleanup discover \
-            --provider=aws,azure,exoscale \
+          ./bin/exasol-cleanup run --all \
+            --provider="${PROVIDERS}" \
+            --aws-region="${CLEANUP_AWS_REGION}" \
+            --older-than="${MAX_AGE_HOURS}h" \
             --owner=* \
             --azure-subscription-id="${AZURE_SUBSCRIPTION_ID}" \
-            --json > discover.json
-
-          jq . discover.json
-
-          threshold_epoch=$(date -u -d "-${MAX_AGE_HOURS} hours" +%s)
-          stale_ids_raw="$(jq -r \
-            --argjson threshold "${threshold_epoch}" \
-            '(.data // [])[] | select((.createdAt | fromdateiso8601) < $threshold) | .id' \
-            discover.json)"
-
-          stale_ids=()
-          while IFS= read -r id; do
-            [ -n "${id}" ] && stale_ids+=("${id}")
-          done <<< "${stale_ids_raw}"
-
-          {
-            echo "## Orphaned deployment cleanup"
-            echo "Age threshold: ${MAX_AGE_HOURS}h"
-          } >> "${GITHUB_STEP_SUMMARY}"
-
-          if [ "${#stale_ids[@]}" -eq 0 ]; then
-            echo "No deployments older than ${MAX_AGE_HOURS}h found." >> "${GITHUB_STEP_SUMMARY}"
-            exit 0
-          fi
-
-          {
-            echo "Found ${#stale_ids[@]} deployment(s) older than ${MAX_AGE_HOURS}h:"
-            printf -- '- `%s`\n' "${stale_ids[@]}"
-          } >> "${GITHUB_STEP_SUMMARY}"
-
-          run_json=$(./bin/exasol-cleanup run "${stale_ids[@]}" \
-            --provider=aws,azure,exoscale \
-            --owner=* \
-            --azure-subscription-id="${AZURE_SUBSCRIPTION_ID}" \
-            --execute \
-            --json)
-
-          jq -r '
-            .deployments[] |
-            if .error then "\(.requested): ERROR - \(.error.message)"
-            else "\(.requested): " + ([.results[] | "\(.action.ref.type) \(.action.ref.id) \(.status)"] | join(", "))
-            end
-          ' <<<"${run_json}"
-
-          # exasol-cleanup run's exit code ignores individual resource failures
-          # (only deployment-level errors), so check for those separately here.
-          failures="$(jq -r '
-            .deployments[] as $d |
-            if $d.error then
-              "\($d.requested): deployment error - \($d.error.message)"
-            else
-              ($d.resolved.provider // "unknown") as $provider |
-              ($d.results // [])[] |
-              select(.status == "failed") |
-              "\($d.requested) (\($provider)): \(.action.ref.type) \(.action.ref.id) failed" + (if .error != "" then " - \(.error)" else "" end)
-            end
-          ' <<<"${run_json}")"
-
-          if [[ -n "${failures}" ]]; then
-            while IFS= read -r failure; do
-              echo "::error::${failure}"
-            done <<<"${failures}"
-            exit 1
-          fi
+            --execute

--- a/doc/ci.md
+++ b/doc/ci.md
@@ -56,6 +56,16 @@ Runs automatically on every push to `main`:
 
 This ensures multi-platform compatibility is validated on the main branch.
 
+### Orphaned Deployment Cleanup (`cleanup-orphaned-deployments.yml`)
+
+Runs nightly (and on manual dispatch) to delete cloud resources left behind by failed or interrupted deployment tests, using the [cleanup tool](../tools/cleanup/README.md).
+Deployments older than the configured age threshold are removed across AWS, Azure, and Exoscale.
+
+Deployments in the region CI currently deploys to (`AWS_REGION`) are removed once they are a day old, as are Azure and Exoscale deployments.
+AWS resources outlive a change of deployment region, so the regions CI deployed to previously are swept as well, but on a longer grace period of three days, since nothing left there belongs to a recent test run.
+Each region runs as its own job with its own threshold, so add the outgoing region as a row whenever `AWS_REGION` changes, and drop a row once its region is known to be empty.
+Splitting by region also keeps a deployment from matching two search targets at once, which the cleanup tool rejects: AWS reports global resources such as IAM roles in `us-east-1` regardless of which region holds the deployment's instances.
+
 ## Manual Workflows
 
 ### Deployment Tests (`tests-deployment.yml`)
@@ -102,7 +112,7 @@ Where it’s used in CI:
 Maintenance tips:
 - Prefer least privilege: attach only the permissions required for deployment tests to the IAM role.
 - Scope trust policies narrowly to this repository/branch/environment using the `sub` claim; adjust as the workflow structure evolves.
-- When rotating roles or changing account setup, update the `AWS_CI_ROLE_PLATFORM` variable with the new role ARN; for region changes, update `AWS_REGION`.
+- When rotating roles or changing account setup, update the `AWS_CI_ROLE_PLATFORM` variable with the new role ARN; for region changes, update `AWS_REGION` and add the outgoing region to the cleanup workflow's matrix.
 - Audit and monitor with AWS CloudTrail; review trust and permission policies regularly.
 
 Authoritative references:

--- a/tools/cleanup/README.md
+++ b/tools/cleanup/README.md
@@ -53,7 +53,14 @@ Run cleanup (dry-run by default):
 ./bin/exasol-cleanup run exasol-123ad553 --execute
 ./bin/exasol-cleanup run --owner=* exasol-123ad553 --execute
 ./bin/exasol-cleanup run --types=ec2-instance,ebs-volume exasol-123ad553 --execute
+# Every deployment left over for more than a day, in one call:
+./bin/exasol-cleanup run --all --older-than=24h --owner=*
+./bin/exasol-cleanup run --all --older-than=24h --owner=* --execute
 ```
+
+`--all` cleans up every deployment the search finds instead of ids you name, which saves discovering first and feeding the ids back in. Narrow it with `--older-than`, a duration such as `24h` or `90m`; `discover` accepts the same flag for listing. A deployment whose creation time cannot be derived from tags or resources counts as old enough, so it does not survive indefinitely. Because `--all` decides what to delete from filters rather than from ids, it refuses to be combined with explicit ids, and `--older-than` is rejected without it. `--execute` remains the safety switch either way.
+
+`run` exits non-zero when a deployment could not be processed *or* when an individual resource action failed, so automation can rely on the exit code instead of inspecting results. Skipped actions are a normal outcome for protected resources and are not failures.
 
 `show` and `run` are intentionally different: `show` lists the resources currently associated with each deployment, while `run` plans ordered cleanup actions and optionally executes them. Because `run` is destructive in execute mode, `--execute` remains the safety switch.
 

--- a/tools/cleanup/cmd/cleanup/cleanup.go
+++ b/tools/cleanup/cmd/cleanup/cleanup.go
@@ -4,6 +4,8 @@
 package main
 
 import (
+	"time"
+
 	"fmt"
 	"io"
 	"slices"
@@ -48,6 +50,7 @@ var cleanupOpts = struct {
 	AzureSubscriptionID string
 	Providers           []string
 	OwnerFilter         string
+	OlderThan           time.Duration
 	JSON                bool
 	Verbose             bool
 }{}
@@ -83,6 +86,14 @@ func shouldUseProvider(providerName string) bool {
 		}
 	}
 	return false
+}
+
+// registerAgeFilterFlag adds --older-than. Not a common flag: show and
+// providers have nothing for it to narrow.
+func registerAgeFilterFlag(cmd *cobra.Command) {
+	cmd.Flags().
+		DurationVar(&cleanupOpts.OlderThan, "older-than", 0,
+			"Only consider deployments created longer ago than this duration (e.g. 24h, 90m)")
 }
 
 func registerCommonFlags(cmd *cobra.Command, options cleanupFlagOptions) {

--- a/tools/cleanup/cmd/cleanup/cleanup_discover.go
+++ b/tools/cleanup/cmd/cleanup/cleanup_discover.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	shared "github.com/exasol/exasol-personal/tools/cleanup/pkg/cleanup"
 	"github.com/spf13/cobra"
@@ -45,6 +46,7 @@ var cleanupDiscoverCmd = &cobra.Command{
 			scopedCollector.Scope.Reason = ""
 			res = append(res, summaries...)
 		}
+		res = shared.FilterSummariesOlderThan(res, cleanupOpts.OlderThan, time.Now())
 
 		if !cleanupOpts.JSON {
 			renderCleanupScope(cmd.OutOrStdout(), plan.Scope)
@@ -245,6 +247,7 @@ func registerCleanupDiscoverFlags(cmd *cobra.Command) {
 			" Default: state,created,resources")
 	cmd.Flags().BoolVar(&cleanupDiscoverOpts.Legacy, "legacy", false,
 		"Discover legacy deployments (ignore mandatory Project=exasol-personal)")
+	registerAgeFilterFlag(cmd)
 }
 
 // nolint: gochecknoinits

--- a/tools/cleanup/cmd/cleanup/cleanup_run.go
+++ b/tools/cleanup/cmd/cleanup/cleanup_run.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	shared "github.com/exasol/exasol-personal/tools/cleanup/pkg/cleanup"
 	"github.com/spf13/cobra"
@@ -15,6 +16,7 @@ import (
 
 var cleanupRunOpts = struct {
 	Execute bool
+	All     bool
 	Types   []string
 }{}
 
@@ -23,9 +25,12 @@ const cleanupRunShort = "Run ordered cleanup (dry-run by default) for one or mor
 var cleanupRunCmd = &cobra.Command{
 	Use:    "run <deployment-id>...",
 	Short:  cleanupRunShort,
-	Args:   cobra.MinimumNArgs(1),
+	Args:   cobra.ArbitraryArgs,
 	PreRun: func(_ *cobra.Command, _ []string) { configureLogger() },
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateCleanupRunSelection(args); err != nil {
+			return err
+		}
 		cmd.SilenceUsage = true
 
 		plan := buildCleanupPlan(cmd.Context(), false)
@@ -67,9 +72,15 @@ var cleanupRunCmd = &cobra.Command{
 			return err
 		}
 
-		results := make([]cleanupRunDeploymentJSONOutput, 0, len(args))
+		deploymentIDs := selectCleanupRunDeployments(args, lookupIndex)
+		if !cleanupOpts.JSON && len(deploymentIDs) == 0 {
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No deployments selected for cleanup.")
+		}
+
+		results := make([]cleanupRunDeploymentJSONOutput, 0, len(deploymentIDs))
 		failureCount := 0
-		for i, deploymentID := range args {
+		resourceFailures := 0
+		for i, deploymentID := range deploymentIDs {
 			if !cleanupOpts.JSON && i > 0 {
 				_, _ = fmt.Fprintln(cmd.OutOrStdout())
 			}
@@ -85,6 +96,7 @@ var cleanupRunCmd = &cobra.Command{
 				continue
 			}
 
+			resourceFailures += countFailedResults(result.Results)
 			if !cleanupOpts.JSON {
 				renderCleanupRunResult(cmd, *result.Resolved, result.Results, execution)
 			}
@@ -99,29 +111,83 @@ var cleanupRunCmd = &cobra.Command{
 			)
 		}
 
+		outcomeCode, outcomeErr := cleanupRunOutcome(failureCount, resourceFailures)
 		if cleanupOpts.JSON {
 			payload := cleanupRunJSONOutput{
 				Scope:       plan.Scope,
 				Execution:   execution,
 				Deployments: results,
 			}
-			if failureCount > 0 {
-				payload.Error = commandError(
-					"deployment_requests_failed",
-					fmt.Errorf("%d deployment requests failed", failureCount),
-				)
+			if outcomeErr != nil {
+				payload.Error = commandError(outcomeCode, outcomeErr)
 			}
 			if encodeErr := encodeJSONOutput(cmd.OutOrStdout(), payload); encodeErr != nil {
 				return encodeErr
 			}
 		}
 
-		if failureCount > 0 {
-			return fmt.Errorf("%d deployment requests failed", failureCount)
-		}
-
-		return nil
+		return outcomeErr
 	},
+}
+
+// validateCleanupRunSelection rejects ambiguous targeting: ids and --all are
+// alternatives, and --older-than does nothing without --all.
+func validateCleanupRunSelection(args []string) error {
+	switch {
+	case cleanupRunOpts.All && len(args) > 0:
+		return fmt.Errorf("--all cannot be combined with deployment ids")
+	case !cleanupRunOpts.All && len(args) == 0:
+		return fmt.Errorf("provide at least one deployment id, or --all to select every discovered deployment")
+	case !cleanupRunOpts.All && cleanupOpts.OlderThan > 0:
+		return fmt.Errorf("--older-than only applies together with --all")
+	}
+
+	return nil
+}
+
+// selectCleanupRunDeployments resolves the run targets: the given ids, or the
+// stale deployments already in the index when --all is set.
+func selectCleanupRunDeployments(args []string, lookupIndex cleanupLookupIndex) []string {
+	if !cleanupRunOpts.All {
+		return args
+	}
+
+	selected := shared.StaleDeploymentIDs(lookupIndex, cleanupOpts.OlderThan, time.Now())
+	slog.Info("selected deployments", "count", len(selected), "older_than", cleanupOpts.OlderThan.String())
+
+	return selected
+}
+
+// countFailedResults counts failed actions. Skipped is a normal outcome for
+// protected resources, not a failure.
+func countFailedResults(results []shared.Result) int {
+	failed := 0
+	for _, result := range results {
+		if result.Status == shared.ResultStatusFailed {
+			failed++
+		}
+	}
+
+	return failed
+}
+
+// cleanupRunOutcome maps run tallies onto an error code and error. Failed
+// resource actions count too, so callers can rely on the exit code alone.
+func cleanupRunOutcome(deploymentFailures, resourceFailures int) (string, error) {
+	switch {
+	case deploymentFailures > 0 && resourceFailures > 0:
+		return "run_failed", fmt.Errorf(
+			"%d deployment requests failed, %d resource actions failed",
+			deploymentFailures,
+			resourceFailures,
+		)
+	case deploymentFailures > 0:
+		return "deployment_requests_failed", fmt.Errorf("%d deployment requests failed", deploymentFailures)
+	case resourceFailures > 0:
+		return "resource_actions_failed", fmt.Errorf("%d resource actions failed", resourceFailures)
+	}
+
+	return "", nil
 }
 
 func loadCleanupRunResult(
@@ -242,6 +308,10 @@ func runMode(execute bool) string {
 func registerCleanupRunFlags(cmd *cobra.Command) {
 	cmd.Flags().
 		BoolVar(&cleanupRunOpts.Execute, "execute", false, "Execute deletions instead of dry-run")
+	cmd.Flags().
+		BoolVar(&cleanupRunOpts.All, "all", false,
+			"Clean up every discovered deployment instead of named ids (combine with --older-than)")
+	registerAgeFilterFlag(cmd)
 	cmd.Flags().
 		StringSliceVar(&cleanupRunOpts.Types, "types", nil,
 			"Optional comma-separated resource types to limit (e.g. ec2-instance,ebs-volume)")

--- a/tools/cleanup/cmd/cleanup/cleanup_run_selection_test.go
+++ b/tools/cleanup/cmd/cleanup/cleanup_run_selection_test.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	shared "github.com/exasol/exasol-personal/tools/cleanup/pkg/cleanup"
+)
+
+func TestValidateCleanupRunSelectionRejectsAmbiguousTargeting(t *testing.T) {
+	originalOpts := cleanupOpts
+	originalRunOpts := cleanupRunOpts
+	t.Cleanup(func() {
+		cleanupOpts = originalOpts
+		cleanupRunOpts = originalRunOpts
+	})
+
+	// Given the two ways of selecting deployments
+	// When ids and --all are combined, or neither is given
+	// Then the run is rejected before anything is searched
+	cleanupRunOpts.All = true
+	if err := validateCleanupRunSelection([]string{"exasol-12345678"}); err == nil {
+		t.Fatal("--all combined with deployment ids should be rejected")
+	}
+
+	cleanupRunOpts.All = false
+	if err := validateCleanupRunSelection(nil); err == nil {
+		t.Fatal("a run without ids and without --all should be rejected")
+	}
+
+	// And --older-than only narrows what --all selects, so it needs --all
+	cleanupOpts.OlderThan = 24 * time.Hour
+	if err := validateCleanupRunSelection([]string{"exasol-12345678"}); err == nil {
+		t.Fatal("--older-than without --all should be rejected")
+	}
+
+	cleanupRunOpts.All = true
+	if err := validateCleanupRunSelection(nil); err != nil {
+		t.Fatalf("--all with --older-than should be accepted, got %v", err)
+	}
+}
+
+func TestSelectCleanupRunDeploymentsAppliesAgeFilterOnlyForAll(t *testing.T) {
+	originalOpts := cleanupOpts
+	originalRunOpts := cleanupRunOpts
+	t.Cleanup(func() {
+		cleanupOpts = originalOpts
+		cleanupRunOpts = originalRunOpts
+	})
+
+	index := cleanupLookupIndex{Matches: map[string][]cleanupLookupMatch{
+		"exasol-stale": {{Summary: shared.DeploymentSummary{CreatedAt: time.Now().Add(-72 * time.Hour)}}},
+		"exasol-fresh": {{Summary: shared.DeploymentSummary{CreatedAt: time.Now()}}},
+	}}
+
+	// Given explicit ids
+	// When --all is not set
+	// Then the ids are used as given, regardless of their age
+	cleanupRunOpts.All = false
+	cleanupOpts.OlderThan = 0
+	selected := selectCleanupRunDeployments([]string{"exasol-fresh"}, index)
+	if len(selected) != 1 || selected[0] != "exasol-fresh" {
+		t.Fatalf("selected = %v, want [exasol-fresh]", selected)
+	}
+
+	// Given --all together with an age threshold
+	// When deployments are selected
+	// Then only the ones past the threshold are cleaned up
+	cleanupRunOpts.All = true
+	cleanupOpts.OlderThan = 24 * time.Hour
+	selected = selectCleanupRunDeployments(nil, index)
+	if len(selected) != 1 || selected[0] != "exasol-stale" {
+		t.Fatalf("selected = %v, want [exasol-stale]", selected)
+	}
+}
+
+func TestCleanupRunOutcomeReportsResourceFailures(t *testing.T) {
+	t.Parallel()
+
+	// Given the tallies of a finished run
+	// When resource actions failed but every deployment was processed
+	// Then the run still reports an error, so the exit code alone is enough
+	code, err := cleanupRunOutcome(0, 2)
+	if err == nil || code != "resource_actions_failed" {
+		t.Fatalf("code = %q, err = %v, want resource_actions_failed", code, err)
+	}
+
+	if code, err = cleanupRunOutcome(1, 0); err == nil || code != "deployment_requests_failed" {
+		t.Fatalf("code = %q, err = %v, want deployment_requests_failed", code, err)
+	}
+
+	if code, err = cleanupRunOutcome(1, 2); err == nil || code != "run_failed" {
+		t.Fatalf("code = %q, err = %v, want run_failed", code, err)
+	}
+
+	if code, err = cleanupRunOutcome(0, 0); err != nil || code != "" {
+		t.Fatalf("code = %q, err = %v, want no error", code, err)
+	}
+}
+
+func TestCountFailedResultsIgnoresSkippedActions(t *testing.T) {
+	t.Parallel()
+
+	results := []shared.Result{
+		{Status: shared.ResultStatusSuccess},
+		{Status: shared.ResultStatusSkipped},
+		{Status: shared.ResultStatusFailed},
+		{Status: shared.ResultStatusFailed},
+	}
+
+	// Given a mix of action outcomes
+	// When failures are counted
+	// Then skipped actions do not count: they are normal for protected resources
+	if got := countFailedResults(results); got != 2 {
+		t.Fatalf("countFailedResults = %d, want 2", got)
+	}
+}

--- a/tools/cleanup/pkg/cleanup/orchestration.go
+++ b/tools/cleanup/pkg/cleanup/orchestration.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 )
 
 const (
@@ -59,6 +60,7 @@ type Plan struct {
 type LookupMatch struct {
 	Collector ProviderCollector
 	Resolved  ResolvedDeployment
+	Summary   DeploymentSummary
 }
 
 type ResolvedDeployment struct {
@@ -142,6 +144,7 @@ func CollectLookupIndex(ctx context.Context, plan *Plan) LookupIndex {
 					Provider:   summary.Provider,
 					Location:   summary.Region,
 				},
+				Summary: summary,
 			})
 		}
 	}
@@ -233,4 +236,53 @@ func shouldUseProvider(providerName string, selectedProviders []string) bool {
 		}
 	}
 	return false
+}
+
+// IsOlderThan reports whether createdAt lies further back than age. A zero
+// createdAt counts as older, so deployments with no derivable creation time
+// still get cleaned up.
+func IsOlderThan(createdAt time.Time, age time.Duration, now time.Time) bool {
+	if age <= 0 {
+		return true
+	}
+
+	return createdAt.Before(now.Add(-age))
+}
+
+// FilterSummariesOlderThan keeps the summaries of deployments older than age.
+func FilterSummariesOlderThan(
+	summaries []DeploymentSummary,
+	age time.Duration,
+	now time.Time,
+) []DeploymentSummary {
+	if age <= 0 {
+		return summaries
+	}
+
+	filtered := make([]DeploymentSummary, 0, len(summaries))
+	for _, summary := range summaries {
+		if IsOlderThan(summary.CreatedAt, age, now) {
+			filtered = append(filtered, summary)
+		}
+	}
+
+	return filtered
+}
+
+// StaleDeploymentIDs returns the ids older than age, sorted for a stable
+// cleanup order. A deployment in several locations is stale if any one is.
+func StaleDeploymentIDs(index LookupIndex, age time.Duration, now time.Time) []string {
+	ids := make([]string, 0, len(index.Matches))
+	for id, matches := range index.Matches {
+		for _, match := range matches {
+			if IsOlderThan(match.Summary.CreatedAt, age, now) {
+				ids = append(ids, id)
+
+				break
+			}
+		}
+	}
+	slices.Sort(ids)
+
+	return ids
 }

--- a/tools/cleanup/pkg/cleanup/orchestration_test.go
+++ b/tools/cleanup/pkg/cleanup/orchestration_test.go
@@ -161,3 +161,69 @@ func TestFilterDeploymentDetailsByTypesReturnsTypedCopy(t *testing.T) {
 		t.Fatalf("original summary resources = %d, want unchanged 2", details.Summary.Resources)
 	}
 }
+
+func TestIsOlderThanTreatsUndatedDeploymentsAsStale(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+
+	// Given a deployment age threshold
+	// When the creation time is unknown, recent, or well past the threshold
+	// Then only the recent deployment survives, and an unknown time counts as stale
+	if !IsOlderThan(time.Time{}, time.Hour, now) {
+		t.Fatal("deployment without a creation time should count as stale")
+	}
+	if IsOlderThan(now.Add(-30*time.Minute), time.Hour, now) {
+		t.Fatal("deployment younger than the threshold should not count as stale")
+	}
+	if !IsOlderThan(now.Add(-2*time.Hour), time.Hour, now) {
+		t.Fatal("deployment older than the threshold should count as stale")
+	}
+	if !IsOlderThan(now, 0, now) {
+		t.Fatal("a zero threshold should select every deployment")
+	}
+}
+
+func TestFilterSummariesOlderThanKeepsOnlyStaleDeployments(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	summaries := []DeploymentSummary{
+		{ID: "dep-fresh", CreatedAt: now.Add(-time.Hour)},
+		{ID: "dep-stale", CreatedAt: now.Add(-48 * time.Hour)},
+	}
+
+	// Given deployments of differing age
+	// When a threshold is applied
+	// Then only the deployments past it remain, and no threshold keeps them all
+	filtered := FilterSummariesOlderThan(summaries, 24*time.Hour, now)
+	if len(filtered) != 1 || filtered[0].ID != "dep-stale" {
+		t.Fatalf("filtered = %v, want [dep-stale]", filtered)
+	}
+
+	if got := FilterSummariesOlderThan(summaries, 0, now); len(got) != 2 {
+		t.Fatalf("unfiltered = %v, want both summaries", got)
+	}
+}
+
+func TestStaleDeploymentIDsSortsAndDeduplicatesLocations(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	index := LookupIndex{Matches: map[string][]LookupMatch{
+		"dep-b": {{Summary: DeploymentSummary{ID: "dep-b", CreatedAt: now.Add(-48 * time.Hour)}}},
+		"dep-a": {
+			{Summary: DeploymentSummary{ID: "dep-a", CreatedAt: now.Add(-time.Minute)}},
+			{Summary: DeploymentSummary{ID: "dep-a", CreatedAt: now.Add(-72 * time.Hour)}},
+		},
+		"dep-fresh": {{Summary: DeploymentSummary{ID: "dep-fresh", CreatedAt: now}}},
+	}}
+
+	// Given deployments found once or in several locations
+	// When stale ids are selected
+	// Then each id appears once, sorted, and one stale location is enough
+	ids := StaleDeploymentIDs(index, 24*time.Hour, now)
+	if len(ids) != 2 || ids[0] != "dep-a" || ids[1] != "dep-b" {
+		t.Fatalf("ids = %v, want [dep-a dep-b]", ids)
+	}
+}

--- a/tools/cleanup/pkg/cleanup/types.go
+++ b/tools/cleanup/pkg/cleanup/types.go
@@ -54,6 +54,14 @@ type Action struct {
 	Reason string      `json:"reason"` // why skip or additional context
 }
 
+// Result statuses reported for a planned or executed action.
+const (
+	ResultStatusPlanned = "planned"
+	ResultStatusSuccess = "success"
+	ResultStatusFailed  = "failed"
+	ResultStatusSkipped = "skipped"
+)
+
 // Result captures execution outcome of an action.
 type Result struct {
 	Action Action `json:"action"`


### PR DESCRIPTION
## Description

CI deployments to AWS now target `eu-west-2`. The region is the repository variable `AWS_REGION`, already updated, so nothing changes on the deployment side — `tests-deployment.yml` and the AWS Terraform preset resolve the region dynamically, and both the AMI lookup and AZ selection are region-agnostic.

What needed adjusting is the nightly orphan cleanup. Deployments created before the switch keep their resources in the region they were deployed to, so the job sweeps those regions too, with a threshold per region:

| Scope | Age threshold |
| --- | --- |
| `AWS_REGION` (currently `eu-west-2`), Azure, Exoscale | 24h, unchanged |
| `eu-west-1`, `eu-central-1`, `us-east-1` | 72h |

The longer grace period reflects that nothing left in a previously used region belongs to a recent test run.

Each region is a matrix row rather than one multi-region search. `exasol-cleanup run` rejects a deployment matching more than one search target (`deployment_ambiguous`), and AWS reports global resources such as IAM roles in `us-east-1` regardless of which region holds a deployment's instances — `discover` sees them because it queries only the Resource Groups Tagging API. A single search across all four regions would hit that ambiguity for any deployment still holding its IAM role. One region per job avoids it by construction, lets a region fail without holding back the others, and means a deployment cleaned in one job is gone before the next region is searched.

That left the workflow step doing age filtering in jq, region iteration in bash, and failure aggregation in a temp file — logic that belongs in the tool, not in YAML. So `exasol-cleanup` gained the ability to select deployments by age, and the step is now a single call:

```yaml
run: |
  ./bin/exasol-cleanup run --all \
    --provider="${PROVIDERS}" \
    --aws-region="${CLEANUP_AWS_REGION}" \
    --older-than="${MAX_AGE_HOURS}h" \
    --owner=* \
    --azure-subscription-id="${AZURE_SUBSCRIPTION_ID}" \
    --execute
```

No jq, no date arithmetic, no arrays, no result parsing, and no second invocation: `run` already builds the provider plan and collects the deployment index, so `--all` selects out of that same index instead of discovering twice. The workflow is 98 lines, down from 129.

The existing commands are untouched. `discover`, `show`, `run`, and `providers` all behave as before, and `run <ids>` is unchanged — the new flags are additive and opt-in.

## Related Issue

<!-- No tracked issue for this change -->

## Type of Change

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [x] `chore`: Maintenance tasks

## Changes Made

**`feat(cleanup)`** — age-based selection in the tool:

- `--all` on `run` cleans up every discovered deployment instead of named ids, reusing the index `run` already collects. It refuses to combine with explicit ids, so a run never deletes a set the caller did not describe.
- `--older-than` (a duration such as `24h`) narrows that selection, and `discover` accepts it for listing. Both stay off `show` and `providers`, where there is nothing to narrow; `--older-than` without `--all` is rejected rather than silently ignored.
- `run` exits non-zero when an individual resource action failed, not only when a whole deployment could not be processed, so callers can rely on the exit code instead of parsing results. Skipped actions remain a normal outcome for protected resources.
- A deployment whose creation time cannot be derived from tags or resources counts as old enough to remove, matching what the workflow's jq did, now stated explicitly in `IsOlderThan`.

**`chore(ci)`** — the workflow:

- Sweep the previously used regions alongside `AWS_REGION`, one matrix job per region, each with its own threshold and `fail-fast: false`.
- Reduce the cleanup step to a single `exasol-cleanup run --all` call.
- Authenticate Azure and Exoscale only for the row that needs them.
- Document the workflow in `doc/ci.md`; it had no section yet, and note in the AWS maintenance tips that a region change should add the outgoing region as a matrix row.

## Testing

- [ ] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

`go build`, `go vet`, and `go test ./...` pass in `tools/cleanup`. Repo-level `task all` was not run: no root-module Go, Python, or Terraform source is touched.

Eight new test cases cover the added logic:

- `IsOlderThan` — the threshold boundary, a zero duration selecting everything, and an undated deployment counting as stale.
- `FilterSummariesOlderThan` and `StaleDeploymentIDs` — filtering, stable sorted output, and a deployment found in several locations being selected once, stale in any one of them.
- `validateCleanupRunSelection` — `--all` with ids, neither given, and `--older-than` without `--all` all rejected.
- `selectCleanupRunDeployments` — explicit ids used as given regardless of age; `--all` applying the threshold.
- `cleanupRunOutcome` and `countFailedResults` — each error-code branch, and skipped actions not counting as failures.

Manually verified against the built binary: the three validation errors surface with usage, `--all` / `--older-than` appear in `run --help`, all four commands are still registered, and `run <id>` still runs its original path. The workflow YAML parses and expands to four matrix rows.

Before the step was reduced to a single call, the earlier shell version was extracted and exercised against a stubbed `exasol-cleanup` to confirm the threshold split behaves as intended — a 30h-old deployment in `eu-west-1` is left alone where a flat 24h rule would have removed it, while a 100h-old one is cleaned.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [ ] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [ ] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

`gofmt` is clean. `task lint` cannot run in `tools/cleanup` on `main` either: that module pins golangci-lint 2.11.4, which has no `gomodguard_v2`, while the shared root `.golangci.yml` enables it — it fails at config parse before reading any source. The new code was linted by building the root module's golangci-lint (2.12.2) and running it in `tools/cleanup`: **0 issues**.

No changelog entry: the change is internal to CI and to an internal tool that is explicitly not part of any release. It does not affect the `exasol-personal` CLI, deployments users run, or supported providers.

## Additional Notes

The job's step summary is gone, as it was produced by the jq this PR removes. Each region is now its own pass/fail job and its log carries the result table. It can come back as a few lines of `tee` into `$GITHUB_STEP_SUMMARY` if that readout is worth keeping.

Two follow-ups deliberately out of scope:

- The golangci-lint pin skew between `tools/cleanup` and the root module, described above. Bumping it belongs in its own PR.
- `tools/cleanup/design.md` still describes the tool as single-region; the multi-value location flags predate this PR.
