### PR TITLE
Deployment list now queries actual status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Notable user-facing changes to Exasol Personal are documented here.
 
 ### Fixed
 
+- `exasol deployments list` now reports the same live status as `exasol status` instead of treating persisted workflow state as current state. Deployment checks run concurrently under one five-second bound.
 - `exasol status` now stops waiting after five seconds by default instead of hanging indefinitely on an unresponsive deployment. Use `--timeout <seconds>` to select another positive limit, for example `exasol status --timeout 10`.
 - Fixed infrastructure and installation presets being unavailable. `exasol presets list` reported no presets, and commands that resolve one, such as `exasol install local` and `exasol presets export`, could not find it. Embedded preset archives are now extracted completely.
 - Fixed `exasol connect` omitting its shell exit hint when standard input was piped and emitting it for interactive `--json` sessions. The hint now follows the CLI output contract: it is written to stderr for text shell sessions and suppressed under `--json`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Notable user-facing changes to Exasol Personal are documented here.
 
 ### Fixed
 
+- `exasol status` now stops waiting after five seconds by default instead of hanging indefinitely on an unresponsive deployment. Use `--timeout <seconds>` to select another positive limit, for example `exasol status --timeout 10`.
 - Fixed infrastructure and installation presets being unavailable. `exasol presets list` reported no presets, and commands that resolve one, such as `exasol install local` and `exasol presets export`, could not find it. Embedded preset archives are now extracted completely.
 - Fixed `exasol connect` omitting its shell exit hint when standard input was piped and emitting it for interactive `--json` sessions. The hint now follows the CLI output contract: it is written to stderr for text shell sessions and suppressed under `--json`.
 - Fixed Data Lakehouse Turbo activation failing on cloud deployments. Activating the feature in the AdminUI hung on a spinner and reported `Activation status for database Exasol could not be retrieved`. Podman is now installed during cloud-init on all supported cloud providers (AWS, Azure, Exoscale, STACKIT), and the provisioned hosts now ship a Podman release that includes the Quadlet systemd generator the feature depends on. Deployments created before this change must be recreated to pick it up.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Use `exasol deployments list` to see every default and named deployment director
 
 ```bash
 $ exasol deployments list
-default status=running preset=local/ubuntu path=/Users/me/.exasol/personal/deployments/default
+default status=database_ready preset=local/ubuntu path=/Users/me/.exasol/personal/deployments/default
 staging status=stopped preset=aws/ubuntu path=/Users/me/.exasol/personal/deployments/staging
 ```
 

--- a/cmd/exasol/deployments.go
+++ b/cmd/exasol/deployments.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"sync"
 
 	"github.com/exasol/exasol-personal/internal/config"
 	"github.com/exasol/exasol-personal/internal/deploy"
@@ -31,10 +32,8 @@ deployment directories selected via an arbitrary --deployment-dir path.
 `, deploymentsRootDisplayPath())
 
 // deploymentListEntry describes one launcher-managed deployment directory for
-// `exasol deployments list`. Status uses the same lifecycle vocabulary as
-// `exasol status` (deploy.StatusNotInitialized, deploy.StatusRunning, etc.),
-// computed via the lock-free, connection-check-free deploy.GetStatus — see
-// deploymentListEntryFor.
+// `exasol deployments list`. Status is resolved through the same live path as
+// `exasol status`.
 type deploymentListEntry struct {
 	Name           string `json:"name"`
 	Path           string `json:"path"`
@@ -42,6 +41,8 @@ type deploymentListEntry struct {
 	Infrastructure string `json:"infrastructure,omitempty"`
 	Installation   string `json:"installation,omitempty"`
 }
+
+var deploymentStatusFn = deploy.Status
 
 var deploymentsCmd = &cobra.Command{
 	Use:   "deployments",
@@ -94,6 +95,12 @@ func listDeploymentDirectories(ctx context.Context) ([]deploymentListEntry, erro
 		return nil, fmt.Errorf("read deployments directory %q: %w", root, err)
 	}
 
+	statusCtx, cancel, err := contextWithStatusTimeout(ctx, defaultStatusTimeoutSeconds)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+
 	entries := make([]deploymentListEntry, 0, len(dirEntries))
 	for _, dirEntry := range dirEntries {
 		if !dirEntry.IsDir() {
@@ -101,8 +108,20 @@ func listDeploymentDirectories(ctx context.Context) ([]deploymentListEntry, erro
 		}
 
 		path := filepath.Join(root, dirEntry.Name())
-		entries = append(entries, deploymentListEntryFor(ctx, dirEntry.Name(), path))
+		entries = append(entries, deploymentListEntry{
+			Name: dirEntry.Name(),
+			Path: path,
+		})
 	}
+
+	var waitGroup sync.WaitGroup
+	for index := range entries {
+		waitGroup.Go(func() {
+			entry := entries[index]
+			entries[index] = deploymentListEntryFor(statusCtx, entry.Name, entry.Path)
+		})
+	}
+	waitGroup.Wait()
 
 	slices.SortFunc(entries, func(a, b deploymentListEntry) int {
 		return cmp.Compare(a.Name, b.Name)
@@ -122,12 +141,7 @@ func deploymentListEntryFor(ctx context.Context, name, path string) deploymentLi
 		Status: deploy.StatusNotInitialized,
 	}
 
-	// deploy.GetStatus with checkConnection=false reads only the persisted
-	// workflow state — no per-directory lock, no DB/VM probe — so it is cheap
-	// enough to call once per listed directory. It already treats a missing
-	// or unreadable state file as StatusNotInitialized, which is exactly the
-	// tolerant fallback this function wants for a malformed entry.
-	status, err := deploy.GetStatus(ctx, config.NewDeploymentDir(path), false)
+	status, err := deploymentStatusFn(ctx, config.NewDeploymentDir(path))
 	if err != nil || status == nil {
 		return entry
 	}

--- a/cmd/exasol/deployments_test.go
+++ b/cmd/exasol/deployments_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/exasol/exasol-personal/internal/config"
 	"github.com/exasol/exasol-personal/internal/deploy"
@@ -112,7 +113,7 @@ func TestListDeploymentDirectories_ReportsUnparseableStateFileAsNotInitialized(t
 }
 
 //nolint:paralleltest // t.Chdir and t.Setenv change process state.
-func TestListDeploymentDirectories_ReportsRunningStatusAndPresetIdentity(t *testing.T) {
+func TestListDeploymentDirectories_ReportsCanonicalStatusAndPresetIdentity(t *testing.T) {
 	home := t.TempDir()
 	setTestHome(t, home)
 	t.Chdir(t.TempDir())
@@ -120,6 +121,17 @@ func TestListDeploymentDirectories_ReportsRunningStatusAndPresetIdentity(t *test
 	runningDir := filepath.Join(deploymentsRoot, "running")
 	mkdirTest(t, runningDir)
 	writeRunningStateWithPresetIdentity(t, runningDir, "name:aws", "name:standard")
+	stubDeploymentStatus(t, func(
+		ctx context.Context,
+		_ config.DeploymentDir,
+	) (*deploy.StatusOutput, error) {
+		deadline, ok := ctx.Deadline()
+		if !ok || time.Until(deadline) > time.Duration(defaultStatusTimeoutSeconds)*time.Second {
+			t.Fatal("expected bounded status context")
+		}
+
+		return &deploy.StatusOutput{Status: deploy.StatusDatabaseReady}, nil
+	})
 
 	entries, err := listDeploymentDirectories(context.Background())
 	if err != nil {
@@ -128,11 +140,91 @@ func TestListDeploymentDirectories_ReportsRunningStatusAndPresetIdentity(t *test
 	if len(entries) != 1 {
 		t.Fatalf("expected a single entry, got: %#v", entries)
 	}
-	if entries[0].Status != deploy.StatusRunning {
-		t.Fatalf("expected status %q, got %#v", deploy.StatusRunning, entries[0])
+	if entries[0].Status != deploy.StatusDatabaseReady {
+		t.Fatalf("expected status %q, got %#v", deploy.StatusDatabaseReady, entries[0])
 	}
 	if entries[0].Infrastructure != "aws" || entries[0].Installation != "standard" {
 		t.Fatalf("expected preset identity to be displayed, got: %#v", entries[0])
+	}
+}
+
+//nolint:paralleltest // t.Chdir, t.Setenv, and deploymentStatusFn change process state.
+func TestListDeploymentDirectories_ResolvesStatusesConcurrently(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+	t.Chdir(t.TempDir())
+	deploymentsRoot := filepath.Join(config.LauncherDirPath(home), "deployments")
+	mkdirTest(t, filepath.Join(deploymentsRoot, "alpha"))
+	mkdirTest(t, filepath.Join(deploymentsRoot, "beta"))
+
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	stubDeploymentStatus(t, func(
+		context.Context,
+		config.DeploymentDir,
+	) (*deploy.StatusOutput, error) {
+		started <- struct{}{}
+		<-release
+
+		return &deploy.StatusOutput{Status: deploy.StatusInitialized}, nil
+	})
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := listDeploymentDirectories(context.Background())
+		result <- err
+	}()
+
+	for range 2 {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			close(release)
+			t.Fatal("expected both status checks to start concurrently")
+		}
+	}
+	close(release)
+
+	if err := <-result; err != nil {
+		t.Fatalf("expected listing to succeed, got: %v", err)
+	}
+}
+
+//nolint:paralleltest // t.Chdir, t.Setenv, and deploymentStatusFn change process state.
+func TestListDeploymentDirectories_StopsWaitingAtParentDeadline(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+	t.Chdir(t.TempDir())
+	deploymentsRoot := filepath.Join(config.LauncherDirPath(home), "deployments")
+	mkdirTest(t, filepath.Join(deploymentsRoot, "alpha"))
+	mkdirTest(t, filepath.Join(deploymentsRoot, "beta"))
+	stubDeploymentStatus(t, func(
+		ctx context.Context,
+		_ config.DeploymentDir,
+	) (*deploy.StatusOutput, error) {
+		<-ctx.Done()
+
+		return nil, ctx.Err()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+
+	entries, err := listDeploymentDirectories(ctx)
+	if err != nil {
+		t.Fatalf("expected listing to tolerate timed-out entries, got: %v", err)
+	}
+	if elapsed := time.Since(started); elapsed >= time.Second {
+		t.Fatalf("expected listing to honor the shared deadline, took %s", elapsed)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected both entries after timeout, got: %#v", entries)
+	}
+	for _, entry := range entries {
+		if entry.Status != deploy.StatusNotInitialized {
+			t.Fatalf("expected timed-out entry fallback, got: %#v", entry)
+		}
 	}
 }
 
@@ -153,6 +245,16 @@ func mkdirTest(t *testing.T, path string) {
 	if err := os.MkdirAll(path, 0o700); err != nil {
 		t.Fatalf("failed to create directory: %v", err)
 	}
+}
+
+func stubDeploymentStatus(
+	t *testing.T,
+	stub func(context.Context, config.DeploymentDir) (*deploy.StatusOutput, error),
+) {
+	t.Helper()
+	original := deploymentStatusFn
+	deploymentStatusFn = stub
+	t.Cleanup(func() { deploymentStatusFn = original })
 }
 
 func writeRunningStateWithPresetIdentity(

--- a/cmd/exasol/status.go
+++ b/cmd/exasol/status.go
@@ -4,16 +4,23 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/exasol/exasol-personal/internal/deploy"
 	"github.com/spf13/cobra"
 )
 
-const statusCmdShortDesc = `Get the status a deployment`
+const statusCmdShortDesc = `Get the status of a deployment`
+
+const (
+	defaultStatusTimeoutSeconds int64 = 5
+	maxStatusTimeoutSeconds           = int64(1<<63-1) / int64(time.Second)
+)
 
 const statusCmdLongDesc = statusCmdShortDesc + `
 
@@ -31,7 +38,8 @@ Display the status of the current deployment.
 `
 
 var statusOpts = struct {
-	unsafe bool
+	unsafe         bool
+	timeoutSeconds int64
 }{}
 
 var statusCmd = &cobra.Command{
@@ -41,16 +49,21 @@ var statusCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cmd.SilenceUsage = true
+		ctx, cancel, err := contextWithStatusTimeout(cmd.Context(), statusOpts.timeoutSeconds)
+		if err != nil {
+			return err
+		}
+		defer cancel()
+
 		deployment := commonFlags.Deployment()
 		var status *deploy.StatusOutput
-		var err error
 
 		if statusOpts.unsafe {
 			slog.Debug("acquiring deployment status without lock")
-			status, err = deploy.StatusUnsafe(cmd.Context(), deployment)
+			status, err = deploy.StatusUnsafe(ctx, deployment)
 		} else {
 			slog.Debug("acquiring deployment status with lock")
-			status, err = deploy.Status(cmd.Context(), deployment)
+			status, err = deploy.Status(ctx, deployment)
 		}
 		if err != nil {
 			return err
@@ -69,6 +82,24 @@ var statusCmd = &cobra.Command{
 
 		return nil
 	},
+}
+
+func contextWithStatusTimeout(
+	parent context.Context,
+	timeoutSeconds int64,
+) (context.Context, context.CancelFunc, error) {
+	if timeoutSeconds <= 0 {
+		return nil, nil, fmt.Errorf("--timeout must be positive, got %d", timeoutSeconds)
+	}
+	if timeoutSeconds > maxStatusTimeoutSeconds {
+		return nil, nil, fmt.Errorf("--timeout is too large, got %d", timeoutSeconds)
+	}
+
+	timeout := time.Duration(timeoutSeconds) * time.Second
+
+	ctx, cancel := context.WithTimeout(parent, timeout)
+
+	return ctx, cancel, nil
 }
 
 func formatStatusJSON(status deploy.StatusOutput) (string, error) {
@@ -95,7 +126,12 @@ func registerStatusFlags() {
 	statusCmd.Flags().BoolVar(
 		&statusOpts.unsafe,
 		"unsafe", false,
-		"Try to read the deployment folder state even it is locked. May fail.",
+		"Try to read the deployment folder state even if it is locked. May fail.",
+	)
+	statusCmd.Flags().Int64Var(
+		&statusOpts.timeoutSeconds,
+		"timeout", defaultStatusTimeoutSeconds,
+		"Maximum number of seconds to wait for the complete status check",
 	)
 }
 

--- a/cmd/exasol/status_test.go
+++ b/cmd/exasol/status_test.go
@@ -5,12 +5,89 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/exasol/exasol-personal/internal/deploy"
 )
+
+func TestStatusCommandRegistersDefaultTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	flag := statusCmd.Flags().Lookup("timeout")
+
+	// Then
+	if flag == nil {
+		t.Fatal("expected status command to register --timeout")
+	}
+	if flag.DefValue != strconv.FormatInt(defaultStatusTimeoutSeconds, 10) {
+		t.Fatalf("expected default timeout %d, got %q", defaultStatusTimeoutSeconds, flag.DefValue)
+	}
+}
+
+func TestContextWithStatusTimeoutUsesSeconds(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	const timeoutSeconds int64 = 1
+
+	// When
+	ctx, cancel, err := contextWithStatusTimeout(context.Background(), timeoutSeconds)
+	if err != nil {
+		t.Fatalf("expected timeout context, got: %v", err)
+	}
+	defer cancel()
+
+	// Then
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		t.Fatal("expected status context to have a deadline")
+	}
+	if remaining := time.Until(deadline); remaining <= 0 || remaining > time.Second {
+		t.Fatalf("expected a one-second deadline, got %s", remaining)
+	}
+}
+
+func TestContextWithStatusTimeoutRejectsNonPositiveSeconds(t *testing.T) {
+	t.Parallel()
+
+	for _, timeoutSeconds := range []int64{0, -1} {
+		// When
+		ctx, cancel, err := contextWithStatusTimeout(context.Background(), timeoutSeconds)
+
+		// Then
+		if err == nil {
+			cancel()
+			t.Fatalf("expected timeout %d to be rejected", timeoutSeconds)
+		}
+		if ctx != nil || cancel != nil {
+			t.Fatalf("expected no context for timeout %d", timeoutSeconds)
+		}
+		if !strings.Contains(err.Error(), "--timeout must be positive") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+}
+
+func TestContextWithStatusTimeoutRejectsOverflow(t *testing.T) {
+	t.Parallel()
+
+	// When
+	ctx, cancel, err := contextWithStatusTimeout(
+		context.Background(),
+		maxStatusTimeoutSeconds+1,
+	)
+
+	// Then
+	if err == nil || ctx != nil || cancel != nil {
+		t.Fatalf("expected oversized timeout to be rejected, got context=%v error=%v", ctx, err)
+	}
+}
 
 func TestFormatStatusText(t *testing.T) {
 	t.Parallel()

--- a/internal/connect/driver_logger.go
+++ b/internal/connect/driver_logger.go
@@ -15,27 +15,31 @@ type discardLogger struct{}
 func (discardLogger) Print(_ ...any)            { /* suppressed */ }
 func (discardLogger) Printf(_ string, _ ...any) { /* suppressed */ }
 
-var loggerMutex sync.Mutex
+var (
+	loggerMutex               sync.Mutex
+	silencedDriverErrorUsers  int
+	originalDriverErrorLogger logger.Logger
+)
 
-// withDriverErrorLogger runs fn with the driver ErrorLogger temporarily replaced.
-// It restores the original logger afterwards. Not safe for concurrent mixed usage;
-// guarded by a mutex.
-func withDriverErrorLogger(temp logger.Logger, callback func() error) error {
+// WithSilencedDriverErrors runs fn with driver errors suppressed.
+func WithSilencedDriverErrors(callback func() error) error { //nolint:revive
 	loggerMutex.Lock()
-	old := logger.ErrorLogger
-	_ = logger.SetLogger(temp)
+	if silencedDriverErrorUsers == 0 {
+		originalDriverErrorLogger = logger.ErrorLogger
+		_ = logger.SetLogger(discardLogger{})
+	}
+	silencedDriverErrorUsers++
 	loggerMutex.Unlock()
 
 	defer func() {
 		loggerMutex.Lock()
-		_ = logger.SetLogger(old)
+		silencedDriverErrorUsers--
+		if silencedDriverErrorUsers == 0 {
+			_ = logger.SetLogger(originalDriverErrorLogger)
+			originalDriverErrorLogger = nil
+		}
 		loggerMutex.Unlock()
 	}()
 
 	return callback()
-}
-
-// WithSilencedDriverErrors runs fn with driver errors suppressed.
-func WithSilencedDriverErrors(fn func() error) error { //nolint:revive
-	return withDriverErrorLogger(discardLogger{}, fn)
 }

--- a/internal/connect/driver_logger_test.go
+++ b/internal/connect/driver_logger_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package connect
+
+import (
+	"testing"
+
+	"github.com/exasol/exasol-driver-go/pkg/logger"
+)
+
+type testDriverLogger struct{}
+
+func (*testDriverLogger) Print(...any)          {}
+func (*testDriverLogger) Printf(string, ...any) {}
+
+//nolint:paralleltest // The test temporarily replaces the process-wide driver logger.
+func TestWithSilencedDriverErrorsRestoresLoggerAfterOverlappingCalls(t *testing.T) {
+	// Given
+	previous := logger.ErrorLogger
+	original := &testDriverLogger{}
+	if err := logger.SetLogger(original); err != nil {
+		t.Fatalf("set test logger: %v", err)
+	}
+	t.Cleanup(func() { _ = logger.SetLogger(previous) })
+
+	firstStarted := make(chan struct{})
+	secondStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	releaseSecond := make(chan struct{})
+	firstDone := make(chan error, 1)
+	secondDone := make(chan error, 1)
+
+	// When
+	go func() {
+		firstDone <- WithSilencedDriverErrors(func() error {
+			close(firstStarted)
+			<-releaseFirst
+
+			return nil
+		})
+	}()
+	<-firstStarted
+	go func() {
+		secondDone <- WithSilencedDriverErrors(func() error {
+			close(secondStarted)
+			<-releaseSecond
+
+			return nil
+		})
+	}()
+	<-secondStarted
+	close(releaseFirst)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first callback failed: %v", err)
+	}
+
+	// Then the logger remains silenced until the overlapping call finishes.
+	if logger.ErrorLogger == original {
+		t.Fatal("expected driver errors to remain silenced")
+	}
+	close(releaseSecond)
+	if err := <-secondDone; err != nil {
+		t.Fatalf("second callback failed: %v", err)
+	}
+	if logger.ErrorLogger != original {
+		t.Fatal("expected original driver logger to be restored")
+	}
+}

--- a/openspec/changes/archive/2026-09-02-bound-status-duration/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-02-bound-status-duration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-02

--- a/openspec/changes/archive/2026-09-02-bound-status-duration/design.md
+++ b/openspec/changes/archive/2026-09-02-bound-status-duration/design.md
@@ -1,0 +1,27 @@
+## Context
+
+The status command passes its unbounded command context through deployment locking, local runtime inspection, and the database readiness probe. The database connection honors context cancellation, but the command currently supplies no deadline.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Bound the complete status operation by default.
+- Let callers select a different positive number of seconds.
+- Reuse Go context cancellation and Cobra integer parsing.
+
+**Non-Goals:**
+
+- Changing status values or database readiness semantics.
+- Changing timeouts for other commands.
+
+## Decisions
+
+Register a `--timeout` integer flag with a five-second default. Validate that the number of seconds is positive and representable as a Go duration, derive a timeout context from the command context, and pass it to the existing safe or unsafe status path. Applying the deadline at the command boundary covers lock acquisition, runtime inspection, and database probing without adding timeout handling to each layer.
+
+The option remains command-specific instead of reusing the interactive connection timeout because a quick observational command has a different latency contract.
+
+## Risks / Trade-offs
+
+- [A healthy but slow deployment exceeds five seconds] -> Callers can increase `--timeout`.
+- [A dependency does not honor context cancellation] -> Existing database and process boundaries already consume the context; tests verify the command-level bound where practical.

--- a/openspec/changes/archive/2026-09-02-bound-status-duration/proposal.md
+++ b/openspec/changes/archive/2026-09-02-bound-status-duration/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+`exasol status` can wait indefinitely while acquiring the deployment lock or probing an unreachable database, preventing callers from reliably completing status checks.
+
+## What Changes
+
+- Bound `exasol status` to five seconds by default.
+- Add a `--timeout` seconds option so callers can choose another positive bound.
+- Report invalid timeout values without starting a status check.
+
+## Capabilities
+
+### New Capabilities
+
+- `deployment-status-timeout`: Defines bounded status checks and caller-configurable timeout behavior.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+This changes the `exasol status` CLI contract and its tests, help text, and changelog entry. It adds no dependency and does not change other commands.

--- a/openspec/changes/archive/2026-09-02-bound-status-duration/specs/deployment-status-timeout/spec.md
+++ b/openspec/changes/archive/2026-09-02-bound-status-duration/specs/deployment-status-timeout/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Deployment status checks are time-bounded
+`exasol status` SHALL apply a five-second timeout to the complete status operation by default and SHALL allow users to select another positive integer number of seconds with `--timeout`.
+
+#### Scenario: Default timeout bounds a status check
+- **WHEN** a user runs `exasol status` without `--timeout`
+- **AND** the status operation does not complete within five seconds
+- **THEN** the command stops waiting
+
+#### Scenario: Explicit timeout bounds a status check
+- **WHEN** a user runs `exasol status --timeout <seconds>` with a positive integer
+- **AND** the status operation does not complete within that number of seconds
+- **THEN** the command stops waiting at the selected bound
+
+#### Scenario: Non-positive timeout is rejected
+- **WHEN** a user runs `exasol status --timeout <seconds>` with a zero or negative integer
+- **THEN** the command reports that the timeout must be positive without starting the status operation

--- a/openspec/changes/archive/2026-09-02-bound-status-duration/tasks.md
+++ b/openspec/changes/archive/2026-09-02-bound-status-duration/tasks.md
@@ -1,0 +1,8 @@
+## 1. Status timeout
+
+- [x] 1.1 Add the positive `--timeout` seconds option with a five-second default and apply it to the complete status operation.
+
+## 2. Verification and documentation
+
+- [x] 2.1 Add focused tests for the default, explicit, non-positive, and oversized timeout behavior.
+- [x] 2.2 Document the bounded status behavior in the changelog and verify formatting, linting, tests, and build.

--- a/openspec/changes/archive/2026-09-02-report-live-deployment-status/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-02-report-live-deployment-status/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-02

--- a/openspec/changes/archive/2026-09-02-report-live-deployment-status/design.md
+++ b/openspec/changes/archive/2026-09-02-report-live-deployment-status/design.md
@@ -1,0 +1,31 @@
+## Context
+
+The listing currently calls the persisted-state-only status path serially. The parent #311 change bounds the canonical status command to five seconds, but library callers must still provide their own deadline.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Reuse canonical deployment status resolution.
+- Bound the complete set of status probes to five seconds.
+- Preserve deterministic output and tolerant directory handling.
+
+**Non-Goals:**
+
+- Changing canonical status semantics, including database identity verification tracked by #309.
+- Adding listing-specific timeout configuration.
+
+## Decisions
+
+Derive one five-second context using the timeout defined by the status command and pass it to every deployment status call. Resolve statuses concurrently with one standard-library goroutine per deployment, writing results to distinct slice indexes before sorting. This keeps total latency bounded without a worker-pool abstraction for the small number of launcher-managed deployments expected per workstation.
+
+Call `deploy.Status` rather than the persisted-state-only `deploy.GetStatus` path so each list entry reports the same value as an individual `exasol status` invocation. Preserve the existing per-entry fallback to `not_initialized` when status or preset metadata cannot be read.
+
+Replace the database driver's nested save-and-restore logger swaps with reference-counted suppression. The first overlapping probe saves the original logger and installs the discard logger; only the last probe restores the original. Holding the mutex for the full probe was rejected because it would serialize the network operations this change needs to run concurrently.
+
+## Risks / Trade-offs
+
+- [Many deployment directories create many short-lived goroutines] -> Add a worker limit only if real deployment counts make this measurable.
+- [Concurrent probes restore a process-global driver logger out of order] -> Reference-count overlapping suppression and restore only after the last probe.
+- [Canonical status can identify the wrong database on a reused port] -> #309 remains responsible for database identity verification.
+- [A timed-out or malformed entry falls back to `not_initialized`] -> Preserve current tolerant behavior so one broken directory cannot fail the complete listing.

--- a/openspec/changes/archive/2026-09-02-report-live-deployment-status/proposal.md
+++ b/openspec/changes/archive/2026-09-02-report-live-deployment-status/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+`exasol deployments list` reports persisted workflow state as status, so stopped or unreachable deployments can be presented as running. This makes the JSON output unsafe for clients that use it to select a deployment.
+
+## What Changes
+
+- Report the same live status that `exasol status` reports for each deployment.
+- Check deployments concurrently under one five-second bound so listing latency does not grow with the number of deployments.
+- Keep the database driver's temporary error suppression correct while status probes overlap.
+- Preserve alphabetical output and tolerant handling of malformed deployment directories.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `deployment-directory-listing`: Require live, bounded, concurrent status resolution for listed deployments.
+
+## Impact
+
+This changes `exasol deployments list` status values, status-probe logging synchronization, tests, user documentation, and changelog. It relies on the bounded status behavior introduced for #311 and adds no dependency.

--- a/openspec/changes/archive/2026-09-02-report-live-deployment-status/specs/deployment-directory-listing/spec.md
+++ b/openspec/changes/archive/2026-09-02-report-live-deployment-status/specs/deployment-directory-listing/spec.md
@@ -1,37 +1,4 @@
-# deployment-directory-listing Specification
-
-## Purpose
-Define how `exasol deployments list` enumerates known deployment directories and reports their deployment status and preset identity, so users can discover and manage multiple named deployment directories.
-## Requirements
-### Requirement: CLI SHALL list known deployment directories
-`exasol deployments list` SHALL enumerate the deployment directories under `~/.exasol/personal/deployments/`, including the default deployment directory and every named deployment directory.
-
-#### Scenario: Listing shows the default deployment directory
-- **WHEN** a user runs `exasol deployments list`
-- **AND** `~/.exasol/personal/deployments/default` exists
-- **THEN** the output includes an entry for `default` with its resolved path
-
-#### Scenario: Listing shows named deployment directories
-- **WHEN** a user runs `exasol deployments list`
-- **AND** one or more named deployment directories exist under `~/.exasol/personal/deployments/`
-- **THEN** the output includes one entry per named deployment directory, with its name and resolved path
-
-#### Scenario: Listing is empty when no deployment directories exist
-- **WHEN** a user runs `exasol deployments list`
-- **AND** `~/.exasol/personal/deployments/` does not exist or contains no deployment directories
-- **THEN** the command succeeds
-- **AND** the output indicates that no deployment directories exist
-
-#### Scenario: Non-directory entries are ignored
-- **WHEN** a user runs `exasol deployments list`
-- **AND** `~/.exasol/personal/deployments/` contains a non-directory entry (a file or symlink)
-- **THEN** the output does not include an entry for it
-- **AND** the command does not fail because of it
-
-#### Scenario: Listing is sorted alphabetically by name
-- **WHEN** a user runs `exasol deployments list`
-- **AND** more than one deployment directory exists under `~/.exasol/personal/deployments/`
-- **THEN** the entries appear in alphabetical order by name, regardless of filesystem iteration order
+## MODIFIED Requirements
 
 ### Requirement: Listing SHALL report deployment status and preset identity
 For each listed deployment directory, `exasol deployments list` SHALL report the same current status as `exasol status`, and when that status is not `not_initialized`, its infrastructure and installation preset identity. The command SHALL resolve deployment statuses concurrently under one five-second bound.
@@ -82,11 +49,3 @@ For each listed deployment directory, `exasol deployments list` SHALL report the
 - **AND** a listed deployment directory's status is not `not_initialized` but its preset identity is not yet persisted in its state file
 - **THEN** that entry reports a derived preset identity
 - **AND** the deployment directory's state file is not modified as a result of running `exasol deployments list`
-
-### Requirement: Listing SHALL support JSON output
-`exasol deployments list` SHALL support a `--json` flag that emits the same information as structured JSON instead of human-readable text.
-
-#### Scenario: JSON output includes all listed fields
-- **WHEN** a user runs `exasol deployments list --json`
-- **THEN** stdout is valid JSON
-- **AND** each entry includes name, path, status, and preset identity when the status is not `not_initialized`

--- a/openspec/changes/archive/2026-09-02-report-live-deployment-status/tasks.md
+++ b/openspec/changes/archive/2026-09-02-report-live-deployment-status/tasks.md
@@ -1,0 +1,9 @@
+## 1. Live bounded status listing
+
+- [x] 1.1 Make overlapping database-probe error suppression restore the original driver logger after the last probe.
+- [x] 1.2 Resolve each listed deployment through canonical status under one concurrent five-second bound.
+
+## 2. Verification and documentation
+
+- [x] 2.1 Test concurrent logger restoration, canonical status values, concurrent resolution, timeout behavior, ordering, and tolerant fallbacks.
+- [x] 2.2 Update user documentation and the changelog, then verify OpenSpec, formatting, linting, tests, and build.

--- a/openspec/specs/deployment-status-timeout/spec.md
+++ b/openspec/specs/deployment-status-timeout/spec.md
@@ -1,0 +1,21 @@
+# deployment-status-timeout Specification
+
+## Purpose
+Ensure `exasol status` completes in bounded time by applying a default timeout and allowing callers to configure it.
+## Requirements
+### Requirement: Deployment status checks are time-bounded
+`exasol status` SHALL apply a five-second timeout to the complete status operation by default and SHALL allow users to select another positive integer number of seconds with `--timeout`.
+
+#### Scenario: Default timeout bounds a status check
+- **WHEN** a user runs `exasol status` without `--timeout`
+- **AND** the status operation does not complete within five seconds
+- **THEN** the command stops waiting
+
+#### Scenario: Explicit timeout bounds a status check
+- **WHEN** a user runs `exasol status --timeout <seconds>` with a positive integer
+- **AND** the status operation does not complete within that number of seconds
+- **THEN** the command stops waiting at the selected bound
+
+#### Scenario: Non-positive timeout is rejected
+- **WHEN** a user runs `exasol status --timeout <seconds>` with a zero or negative integer
+- **THEN** the command reports that the timeout must be positive without starting the status operation

--- a/tests/tests/integration/test_deployments_list.py
+++ b/tests/tests/integration/test_deployments_list.py
@@ -95,12 +95,10 @@ def _set_workflow_state(
     launcher_state_path.write_text(json.dumps(state))
 
 
-def test_deployments_list_reports_running_status_for_deployed_deployment(
+def test_deployments_list_reports_same_status_as_status_command(
     exasol_path: str, tmp_path: Path
 ) -> None:
-    # Given a named deployment that has been initialized and is now running
-    # (simulated by writing the running workflow state directly, the same
-    # approach test_reconfiguration.py uses to avoid a real deploy)
+    # Given a named deployment whose persisted workflow state is running
     home = tmp_path / "home"
     home.mkdir()
     infra_id = first_infrastructure_preset_id_or_skip(exasol_path)
@@ -118,6 +116,13 @@ def test_deployments_list_reports_running_status_for_deployed_deployment(
         env=_env_with_home(home),
     )
     _set_workflow_state(named_dir, {"running": {}})
+    status_result = subprocess.run(
+        [launcher, "status", "--deployment", "staging", "--json"],
+        env=_env_with_home(home),
+        capture_output=True,
+        text=True,
+        check=True,
+    )
 
     # When deployments list is invoked with --json
     result = subprocess.run(
@@ -128,10 +133,10 @@ def test_deployments_list_reports_running_status_for_deployed_deployment(
         check=True,
     )
 
-    # Then the entry reports status "running" and keeps its preset identity
+    # Then the entry reports the canonical status and keeps its preset identity
     entries = json.loads(result.stdout)
     staging = next(entry for entry in entries if entry["name"] == "staging")
-    assert staging["status"] == "running"
+    assert staging["status"] == json.loads(status_result.stdout)["status"]
     assert staging["infrastructure"]
     assert staging["installation"]
     assert "active" not in staging


### PR DESCRIPTION
## Description

This PR enables `exasol deployment list` to fetch the actual status of a deployment instead of relying on the persisted status field. It requires #322 

## Related Issue
Fixes #310 

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

<!-- List the key changes in this PR -->

- Make `exasol deployments list` report the same live status as `exasol status`
- Check all deployments concurrently under one shared five second timeout
- Make overlapping database probes restore the global driver logger safely

## Testing

<!-- Describe how you tested your changes -->

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

<!-- Describe your testing approach -->

## Checklist

<!-- Mark completed items with an "x" -->

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

<!-- Any additional information, screenshots, or context -->
