### PR TITLE
test: Correct local Parquet e2e coverage

### DIFF
--- a/tests/tests/e2e/test_import_local_data.py
+++ b/tests/tests/e2e/test_import_local_data.py
@@ -188,16 +188,20 @@ def test_import_parquet_missing_file_reports_client_side(
     statements = [
         f"CREATE SCHEMA {schema};",
         f"OPEN SCHEMA {schema};",
-        'CREATE TABLE Data ("id" BIGINT, "name" VARCHAR(32));',
-        f"IMPORT INTO Data FROM LOCAL PARQUET FILE '{missing}';",
+        'CREATE TABLE ParquetRows ("id" BIGINT, "name" VARCHAR(32));',
+        f"IMPORT INTO ParquetRows FROM LOCAL PARQUET FILE '{missing}';",
     ]
 
     # ========== WHEN ==========
-    proc = reusable_deployment.connect(input="\n".join(statements), capture_output=True)
+    with pytest.raises(subprocess.CalledProcessError) as error_info:
+        reusable_deployment.connect(
+            "--command", "\n".join(statements), capture_output=True
+        )
 
     # ========== THEN ==========
-    combined = (proc.stdout + proc.stderr).lower()
-    assert proc.returncode != 0
+    error = error_info.value
+    combined = (_decode_stream(error.stdout) + _decode_stream(error.stderr)).lower()
+    assert error.returncode != 0
     assert any(
         token in combined
         for token in ("not found", "no such file", "does not exist", "cannot open")

--- a/tests/tests/e2e/test_import_local_data.py
+++ b/tests/tests/e2e/test_import_local_data.py
@@ -157,9 +157,9 @@ def test_import_parquet_uses_local_filesystem(
     statements = [
         f"CREATE SCHEMA {schema};",
         f"OPEN SCHEMA {schema};",
-        'CREATE TABLE Data ("id" BIGINT, "name" VARCHAR(32));',
-        f"IMPORT INTO Data FROM LOCAL PARQUET FILE '{local_only}';",
-        'SELECT "id", "name" FROM Data ORDER BY "id";',
+        'CREATE TABLE ParquetRows ("id" BIGINT, "name" VARCHAR(32));',
+        f"IMPORT INTO ParquetRows FROM LOCAL PARQUET FILE '{local_only}';",
+        'SELECT "id", "name" FROM ParquetRows ORDER BY "id";',
     ]
 
     # ========== WHEN ==========


### PR DESCRIPTION
## Description

The local Parquet e2e tests used `Data` as an unquoted table name, but `DATA` is a reserved Exasol keyword. The database rejected the setup statements before the successful test could reach the import.

The missing-file test had a second issue: it drove the buffered stdin shell while expecting a non-zero process status. Shell statement errors are reported while the shell continues; `--command` is the documented non-interactive mode that stops on an error and exits non-zero.

## Related Issue

[SPOT-32344](https://exasol.atlassian.net/browse/SPOT-32344)

## Type of Change

- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Use the valid `ParquetRows` identifier in the successful local Parquet test.
- Use the valid identifier in the missing-file test.
- Run the missing-file scenario through `--command` and assert its non-zero `CalledProcessError`.

## Testing

- [ ] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

### Test Details

- Targeted Ruff check and format check: passed.
- `task lint-mypy`: passed for 42 source files.
- Pytest collection: all 5 local-data e2e tests collected.
- `task tests-integration`: 117 passed, 6 skipped.
- `task all` is blocked by a pre-existing Ruff `BLE001` violation in `tests/chaos/test_lifecycle_faults.py:245`.
- Cloud e2e execution remains the final acceptance check.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [ ] Ran `task fmt` and `task lint`
- [x] Documentation is unchanged because behavior is unchanged
- [x] Changelog is unchanged because this is test-only
- [x] Added/updated tests
- [ ] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

No new OpenSpec change is needed because the tests now exercise the existing `local-parquet-import` and `connect-sql-input` specifications.

[SPOT-32344]: https://exasol.atlassian.net/browse/SPOT-32344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ