### PR TITLE
fix: Restore macOS local deployment startup

### DIFF
--- a/.github/workflows/tests-deployment.yml
+++ b/.github/workflows/tests-deployment.yml
@@ -86,7 +86,7 @@ jobs:
             {
               "os": "macos-latest",
               "platform": "macos-arm64",
-              "runner": ["self-hosted", "macOS", "ARM64", "virtualization"],
+              "runner": ["self-hosted", "macOS", "ARM64", "virtualization","osx06"],
               "system_python": "true",
               "status_context": "tests-deployment-local-self-hosted"
             }

--- a/internal/localinstall/podman_install.go
+++ b/internal/localinstall/podman_install.go
@@ -207,17 +207,7 @@ func (install *PodmanInstall) Start(
 		"--pids-limit=" + nanoPIDsLimit,
 		"--security-opt", nanoSecurityOpt,
 		"--restart", nanoRestartPolicy,
-		// Publish on 127.0.0.1 rather than the wildcard. On Windows the
-		// WSL2 podman machine has no IPv6 route, but pasta still creates a
-		// dual-stack published listener, and WSL's NAT localhost relay
-		// mirrors that as [::1] only. Clients then prefer the IPv6 path,
-		// connect successfully, and get reset because pasta cannot forward
-		// to the container's IPv4-only listener. Binding IPv4 explicitly
-		// keeps the relay on 127.0.0.1. See
-		// https://github.com/microsoft/WSL/issues/6387 and
-		// https://github.com/microsoft/WSL/blob/master/doc/docs/
-		// technical-documentation/localhost.md
-		"-p", fmt.Sprintf("127.0.0.1:%d:%d", startConfig.ContainerDBPort, nanoInternalDBPort),
+		"-p", podmanDBPortMapping(startConfig),
 		"-v", startConfig.DataDir + ":" + nanoDataMountTarget,
 	}
 	for _, slc := range availableSLCs {
@@ -240,6 +230,15 @@ func (install *PodmanInstall) Start(
 	}
 
 	return nil
+}
+
+func podmanDBPortMapping(startConfig StartConfig) string {
+	ports := fmt.Sprintf("%d:%d", startConfig.ContainerDBPort, nanoInternalDBPort)
+	if startConfig.ContainerDBBindHost == "" {
+		return ports
+	}
+
+	return startConfig.ContainerDBBindHost + ":" + ports
 }
 
 func (install *PodmanInstall) Stop(ctx context.Context, out, outErr io.Writer) error {

--- a/internal/localinstall/podman_install_test.go
+++ b/internal/localinstall/podman_install_test.go
@@ -57,6 +57,27 @@ func TestPodmanInstallStart_StartsFreshPersistentDatabase(t *testing.T) {
 	}
 }
 
+func TestPodmanInstallStart_PublishesDatabaseForVMForwarding(t *testing.T) {
+	t.Parallel()
+	skipPodmanInstallTestOnWindows(t)
+
+	// Given
+	install, startConfig, fixture := newPodmanInstallFixture(t)
+	startConfig.ContainerDBBindHost = ""
+
+	// When
+	err := install.Start(context.Background(), nil, nil, startConfig)
+	// Then
+	if err != nil {
+		t.Fatalf("expected VM-facing start to succeed, got %v", err)
+	}
+	commands := readCommandLog(t, fixture.logPath)
+	runCommand := commands[len(commands)-1]
+	if !strings.Contains(runCommand, "<-p><28563:8563>") {
+		t.Fatalf("expected VM-accessible DB port mapping, got %q", runCommand)
+	}
+}
+
 func TestPodmanInstallStart_UsesLoadedNanoImageID(t *testing.T) {
 	t.Parallel()
 	skipPodmanInstallTestOnWindows(t)
@@ -651,9 +672,10 @@ func newPodmanInstallFixture(t *testing.T) (*PodmanInstall, StartConfig, podmanI
 		slcStatusPath,
 	)
 	startConfig := StartConfig{
-		ContainerDBPort: 28563,
-		DataDir:         filepath.Join(root, "runtime", "exa"),
-		InitParams:      []string{"maxConnectionsLicenseLimit=20"},
+		ContainerDBPort:     28563,
+		ContainerDBBindHost: "127.0.0.1",
+		DataDir:             filepath.Join(root, "runtime", "exa"),
+		InitParams:          []string{"maxConnectionsLicenseLimit=20"},
 	}
 	fixture := podmanInstallFixture{
 		logPath:       logPath,

--- a/internal/localinstall/types.go
+++ b/internal/localinstall/types.go
@@ -10,6 +10,7 @@ import (
 
 type StartConfig struct {
 	ContainerDBPort      int
+	ContainerDBBindHost  string
 	DataDir              string
 	InitParams           []string
 	VersionCheck         VersionCheckConfig

--- a/internal/localruntime/host_runtime.go
+++ b/internal/localruntime/host_runtime.go
@@ -23,8 +23,9 @@ import (
 )
 
 const (
-	nanoDBPort      = 8563
-	nanoDataDirName = "exa"
+	nanoDBPort       = 8563
+	nanoDataDirName  = "exa"
+	hostLoopbackHost = "127.0.0.1"
 )
 
 var nanoInitParams = []string{"maxConnectionsLicenseLimit=20"}
@@ -233,7 +234,7 @@ func (runtime *HostRuntime) HealthCheck(ctx context.Context) (*HealthCheckResult
 	if err != nil {
 		return nil, err
 	}
-	address := net.JoinHostPort("127.0.0.1", strconv.Itoa(endpoint.DBPort))
+	address := net.JoinHostPort(hostLoopbackHost, strconv.Itoa(endpoint.DBPort))
 	dialContext := runtime.dialContext
 	if dialContext == nil {
 		dialContext = (&net.Dialer{}).DialContext
@@ -324,10 +325,21 @@ func (runtime *HostRuntime) podmanStartConfig(
 
 	return localinstall.StartConfig{
 		ContainerDBPort: hostDBPort,
-		DataDir:         filepath.Join(runtime.paths.WorkDir, nanoDataDirName),
-		InitParams:      append([]string(nil), nanoInitParams...),
-		VersionCheck:    runtimeConfig.VersionCheck,
-		SLCs:            runtimeConfig.SLCs,
+		// Publish on 127.0.0.1 rather than the wildcard. On Windows the
+		// WSL2 podman machine has no IPv6 route, but pasta still creates a
+		// dual-stack published listener, and WSL's NAT localhost relay
+		// mirrors that as [::1] only. Clients then prefer the IPv6 path,
+		// connect successfully, and get reset because pasta cannot forward
+		// to the container's IPv4-only listener. Binding IPv4 explicitly
+		// keeps the relay on 127.0.0.1. See
+		// https://github.com/microsoft/WSL/issues/6387 and
+		// https://github.com/microsoft/WSL/blob/master/doc/docs/
+		// technical-documentation/localhost.md
+		ContainerDBBindHost: hostLoopbackHost,
+		DataDir:             filepath.Join(runtime.paths.WorkDir, nanoDataDirName),
+		InitParams:          append([]string(nil), nanoInitParams...),
+		VersionCheck:        runtimeConfig.VersionCheck,
+		SLCs:                runtimeConfig.SLCs,
 	}, nil
 }
 

--- a/internal/localruntime/host_runtime_test.go
+++ b/internal/localruntime/host_runtime_test.go
@@ -35,6 +35,9 @@ func TestLinuxHostPodmanStartConfig_UsesReferenceDefaults(t *testing.T) {
 	if startConfig.ContainerDBPort != nanoDBPort {
 		t.Fatalf("unexpected default DB port: %#v", startConfig)
 	}
+	if startConfig.ContainerDBBindHost != hostLoopbackHost {
+		t.Fatalf("expected loopback DB bind, got %#v", startConfig)
+	}
 	if startConfig.DataDir != filepath.Join(localRuntime.paths.WorkDir, nanoDataDirName) {
 		t.Fatalf("unexpected Nano data directory %q", startConfig.DataDir)
 	}

--- a/internal/localruntime/runtime_test.go
+++ b/internal/localruntime/runtime_test.go
@@ -99,6 +99,9 @@ func TestMacVMRuntimeLifecycleUsesV2RunnerThenSharedInstall(t *testing.T) {
 		install.startConfig.DataDir != vmNanoDataDir {
 		t.Fatalf("unexpected guest Podman config: %#v", install.startConfig)
 	}
+	if install.startConfig.ContainerDBBindHost != "" {
+		t.Fatalf("expected VM-accessible DB bind, got %#v", install.startConfig)
+	}
 	if len(install.startConfig.LegacyContainerNames) != 1 ||
 		install.startConfig.LegacyContainerNames[0] != legacyNanoContainer {
 		t.Fatalf("expected legacy container migration config, got %#v", install.startConfig)


### PR DESCRIPTION
## Description

Restores macOS local deployments by making the database port reachable
through the managed VM's host-to-VM forwarding. Direct host runtimes
continue binding the database port exclusively to the loopback interface.
This fixes the consistent readiness failures introduced when the Podman
port mapping was globally restricted to the container host's loopback
interface.
## Related Issue

<!-- Link to the related issue(s). Use "Fixes #123" or "Closes #123" to auto-close issues when PR is merged -->

Fixes #

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

<!-- List the key changes in this PR -->

- Made the Podman database bind host runtime-specific
- Retained loopback-only binding for Linux and Windows host runtimes
- Restored VM-accessible binding for macOS
- Added regression tests

## Testing

<!-- Describe how you tested your changes -->

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

<!-- Describe your testing approach -->

## Checklist

<!-- Mark completed items with an "x" -->

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [ ] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

<!-- Any additional information, screenshots, or context -->
