### PR TITLE
fix: Preserve local shell delegation errors SPOT-32275

### DIFF
--- a/internal/deploy/connection_instructions_test.go
+++ b/internal/deploy/connection_instructions_test.go
@@ -217,3 +217,42 @@ func TestRenderConnectionInstructionsText_IncludesAdminUIWhenMetadataPresent(t *
 		}
 	}
 }
+
+func TestRenderConnectionInstructionsText_IncludesSSHAlternativeWhenAvailable(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	report := &DeploymentInfoReport{
+		DeploymentDir:   "/deployment",
+		DeploymentID:    "test-deployment",
+		DeploymentState: StatusRunning,
+		Deployment: &config.DeploymentInfo{
+			ClusterSize:  1,
+			ClusterState: StatusRunning,
+		},
+		Connection: &ConnectionDetails{
+			DisplayHost:     "db.example.local",
+			PublicIp:        "192.0.2.10",
+			DBPort:          8563,
+			Username:        "sys",
+			SecretsFilePath: "/deployment/secrets.json",
+			ShellSupported:  true,
+			SSHCommand:      "ssh -i /deployment/id_rsa user@192.0.2.10",
+		},
+	}
+
+	// When
+	content, err := RenderConnectionInstructionsText(report)
+	// Then
+	if err != nil {
+		t.Fatalf("expected deployment info to render: %v", err)
+	}
+	for _, expected := range []string{
+		"=== SSH Connection Instructions ===",
+		"Alternative: ssh -i /deployment/id_rsa user@192.0.2.10",
+	} {
+		if !strings.Contains(content, expected) {
+			t.Fatalf("expected instructions to contain %q, got %q", expected, content)
+		}
+	}
+}

--- a/internal/deploy/local_backend.go
+++ b/internal/deploy/local_backend.go
@@ -440,19 +440,11 @@ func (b *localBackend) OpenHostShell(
 	ctx context.Context,
 	_ string,
 ) error {
-	if err := b.runtime.OpenHostShell(ctx, os.Stdin, os.Stdout, os.Stderr); err != nil {
-		return diagnoseLocalFailure(ctx, b.runtime, err)
-	}
-
-	return nil
+	return b.runtime.OpenHostShell(ctx, os.Stdin, os.Stdout, os.Stderr)
 }
 
 func (b *localBackend) OpenCOSShell(ctx context.Context) error {
-	if err := b.runtime.OpenContainerShell(ctx, os.Stdin, os.Stdout, os.Stderr); err != nil {
-		return diagnoseLocalFailure(ctx, b.runtime, err)
-	}
-
-	return nil
+	return b.runtime.OpenContainerShell(ctx, os.Stdin, os.Stdout, os.Stderr)
 }
 
 type localRuntimeConfig struct {

--- a/internal/deploy/local_backend.go
+++ b/internal/deploy/local_backend.go
@@ -219,6 +219,7 @@ func validateLocalInitMemory(
 	)
 }
 
+// nolint: unparam
 func validateLocalInitMemoryForPlatform(
 	ctx context.Context,
 	manifest *presets.InfrastructureManifest,

--- a/internal/deploy/local_backend_test.go
+++ b/internal/deploy/local_backend_test.go
@@ -607,6 +607,77 @@ func TestLocalBackend_LinuxShellsAreUnsupported(t *testing.T) {
 	}
 }
 
+func TestLocalBackendShellErrorsBypassReachabilityClassification(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		openShell      func(*localBackend) error
+		configureError func(*endpointRuntimeStub, error)
+	}{
+		{
+			name: "host shell",
+			openShell: func(backend *localBackend) error {
+				return backend.OpenHostShell(context.Background(), "")
+			},
+			configureError: func(runtime *endpointRuntimeStub, err error) {
+				runtime.hostShellErr = err
+			},
+		},
+		{
+			name: "container shell",
+			openShell: func(backend *localBackend) error {
+				return backend.OpenCOSShell(context.Background())
+			},
+			configureError: func(runtime *endpointRuntimeStub, err error) {
+				runtime.containerShellErr = err
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Given
+			deployment := newLocalTestDeployment(t)
+			shellErr := errors.New("runtime shell failed")
+			runtime := &endpointRuntimeStub{
+				deployment: deployment,
+				healthResult: &localruntime.HealthCheckResult{
+					Ports: map[string]localruntime.PortHealth{
+						"db": {State: localruntime.PortStateBlocked},
+					},
+				},
+			}
+			test.configureError(runtime, shellErr)
+			backend := newLocalBackendForPlatform(
+				deployment,
+				&presets.InfrastructureManifest{Backend: backendTypeLocal},
+				runtime,
+				localMacOS,
+				localMacArch,
+			)
+
+			// When
+			err := test.openShell(backend)
+
+			// Then
+			if !errors.Is(err, shellErr) {
+				t.Fatalf("expected runtime shell error, got %v", err)
+			}
+			if errors.Is(err, ErrLocalReachability) {
+				t.Fatalf("runtime shell error was replaced by reachability error: %v", err)
+			}
+			if runtime.healthCalls != 0 {
+				t.Fatalf(
+					"expected shell failure not to query endpoint health, got %d calls",
+					runtime.healthCalls,
+				)
+			}
+		})
+	}
+}
+
 func assertConfigValue(
 	t *testing.T,
 	values []DeploymentConfigValue,

--- a/internal/deploy/local_backend_test.go
+++ b/internal/deploy/local_backend_test.go
@@ -597,12 +597,23 @@ func TestLocalBackend_LinuxShellsAreUnsupported(t *testing.T) {
 		localruntime.NewHostLinuxRuntime(deployment, nil),
 		localLinuxOS, localLinuxAMD64,
 	)
-	if err := backend.OpenHostShell(context.Background(), ""); err == nil ||
-		!strings.Contains(err.Error(), "host shell is not supported") {
+	if err := backend.OpenHostShell(
+		context.Background(),
+		"",
+	); !errors.Is(
+		err,
+		localruntime.ErrHostShellUnsupported,
+	) ||
+		!strings.Contains(err.Error(), "linux host runtime") {
 		t.Fatalf("expected explicit Linux host shell error, got %v", err)
 	}
-	if err := backend.OpenCOSShell(context.Background()); err == nil ||
-		!strings.Contains(err.Error(), "container shell is not supported") {
+	if err := backend.OpenCOSShell(
+		context.Background(),
+	); !errors.Is(
+		err,
+		localruntime.ErrContainerShellUnsupported,
+	) ||
+		!strings.Contains(err.Error(), "linux host runtime") {
 		t.Fatalf("expected explicit Linux container shell error, got %v", err)
 	}
 }

--- a/internal/deploy/local_reachability_test.go
+++ b/internal/deploy/local_reachability_test.go
@@ -60,7 +60,7 @@ func TestClassifyLocalReachability_AllPortsBlocked(t *testing.T) {
 
 	deployment := newLocalTestDeployment(t)
 	ensureLocalRuntimeWorkDir(t, deployment)
-	blockedJSON := `{"ports":{"ssh":{"state":"blocked"},"db":{"state":"blocked"}}}`
+	blockedJSON := `{"ports":{"db":{"state":"blocked"},"ui":{"state":"blocked"}}}`
 	manager := writeFakeCombinedRunner(t, fakeRunnerRunningStatus, blockedJSON)
 	localRuntime := localruntime.NewMacVMRuntime(deployment, manager)
 
@@ -77,11 +77,11 @@ func TestClassifyLocalReachability_OnlyDatabasePortBlocked(t *testing.T) {
 	t.Parallel()
 	skipOnWindows(t)
 
-	// A reachable SSH port alongside a blocked database port means the
-	// network path itself is fine; the problem is database-specific.
+	// A reachable application endpoint alongside a blocked database endpoint means
+	// the network path itself is fine; the problem is database-specific.
 	deployment := newLocalTestDeployment(t)
 	ensureLocalRuntimeWorkDir(t, deployment)
-	mixedJSON := `{"ports":{"ssh":{"state":"reachable"},"db":{"state":"blocked"}}}`
+	mixedJSON := `{"ports":{"db":{"state":"blocked"},"ui":{"state":"reachable"}}}`
 	manager := writeFakeCombinedRunner(t, fakeRunnerRunningStatus, mixedJSON)
 	localRuntime := localruntime.NewMacVMRuntime(deployment, manager)
 
@@ -148,7 +148,7 @@ func TestDiagnoseLocalFailurePreservesCausalError(t *testing.T) {
 
 	deployment := newLocalTestDeployment(t)
 	ensureLocalRuntimeWorkDir(t, deployment)
-	blockedJSON := `{"ports":{"ssh":{"state":"blocked"},"db":{"state":"blocked"}}}`
+	blockedJSON := `{"ports":{"ui":{"state":"blocked"},"db":{"state":"blocked"}}}`
 	manager := writeFakeCombinedRunner(t, fakeRunnerRunningStatus, blockedJSON)
 	localRuntime := localruntime.NewMacVMRuntime(deployment, manager)
 
@@ -181,7 +181,7 @@ func TestDiagnoseLocalFailureReturnsCauseUnchangedWhenReachable(t *testing.T) {
 
 	deployment := newLocalTestDeployment(t)
 	ensureLocalRuntimeWorkDir(t, deployment)
-	mixedJSON := `{"ports":{"ssh":{"state":"reachable"},"db":{"state":"blocked"}}}`
+	mixedJSON := `{"ports":{"ui":{"state":"reachable"},"db":{"state":"blocked"}}}`
 	manager := writeFakeCombinedRunner(t, fakeRunnerRunningStatus, mixedJSON)
 	localRuntime := localruntime.NewMacVMRuntime(deployment, manager)
 
@@ -206,7 +206,7 @@ func TestDiagnoseLocalFailureSkipsGuidanceWhenRuntimeNotRunning(t *testing.T) {
 
 	deployment := newLocalTestDeployment(t)
 	ensureLocalRuntimeWorkDir(t, deployment)
-	blockedJSON := `{"ports":{"ssh":{"state":"blocked"},"db":{"state":"blocked"}}}`
+	blockedJSON := `{"ports":{"ui":{"state":"blocked"},"db":{"state":"blocked"}}}`
 	manager := writeFakeCombinedRunner(t, `{"running":false}`, blockedJSON)
 	localRuntime := localruntime.NewMacVMRuntime(deployment, manager)
 
@@ -316,7 +316,6 @@ func writeFakeCombinedRunner(
 	script := "#!/bin/sh\n" +
 		"if [ \"$1\" = status ]; then echo '" + statusJSON + "'; exit 0; fi\n" +
 		"if [ \"$1\" = health-check ]; then echo '" + healthCheckJSON + "'; exit 0; fi\n" +
-		"if [ \"$1\" = stop ]; then exit 0; fi\n" +
 		"if [ \"$1\" = run ]; then\n" +
 		"  shift; [ \"$1\" = -- ]; shift\n" +
 		"  if [ \"$1 $2 $3\" = 'podman container exists' ]; then exit 0; fi\n" +

--- a/internal/deploy/local_runtime_test.go
+++ b/internal/deploy/local_runtime_test.go
@@ -19,10 +19,9 @@ import (
 )
 
 const (
-	localTestDeploymentID     = "exasol-local-test"
-	localTestClusterIdentity  = "exasol-personal;exasol-local-test;local;local"
-	localTestDatabasePort     = 28563
-	localTestSSHForwardedPort = 20022
+	localTestDeploymentID    = "exasol-local-test"
+	localTestClusterIdentity = "exasol-personal;exasol-local-test;local;local"
+	localTestDatabasePort    = 28563
 )
 
 func TestToLocalRuntimeConfig_TranslatesPortableStartupState(t *testing.T) {

--- a/internal/deploy/local_runtime_test.go
+++ b/internal/deploy/local_runtime_test.go
@@ -220,6 +220,9 @@ func TestWriteLocalDeploymentArtifacts_OmitsLocalOnlyCloudMetadataInJSON(t *test
 	if _, exists := connection["uiPort"]; exists {
 		t.Fatalf("expected local deployment JSON to omit uiPort, got %s", string(data))
 	}
+	if shellSupported, ok := connection["shellSupported"].(bool); !ok || !shellSupported {
+		t.Fatalf("expected local deployment JSON to enable shell support, got %s", string(data))
+	}
 	if _, exists := connection["sshPort"]; exists {
 		t.Fatalf("expected local deployment JSON to omit sshPort, got %s", string(data))
 	}

--- a/internal/deploy/local_runtime_test.go
+++ b/internal/deploy/local_runtime_test.go
@@ -469,13 +469,17 @@ func newTestDeploymentWithState(t *testing.T) config.DeploymentDir {
 }
 
 type endpointRuntimeStub struct {
-	deployment config.DeploymentDir
-	endpoint   *localruntime.RuntimeEndpoint
-	startErr   error
-	syncErr    error
-	syncCalls  int
-	syncOut    io.Writer
-	syncOutErr io.Writer
+	deployment        config.DeploymentDir
+	endpoint          *localruntime.RuntimeEndpoint
+	startErr          error
+	syncErr           error
+	syncCalls         int
+	syncOut           io.Writer
+	syncOutErr        io.Writer
+	healthResult      *localruntime.HealthCheckResult
+	healthCalls       int
+	hostShellErr      error
+	containerShellErr error
 }
 
 func (runtime *endpointRuntimeStub) Deployment() config.DeploymentDir {
@@ -530,27 +534,40 @@ func (runtime *endpointRuntimeStub) ReadEndpoints() (*localruntime.VMRuntimeEndp
 	return &localruntime.VMRuntimeEndpoint{RuntimeEndpoint: *runtime.endpoint}, nil
 }
 
-func (*endpointRuntimeStub) HealthCheck(
+func (runtime *endpointRuntimeStub) HealthCheck(
 	context.Context,
 ) (*localruntime.HealthCheckResult, error) {
+	runtime.healthCalls++
+	if runtime.healthResult != nil {
+		return runtime.healthResult, nil
+	}
+
 	return nil, errors.New("not implemented")
 }
 
-func (*endpointRuntimeStub) OpenHostShell(
+func (runtime *endpointRuntimeStub) OpenHostShell(
 	context.Context,
 	io.Reader,
 	io.Writer,
 	io.Writer,
 ) error {
+	if runtime.hostShellErr != nil {
+		return runtime.hostShellErr
+	}
+
 	return localruntime.ErrHostShellUnsupported
 }
 
-func (*endpointRuntimeStub) OpenContainerShell(
+func (runtime *endpointRuntimeStub) OpenContainerShell(
 	context.Context,
 	io.Reader,
 	io.Writer,
 	io.Writer,
 ) error {
+	if runtime.containerShellErr != nil {
+		return runtime.containerShellErr
+	}
+
 	return localruntime.ErrContainerShellUnsupported
 }
 

--- a/internal/localruntime/host_runtime.go
+++ b/internal/localruntime/host_runtime.go
@@ -249,22 +249,30 @@ func (runtime *HostRuntime) HealthCheck(ctx context.Context) (*HealthCheckResult
 	}}, nil
 }
 
-func (*HostRuntime) OpenHostShell(
+func (runtime *HostRuntime) OpenHostShell(
 	context.Context,
 	io.Reader,
 	io.Writer,
 	io.Writer,
 ) error {
-	return ErrHostShellUnsupported
+	return fmt.Errorf(
+		"%s host runtime does not support host shells: %w",
+		runtime.Platform(),
+		ErrHostShellUnsupported,
+	)
 }
 
-func (*HostRuntime) OpenContainerShell(
+func (runtime *HostRuntime) OpenContainerShell(
 	context.Context,
 	io.Reader,
 	io.Writer,
 	io.Writer,
 ) error {
-	return ErrContainerShellUnsupported
+	return fmt.Errorf(
+		"%s host runtime does not support container shells: %w",
+		runtime.Platform(),
+		ErrContainerShellUnsupported,
+	)
 }
 
 func classifyHostPortHealth(err error) PortState {

--- a/internal/localruntime/host_runtime_test.go
+++ b/internal/localruntime/host_runtime_test.go
@@ -116,6 +116,50 @@ func TestLinuxHostReadEndpoint_RejectsReadBeforeStart(t *testing.T) {
 	}
 }
 
+func TestLinuxHostShellErrorsPreserveUnsupportedIdentity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		openShell func(*HostRuntime) error
+		sentinel  error
+	}{
+		{
+			name: "host shell",
+			openShell: func(runtime *HostRuntime) error {
+				return runtime.OpenHostShell(context.Background(), nil, nil, nil)
+			},
+			sentinel: ErrHostShellUnsupported,
+		},
+		{
+			name: "container shell",
+			openShell: func(runtime *HostRuntime) error {
+				return runtime.OpenContainerShell(context.Background(), nil, nil, nil)
+			},
+			sentinel: ErrContainerShellUnsupported,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Given
+			runtime := NewHostLinuxRuntime(config.NewDeploymentDir(t.TempDir()), nil)
+
+			// When
+			err := test.openShell(runtime)
+
+			// Then
+			if !errors.Is(err, test.sentinel) {
+				t.Fatalf("expected unsupported shell identity, got %v", err)
+			}
+			if !strings.Contains(err.Error(), "linux host runtime") {
+				t.Fatalf("expected Linux host-runtime context, got %v", err)
+			}
+		})
+	}
+}
+
 func TestLinuxHostWorkaroundNanoStartupDurabilityDelegatesToExecutionEnvironment(
 	t *testing.T,
 ) {

--- a/internal/localruntime/mac_vm_runtime_test.go
+++ b/internal/localruntime/mac_vm_runtime_test.go
@@ -36,6 +36,9 @@ func TestReadRunnerStateUsesLabeledForwardsWithoutTransportMetadata(t *testing.T
 	if err != nil || endpoint.DBPort != 28563 {
 		t.Fatalf("unexpected endpoint %#v, err=%v", endpoint, err)
 	}
+	if !endpoint.ShellSupported {
+		t.Fatalf("expected runner endpoint to advertise shell support, got %#v", endpoint)
+	}
 }
 
 func TestReadRunnerStateRejectsMissingOrWrongDatabaseForward(t *testing.T) {

--- a/internal/localruntime/mac_vm_runtime_test.go
+++ b/internal/localruntime/mac_vm_runtime_test.go
@@ -135,6 +135,54 @@ func TestMaterializeFileAtomicallyStagesAndReusesUnchangedArtifact(t *testing.T)
 	}
 }
 
+func TestMaterializeFileAtomicallyRepairsWrongModeWithoutContentChange(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "source.tar")
+	targetPath := filepath.Join(root, "share", "nano.tar")
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o750); err != nil {
+		t.Fatalf("failed to create target directory: %v", err)
+	}
+	content := []byte("image")
+	if err := os.WriteFile(sourcePath, content, 0o600); err != nil {
+		t.Fatalf("failed to write source: %v", err)
+	}
+	if err := os.WriteFile(targetPath, content, 0o600); err != nil {
+		t.Fatalf("failed to write target: %v", err)
+	}
+	modTime := time.Unix(1_700_000_000, 123)
+	if err := os.Chtimes(sourcePath, modTime, modTime); err != nil {
+		t.Fatalf("failed to set source time: %v", err)
+	}
+	if err := os.Chtimes(targetPath, modTime, modTime); err != nil {
+		t.Fatalf("failed to set target time: %v", err)
+	}
+
+	// When
+	if err := materializeFileAtomically(sourcePath, targetPath); err != nil {
+		t.Fatalf("failed to repair staged artifact: %v", err)
+	}
+
+	// Then
+	targetInfo, err := os.Stat(targetPath)
+	if err != nil {
+		t.Fatalf("failed to stat repaired target: %v", err)
+	}
+	if targetInfo.Mode().Perm() != artifactFileMode {
+		t.Fatalf(
+			"expected repaired mode %o, got %o",
+			artifactFileMode,
+			targetInfo.Mode().Perm(),
+		)
+	}
+	actualContent, err := os.ReadFile(targetPath)
+	if err != nil || string(actualContent) != string(content) {
+		t.Fatalf("repaired content = %q, err=%v; want %q", actualContent, err, content)
+	}
+}
+
 func TestMaterializeFileAtomicallyRejectsDirectorySource(t *testing.T) {
 	t.Parallel()
 

--- a/internal/localruntime/runtime_test.go
+++ b/internal/localruntime/runtime_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -316,6 +317,36 @@ printf 'container-stderr' >&2
 			stdout.String(),
 			stderr.String(),
 		)
+	}
+}
+
+//nolint:paralleltest // test runner scripts fork executable fixtures.
+func TestMacVMRuntimeOpenHostShellPreservesRunnerFailure(t *testing.T) {
+	requirePOSIXRunnerTest(t)
+
+	// Given
+	deployment := config.NewDeploymentDir(t.TempDir())
+	runnerScript := []byte("#!/bin/sh\nexit 23\n")
+	localRuntime := NewMacVMRuntime(deployment, newTestManagerForRunner(t, runnerScript))
+	if err := os.MkdirAll(localRuntime.paths.WorkDir, dirMode); err != nil {
+		t.Fatalf("failed to create runtime work dir: %v", err)
+	}
+
+	// When
+	err := localRuntime.OpenHostShell(
+		context.Background(), strings.NewReader(""), io.Discard, io.Discard,
+	)
+
+	// Then
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected underlying command failure, got %v", err)
+	}
+	if exitErr.ExitCode() != 23 {
+		t.Fatalf("expected runner exit code 23, got %d", exitErr.ExitCode())
+	}
+	if !strings.Contains(err.Error(), `local runner command "run" failed`) {
+		t.Fatalf("expected contextual runner error, got %v", err)
 	}
 }
 

--- a/internal/localruntime/runtime_test.go
+++ b/internal/localruntime/runtime_test.go
@@ -236,6 +236,89 @@ printf 'host-stderr' >&2
 	}
 }
 
+//nolint:paralleltest // test runner scripts fork executable fixtures.
+func TestMacVMRuntimeOpenContainerShellDelegatesToRunner(t *testing.T) {
+	requirePOSIXRunnerTest(t)
+
+	// Given
+	deployment := config.NewDeploymentDir(t.TempDir())
+	state := &config.ExasolPersonalState{DeploymentId: "shell-test"}
+	if err := state.SetWorkflowStateAndWrite(
+		&config.WorkflowStateRunning{}, deployment,
+	); err != nil {
+		t.Fatalf("failed to write deployment state: %v", err)
+	}
+	observationsDir := t.TempDir()
+	argsPath := filepath.Join(observationsDir, "container-args")
+	workingDirPath := filepath.Join(observationsDir, "container-working-dir")
+	stdinPath := filepath.Join(observationsDir, "container-stdin")
+	runnerScript := fmt.Sprintf(`#!/bin/sh
+set -eu
+: > %q
+for arg do printf '%%s\n' "$arg" >> %q; done
+printf '%%s' "$PWD" > %q
+cat > %q
+printf 'container-stdout'
+printf 'container-stderr' >&2
+`, argsPath, argsPath, workingDirPath, stdinPath)
+	localRuntime := NewMacVMRuntime(
+		deployment, newTestManagerForRunner(t, []byte(runnerScript)),
+	)
+	if err := os.MkdirAll(localRuntime.paths.WorkDir, dirMode); err != nil {
+		t.Fatalf("failed to create runtime work dir: %v", err)
+	}
+	var stdout, stderr bytes.Buffer
+
+	// When
+	if err := localRuntime.OpenContainerShell(
+		context.Background(), strings.NewReader("container-input\n"), &stdout, &stderr,
+	); err != nil {
+		t.Fatalf("container shell failed: %v", err)
+	}
+
+	// Then
+	args, err := os.ReadFile(argsPath)
+	wantArgs := strings.Join([]string{
+		"run",
+		"--tty",
+		"--",
+		"sh",
+		"-c",
+		containerShellScript,
+		"sh",
+		"exasol-db-shell-test",
+		"",
+	}, "\n")
+	if err != nil || string(args) != wantArgs {
+		t.Fatalf("container shell args = %q, err=%v; want %q", args, err, wantArgs)
+	}
+	workingDir, err := os.ReadFile(workingDirPath)
+	if err != nil || string(workingDir) != localRuntime.paths.WorkDir {
+		t.Fatalf(
+			"container shell working directory = %q, err=%v; want %q",
+			workingDir,
+			err,
+			localRuntime.paths.WorkDir,
+		)
+	}
+	stdin, err := os.ReadFile(stdinPath)
+	if err != nil || string(stdin) != "container-input\n" {
+		t.Fatalf(
+			"container shell stdin = %q, err=%v; want %q",
+			stdin,
+			err,
+			"container-input\n",
+		)
+	}
+	if stdout.String() != "container-stdout" || stderr.String() != "container-stderr" {
+		t.Fatalf(
+			"unexpected container shell streams stdout=%q stderr=%q",
+			stdout.String(),
+			stderr.String(),
+		)
+	}
+}
+
 func fakeV2RunnerScript(eventsPath string, hostDBPort int) string {
 	return fmt.Sprintf(`#!/bin/sh
 set -eu

--- a/internal/localruntime/runtime_test.go
+++ b/internal/localruntime/runtime_test.go
@@ -5,6 +5,7 @@ package localruntime
 
 import (
 	"archive/zip"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -175,49 +176,63 @@ func TestMacVMRuntimeStartStopsVMWhenInstallFails(t *testing.T) {
 }
 
 //nolint:paralleltest // test runner scripts fork executable fixtures.
-func TestMacVMRuntimeShellsDelegateToRunner(t *testing.T) {
+func TestMacVMRuntimeOpenHostShellDelegatesToRunner(t *testing.T) {
 	requirePOSIXRunnerTest(t)
 
+	// Given
 	deployment := config.NewDeploymentDir(t.TempDir())
-	state := &config.ExasolPersonalState{DeploymentId: "shell-test"}
-	if err := state.SetWorkflowStateAndWrite(
-		&config.WorkflowStateRunning{}, deployment,
-	); err != nil {
-		t.Fatalf("failed to write deployment state: %v", err)
-	}
-	logPath := filepath.Join(t.TempDir(), "runner-args")
+	observationsDir := t.TempDir()
+	argsPath := filepath.Join(observationsDir, "host-args")
+	workingDirPath := filepath.Join(observationsDir, "host-working-dir")
+	stdinPath := filepath.Join(observationsDir, "host-stdin")
 	runnerScript := fmt.Sprintf(`#!/bin/sh
-printf '%%s\n' "$*" >> %q
-`, logPath)
+set -eu
+: > %q
+for arg do printf '%%s\n' "$arg" >> %q; done
+printf '%%s' "$PWD" > %q
+cat > %q
+printf 'host-stdout'
+printf 'host-stderr' >&2
+`, argsPath, argsPath, workingDirPath, stdinPath)
 	localRuntime := NewMacVMRuntime(
 		deployment, newTestManagerForRunner(t, []byte(runnerScript)),
 	)
 	if err := os.MkdirAll(localRuntime.paths.WorkDir, dirMode); err != nil {
 		t.Fatalf("failed to create runtime work dir: %v", err)
 	}
+	var stdout, stderr bytes.Buffer
 
+	// When
 	if err := localRuntime.OpenHostShell(
-		context.Background(), strings.NewReader(""), io.Discard, io.Discard,
+		context.Background(), strings.NewReader("host-input\n"), &stdout, &stderr,
 	); err != nil {
 		t.Fatalf("host shell failed: %v", err)
 	}
-	if err := localRuntime.OpenContainerShell(
-		context.Background(), strings.NewReader(""), io.Discard, io.Discard,
-	); err != nil {
-		t.Fatalf("container shell failed: %v", err)
-	}
 
-	args, err := os.ReadFile(logPath)
-	if err != nil {
-		t.Fatalf("failed to read runner args: %v", err)
+	// Then
+	args, err := os.ReadFile(argsPath)
+	if err != nil || string(args) != "run\n" {
+		t.Fatalf("host shell args = %q, err=%v; want %q", args, err, "run\n")
 	}
-	want := strings.Join([]string{
-		"run",
-		"run --tty -- sh -c " + containerShellScript + " sh exasol-db-shell-test",
-		"",
-	}, "\n")
-	if string(args) != want {
-		t.Fatalf("runner shell args = %q, want %q", args, want)
+	workingDir, err := os.ReadFile(workingDirPath)
+	if err != nil || string(workingDir) != localRuntime.paths.WorkDir {
+		t.Fatalf(
+			"host shell working directory = %q, err=%v; want %q",
+			workingDir,
+			err,
+			localRuntime.paths.WorkDir,
+		)
+	}
+	stdin, err := os.ReadFile(stdinPath)
+	if err != nil || string(stdin) != "host-input\n" {
+		t.Fatalf("host shell stdin = %q, err=%v; want %q", stdin, err, "host-input\n")
+	}
+	if stdout.String() != "host-stdout" || stderr.String() != "host-stderr" {
+		t.Fatalf(
+			"unexpected host shell streams stdout=%q stderr=%q",
+			stdout.String(),
+			stderr.String(),
+		)
 	}
 }
 

--- a/openspec/changes/archive/2026-08-27-harden-local-shell-delegation/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-27-harden-local-shell-delegation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-24

--- a/openspec/changes/archive/2026-08-27-harden-local-shell-delegation/design.md
+++ b/openspec/changes/archive/2026-08-27-harden-local-shell-delegation/design.md
@@ -1,0 +1,64 @@
+## Context
+
+The local runtime interface owns host and container shell execution as well as database-endpoint health checks. The deployment backend currently sends every shell error through the database reachability classifier, so an unhealthy endpoint can replace a runner failure or an unsupported-operation error. The macOS runtime already invokes shells without SSH, while the reachability specification still describes guest IPs, SSH ports, and SSH connection failures.
+
+The implementation spans the runtime and deployment packages, and the existing shell fixture does not protect the interactive process contract. See `proposal.md` for motivation and the delta specs for observable requirements.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Report the actual shell failure instead of unrelated connectivity guidance.
+- Provide actionable guidance when a local connectivity problem is recognized without hiding the underlying operation failure.
+- Keep permanent requirements focused on behavior observable from the built CLI.
+- Protect the runner process boundary and related deployment contracts with focused regression tests.
+
+**Non-Goals:**
+
+- Reintroducing SSH or exposing guest-network details.
+- Changing cloud shell behavior, command-line syntax, or the deployment JSON schema.
+- Changing which supported local-deployment platforms provide shell access.
+- Rewriting unrelated architecture-oriented capabilities as part of this change.
+- Rewriting historical commits or reverting unrelated formatting-only changes.
+
+## Decisions
+
+### Specify behavior at the CLI boundary
+
+Permanent requirements will describe failures, guidance, diagnostics, and shell behavior that can be verified against the built CLI. Runtime delegation, endpoint-health classification, process arguments, working directories, standard streams, and error identities remain in this design, implementation tasks, and unit tests because they are internal contracts that may change without changing the product behavior.
+
+The shell behavior touched by this change will be specified in `exasol-local-deployment` through user-visible supported and unsupported behavior. The reachability requirements will be consolidated around accurate errors and corrective guidance instead of enumerating commands, endpoints, and classification states. Unrelated requirements already present in architecture-oriented capabilities are outside this change.
+
+### Return runtime shell errors without database reachability classification
+
+The local backend will return the result of each runtime shell method directly. Reachability classification remains appropriate for database startup and connection failures, but a database endpoint cannot explain a failure to launch a runtime-owned shell. This applies to every shell error, not only known unsupported sentinels, so runner exit failures and future runtime-specific errors cannot be masked.
+
+An alternative was to bypass classification only for known unsupported errors. That would leave macOS runner failures vulnerable to the same misclassification and require the deployment layer to know every runtime error category.
+
+### Add platform context while preserving unsupported-error identity
+
+The Linux runtime will wrap the existing host-shell and container-shell unsupported sentinels with Linux host-runtime context. This satisfies the existing platform-specific user-facing contract while preserving machine-detectable error identity for callers and tests.
+
+An alternative was to create new Linux-only sentinels. That would split the common runtime contract and make callers handle platform-specific error types unnecessarily.
+
+### Define reachability in terms of application endpoints
+
+Reachability classification will consume the runtime's reported application-port health and remain conservative: it will classify a reachability problem only when every reported application endpoint is blocked or timed out. Reachable, refused, missing, unknown, or unavailable health preserves the operation's original error. The diagnostics command will report runtime status, bound application ports, their health, and SQL readiness without depending on guest IP or transport-port metadata.
+
+Keeping compatibility fields solely to support the retired SSH-oriented diagnostics was rejected because new runner state and deployment metadata intentionally omit those fields.
+
+### Test the interactive runner contract at process boundaries
+
+Executable runner fixtures will record arguments without flattening them, verify the runtime working directory, consume known standard input, write distinct standard output and error, and support a controlled non-zero exit. Host and container cases will be independently named so failures identify the broken contract. Deployment tests will assert unsupported errors by identity as well as message context.
+
+Focused tests will also cover the already-required shell-support JSON field, both branches of conditional connection-instruction rendering, and repair of an otherwise unchanged staged artifact whose permission mode is wrong. Obsolete fake-runner branches will be removed when no production path exercises them.
+
+## Risks / Trade-offs
+
+- **Risk:** Users may see an operation-specific shell error where they previously saw reachability guidance. → **Mitigation:** This is intentional because connectivity guidance cannot explain a failure to open a shell; the reported error retains useful context.
+- **Risk:** Script-based tests can be sensitive to shell behavior. → **Mitigation:** Keep fixtures POSIX-only behind the repository's existing platform guard and use files/streams for exact observations instead of shell word flattening.
+- **Risk:** Tight assertions can over-specify incidental command construction. → **Mitigation:** Assert the documented runtime boundary—argument boundaries, working directory, streams, and error propagation—without asserting unrelated environment or process details.
+
+## Migration Plan
+
+No persisted-data migration is required. Implement the error-routing and Linux wrapping changes, update diagnostics, fixtures, and the changelog, then run formatting, linting, and the unit-test suite. Rollback consists of reverting the code and spec changes; deployment artifacts remain compatible in either direction.

--- a/openspec/changes/archive/2026-08-27-harden-local-shell-delegation/proposal.md
+++ b/openspec/changes/archive/2026-08-27-harden-local-shell-delegation/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Local shell commands can replace the actual reason a shell could not be opened with unrelated database-reachability guidance. The existing shell and reachability requirements also describe runtime, transport, and endpoint architecture instead of the durable CLI behavior users need: accurate failures and actionable next steps.
+
+## What Changes
+
+- Report the actual reason a local shell command failed instead of replacing it with unrelated connectivity guidance, including explicit platform-specific unsupported errors.
+- Define supported and unsupported shell behavior at the user-facing CLI boundary.
+- Report recognized local connectivity problems with platform-appropriate corrective guidance while retaining the underlying command failure.
+- Describe local diagnostics in terms of deployment usability, exposed-service reachability, and database readiness rather than runtime or transport architecture.
+- Move shell requirements touched by this change to the user-facing local deployment capability and keep implementation contracts in the design and tests.
+- Strengthen runtime shell tests to verify exact argument boundaries, working directory, standard streams, and command-failure propagation.
+- Add regression coverage for shell-support deployment metadata, conditional connection instructions, and correction of staged artifact permissions.
+- Remove obsolete test-fixture behavior that only supported the retired SSH-oriented implementation.
+- Document the corrected user-visible shell error behavior in the changelog.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `exasol-local-deployment`: Define supported shell behavior and accurate shell failures at the CLI boundary.
+- `local-reachability-diagnostics`: Consolidate reachability failures into an actionable CLI error contract and describe diagnostics through observable deployment health.
+
+## Impact
+
+The change affects local shell error handling, reachability diagnostics, and their supporting implementation tests. User-visible failures become more accurate and actionable; no command-line syntax, deployment JSON schema, or external dependency changes are introduced.

--- a/openspec/changes/archive/2026-08-27-harden-local-shell-delegation/specs/exasol-local-deployment/spec.md
+++ b/openspec/changes/archive/2026-08-27-harden-local-shell-delegation/specs/exasol-local-deployment/spec.md
@@ -1,0 +1,34 @@
+## MODIFIED Requirements
+
+### Requirement: Local shell access
+
+The CLI SHALL provide `exasol shell host` and `exasol shell container` for supported local deployments and SHALL report the shell-specific cause as the authoritative error when a requested shell cannot be opened.
+
+#### Scenario: Host shell
+
+- **WHEN** a macOS local deployment is running and the user runs `exasol shell host`
+- **THEN** the command opens an interactive shell in the environment hosting the local deployment
+
+#### Scenario: Container shell
+
+- **WHEN** a macOS local deployment is running and the user runs `exasol shell container`
+- **THEN** the command opens an interactive shell in the local deployment's database container environment
+
+#### Scenario: Shell launch fails
+
+- **WHEN** a supported local shell command cannot open the requested environment
+- **THEN** the command fails and reports the shell-specific cause as the authoritative error
+
+### Requirement: Linux local shell commands fail explicitly
+
+The CLI SHALL report host and container shell commands as unsupported for Linux local deployments.
+
+#### Scenario: Host shell requested on Linux
+
+- **WHEN** a user runs `exasol shell host` for a Linux local deployment
+- **THEN** the command fails with an explicit error identifying host shell access as unsupported on Linux
+
+#### Scenario: Container shell requested on Linux
+
+- **WHEN** a user runs `exasol shell container` for a Linux local deployment
+- **THEN** the command fails with an explicit error identifying container shell access as unsupported on Linux

--- a/openspec/changes/archive/2026-08-27-harden-local-shell-delegation/specs/local-reachability-diagnostics/spec.md
+++ b/openspec/changes/archive/2026-08-27-harden-local-shell-delegation/specs/local-reachability-diagnostics/spec.md
@@ -1,8 +1,5 @@
-# local-reachability-diagnostics Specification
+## ADDED Requirements
 
-## Purpose
-TBD - created by archiving change improve-local-reachability-diagnostics. Update Purpose after archive.
-## Requirements
 ### Requirement: Local command failures are actionable and accurate
 
 The CLI SHALL identify recognized connectivity problems affecting a local deployment, provide platform-appropriate corrective guidance, include the operation's actual failure, and treat command-specific failures as authoritative when connectivity is not established as a relevant cause.
@@ -45,3 +42,29 @@ The CLI SHALL provide a read-only `exasol diag local` command that summarizes wh
 
 - **WHEN** local deployment resources remain active even though the recorded deployment state does not expect them
 - **THEN** `exasol diag local` reports an explicit warning and corrective guidance before the user retries a lifecycle command
+
+## REMOVED Requirements
+
+### Requirement: Local diagnostics command
+
+**Reason**: The requirement encodes runtime, VM, transport, and individual port details instead of the durable diagnostic outcome visible to users.
+
+**Migration**: Use `Local diagnostics report deployment usability`, which summarizes platform support, deployment state, exposed-service reachability, database readiness, and corrective guidance through `exasol diag local`.
+
+### Requirement: Local network reachability failures are classified distinctly
+
+**Reason**: The requirement enumerates commands and transport observations instead of specifying the durable user-facing error behavior.
+
+**Migration**: Use `Local command failures are actionable and accurate`, which requires recognized connectivity failures to provide corrective guidance without masking the operation failure.
+
+### Requirement: Reachability error explains the macOS Local Network permission cause
+
+**Reason**: Platform-specific guidance remains required, but its permanent requirement does not need to encode the current forwarding architecture or fixed endpoint details.
+
+**Migration**: Use `Local command failures are actionable and accurate`; macOS guidance continues to direct users to grant Local Network access to the invoking application when that is the recognized cause.
+
+### Requirement: Reachability classification distinguishes network-wide from database-specific problems
+
+**Reason**: Endpoint comparison and classification states are internal diagnostic policy rather than behavior consumed through the CLI.
+
+**Migration**: Use `Local command failures are actionable and accurate`, which preserves unrelated failures whenever blocked access is not established as a relevant cause.

--- a/openspec/changes/archive/2026-08-27-harden-local-shell-delegation/tasks.md
+++ b/openspec/changes/archive/2026-08-27-harden-local-shell-delegation/tasks.md
@@ -1,0 +1,21 @@
+## 1. Preserve Runtime Shell Errors
+
+- [x] 1.1 Return host-shell and container-shell runtime errors directly from the local deployment backend, and verify deployment tests show that blocked health for every reported application endpoint cannot replace either error with a reachability error.
+- [x] 1.2 Wrap Linux host-runtime shell failures with platform-specific context while preserving the host-shell and container-shell unsupported error identities, and verify runtime and backend tests assert both `errors.Is` identity and user-facing Linux context.
+
+## 2. Protect the Interactive Runner Boundary
+
+- [x] 2.1 Replace the flattened host-shell runner fixture with a Given/When/Then test that records argument boundaries and working directory, consumes known standard input, and emits distinct standard output and error; verify `go test -race ./internal/localruntime -run TestMacVMRuntimeOpenHostShellDelegatesToRunner` passes.
+- [x] 2.2 Add `TestMacVMRuntimeOpenContainerShellDelegatesToRunner` to verify the complete container-shell argument vector and standard streams without sharing assertions that could hide a host/container regression; verify the targeted test passes.
+- [x] 2.3 Add a controlled non-zero runner exit case and verify the runtime returns a contextual error that preserves the underlying command failure.
+
+## 3. Fill Contract-Coverage Gaps
+
+- [x] 3.1 Extend runner-state endpoint tests to assert shell support and raw deployment JSON tests to assert `connection.shellSupported` is `true` while SSH fields remain absent; verify the targeted local-runtime and deployment artifact tests pass.
+- [x] 3.2 Cover both branches of conditional connection-instruction rendering by asserting local output omits the SSH alternative and an SSH-capable deployment still renders it; verify the targeted rendering tests pass.
+- [x] 3.3 Add a regression test where a staged runtime artifact has unchanged content metadata but the wrong file mode, and verify materialization repairs the mode without requiring a content change.
+- [x] 3.4 Update reachability comments and fixtures to use application-endpoint terminology and remove the unused fake-runner `stop` behavior; verify the local reachability and diagnostics tests pass.
+
+## 4. Document and Verify
+
+- [x] 4.1 Add an `Unreleased` `Fixed` changelog entry for preserved local shell errors, then run `env GOFLAGS=-tags=containers_image_openpgp GOSUMDB=sum.golang.org GOTOOLCHAIN=auto task fmt lint tests-unit` and verify formatting, linting, and the complete unit-test suite succeed.

--- a/openspec/specs/exasol-local-deployment/spec.md
+++ b/openspec/specs/exasol-local-deployment/spec.md
@@ -139,15 +139,23 @@ The system SHALL support standard lifecycle commands for local deployments.
 - **THEN** the launcher removes the disposable container, stops its execution environment if needed, deletes runtime data and connection artifacts, and records the deployment as initialized
 
 ### Requirement: Local shell access
-The system SHALL provide shell access for local deployments through the selected local runtime.
+
+The CLI SHALL provide `exasol shell host` and `exasol shell container` for supported local deployments and SHALL report the shell-specific cause as the authoritative error when a requested shell cannot be opened.
 
 #### Scenario: Host shell
+
 - **WHEN** a macOS local deployment is running and the user runs `exasol shell host`
-- **THEN** the runtime opens an interactive shell in the VM without exposing the underlying transport
+- **THEN** the command opens an interactive shell in the environment hosting the local deployment
 
 #### Scenario: Container shell
+
 - **WHEN** a macOS local deployment is running and the user runs `exasol shell container`
-- **THEN** the runtime opens an interactive VM shell against the deployment's mounted Nano rootfs and container namespaces without exposing the underlying transport
+- **THEN** the command opens an interactive shell in the local deployment's database container environment
+
+#### Scenario: Shell launch fails
+
+- **WHEN** a supported local shell command cannot open the requested environment
+- **THEN** the command fails and reports the shell-specific cause as the authoritative error
 
 ### Requirement: macOS local VM memory default
 The system SHALL default local deployment VM memory on macOS to approximately 50% of total host memory when the user has not configured local VM memory explicitly.
@@ -201,15 +209,18 @@ The system SHALL derive Linux runtime status from the exact Podman deployment co
 - **THEN** diagnostics describe the Linux host-container failure without macOS host-to-VM guidance
 
 ### Requirement: Linux local shell commands fail explicitly
-The system SHALL return platform-specific unsupported errors for host and container shell commands when the selected runtime cannot provide shell access.
+
+The CLI SHALL report host and container shell commands as unsupported for Linux local deployments.
 
 #### Scenario: Host shell requested on Linux
+
 - **WHEN** a user runs `exasol shell host` for a Linux local deployment
-- **THEN** the command fails with an explicit Linux host-runtime unsupported message
+- **THEN** the command fails with an explicit error identifying host shell access as unsupported on Linux
 
 #### Scenario: Container shell requested on Linux
+
 - **WHEN** a user runs `exasol shell container` for a Linux local deployment
-- **THEN** the command fails with an explicit Linux host-runtime unsupported message
+- **THEN** the command fails with an explicit error identifying container shell access as unsupported on Linux
 
 ### Requirement: Historical local data remains persistent during adoption
 


### PR DESCRIPTION
## Description

Preserve local runtime errors when opening host or container shells, so unrelated database reachability guidance does not obscure the real failure.

## Related Issue

SPOT-32275

## Type of Change

- [x] `fix`: Bug fix

## Changes Made

- Return local shell delegation errors directly without reachability reclassification.
- Add Linux host-runtime context while preserving unsupported-shell error identity.
- Verify macOS shell delegation, runtime capability metadata, conditional instructions, and staged artifact permissions.

## Testing

- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

- Unit tests cover runtime error propagation, Linux error context, macOS delegation behavior, metadata, instructions, and artifact permissions.
- macOS unit test and manual validation completed successfully.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

None.
