### PR TITLE
Bind Exasol status to a timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Notable user-facing changes to Exasol Personal are documented here.
 
 ### Fixed
 
+- `exasol status` now stops waiting after five seconds by default instead of hanging indefinitely on an unresponsive deployment. Use `--timeout <seconds>` to select another positive limit, for example `exasol status --timeout 10`.
 - Fixed infrastructure and installation presets being unavailable. `exasol presets list` reported no presets, and commands that resolve one, such as `exasol install local` and `exasol presets export`, could not find it. Embedded preset archives are now extracted completely.
 - Fixed `exasol connect` omitting its shell exit hint when standard input was piped and emitting it for interactive `--json` sessions. The hint now follows the CLI output contract: it is written to stderr for text shell sessions and suppressed under `--json`.
 - Fixed Data Lakehouse Turbo activation failing on cloud deployments. Activating the feature in the AdminUI hung on a spinner and reported `Activation status for database Exasol could not be retrieved`. Podman is now installed during cloud-init on all supported cloud providers (AWS, Azure, Exoscale, STACKIT), and the provisioned hosts now ship a Podman release that includes the Quadlet systemd generator the feature depends on. Deployments created before this change must be recreated to pick it up.

--- a/cmd/exasol/status.go
+++ b/cmd/exasol/status.go
@@ -4,16 +4,23 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/exasol/exasol-personal/internal/deploy"
 	"github.com/spf13/cobra"
 )
 
-const statusCmdShortDesc = `Get the status a deployment`
+const statusCmdShortDesc = `Get the status of a deployment`
+
+const (
+	defaultStatusTimeoutSeconds int64 = 5
+	maxStatusTimeoutSeconds           = int64(1<<63-1) / int64(time.Second)
+)
 
 const statusCmdLongDesc = statusCmdShortDesc + `
 
@@ -31,7 +38,8 @@ Display the status of the current deployment.
 `
 
 var statusOpts = struct {
-	unsafe bool
+	unsafe         bool
+	timeoutSeconds int64
 }{}
 
 var statusCmd = &cobra.Command{
@@ -41,16 +49,21 @@ var statusCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cmd.SilenceUsage = true
+		ctx, cancel, err := contextWithStatusTimeout(cmd.Context(), statusOpts.timeoutSeconds)
+		if err != nil {
+			return err
+		}
+		defer cancel()
+
 		deployment := commonFlags.Deployment()
 		var status *deploy.StatusOutput
-		var err error
 
 		if statusOpts.unsafe {
 			slog.Debug("acquiring deployment status without lock")
-			status, err = deploy.StatusUnsafe(cmd.Context(), deployment)
+			status, err = deploy.StatusUnsafe(ctx, deployment)
 		} else {
 			slog.Debug("acquiring deployment status with lock")
-			status, err = deploy.Status(cmd.Context(), deployment)
+			status, err = deploy.Status(ctx, deployment)
 		}
 		if err != nil {
 			return err
@@ -69,6 +82,24 @@ var statusCmd = &cobra.Command{
 
 		return nil
 	},
+}
+
+func contextWithStatusTimeout(
+	parent context.Context,
+	timeoutSeconds int64,
+) (context.Context, context.CancelFunc, error) {
+	if timeoutSeconds <= 0 {
+		return nil, nil, fmt.Errorf("--timeout must be positive, got %d", timeoutSeconds)
+	}
+	if timeoutSeconds > maxStatusTimeoutSeconds {
+		return nil, nil, fmt.Errorf("--timeout is too large, got %d", timeoutSeconds)
+	}
+
+	timeout := time.Duration(timeoutSeconds) * time.Second
+
+	ctx, cancel := context.WithTimeout(parent, timeout)
+
+	return ctx, cancel, nil
 }
 
 func formatStatusJSON(status deploy.StatusOutput) (string, error) {
@@ -95,7 +126,12 @@ func registerStatusFlags() {
 	statusCmd.Flags().BoolVar(
 		&statusOpts.unsafe,
 		"unsafe", false,
-		"Try to read the deployment folder state even it is locked. May fail.",
+		"Try to read the deployment folder state even if it is locked. May fail.",
+	)
+	statusCmd.Flags().Int64Var(
+		&statusOpts.timeoutSeconds,
+		"timeout", defaultStatusTimeoutSeconds,
+		"Maximum number of seconds to wait for the complete status check",
 	)
 }
 

--- a/cmd/exasol/status_test.go
+++ b/cmd/exasol/status_test.go
@@ -5,12 +5,89 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/exasol/exasol-personal/internal/deploy"
 )
+
+func TestStatusCommandRegistersDefaultTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	flag := statusCmd.Flags().Lookup("timeout")
+
+	// Then
+	if flag == nil {
+		t.Fatal("expected status command to register --timeout")
+	}
+	if flag.DefValue != strconv.FormatInt(defaultStatusTimeoutSeconds, 10) {
+		t.Fatalf("expected default timeout %d, got %q", defaultStatusTimeoutSeconds, flag.DefValue)
+	}
+}
+
+func TestContextWithStatusTimeoutUsesSeconds(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	const timeoutSeconds int64 = 1
+
+	// When
+	ctx, cancel, err := contextWithStatusTimeout(context.Background(), timeoutSeconds)
+	if err != nil {
+		t.Fatalf("expected timeout context, got: %v", err)
+	}
+	defer cancel()
+
+	// Then
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("expected status context to have a deadline")
+	}
+	if remaining := time.Until(deadline); remaining <= 0 || remaining > time.Second {
+		t.Fatalf("expected a one-second deadline, got %s", remaining)
+	}
+}
+
+func TestContextWithStatusTimeoutRejectsNonPositiveSeconds(t *testing.T) {
+	t.Parallel()
+
+	for _, timeoutSeconds := range []int64{0, -1} {
+		// When
+		ctx, cancel, err := contextWithStatusTimeout(context.Background(), timeoutSeconds)
+
+		// Then
+		if err == nil {
+			cancel()
+			t.Fatalf("expected timeout %d to be rejected", timeoutSeconds)
+		}
+		if ctx != nil || cancel != nil {
+			t.Fatalf("expected no context for timeout %d", timeoutSeconds)
+		}
+		if !strings.Contains(err.Error(), "--timeout must be positive") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+}
+
+func TestContextWithStatusTimeoutRejectsOverflow(t *testing.T) {
+	t.Parallel()
+
+	// When
+	ctx, cancel, err := contextWithStatusTimeout(
+		context.Background(),
+		maxStatusTimeoutSeconds+1,
+	)
+
+	// Then
+	if err == nil || ctx != nil || cancel != nil {
+		t.Fatalf("expected oversized timeout to be rejected, got context=%v error=%v", ctx, err)
+	}
+}
 
 func TestFormatStatusText(t *testing.T) {
 	t.Parallel()

--- a/openspec/changes/archive/2026-09-02-bound-status-duration/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-02-bound-status-duration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-02

--- a/openspec/changes/archive/2026-09-02-bound-status-duration/design.md
+++ b/openspec/changes/archive/2026-09-02-bound-status-duration/design.md
@@ -1,0 +1,27 @@
+## Context
+
+The status command passes its unbounded command context through deployment locking, local runtime inspection, and the database readiness probe. The database connection honors context cancellation, but the command currently supplies no deadline.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Bound the complete status operation by default.
+- Let callers select a different positive number of seconds.
+- Reuse Go context cancellation and Cobra integer parsing.
+
+**Non-Goals:**
+
+- Changing status values or database readiness semantics.
+- Changing timeouts for other commands.
+
+## Decisions
+
+Register a `--timeout` integer flag with a five-second default. Validate that the number of seconds is positive and representable as a Go duration, derive a timeout context from the command context, and pass it to the existing safe or unsafe status path. Applying the deadline at the command boundary covers lock acquisition, runtime inspection, and database probing without adding timeout handling to each layer.
+
+The option remains command-specific instead of reusing the interactive connection timeout because a quick observational command has a different latency contract.
+
+## Risks / Trade-offs
+
+- [A healthy but slow deployment exceeds five seconds] -> Callers can increase `--timeout`.
+- [A dependency does not honor context cancellation] -> Existing database and process boundaries already consume the context; tests verify the command-level bound where practical.

--- a/openspec/changes/archive/2026-09-02-bound-status-duration/proposal.md
+++ b/openspec/changes/archive/2026-09-02-bound-status-duration/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+`exasol status` can wait indefinitely while acquiring the deployment lock or probing an unreachable database, preventing callers from reliably completing status checks.
+
+## What Changes
+
+- Bound `exasol status` to five seconds by default.
+- Add a `--timeout` seconds option so callers can choose another positive bound.
+- Report invalid timeout values without starting a status check.
+
+## Capabilities
+
+### New Capabilities
+
+- `deployment-status-timeout`: Defines bounded status checks and caller-configurable timeout behavior.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+This changes the `exasol status` CLI contract and its tests, help text, and changelog entry. It adds no dependency and does not change other commands.

--- a/openspec/changes/archive/2026-09-02-bound-status-duration/specs/deployment-status-timeout/spec.md
+++ b/openspec/changes/archive/2026-09-02-bound-status-duration/specs/deployment-status-timeout/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Deployment status checks are time-bounded
+`exasol status` SHALL apply a five-second timeout to the complete status operation by default and SHALL allow users to select another positive integer number of seconds with `--timeout`.
+
+#### Scenario: Default timeout bounds a status check
+- **WHEN** a user runs `exasol status` without `--timeout`
+- **AND** the status operation does not complete within five seconds
+- **THEN** the command stops waiting
+
+#### Scenario: Explicit timeout bounds a status check
+- **WHEN** a user runs `exasol status --timeout <seconds>` with a positive integer
+- **AND** the status operation does not complete within that number of seconds
+- **THEN** the command stops waiting at the selected bound
+
+#### Scenario: Non-positive timeout is rejected
+- **WHEN** a user runs `exasol status --timeout <seconds>` with a zero or negative integer
+- **THEN** the command reports that the timeout must be positive without starting the status operation

--- a/openspec/changes/archive/2026-09-02-bound-status-duration/tasks.md
+++ b/openspec/changes/archive/2026-09-02-bound-status-duration/tasks.md
@@ -1,0 +1,8 @@
+## 1. Status timeout
+
+- [x] 1.1 Add the positive `--timeout` seconds option with a five-second default and apply it to the complete status operation.
+
+## 2. Verification and documentation
+
+- [x] 2.1 Add focused tests for the default, explicit, non-positive, and oversized timeout behavior.
+- [x] 2.2 Document the bounded status behavior in the changelog and verify formatting, linting, tests, and build.

--- a/openspec/specs/deployment-status-timeout/spec.md
+++ b/openspec/specs/deployment-status-timeout/spec.md
@@ -1,0 +1,21 @@
+# deployment-status-timeout Specification
+
+## Purpose
+Ensure `exasol status` completes in bounded time by applying a default timeout and allowing callers to configure it.
+## Requirements
+### Requirement: Deployment status checks are time-bounded
+`exasol status` SHALL apply a five-second timeout to the complete status operation by default and SHALL allow users to select another positive integer number of seconds with `--timeout`.
+
+#### Scenario: Default timeout bounds a status check
+- **WHEN** a user runs `exasol status` without `--timeout`
+- **AND** the status operation does not complete within five seconds
+- **THEN** the command stops waiting
+
+#### Scenario: Explicit timeout bounds a status check
+- **WHEN** a user runs `exasol status --timeout <seconds>` with a positive integer
+- **AND** the status operation does not complete within that number of seconds
+- **THEN** the command stops waiting at the selected bound
+
+#### Scenario: Non-positive timeout is rejected
+- **WHEN** a user runs `exasol status --timeout <seconds>` with a zero or negative integer
+- **THEN** the command reports that the timeout must be positive without starting the status operation


### PR DESCRIPTION
## Description

Binds `exasol status` on a default 5s timeout, overridable with a positive `--timeout` integer.
## Related Issue

Fixes #311 

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

<!-- List the key changes in this PR -->

- Add --timeout to `status` cobra command
- Set a default `5s` timeout for `status`


## Testing

<!-- Describe how you tested your changes -->

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

<!-- Describe your testing approach -->

## Checklist

<!-- Mark completed items with an "x" -->

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

<!-- Any additional information, screenshots, or context -->
