### PR TITLE
fix: Show connect exit hint for piped text sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Notable user-facing changes to Exasol Personal are documented here.
 
 ### Fixed
 
+- Fixed `exasol connect` omitting its shell exit hint when standard input was piped and emitting it for interactive `--json` sessions. The hint now follows the CLI output contract: it is written to stderr for text shell sessions and suppressed under `--json`.
 - Fixed Data Lakehouse Turbo activation failing on cloud deployments. Podman was missing from the deployment hosts, so activating the feature in the AdminUI hung on a spinner and reported `Activation status for database Exasol could not be retrieved`. Podman is now installed during cloud-init on all supported cloud providers (AWS, Azure, Exoscale, STACKIT).
 - Local runtime host preparation no longer proceeds without approval when a command cannot prompt. Previously a non-interactive invocation was treated as consent, so a scripted run could install Podman unattended. Such runs now fail and explain how to proceed; pass `--auto-approve` for unattended setup.
 

--- a/cmd/exasol/connect.go
+++ b/cmd/exasol/connect.go
@@ -52,6 +52,9 @@ var connectCmd = &cobra.Command{
 		connectOpts.OutputFormat = selectedConnectOutputFormat(cmd)
 		connectOpts.Stdout = cmd.OutOrStdout()
 		connectOpts.Stderr = cmd.ErrOrStderr()
+		connectOpts.ShowExitHint = callsToActionVisible(
+			connectOpts.OutputFormat == connect.OutputFormatJSON,
+		)
 
 		return deploy.Connect(cmd.Context(), &connectOpts, commonFlags.Deployment())
 	},

--- a/cmd/exasol/terminal_notice.go
+++ b/cmd/exasol/terminal_notice.go
@@ -51,16 +51,14 @@ func printTerminalMessages() {
 	writeTerminalMessages(terminalConfig{
 		stdout:            os.Stdout,
 		stderr:            os.Stderr,
-		showCallsToAction: callsToActionVisible(),
+		showCallsToAction: callsToActionVisible(commonFlags.OutputJson),
 	})
 }
 
-// callsToActionVisible reports whether call-to-action guidance should be shown.
-// Calls to action help any reader, including a non-interactive agent driving the
-// CLI, so they are not TTY-gated; they are suppressed only under --json, where
-// consumers branch on structured fields instead of prose.
-func callsToActionVisible() bool {
-	return !commonFlags.OutputJson
+// Calls to action help any reader, including a non-interactive agent driving
+// the CLI, so they are suppressed only for JSON output.
+func callsToActionVisible(jsonOutput bool) bool {
+	return !jsonOutput
 }
 
 type terminalConfig struct {

--- a/cmd/exasol/terminal_notice_test.go
+++ b/cmd/exasol/terminal_notice_test.go
@@ -118,21 +118,23 @@ func TestTerminalMessagesPrintCallsToActionLastInCombinedTerminalOutput(t *testi
 	}
 }
 
-// TestCallToActionsVisibleFollowsJSONFlag must not run in parallel: it mutates
-// the shared commonFlags global.
-//
-//nolint:paralleltest // mutates shared package globals; must run serially
-func TestCallToActionsVisibleFollowsJSONFlag(t *testing.T) {
-	old := commonFlags.OutputJson
-	defer func() { commonFlags.OutputJson = old }()
+func TestCallsToActionVisible(t *testing.T) {
+	t.Parallel()
 
-	// Text output (interactive or not) shows guidance; only --json suppresses it.
-	commonFlags.OutputJson = false
-	if !callsToActionVisible() {
-		t.Fatal("expected calls to action to be visible for text output")
-	}
-	commonFlags.OutputJson = true
-	if callsToActionVisible() {
-		t.Fatal("expected calls to action to be suppressed under --json")
+	for _, test := range []struct {
+		name       string
+		jsonOutput bool
+		expected   bool
+	}{
+		{name: "text output", jsonOutput: false, expected: true},
+		{name: "JSON output", jsonOutput: true, expected: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if callsToActionVisible(test.jsonOutput) != test.expected {
+				t.Fatalf("unexpected visibility for JSON output %t", test.jsonOutput)
+			}
+		})
 	}
 }

--- a/doc/best_practices.md
+++ b/doc/best_practices.md
@@ -41,7 +41,7 @@ Classify every piece of terminal output as one of three kinds and route it accor
 
 - **Primary output** — the result the user asked for. Goes to stdout. Under `--json` it is the only content on stdout and must be valid JSON, so callers can parse it without filtering.
 - **Operational notice** — context a user needs to interpret the result, such as which deployment directory was used or that the license was accepted. Goes to stderr, and is shown even when stdout is piped or `--json` is selected. It never appears on stdout.
-- **Call-to-action (CTA)** — decorative next-step guidance that nudges the user toward a follow-up command (for example "run `exasol deploy` to apply", an available-update hint, or a "Next steps" block). Goes to stderr, and is shown only to interactive users.
+- **Call-to-action (CTA)** — decorative next-step guidance that nudges the user toward a follow-up command (for example "run `exasol deploy` to apply", an available-update hint, or a "Next steps" block). Goes to stderr for text output and is suppressed only under `--json`.
 
 Use the delete-test to tell a CTA from a notice: if removing the message changes neither the result nor its correctness reporting, it is a CTA.
 

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -81,6 +81,8 @@ type Opts struct {
 	// Stderr receives interactive notices and truncation messages. The command
 	// layer owns the concrete terminal stream.
 	Stderr io.Writer
+	// ShowExitHint controls whether the SQL shell prints its exit guidance.
+	ShowExitHint bool
 }
 
 // MaxRowsUnset is the sentinel for a MaxRows that was not set on the command
@@ -217,7 +219,7 @@ func Connect(
 		return runStatements(nonInteractiveSQL, processInput)
 	}
 
-	if shouldPrintShellExitHint(opts.OutputFormat) {
+	if opts.ShowExitHint {
 		if err := printExitHint(writers.stderr); err != nil {
 			return err
 		}
@@ -378,10 +380,6 @@ func printExitHint(output io.Writer) error {
 	_, err := fmt.Fprintln(output, "Type \"exit\" to exit the shell")
 
 	return err
-}
-
-func shouldPrintShellExitHint(format OutputFormat) bool {
-	return format != OutputFormatJSON
 }
 
 func normalizeJSONFormat(format JSONFormat) JSONFormat {

--- a/internal/connect/connect.go
+++ b/internal/connect/connect.go
@@ -217,7 +217,7 @@ func Connect(
 		return runStatements(nonInteractiveSQL, processInput)
 	}
 
-	if interactiveShell {
+	if shouldPrintShellExitHint(opts.OutputFormat) {
 		if err := printExitHint(writers.stderr); err != nil {
 			return err
 		}
@@ -378,6 +378,10 @@ func printExitHint(output io.Writer) error {
 	_, err := fmt.Fprintln(output, "Type \"exit\" to exit the shell")
 
 	return err
+}
+
+func shouldPrintShellExitHint(format OutputFormat) bool {
+	return format != OutputFormatJSON
 }
 
 func normalizeJSONFormat(format JSONFormat) JSONFormat {

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -366,6 +366,26 @@ func TestResolveNonInteractiveSQL(t *testing.T) {
 	})
 }
 
+func TestShouldPrintShellExitHint(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name     string
+		format   OutputFormat
+		expected bool
+	}{
+		{name: "table output", format: OutputFormatTable, expected: true},
+		{name: "csv output", format: OutputFormatCSV, expected: true},
+		{name: "json output", format: OutputFormatJSON, expected: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, test.expected, shouldPrintShellExitHint(test.format))
+		})
+	}
+}
+
 type stubDatabase struct {
 	results []stubExecResult
 	queries []string

--- a/internal/connect/connect_test.go
+++ b/internal/connect/connect_test.go
@@ -366,26 +366,6 @@ func TestResolveNonInteractiveSQL(t *testing.T) {
 	})
 }
 
-func TestShouldPrintShellExitHint(t *testing.T) {
-	t.Parallel()
-
-	for _, test := range []struct {
-		name     string
-		format   OutputFormat
-		expected bool
-	}{
-		{name: "table output", format: OutputFormatTable, expected: true},
-		{name: "csv output", format: OutputFormatCSV, expected: true},
-		{name: "json output", format: OutputFormatJSON, expected: false},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-
-			require.Equal(t, test.expected, shouldPrintShellExitHint(test.format))
-		})
-	}
-}
-
 type stubDatabase struct {
 	results []stubExecResult
 	queries []string

--- a/tests/tests/e2e/test_connect_query.py
+++ b/tests/tests/e2e/test_connect_query.py
@@ -433,7 +433,7 @@ def test_password_marker_not_leaked_to_logs(reusable_deployment: Deployment) -> 
     sys.platform.startswith("win"), reason="Test is not supported on Windows OS"
 )
 def test_connect_shows_exit_hint(reusable_deployment: Deployment) -> None:
-    """An interactive connection must print the 'how to exit' banner.
+    """A piped text connection must print the 'how to exit' banner.
 
     The launcher reads the DB password from the encrypted secrets file rather
     than prompting interactively, so the PDF's user/password-prompt expectation
@@ -445,11 +445,11 @@ def test_connect_shows_exit_hint(reusable_deployment: Deployment) -> None:
     assert reusable_deployment.db_connectable()
 
     # ========== WHEN ==========
-    # Connect is invoked with an immediate "exit" on stdin
+    # Connect is driven through piped stdin with an immediate "exit"
     proc = reusable_deployment.connect(input="exit\n", capture_output=True)
 
     # ========== THEN ==========
-    # The shell prints its exit hint to stderr and exits cleanly
+    # The text shell prints its exit hint to stderr and exits cleanly
     assert proc.returncode == 0
     assert 'Type "exit" to exit the shell' in proc.stderr
 


### PR DESCRIPTION
## Description

`exasol connect` printed its shell exit hint only when standard input was a terminal. Piped text sessions therefore omitted the call-to-action even though the CLI output contract requires text guidance on stderr regardless of TTY attachment.

This change makes the hint depend on the output contract instead of terminal detection: text and CSV shell sessions receive it on stderr, while `--json` suppresses it. `--command` and `--file` remain unchanged because they do not start the shell.

## Related Issue

[SPOT-32345](https://exasol.atlassian.net/browse/SPOT-32345)

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [x] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Show the shell exit hint for piped text and CSV sessions.
- Suppress the hint for JSON shell sessions.
- Add unit coverage and clarify the piped e2e scenario.
- Reconcile the CTA best-practice summary with the existing OpenSpec contract.
- Document the released-behavior fix in the changelog.

## Testing

- [ ] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

### Test Details

- `task tests-unit`: passed with the race detector.
- `task lint-golang`: 0 issues.
- Targeted Ruff check and format check: passed.
- `task build`: passed.
- `task tests-integration`: 117 passed, 6 skipped.
- `task all` is blocked by a pre-existing Ruff `BLE001` violation in `tests/chaos/test_lifecycle_faults.py:245`.
- The cloud e2e test was not rerun in isolation because the full AWS lane also contains the separate SPOT-32344 failures.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [ ] Ran `task fmt` and `task lint`
- [x] Updated documentation
- [x] Updated `CHANGELOG.md`
- [x] Added/updated tests
- [ ] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

No new OpenSpec change is needed because this restores the existing `cli-output-contract` specification.

[SPOT-32345]: https://exasol.atlassian.net/browse/SPOT-32345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ