### PR TITLE
fix: Bound local database readiness wait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,8 @@ Notable user-facing changes to Exasol Personal are documented here.
 
 ### Fixed
 
+- Fixed local install and start operations to fail within 30 seconds when the database does not accept connections, retaining the latest connection failure and applicable reachability guidance.
+
 - Fixed the personal installer script so it remains compatible with POSIX shell environments.
 
 - Fixed `exasol connect` so `CREATE SCRIPT` / `CREATE FUNCTION` definitions terminate on a line containing only `/` (the EXAplus rule) instead of the first `;`. UDF bodies that contain semicolons (for example Java and R) now parse and run correctly through `-c`, `-f`, and interactive input.

--- a/internal/deploy/local_runtime.go
+++ b/internal/deploy/local_runtime.go
@@ -255,9 +255,7 @@ func writeLocalRuntimeArtifactsAndWait(
 		return nil
 	}
 
-	if waitTimeoutSeconds <= 0 {
-		waitTimeoutSeconds = LocalDatabaseStartedDefaultTimeoutSeconds
-	}
+	waitTimeoutSeconds = boundedLocalDatabaseStartedTimeout(waitTimeoutSeconds)
 
 	return waitForLocalDatabaseAndSync(
 		ctx,
@@ -267,6 +265,14 @@ func writeLocalRuntimeArtifactsAndWait(
 		outErr,
 		WaitForLocalDatabaseStarted,
 	)
+}
+
+func boundedLocalDatabaseStartedTimeout(waitTimeoutSeconds int) int {
+	if waitTimeoutSeconds <= 0 || waitTimeoutSeconds > LocalDatabaseStartedDefaultTimeoutSeconds {
+		return LocalDatabaseStartedDefaultTimeoutSeconds
+	}
+
+	return waitTimeoutSeconds
 }
 
 func waitForLocalDatabaseAndSync(

--- a/internal/deploy/local_runtime_test.go
+++ b/internal/deploy/local_runtime_test.go
@@ -480,6 +480,7 @@ type endpointRuntimeStub struct {
 	syncOutErr        io.Writer
 	healthResult      *localruntime.HealthCheckResult
 	healthCalls       int
+	honorContext      bool
 	hostShellErr      error
 	containerShellErr error
 }
@@ -513,7 +514,13 @@ func (*endpointRuntimeStub) Stop(context.Context, io.Writer, io.Writer) error {
 	return nil
 }
 
-func (*endpointRuntimeStub) Status(context.Context) (*localruntime.RuntimeStatus, error) {
+func (runtime *endpointRuntimeStub) Status(
+	ctx context.Context,
+) (*localruntime.RuntimeStatus, error) {
+	if runtime.honorContext && ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
 	return &localruntime.RuntimeStatus{Running: true}, nil
 }
 
@@ -537,8 +544,12 @@ func (runtime *endpointRuntimeStub) ReadEndpoints() (*localruntime.VMRuntimeEndp
 }
 
 func (runtime *endpointRuntimeStub) HealthCheck(
-	context.Context,
+	ctx context.Context,
 ) (*localruntime.HealthCheckResult, error) {
+	if runtime.honorContext && ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
 	runtime.healthCalls++
 	if runtime.healthResult != nil {
 		return runtime.healthResult, nil

--- a/internal/deploy/ready.go
+++ b/internal/deploy/ready.go
@@ -85,36 +85,41 @@ func WaitForDatabaseStarted(
 	)
 }
 
-// localReachabilityRecheckDelay absorbs a transient container-startup race
-// in which the runtime's port forwarder is briefly in an ambiguous state
-// (accepts SYN but has no listener behind it yet) and returns errors that
-// classifyHostPortHealth cannot map to "refused" on Windows.
-const localReachabilityRecheckDelay = 3 * time.Second
-
 func WaitForLocalDatabaseStarted(ctx context.Context, runtime localruntime.Runtime) error {
-	// Fail fast on a *persistently* blocked network path instead of waiting
-	// out the whole backoff window. A single classification failure is not
-	// enough: container startup can transiently look blocked before the
-	// forwarder settles. Re-check once after a short delay before giving up.
-	if err := classifyLocalReachability(ctx, runtime); err != nil {
-		slog.Debug("initial local reachability check reported network blocked; retrying",
-			"error", err, "retryAfter", localReachabilityRecheckDelay)
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(localReachabilityRecheckDelay):
-		}
-		if err := classifyLocalReachability(ctx, runtime); err != nil {
-			return err
-		}
-	}
+	waitCtx, cancel := localReadinessPollingContext(ctx)
+	defer cancel()
 
-	return waitForDatabaseStartedWithBackoff(
-		ctx,
+	err := waitForDatabaseStartedWithBackoff(
+		waitCtx,
 		runtime.Deployment(),
 		LocalDatabaseStartedInitialBackoff,
 		LocalDatabaseStartedMaxBackoff,
 	)
+	if err != nil {
+		diagnosisCtx, cancel := context.WithTimeout(ctx, localReadinessDiagnosisWindow)
+		defer cancel()
+
+		return diagnoseLocalFailure(diagnosisCtx, runtime, err)
+	}
+
+	return nil
+}
+
+const (
+	localReadinessDiagnosisWindow        = 2 * time.Second
+	localReadinessDiagnosisWindowDivisor = 2
+)
+
+func localReadinessPollingContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return ctx, func() {}
+	}
+
+	remaining := time.Until(deadline)
+	reserved := min(localReadinessDiagnosisWindow, remaining/localReadinessDiagnosisWindowDivisor)
+
+	return context.WithTimeout(ctx, remaining-reserved)
 }
 
 func waitForDatabaseStartedWithBackoff(

--- a/internal/deploy/ready_test.go
+++ b/internal/deploy/ready_test.go
@@ -1,0 +1,132 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/localruntime"
+)
+
+func withFakeDatabaseConnectionVerification(
+	t *testing.T,
+	verify func(context.Context, config.DeploymentDir) error,
+) {
+	t.Helper()
+
+	original := verifyDatabaseConnectionFn
+	verifyDatabaseConnectionFn = verify
+	t.Cleanup(func() {
+		verifyDatabaseConnectionFn = original
+	})
+}
+
+//nolint:paralleltest // Mutates package-level verifyDatabaseConnectionFn.
+func TestWaitForDatabaseStartedKeepsCloudReadinessPolicy(t *testing.T) {
+	// Given
+	withFakeDatabaseConnectionVerification(t, func(context.Context, config.DeploymentDir) error {
+		return nil
+	})
+
+	// When
+	err := WaitForDatabaseStarted(context.Background(), config.NewDeploymentDir(t.TempDir()))
+	// Then
+	if err != nil {
+		t.Fatalf("expected cloud readiness to succeed immediately, got %v", err)
+	}
+	if StartedInitialBackoff != 10 || StartedMaxBackoff != 60 ||
+		StartedDefaultTimeoutSeconds != 30*60 {
+		t.Fatalf(
+			"cloud readiness policy changed: initial=%d max=%d timeout=%d",
+			StartedInitialBackoff,
+			StartedMaxBackoff,
+			StartedDefaultTimeoutSeconds,
+		)
+	}
+}
+
+func TestBoundedLocalDatabaseStartedTimeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		requested int
+		want      int
+	}{
+		{name: "default", requested: 0, want: 30},
+		{name: "shorter caller timeout", requested: 15, want: 15},
+		{name: "longer caller timeout", requested: 60, want: 30},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			// When
+			got := boundedLocalDatabaseStartedTimeout(test.requested)
+
+			// Then
+			if got != test.want {
+				t.Fatalf("expected timeout %d, got %d", test.want, got)
+			}
+		})
+	}
+}
+
+//nolint:paralleltest // Mutates package-level verifyDatabaseConnectionFn.
+func TestWaitForLocalDatabaseStartedPreservesConnectionFailureWithGuidance(t *testing.T) {
+	// Given
+	connectionErr := errors.New("database connection refused")
+	withFakeDatabaseConnectionVerification(t, func(context.Context, config.DeploymentDir) error {
+		return connectionErr
+	})
+	runtime := &endpointRuntimeStub{
+		deployment: newLocalTestDeployment(t),
+		healthResult: &localruntime.HealthCheckResult{Ports: map[string]localruntime.PortHealth{
+			"db": {State: localruntime.PortStateBlocked},
+		}},
+		honorContext: true,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	// When
+	err := WaitForLocalDatabaseStarted(ctx, runtime)
+
+	// Then
+	if !errors.Is(err, connectionErr) {
+		t.Fatalf("expected the last connection failure, got %v", err)
+	}
+	if !errors.Is(err, ErrLocalReachability) {
+		t.Fatalf("expected local reachability guidance, got %v", err)
+	}
+}
+
+//nolint:paralleltest // Mutates package-level verifyDatabaseConnectionFn.
+func TestWaitForLocalDatabaseStartedSucceedsWithoutExtraDelay(t *testing.T) {
+	// Given
+	withFakeDatabaseConnectionVerification(t, func(context.Context, config.DeploymentDir) error {
+		return nil
+	})
+	runtime := &endpointRuntimeStub{deployment: newLocalTestDeployment(t)}
+
+	// When
+	err := WaitForLocalDatabaseStarted(context.Background(), runtime)
+	// Then
+	if err != nil {
+		t.Fatalf("expected an immediately ready local database to succeed, got %v", err)
+	}
+	if LocalDatabaseStartedInitialBackoff != 1 || LocalDatabaseStartedMaxBackoff != 2 ||
+		LocalDatabaseStartedDefaultTimeoutSeconds != 30 {
+		t.Fatalf(
+			"unexpected local readiness policy: initial=%d max=%d timeout=%d",
+			LocalDatabaseStartedInitialBackoff,
+			LocalDatabaseStartedMaxBackoff,
+			LocalDatabaseStartedDefaultTimeoutSeconds,
+		)
+	}
+}

--- a/internal/deploy/shared.go
+++ b/internal/deploy/shared.go
@@ -82,13 +82,13 @@ const (
 	InstanceRefreshTimeoutMinutes      = 5
 	StartedDefaultTimeoutSeconds       = StartedDefaultTimeoutInMinutes * 60
 	InstanceRefreshTimeoutSeconds      = InstanceRefreshTimeoutMinutes * 60
-	LocalDatabaseStartedInitialBackoff = 2
-	LocalDatabaseStartedMaxBackoff     = 8
+	LocalDatabaseStartedInitialBackoff = 1
+	LocalDatabaseStartedMaxBackoff     = 2
 	StartedInitialBackoff              = 10
 	StartedMaxBackoff                  = 60
-	// LocalDatabaseStartedDefaultTimeoutSeconds is shorter than the cloud
-	// default since a local VM boots in seconds, not minutes.
-	LocalDatabaseStartedDefaultTimeoutSeconds = 5 * 60
+	// LocalDatabaseStartedDefaultTimeoutSeconds bounds local startup because
+	// a healthy local database accepts connections within seconds.
+	LocalDatabaseStartedDefaultTimeoutSeconds = 30
 )
 
 func Getn11Details(deployment config.DeploymentDir) (*config.SSHDetails, error) {

--- a/openspec/changes/archive/2026-09-02-bound-local-readiness-wait/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-02-bound-local-readiness-wait/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-02

--- a/openspec/changes/archive/2026-09-02-bound-local-readiness-wait/design.md
+++ b/openspec/changes/archive/2026-09-02-bound-local-readiness-wait/design.md
@@ -1,0 +1,37 @@
+## Context
+
+Local lifecycle operations share generic database polling with cloud workflows, but local startup uses a five-minute timeout and a 2/4/8-second backoff. Local runtime reachability classification already provides actionable guidance and can preserve a causal error. Cloud readiness has a separate operational profile and must remain unchanged.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make unsuccessful local install and start operations finish within 30 seconds.
+- Preserve the last database connection error when local reachability guidance applies.
+- Keep successful local startup and cloud readiness behavior intact.
+
+**Non-Goals:**
+
+- Change cloud timeouts, backoff policy, or lifecycle command options.
+- Add new diagnostics or alter local network-block classification.
+- Change runtime startup, endpoint publication, or durability synchronization.
+
+## Decisions
+
+- Give local readiness its own 1/2-second polling values and a 30-second upper bound. The generic polling helper remains shared, while local settings express the materially faster local startup expectation.
+- Enforce the local upper bound after the local backend receives its timeout. This covers install, default start, and an explicit `--wait-timeout-minutes` value without narrowing the cloud command's configurable timeout.
+- Diagnose an unsuccessful local readiness wait with the existing reachability classifier. Its error wrapper retains the last connection failure and adds guidance only when the runtime reports a network-wide reachability condition. Replacing the connection failure with guidance would hide the actionable underlying cause.
+
+## Risks / Trade-offs
+
+- [Slow but ultimately healthy local environments can exceed 30 seconds] → The bounded wait favors prompt recovery; users can retry after investigating the reported cause.
+- [Reachability health can be temporarily ambiguous during container startup] → Keep the existing classifier's conservative checks and only add its guidance when it recognizes the condition.
+- [Shared lifecycle code could accidentally alter cloud behavior] → Keep cloud constants and timeout handling unchanged, with regression coverage for local-only policy.
+
+## Migration Plan
+
+No data or configuration migration is needed. A released launcher applies the shorter bound to future local install and start operations; rollback restores the prior launcher behavior.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-09-02-bound-local-readiness-wait/proposal.md
+++ b/openspec/changes/archive/2026-09-02-bound-local-readiness-wait/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Local install and start can wait five minutes after unsuccessful database connection attempts, although a healthy local database normally becomes ready within seconds. This delays failure recovery and can conceal reachability problems as a stuck deployment.
+
+## What Changes
+
+- Limit local database readiness waits for install and start to 30 seconds.
+- Poll local database readiness every one to two seconds while it is starting.
+- Retain the final database connection failure and add existing local reachability guidance when the failure is recognized as a network-wide local problem.
+- Keep cloud deployment readiness timing unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `exasol-local-deployment`: Bound local install and start readiness behavior and failure reporting.
+
+## Impact
+
+The local deployment workflow, readiness polling, and their Go tests change. The CLI's cloud lifecycle behavior and external dependencies remain unchanged.

--- a/openspec/changes/archive/2026-09-02-bound-local-readiness-wait/specs/exasol-local-deployment/spec.md
+++ b/openspec/changes/archive/2026-09-02-bound-local-readiness-wait/specs/exasol-local-deployment/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Local readiness wait is short and diagnostic
+The system SHALL check local database readiness every one to two seconds and SHALL fail a local install or start operation within 30 seconds when the database does not accept connections. When the local runtime identifies a network-wide reachability problem, the failure SHALL retain the most recent database connection error and include the runtime's actionable reachability guidance.
+
+#### Scenario: Local database becomes ready
+- **WHEN** a local database accepts connections during install or start
+- **THEN** the launcher completes startup without an unnecessary readiness delay
+
+#### Scenario: Local database does not become ready
+- **WHEN** a local database does not accept connections during install or start
+- **THEN** the launcher fails the operation within 30 seconds and reports the most recent connection failure
+
+#### Scenario: Local network path is blocked
+- **WHEN** a local readiness wait ends and the runtime identifies a network-wide reachability problem
+- **THEN** the launcher reports actionable reachability guidance together with the most recent connection failure
+
+#### Scenario: Cloud database readiness is unchanged
+- **WHEN** a cloud deployment waits for its database to accept connections
+- **THEN** the launcher continues to use the cloud readiness timing behavior

--- a/openspec/changes/archive/2026-09-02-bound-local-readiness-wait/tasks.md
+++ b/openspec/changes/archive/2026-09-02-bound-local-readiness-wait/tasks.md
@@ -1,0 +1,13 @@
+## 1. Local readiness policy
+
+- [x] 1.1 Set the local readiness timeout and polling interval to the bounded local policy.
+- [x] 1.2 Apply the local timeout ceiling to install and start without changing cloud timeout behavior.
+
+## 2. Failure reporting
+
+- [x] 2.1 Preserve the final local database connection failure when adding recognized reachability guidance.
+
+## 3. Validation
+
+- [x] 3.1 Add focused Go tests for local timing policy, preserved causes, and unchanged cloud behavior.
+- [x] 3.2 Run the relevant unit tests, formatting, linting, and build checks.

--- a/openspec/specs/exasol-local-deployment/spec.md
+++ b/openspec/specs/exasol-local-deployment/spec.md
@@ -270,7 +270,3 @@ The system SHALL check local database readiness every one to two seconds and SHA
 - **WHEN** a local readiness wait ends and the runtime identifies a network-wide reachability problem
 - **THEN** the launcher reports actionable reachability guidance together with the most recent connection failure
 
-#### Scenario: Cloud database readiness is unchanged
-- **WHEN** a cloud deployment waits for its database to accept connections
-- **THEN** the launcher continues to use the cloud readiness timing behavior
-

--- a/openspec/specs/exasol-local-deployment/spec.md
+++ b/openspec/specs/exasol-local-deployment/spec.md
@@ -254,3 +254,23 @@ The system SHALL synchronize local runtime storage on Linux and macOS after prep
 
 - **WHEN** either startup synchronization fails
 - **THEN** the launcher fails startup without automatically repairing or resetting the Podman store
+
+### Requirement: Local readiness wait is short and diagnostic
+The system SHALL check local database readiness every one to two seconds and SHALL fail a local install or start operation within 30 seconds when the database does not accept connections. When the local runtime identifies a network-wide reachability problem, the failure SHALL retain the most recent database connection error and include the runtime's actionable reachability guidance.
+
+#### Scenario: Local database becomes ready
+- **WHEN** a local database accepts connections during install or start
+- **THEN** the launcher completes startup without an unnecessary readiness delay
+
+#### Scenario: Local database does not become ready
+- **WHEN** a local database does not accept connections during install or start
+- **THEN** the launcher fails the operation within 30 seconds and reports the most recent connection failure
+
+#### Scenario: Local network path is blocked
+- **WHEN** a local readiness wait ends and the runtime identifies a network-wide reachability problem
+- **THEN** the launcher reports actionable reachability guidance together with the most recent connection failure
+
+#### Scenario: Cloud database readiness is unchanged
+- **WHEN** a cloud deployment waits for its database to accept connections
+- **THEN** the launcher continues to use the cloud readiness timing behavior
+


### PR DESCRIPTION
## Description

Bounds local database readiness waits to 30 seconds, retries every one to two seconds, and preserves the final connection failure when reachability guidance applies. Cloud readiness behavior is unchanged.

## Related Issue

[SPOT-32433](https://exasol.atlassian.net/browse/SPOT-32433)

## Type of Change

- [x] `fix`: Bug fix

## Changes Made

- Bound local install and start readiness waits to 30 seconds.
- Reduced local readiness polling to a one or two second interval.
- Preserved database connection failures with recognized local reachability guidance.

## Testing

- [x] All Go unit tests pass (`task tests-unit`)
- [x] Added new tests for the readiness policy and error behavior
- [x] Ran `task fmt` and `task build`

## Additional Notes

Cloud database readiness timing is unchanged.

[SPOT-32433]: https://exasol.atlassian.net/browse/SPOT-32433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ