### PR TITLE
test(localruntime): Run fork-and-exec fixtures sequentially

### DIFF
--- a/internal/localruntime/runner_environment_test.go
+++ b/internal/localruntime/runner_environment_test.go
@@ -37,8 +37,8 @@ func TestVMPathMapperMapsOnlySharedPaths(t *testing.T) {
 	}
 }
 
+//nolint:paralleltest // the test forks an executable fixture it just wrote.
 func TestRunnerExecutionEnvironmentPreservesCommandIOAndExitStatus(t *testing.T) {
-	t.Parallel()
 	requireRunnerEnvironmentPOSIX(t)
 
 	environment := newTestRunnerExecutionEnvironment(t)
@@ -60,8 +60,8 @@ func TestRunnerExecutionEnvironmentPreservesCommandIOAndExitStatus(t *testing.T)
 	}
 }
 
+//nolint:paralleltest // the test forks an executable fixture it just wrote.
 func TestRunnerExecutionEnvironmentSyncsInsideRuntime(t *testing.T) {
-	t.Parallel()
 	requireRunnerEnvironmentPOSIX(t)
 
 	environment := newTestRunnerExecutionEnvironment(t)
@@ -70,8 +70,8 @@ func TestRunnerExecutionEnvironmentSyncsInsideRuntime(t *testing.T) {
 	}
 }
 
+//nolint:paralleltest // the test forks an executable fixture it just wrote.
 func TestRunnerExecutionEnvironmentFilesystemOperations(t *testing.T) {
-	t.Parallel()
 	requireRunnerEnvironmentPOSIX(t)
 
 	ctx := context.Background()


### PR DESCRIPTION
## Description

The local runtime fixture tests fork executables that they create during the test. Running these tests in parallel can cause filesystem and process races.

Run the three fork-and-exec tests sequentially and document the intentional linter exception.

## Type of Change

- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Removed parallel execution from the three fork-and-exec fixture tests.
- Added focused `paralleltest` linter suppressions with the reason.

## Testing

- [x] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [ ] Manually tested the changes

## Checklist

- [x] Code follows the project's coding guidelines
- [x] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [ ] Updated `CHANGELOG.md` for user-facing changes
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow Conventional Commits format