### PR TITLE
feat(cli): Show preset-specific help for the selected presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ Notable user-facing changes to Exasol Personal are documented here.
 - Custom SLC language identifiers are no longer limited to Python, Java, and R. The launcher now
   accepts any valid client-defined identifier, such as `rust`, for a custom SLC.
 
+- `exasol install <preset> --help` and `exasol init <preset> --help` now describe the selected preset instead of every built-in preset. The help shows the preset's description, the installation presets compatible with it, and usage and examples for that preset; selecting an installation preset as well describes both. Without a preset argument, `exasol install --help` and `exasol init --help` keep the full preset overview and compatibility matrix.
+
+  Example: `exasol install local --help` reports "Infrastructure preset `local`" with `Compatible installation presets: local`, and suggests `exasol install local local`.
+
 - Documented named deployments, the `exasol slc` command group, and `exasol diag local` in the README, and made clear which features apply to local versus cloud deployments. Named deployments now have their own README section (they apply to both deployment types, not just cloud), a new section covers UDFs and script language containers, and the Limitations section no longer states that UDFs are unavailable on local deployments.
 - macOS local deployments now run the same Podman installation used on Linux inside a managed VM. The VM launcher is responsible only for VM lifecycle, port forwarding, shared files, and command execution; deployment state no longer exposes its SSH transport.
 - Local runtime host preparation now runs before a deployment records an operation in progress, so a declined or failed prerequisite leaves the deployment in its previous state and the command can simply be retried.

--- a/cmd/exasol/infra_variables.go
+++ b/cmd/exasol/infra_variables.go
@@ -270,9 +270,9 @@ func collectInfrastructureVariableOverrides(cmd *cobra.Command) map[string]strin
 	return overrides
 }
 
-func scanInfrastructurePresetSelection(
-	ctx context.Context, args []string,
-) (*deploy.PresetRef, error) {
+// scanPresetPositionals returns the positional arguments of the pre-registered command when
+// that command takes preset arguments.
+func scanPresetPositionals(args []string) ([]string, error) {
 	// Handle "exasol help init local" form: strip the leading "help" token so the
 	// preset scanner finds the actual command. Cobra registers its help subcommand
 	// lazily inside ExecuteC, so rootCmd.Find won't resolve it at this point.
@@ -281,10 +281,16 @@ func scanInfrastructurePresetSelection(
 	}
 	cmd, remainingArgs := preregisteredCommand(args)
 	if cmd != initCmd && cmd != installCmd {
-		return nil, errors.New("no command with infrastructure preset argument found")
+		return nil, errors.New("no command with preset arguments found")
 	}
 
-	positionals, err := preregisteredPositionals(cmd, remainingArgs)
+	return preregisteredPositionals(cmd, remainingArgs)
+}
+
+func scanInfrastructurePresetSelection(
+	ctx context.Context, args []string,
+) (*deploy.PresetRef, error) {
+	positionals, err := scanPresetPositionals(args)
 	if err != nil {
 		return nil, err
 	}
@@ -294,7 +300,7 @@ func scanInfrastructurePresetSelection(
 	}
 
 	ref, err := resolvePresetRef(
-		ctx, positionals[0], presets.PresetTypeInfrastructure,
+		ctx, positionals[infrastructurePresetArgIndex], presets.PresetTypeInfrastructure,
 	)
 	if err != nil {
 		return nil, err

--- a/cmd/exasol/init.go
+++ b/cmd/exasol/init.go
@@ -17,6 +17,9 @@ import (
 const (
 	minPresetArgs = 1
 	maxPresetArgs = 2
+
+	infrastructurePresetArgIndex = 0
+	installationPresetArgIndex   = 1
 )
 
 var initCmdShortDesc = `Initialize a new deployment directory`
@@ -30,27 +33,34 @@ var deploymentDirectoryResolutionHelp = fmt.Sprintf(`
 	%s%c<name> instead.
 `, defaultDeploymentDirDisplayPath(), deploymentsRootDisplayPath(), os.PathSeparator)
 
+// presetArgumentsHelp and presetDiscoveryTipHelp are separate fragments because
+// preset-specific help substitutes the selected preset's description for the positional
+// argument explanation while keeping the discovery tip (see applySelectedPresetHelp).
 const (
-	presetSelectionHelp = `
+	presetArgumentsHelp = `
 	Preset arguments:
 	  - The first argument selects the infrastructure preset (required).
 	  - The optional second argument selects the installation preset.
 
 	Each argument can be either an embedded preset name (e.g. "aws") or a preset directory path.
 	To force path selection, pass a path-like value such as "./my-preset" or "/abs/path/to/preset".
-
+`
+	presetDiscoveryTipHelp = `
 	Tip: use "exasol presets" to discover and export presets.
 	`
 )
 
-var initCmdLongDesc = initCmdShortDesc + `
+// initCmdBaseDesc is the part of the long description that preset-specific help keeps.
+var initCmdBaseDesc = initCmdShortDesc + `
 
 	Extracts the specified infrastructure and installation presets into the deployment directory.
 	For an already initialized deployment with the same presets, supplied configuration
 	flags update only the selected parameters. Omitted parameters keep their values.
 	To switch presets, run exasol destroy --remove first, or exasol remove if the
 	deployment resources are already gone.` +
-	deploymentDirectoryResolutionHelp + presetSelectionHelp
+	deploymentDirectoryResolutionHelp
+
+var initCmdLongDesc = presetCommandLongDesc(initCmdBaseDesc, presetArgumentsHelp)
 
 var initCmd = &cobra.Command{
 	Use:   "init <infra preset name-or-path> [install preset name-or-path]",
@@ -75,7 +85,7 @@ func init() {
 	// Embedded preset names and the compatibility matrix are appended to help
 	// text lazily (see deferPresetHelpText) since resolving them needs a
 	// request context this package-init function doesn't have.
-	deferPresetHelpText(initCmd)
+	deferPresetHelpText(initCmd, initCmdBaseDesc)
 
 	initCmd.RunE = func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true

--- a/cmd/exasol/install.go
+++ b/cmd/exasol/install.go
@@ -14,14 +14,17 @@ import (
 
 var installCmdShortDesc = `Initialize, apply configuration, and deploy Exasol in one step`
 
-var installCmdLongDesc = installCmdShortDesc + `
+// installCmdBaseDesc is the part of the long description that preset-specific help keeps.
+var installCmdBaseDesc = installCmdShortDesc + `
 
 	Initializes the deployment directory or applies supplied configuration, prepares infrastructure,
 	and installs Exasol.
 	Rerunning install with the same presets is safe for retrying failed deployments.
 	To switch presets, run exasol destroy --remove first, or exasol remove if the
 	deployment resources are already gone.` +
-	deploymentDirectoryResolutionHelp + presetSelectionHelp
+	deploymentDirectoryResolutionHelp
+
+var installCmdLongDesc = presetCommandLongDesc(installCmdBaseDesc, presetArgumentsHelp)
 
 var installCmd = &cobra.Command{
 	Use:   "install <infra preset name-or-path> [install preset name-or-path]",
@@ -62,7 +65,7 @@ func init() {
 // their compatibility matrix to the command's long description (see
 // deferPresetHelpText).
 func appendInstallCmdPresetHelp() {
-	deferPresetHelpText(installCmd)
+	deferPresetHelpText(installCmd, installCmdBaseDesc)
 }
 
 func runInstallPreRun(cmd *cobra.Command, args []string) error {

--- a/cmd/exasol/install_variables.go
+++ b/cmd/exasol/install_variables.go
@@ -225,15 +225,7 @@ func collectInstallationVariableOverrides(cmd *cobra.Command) map[string]string 
 func scanInstallationPresetSelection(
 	ctx context.Context, args []string,
 ) (*deploy.PresetRef, error) {
-	if len(args) > 0 && args[0] == helpCommandName {
-		args = args[1:]
-	}
-	cmd, remainingArgs := preregisteredCommand(args)
-	if cmd != initCmd && cmd != installCmd {
-		return nil, errors.New("no command with installation preset argument found")
-	}
-
-	positionals, err := preregisteredPositionals(cmd, remainingArgs)
+	positionals, err := scanPresetPositionals(args)
 	if err != nil {
 		return nil, err
 	}
@@ -242,9 +234,9 @@ func scanInstallationPresetSelection(
 		return nil, errors.New("infra preset not provided")
 	}
 
-	if len(positionals) > 1 {
+	if len(positionals) > installationPresetArgIndex {
 		ref, err := resolvePresetRef(
-			ctx, positionals[1], presets.PresetTypeInstallation,
+			ctx, positionals[installationPresetArgIndex], presets.PresetTypeInstallation,
 		)
 		if err != nil {
 			return nil, err
@@ -254,7 +246,7 @@ func scanInstallationPresetSelection(
 	}
 
 	infraRef, err := resolvePresetRef(
-		ctx, positionals[0], presets.PresetTypeInfrastructure,
+		ctx, positionals[infrastructurePresetArgIndex], presets.PresetTypeInfrastructure,
 	)
 	if err != nil {
 		return nil, err

--- a/cmd/exasol/preset_help.go
+++ b/cmd/exasol/preset_help.go
@@ -8,40 +8,292 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/exasol/exasol-personal/internal/deploy"
 	"github.com/exasol/exasol-personal/internal/presets"
 	"github.com/spf13/cobra"
 )
 
-// deferPresetHelpText appends the embedded preset name list and compatibility
-// matrix to cmd's Long text the first time its help is actually requested,
-// rather than unconditionally at process startup (package init() runs for
+// presetCommandLongDesc assembles the long help of a command that takes preset arguments:
+// the command's own description, then a section about the presets, then the tip pointing at
+// preset discovery. Both the generic and the preset-specific help are built through here so
+// the order of the sections has one owner.
+func presetCommandLongDesc(baseDesc, presetSection string) string {
+	return baseDesc + presetSection + presetDiscoveryTipHelp
+}
+
+// presetHelpSelection records the presets selected on the command line. Installation is
+// set only when a second preset argument selects it explicitly.
+//
+// The labels are the arguments as typed. Resolving a preset canonicalizes a local path and
+// resolves a remote preset into the artifact cache, neither of which the user wrote, so the
+// resolved reference is used to read manifests while the label is what help echoes back.
+type presetHelpSelection struct {
+	Infrastructure      deploy.PresetRef
+	InfrastructureLabel string
+	Installation        *deploy.PresetRef
+	InstallationLabel   string
+}
+
+// selectedPresetHelp holds the preset selection scanned from the raw arguments before Cobra
+// parses them. It is recorded separately from the preset variable flags because registering
+// those stops early for a preset that declares no variables, which would leave such a preset
+// looking unselected.
+var selectedPresetHelp *presetHelpSelection
+
+// preparePresetHelpSelection records the preset selection that preset-specific help
+// describes. A selection that cannot be resolved leaves the generic help in place.
+//
+// Only an explicit help request scans: resolving a preset argument reaches the resource
+// manager, which re-fetches an artifact that carries no checksum, so scanning
+// unconditionally would add a download to every normal init or deploy.
+func preparePresetHelpSelection(ctx context.Context, args []string) {
+	if !rawArgsRequestHelp(args) {
+		return
+	}
+
+	positionals, err := scanPresetPositionals(args)
+	if err != nil || len(positionals) == 0 {
+		return
+	}
+
+	infrastructure, err := resolvePresetRef(
+		ctx, positionals[infrastructurePresetArgIndex], presets.PresetTypeInfrastructure,
+	)
+	if err != nil {
+		return
+	}
+
+	selection := &presetHelpSelection{
+		Infrastructure:      infrastructure,
+		InfrastructureLabel: strings.TrimSpace(positionals[infrastructurePresetArgIndex]),
+	}
+	if len(positionals) > installationPresetArgIndex {
+		installationArg := positionals[installationPresetArgIndex]
+		installation, err := resolvePresetRef(
+			ctx, installationArg, presets.PresetTypeInstallation,
+		)
+		if err != nil {
+			return
+		}
+		selection.Installation = &installation
+		selection.InstallationLabel = strings.TrimSpace(installationArg)
+	}
+	selectedPresetHelp = selection
+}
+
+// deferPresetHelpText completes cmd's Long text the first time its help is actually
+// requested, rather than unconditionally at process startup (package init() runs for
 // every invocation regardless of which subcommand is selected, and has no
-// request context to resolve presets with): computing either resolves every
-// embedded preset through the resource cache, which bumps each preset's
-// last-used bookkeeping as a side effect.
-func deferPresetHelpText(cmd *cobra.Command) {
+// request context to resolve presets with): resolving presets goes through the resource
+// cache, which bumps each preset's last-used bookkeeping as a side effect.
+//
+// baseDesc is the part of the long description that preset-specific help keeps.
+func deferPresetHelpText(cmd *cobra.Command, baseDesc string) {
 	defaultHelpFunc := cmd.HelpFunc()
-	appended := false
+	applied := false
 	cmd.SetHelpFunc(func(helpCmd *cobra.Command, args []string) {
-		if !appended {
-			ctx := helpCmd.Context()
-			helpCmd.Long = strings.TrimRight(helpCmd.Long, "\n") +
-				"\n\t" + presetNamesForHelp(
-				presets.PresetTypeInfrastructure,
-				presets.ListEmbeddedPresets(ctx, presets.Infrastructure),
-			) +
-				"\n\t" + presetNamesForHelp(
-				presets.PresetTypeInstallation,
-				presets.ListEmbeddedPresets(ctx, presets.Installation),
-			)
-			if matrix := embeddedPresetCompatibilityMatrix(ctx); matrix != "" {
-				helpCmd.Long = strings.TrimRight(helpCmd.Long, "\n") +
-					"\n\n\t" + strings.ReplaceAll(matrix, "\n", "\n\t")
-			}
-			appended = true
+		if !applied {
+			applyPresetHelpText(helpCmd, baseDesc)
+			applied = true
 		}
 		defaultHelpFunc(helpCmd, args)
 	})
+}
+
+func applyPresetHelpText(cmd *cobra.Command, baseDesc string) {
+	ctx := cmd.Context()
+	if selectedPresetHelp != nil &&
+		applySelectedPresetHelp(ctx, cmd, baseDesc, *selectedPresetHelp) {
+		return
+	}
+
+	appendGenericPresetHelp(ctx, cmd)
+}
+
+// applySelectedPresetHelp describes the selected presets in place of the overview of every
+// embedded preset. It reports whether the selection could be described.
+func applySelectedPresetHelp(
+	ctx context.Context,
+	cmd *cobra.Command,
+	baseDesc string,
+	selection presetHelpSelection,
+) bool {
+	manifest, err := readInfrastructureManifestForRef(ctx, selection.Infrastructure)
+	if err != nil {
+		return false
+	}
+
+	compatible := compatibleInstallationPresetNames(ctx, manifest)
+	body, err := renderSelectedPresetHelp(ctx, selection, manifest, compatible)
+	if err != nil {
+		return false
+	}
+
+	cmd.Long = presetCommandLongDesc(baseDesc, body)
+	cmd.Use = selectedPresetUseLine(cmd.Name(), selection)
+	cmd.Example = selectedPresetExamples(cmd.Name(), selection, compatible)
+
+	return true
+}
+
+func appendGenericPresetHelp(ctx context.Context, cmd *cobra.Command) {
+	cmd.Long = strings.TrimRight(cmd.Long, "\n") +
+		"\n\t" + presetNamesForHelp(
+		presets.PresetTypeInfrastructure,
+		presets.ListEmbeddedPresets(ctx, presets.Infrastructure),
+	) +
+		"\n\t" + presetNamesForHelp(
+		presets.PresetTypeInstallation,
+		presets.ListEmbeddedPresets(ctx, presets.Installation),
+	)
+	if matrix := embeddedPresetCompatibilityMatrix(ctx); matrix != "" {
+		cmd.Long = strings.TrimRight(cmd.Long, "\n") +
+			"\n\n\t" + strings.ReplaceAll(matrix, "\n", "\n\t")
+	}
+}
+
+// renderSelectedPresetHelp describes the selected presets. It fails when a selected preset
+// cannot be described, so that help falls back to the overview of every preset rather than
+// omitting one preset's description while the usage line still advertises it.
+func renderSelectedPresetHelp(
+	ctx context.Context,
+	selection presetHelpSelection,
+	infraManifest *presets.InfrastructureManifest,
+	compatible []string,
+) (string, error) {
+	var builder strings.Builder
+	_ = builder.WriteByte('\n')
+	writePresetHelpEntry(
+		&builder,
+		"Infrastructure",
+		selection.InfrastructureLabel,
+		infraManifest.Description,
+	)
+	_, _ = fmt.Fprintf(
+		&builder,
+		"\t  Compatible installation presets: %s\n",
+		compatibleInstallationPresetsForHelp(compatible),
+	)
+
+	if selection.Installation == nil {
+		return builder.String(), nil
+	}
+
+	installManifest, err := readInstallManifestForRef(ctx, *selection.Installation)
+	if err != nil {
+		return "", err
+	}
+	_ = builder.WriteByte('\n')
+	writePresetHelpEntry(
+		&builder,
+		"Installation",
+		selection.InstallationLabel,
+		installManifest.Description,
+	)
+
+	return builder.String(), nil
+}
+
+func writePresetHelpEntry(builder *strings.Builder, kind, label, description string) {
+	_, _ = fmt.Fprintf(builder, "\t%s preset `%s`:\n", kind, label)
+	if strings.TrimSpace(description) != "" {
+		_, _ = fmt.Fprintf(builder, "\t  %s\n", strings.TrimSpace(description))
+	}
+}
+
+// compatibleInstallationPresetNames lists the embedded installation presets the selected
+// infrastructure preset provides the required capabilities for, using the same comparison
+// that builds the compatibility matrix.
+func compatibleInstallationPresetNames(
+	ctx context.Context, infraManifest *presets.InfrastructureManifest,
+) []string {
+	installIDs := presets.ListEmbeddedPresets(ctx, presets.Installation)
+	installManifests := readEmbeddedInstallationManifests(ctx, installIDs)
+
+	compatible := make([]string, 0, len(installIDs))
+	for _, installID := range installIDs {
+		installManifest, ok := installManifests[installID]
+		if !ok {
+			continue
+		}
+		if embeddedPresetPairCompatible(infraManifest, installManifest) {
+			compatible = append(compatible, installID)
+		}
+	}
+
+	return compatible
+}
+
+func compatibleInstallationPresetsForHelp(compatible []string) string {
+	if len(compatible) == 0 {
+		return "none"
+	}
+
+	return strings.Join(compatible, ", ")
+}
+
+func selectedPresetUseLine(commandName string, selection presetHelpSelection) string {
+	infraArg := shellQuotedPresetArg(selection.InfrastructureLabel)
+	if selection.Installation != nil {
+		return fmt.Sprintf(
+			"%s %s %s",
+			commandName, infraArg, shellQuotedPresetArg(selection.InstallationLabel),
+		)
+	}
+
+	return fmt.Sprintf("%s %s [install preset name-or-path]", commandName, infraArg)
+}
+
+func selectedPresetExamples(
+	commandName string, selection presetHelpSelection, compatible []string,
+) string {
+	infraArg := shellQuotedPresetArg(selection.InfrastructureLabel)
+	if selection.Installation != nil {
+		return fmt.Sprintf(
+			"  exasol %s %s %s",
+			commandName, infraArg, shellQuotedPresetArg(selection.InstallationLabel),
+		)
+	}
+
+	example := fmt.Sprintf("  exasol %s %s", commandName, infraArg)
+	if len(compatible) == 0 {
+		return example
+	}
+
+	return example + fmt.Sprintf(
+		"\n  exasol %s %s %s", commandName, infraArg, shellQuotedPresetArg(compatible[0]),
+	)
+}
+
+// shellQuotedPresetArg wraps a preset argument in double quotes when it contains
+// whitespace, so that an example stays one argument when it is copied into a shell. Double
+// quotes group an argument in POSIX shells, cmd.exe, and PowerShell alike.
+func shellQuotedPresetArg(arg string) string {
+	if !strings.ContainsAny(arg, " \t") {
+		return arg
+	}
+
+	return `"` + arg + `"`
+}
+
+func readInfrastructureManifestForRef(
+	ctx context.Context, ref deploy.PresetRef,
+) (*presets.InfrastructureManifest, error) {
+	if ref.IsPath() {
+		return presets.ReadInfrastructureManifestFromDir(ref.Path)
+	}
+
+	return presets.ReadInfrastructureManifest(ctx, ref.Name)
+}
+
+func readInstallManifestForRef(
+	ctx context.Context, ref deploy.PresetRef,
+) (*presets.InstallManifest, error) {
+	if ref.IsPath() {
+		return presets.ReadInstallManifestFromDir(ref.Path)
+	}
+
+	return presets.ReadInstallManifest(ctx, ref.Name)
 }
 
 func embeddedPresetCompatibilityMatrix(ctx context.Context) string {

--- a/cmd/exasol/preset_help_test.go
+++ b/cmd/exasol/preset_help_test.go
@@ -1,0 +1,317 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/deploy"
+	"github.com/exasol/exasol-personal/internal/presets"
+)
+
+func TestSelectedPresetUseLine_KeepsInstallationPresetOptional(t *testing.T) {
+	t.Parallel()
+
+	// Given only an infrastructure preset is selected
+	selection := presetHelpSelection{
+		Infrastructure:      deploy.PresetRef{Name: "local"},
+		InfrastructureLabel: "local",
+	}
+
+	// When the usage line is built
+	useLine := selectedPresetUseLine("install", selection)
+
+	// Then the selected preset replaces the infrastructure placeholder
+	if useLine != "install local [install preset name-or-path]" {
+		t.Fatalf("unexpected usage line: %q", useLine)
+	}
+}
+
+func TestSelectedPresetUseLine_ShowsBothSelectedPresets(t *testing.T) {
+	t.Parallel()
+
+	// Given both presets are selected
+	selection := presetHelpSelection{
+		Infrastructure:      deploy.PresetRef{Name: "aws"},
+		InfrastructureLabel: "aws",
+		Installation:        &deploy.PresetRef{Name: "ubuntu"},
+		InstallationLabel:   "ubuntu",
+	}
+
+	// When the usage line is built
+	useLine := selectedPresetUseLine("init", selection)
+
+	// Then both selected presets appear and no placeholder remains
+	if useLine != "init aws ubuntu" {
+		t.Fatalf("unexpected usage line: %q", useLine)
+	}
+}
+
+func TestSelectedPresetUseLine_IdentifiesPathPresetsByPath(t *testing.T) {
+	t.Parallel()
+
+	// Given a preset selected by a relative directory path, resolved to an absolute one
+	selection := presetHelpSelection{
+		Infrastructure:      deploy.PresetRef{Path: "/resolved/elsewhere/my-preset"},
+		InfrastructureLabel: "./my-preset",
+	}
+
+	// When the usage line is built
+	useLine := selectedPresetUseLine("install", selection)
+
+	// Then the path the user typed identifies the preset, not the resolved one
+	if !strings.HasPrefix(useLine, "install ./my-preset ") {
+		t.Fatalf("unexpected usage line: %q", useLine)
+	}
+}
+
+func TestSelectedPresetUseLine_QuotesAnArgumentContainingSpaces(t *testing.T) {
+	t.Parallel()
+
+	// Given a preset selected by a path containing a space
+	selection := presetHelpSelection{
+		Infrastructure:      deploy.PresetRef{Path: "/tmp/my preset"},
+		InfrastructureLabel: "/tmp/my preset",
+	}
+
+	// When the usage line is built
+	useLine := selectedPresetUseLine("install", selection)
+
+	// Then the path stays a single argument
+	if !strings.HasPrefix(useLine, `install "/tmp/my preset" `) {
+		t.Fatalf("unexpected usage line: %q", useLine)
+	}
+}
+
+func TestSelectedPresetExamples_QuoteAnArgumentContainingSpaces(t *testing.T) {
+	t.Parallel()
+
+	// Given a preset selected by a path containing a space
+	selection := presetHelpSelection{
+		Infrastructure:      deploy.PresetRef{Path: "/tmp/my preset"},
+		InfrastructureLabel: "/tmp/my preset",
+	}
+
+	// When the examples are built
+	examples := selectedPresetExamples("install", selection, []string{"ubuntu"})
+
+	// Then every example keeps the path as a single argument
+	want := "  exasol install \"/tmp/my preset\"\n" +
+		"  exasol install \"/tmp/my preset\" ubuntu"
+	if examples != want {
+		t.Fatalf("unexpected examples:\n%s", examples)
+	}
+}
+
+func TestSelectedPresetExamples_SuggestsACompatibleInstallationPreset(t *testing.T) {
+	t.Parallel()
+
+	// Given an infrastructure preset with compatible installation presets
+	selection := presetHelpSelection{
+		Infrastructure:      deploy.PresetRef{Name: "aws"},
+		InfrastructureLabel: "aws",
+	}
+
+	// When the examples are built
+	examples := selectedPresetExamples("install", selection, []string{"ubuntu", "other"})
+
+	// Then the selected preset is shown alone and paired with the first compatible preset
+	want := "  exasol install aws\n  exasol install aws ubuntu"
+	if examples != want {
+		t.Fatalf("unexpected examples:\n%s", examples)
+	}
+}
+
+func TestSelectedPresetExamples_OmitsThePairWithoutACompatiblePreset(t *testing.T) {
+	t.Parallel()
+
+	// Given an infrastructure preset without compatible installation presets
+	selection := presetHelpSelection{
+		Infrastructure:      deploy.PresetRef{Name: "local"},
+		InfrastructureLabel: "local",
+	}
+
+	// When the examples are built
+	examples := selectedPresetExamples("install", selection, nil)
+
+	// Then only the infrastructure preset is exemplified
+	if examples != "  exasol install local" {
+		t.Fatalf("unexpected examples:\n%s", examples)
+	}
+}
+
+func TestSelectedPresetExamples_UsesBothSelectedPresets(t *testing.T) {
+	t.Parallel()
+
+	// Given both presets are selected
+	selection := presetHelpSelection{
+		Infrastructure:      deploy.PresetRef{Name: "aws"},
+		InfrastructureLabel: "aws",
+		Installation:        &deploy.PresetRef{Name: "ubuntu"},
+		InstallationLabel:   "ubuntu",
+	}
+
+	// When the examples are built
+	examples := selectedPresetExamples("install", selection, []string{"ubuntu"})
+
+	// Then the selected pair is the only example
+	if examples != "  exasol install aws ubuntu" {
+		t.Fatalf("unexpected examples:\n%s", examples)
+	}
+}
+
+func TestCompatibleInstallationPresetsForHelp_ListsPresetNames(t *testing.T) {
+	t.Parallel()
+
+	// Given compatible installation presets
+	// When they are rendered for help
+	rendered := compatibleInstallationPresetsForHelp([]string{"local", "ubuntu"})
+
+	// Then they are listed
+	if rendered != "local, ubuntu" {
+		t.Fatalf("unexpected compatible presets: %q", rendered)
+	}
+}
+
+func TestCompatibleInstallationPresetsForHelp_ReportsNone(t *testing.T) {
+	t.Parallel()
+
+	// Given no compatible installation preset
+	// When the compatible presets are rendered for help
+	rendered := compatibleInstallationPresetsForHelp(nil)
+
+	// Then the absence is stated rather than left blank
+	if rendered != "none" {
+		t.Fatalf("unexpected compatible presets: %q", rendered)
+	}
+}
+
+func TestRenderSelectedPresetHelp_DescribesTheInfrastructurePreset(t *testing.T) {
+	t.Parallel()
+
+	// Given a selected infrastructure preset with a description
+	selection := presetHelpSelection{
+		Infrastructure:      deploy.PresetRef{Name: "local"},
+		InfrastructureLabel: "local",
+	}
+	manifest := &presets.InfrastructureManifest{
+		Name:        "Exasol Local",
+		Description: "Exasol Local deployment.",
+	}
+
+	// When the preset help is rendered
+	rendered, err := renderSelectedPresetHelp(
+		t.Context(), selection, manifest, []string{"local"},
+	)
+	if err != nil {
+		t.Fatalf("rendering the selected preset help failed: %v", err)
+	}
+
+	// Then it identifies the preset, describes it, and names its compatible presets
+	for _, want := range []string{
+		"Infrastructure preset `local`:",
+		"Exasol Local deployment.",
+		"Compatible installation presets: local",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("expected %q in rendered help:\n%s", want, rendered)
+		}
+	}
+}
+
+func TestRenderSelectedPresetHelp_OmitsAnEmptyDescriptionLine(t *testing.T) {
+	t.Parallel()
+
+	// Given a selected preset whose manifest carries no description
+	selection := presetHelpSelection{
+		Infrastructure:      deploy.PresetRef{Name: "local"},
+		InfrastructureLabel: "local",
+	}
+	manifest := &presets.InfrastructureManifest{Name: "Exasol Local"}
+
+	// When the preset help is rendered
+	rendered, err := renderSelectedPresetHelp(
+		t.Context(), selection, manifest, []string{"local"},
+	)
+	if err != nil {
+		t.Fatalf("rendering the selected preset help failed: %v", err)
+	}
+
+	// Then no blank description line separates the preset from its compatibility line
+	if strings.Contains(rendered, "\n\t  \n") {
+		t.Fatalf("expected no blank description line in rendered help:\n%q", rendered)
+	}
+}
+
+func TestRenderSelectedPresetHelp_IdentifiesAPresetByTheArgumentAsTyped(t *testing.T) {
+	t.Parallel()
+
+	// Given a preset selected by a relative path, resolved to an absolute one
+	selection := presetHelpSelection{
+		Infrastructure:      deploy.PresetRef{Path: "/resolved/elsewhere/my-preset"},
+		InfrastructureLabel: "./my-preset",
+	}
+	manifest := &presets.InfrastructureManifest{Description: "A preset of my own."}
+
+	// When the preset help is rendered
+	rendered, err := renderSelectedPresetHelp(t.Context(), selection, manifest, nil)
+	if err != nil {
+		t.Fatalf("rendering the selected preset help failed: %v", err)
+	}
+
+	// Then the help names the path the user typed, not the resolved location
+	if !strings.Contains(rendered, "Infrastructure preset `./my-preset`:") {
+		t.Fatalf("expected the typed path in rendered help:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "/resolved/elsewhere") {
+		t.Fatalf("expected no resolved path in rendered help:\n%s", rendered)
+	}
+}
+
+func TestRenderSelectedPresetHelp_FailsWhenAnInstallationPresetCannotBeDescribed(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	// Given a selected installation preset whose manifest cannot be read
+	selection := presetHelpSelection{
+		Infrastructure:      deploy.PresetRef{Name: "aws"},
+		InfrastructureLabel: "aws",
+		Installation:        &deploy.PresetRef{Path: "/nonexistent/preset/directory"},
+		InstallationLabel:   "/nonexistent/preset/directory",
+	}
+	manifest := &presets.InfrastructureManifest{Description: "Provisioning in AWS."}
+
+	// When the preset help is rendered
+	rendered, err := renderSelectedPresetHelp(t.Context(), selection, manifest, []string{"ubuntu"})
+
+	// Then rendering fails rather than describing only one of the selected presets
+	if err == nil {
+		t.Fatalf("expected rendering to fail, got:\n%s", rendered)
+	}
+	if rendered != "" {
+		t.Fatalf("expected no partial help, got:\n%s", rendered)
+	}
+}
+
+// nolint: paralleltest
+func TestPreparePresetHelpSelection_DoesNotScanWithoutAHelpRequest(t *testing.T) {
+	// Do not run in parallel: this test reads and restores the package-level selection.
+	t.Cleanup(func() { selectedPresetHelp = nil })
+	selectedPresetHelp = nil
+
+	// Given a normal command invocation that does not request help
+	args := []string{"install", "local", "--deployment-dir", "/tmp/deployment"}
+
+	// When the preset help selection is prepared
+	// (a context without a resource manager: resolving a preset would panic or fail,
+	// so reaching the resolver at all is what this test rules out)
+	preparePresetHelpSelection(t.Context(), args)
+
+	// Then no selection is recorded and no preset was resolved
+	if selectedPresetHelp != nil {
+		t.Fatalf("expected no preset help selection, got %+v", selectedPresetHelp)
+	}
+}

--- a/cmd/exasol/root.go
+++ b/cmd/exasol/root.go
@@ -183,6 +183,10 @@ func Execute() error {
 		return err
 	}
 
+	// Record the preset selection that preset-specific help describes; scans only when
+	// help is requested.
+	preparePresetHelpSelection(ctx, os.Args[1:])
+
 	// Customize usage/help formatting.
 	rootCmd.SetUsageTemplate(customUsageTemplate)
 	rootCmd.SetHelpTemplate(

--- a/openspec/changes/archive/2026-09-02-add-preset-contextual-help/design.md
+++ b/openspec/changes/archive/2026-09-02-add-preset-contextual-help/design.md
@@ -1,0 +1,36 @@
+## Context
+
+`init` and `install` take the preset selection as positional arguments rather than as subcommands, so a single Cobra command serves every preset. Both build their `Long` text at package scope from shared fragments and append the embedded preset list plus the compatibility matrix lazily, the first time help is actually requested, because resolving presets needs a request context that package initialization does not have.
+
+The preset selection is already known before Cobra parses: the launcher scans the raw arguments up front so it can register only the selected preset's variable flags. Contextual help therefore needs no new resolution mechanism, only a reliable record of what that scan found.
+
+## Goals / Non-Goals
+
+- Goal: help for a selected preset describes that preset instead of every preset.
+- Goal: help without a resolvable selection keeps its current content, since the top-level help points at `install --help` for the compatibility matrix.
+- Non-Goal: changing preset resolution, flag registration, or deployment behavior.
+- Non-Goal: restructuring the introduction or the deployment directory help.
+
+## Decisions
+
+### Record the selection separately from flag registration
+
+The existing preset label annotation is set while registering a preset's variable flags, and that registration returns early for a preset that declares no variables. Reusing the annotation would therefore leave presets without variables looking unselected. The argument scan records the resolved selection in its own state instead, so help sees the selection regardless of whether the preset contributes flags.
+
+### Compose the long description from named fragments
+
+The generic help is the concatenation of an introduction, the deployment directory help, the positional argument explanation, and the preset discovery tip. Splitting the last two apart lets preset-specific help substitute the preset description for the positional argument explanation while keeping the discovery tip, and lets the generic text stay a plain concatenation whose output does not change.
+
+### Treat a defaulted installation preset as unselected
+
+When only one preset argument is given, the launcher resolves a default installation preset for the deployment. Presenting that default as if the user had chosen it would misreport the command line, so the installation preset is described only when a second argument selects it explicitly. The infrastructure preset's compatible installation presets are listed regardless, which is what a user needs in order to choose one.
+
+### Derive compatibility from the manifests already read for the matrix
+
+Compatible installation presets come from the same provided/required capability comparison that builds the compatibility matrix, so a preset pair is reported consistently by both forms of help. A preset selected by directory path is compared against the embedded installation presets the same way.
+
+## Risks / Trade-offs
+
+Usage and example lines are rewritten for the selected preset while help renders. This is confined to the help path, which prints and exits, so no command execution observes the rewritten values.
+
+Help formatting is asserted by tests that compare against preset metadata reported by the preset listing command rather than against literal descriptions, so preset wording can change without breaking them.

--- a/openspec/changes/archive/2026-09-02-add-preset-contextual-help/proposal.md
+++ b/openspec/changes/archive/2026-09-02-add-preset-contextual-help/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+`exasol install local --help` and `exasol init local --help` render the generic introduction, the overview of every embedded preset, and the full compatibility matrix, so a user who already selected a preset reads mostly information about other presets instead of the one they chose.
+
+## What Changes
+
+- Describe the selected infrastructure preset and the installation presets compatible with it when a preset argument is present.
+- Describe an explicitly selected installation preset as well.
+- Show usage and examples for the selected presets.
+- Keep the generic preset overview and compatibility matrix for `exasol install --help`, `exasol init --help`, and preset arguments that cannot be resolved.
+
+## Capabilities
+
+### New Capabilities
+
+- `preset-contextual-help`: Defines how command help adapts to the preset selected on the command line.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+This changes the help output of `exasol install` and `exasol init`, their tests, and the changelog entry. Deployment behavior, flag parsing, and other commands are unaffected.

--- a/openspec/changes/archive/2026-09-02-add-preset-contextual-help/specs/preset-contextual-help/spec.md
+++ b/openspec/changes/archive/2026-09-02-add-preset-contextual-help/specs/preset-contextual-help/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: Help for a selected infrastructure preset identifies and describes it
+`exasol install` and `exasol init` SHALL identify the infrastructure preset selected by their first preset argument, describe it, and show the parameters it supports.
+
+#### Scenario: Install help describes the selected infrastructure preset
+- **WHEN** a user runs `exasol install <infra-preset> --help`
+- **THEN** the help identifies the selected infrastructure preset by the name given on the command line
+- **AND** the help shows that preset's description
+- **AND** the help shows the parameters that preset supports
+
+#### Scenario: Init help describes the selected infrastructure preset
+- **WHEN** a user runs `exasol init <infra-preset> --help`
+- **THEN** the help identifies the selected infrastructure preset by the name given on the command line
+- **AND** the help shows that preset's description
+
+#### Scenario: A preset selected by directory path is identified by that path
+- **WHEN** a user requests help with a preset directory path as the preset argument
+- **THEN** the help identifies the selected preset by the path the user wrote
+- **AND** the help shows the description recorded in that preset directory
+
+### Requirement: Help for a selected infrastructure preset names its compatible installation presets
+`exasol install` and `exasol init` SHALL name the installation presets that can be deployed on the selected infrastructure preset.
+
+#### Scenario: Compatible installation presets are named
+- **WHEN** a user requests help with an infrastructure preset that has compatible installation presets
+- **THEN** the help names each compatible installation preset
+
+#### Scenario: An infrastructure preset without compatible installation presets reports none
+- **WHEN** a user requests help with an infrastructure preset that has no compatible installation preset
+- **THEN** the help reports that no installation preset is compatible
+
+### Requirement: Help for a selected installation preset identifies and describes it
+`exasol install` and `exasol init` SHALL identify the installation preset selected by their second preset argument and describe it.
+
+#### Scenario: Both selected presets are described
+- **WHEN** a user runs `exasol install <infra-preset> <install-preset> --help`
+- **THEN** the help identifies the selected installation preset by the name given on the command line
+- **AND** the help shows that preset's description
+- **AND** the help describes the selected infrastructure preset
+
+### Requirement: Help with a preset selected describes only the selected presets
+When a preset argument selects a preset, `exasol install` and `exasol init` SHALL limit the presets their help describes to the selected ones.
+
+#### Scenario: One selected preset is the only preset described
+- **WHEN** a user runs `exasol install <infra-preset> --help`
+- **THEN** the only infrastructure preset the help describes is the selected one
+
+#### Scenario: Two selected presets are the only presets described
+- **WHEN** a user runs `exasol install <infra-preset> <install-preset> --help`
+- **THEN** the only presets the help describes are the two selected ones
+
+### Requirement: Help shows the usage and examples for the selected presets
+`exasol install` and `exasol init` SHALL show a usage line and examples that invoke the command with the presets selected on the command line.
+
+#### Scenario: Usage and examples use a selected infrastructure preset
+- **WHEN** a user requests help with an infrastructure preset selected
+- **THEN** the usage line names the selected preset in the position of the infrastructure preset argument
+- **AND** an example invokes the command with the selected preset
+
+#### Scenario: An example pairs the selected preset with a compatible installation preset
+- **WHEN** a user requests help with an infrastructure preset that has compatible installation presets
+- **THEN** an example invokes the command with the selected preset and one of those compatible installation presets
+
+#### Scenario: Usage and examples repeat the preset argument as the user wrote it
+- **WHEN** a user requests help with a preset selected by a path
+- **THEN** the usage line and the examples name that preset by the argument the user wrote
+- **AND** an argument containing spaces is quoted so that it stays one argument when an example is run
+
+#### Scenario: Examples use both selected presets
+- **WHEN** a user requests help with an infrastructure preset and an installation preset selected
+- **THEN** the usage line names both selected presets
+- **AND** an example invokes the command with both selected presets
+
+### Requirement: Help without a selected preset lists every built-in preset and how they combine
+`exasol install` and `exasol init` SHALL list the built-in infrastructure and installation presets and show which of them are compatible whenever no preset argument selects a preset.
+
+#### Scenario: Help without a preset argument lists every built-in preset
+- **WHEN** a user runs `exasol install --help` or `exasol init --help`
+- **THEN** the help lists the built-in infrastructure presets
+- **AND** the help lists the built-in installation presets
+- **AND** the help shows which infrastructure and installation presets are compatible with each other
+
+#### Scenario: Help with a preset argument that selects no preset lists every built-in preset
+- **WHEN** a user requests help with a preset argument that names neither a built-in preset nor a readable preset directory
+- **THEN** the command prints help and succeeds
+- **AND** the help lists the built-in presets and shows which of them are compatible with each other
+
+### Requirement: Command help points to preset discovery
+`exasol install` and `exasol init` SHALL point users to the command that lists and exports presets.
+
+#### Scenario: Help names the preset discovery command
+- **WHEN** a user requests help with or without a preset selected
+- **THEN** the help names the command that lists and exports presets

--- a/openspec/changes/archive/2026-09-02-add-preset-contextual-help/tasks.md
+++ b/openspec/changes/archive/2026-09-02-add-preset-contextual-help/tasks.md
@@ -1,0 +1,8 @@
+## 1. Preset-specific command help
+
+- [x] 1.1 Render the selected preset's description, its compatible installation presets, and matching usage and examples for `exasol install` and `exasol init`, keeping the generic overview when no preset resolves.
+
+## 2. Verification and documentation
+
+- [x] 2.1 Add focused tests for selected infrastructure presets, explicitly selected installation presets, the generic overview, and unresolvable preset arguments.
+- [x] 2.2 Document the contextual help in the changelog and verify formatting, linting, tests, and build.

--- a/openspec/specs/preset-contextual-help/spec.md
+++ b/openspec/specs/preset-contextual-help/spec.md
@@ -1,0 +1,98 @@
+# preset-contextual-help Specification
+
+## Purpose
+Defines how the help of `exasol install` and `exasol init` adapts to the presets selected on the command line: what a user reads about a preset they selected, and what they read when they have not selected one.
+
+## Requirements
+### Requirement: Help for a selected infrastructure preset identifies and describes it
+`exasol install` and `exasol init` SHALL identify the infrastructure preset selected by their first preset argument, describe it, and show the parameters it supports.
+
+#### Scenario: Install help describes the selected infrastructure preset
+- **WHEN** a user runs `exasol install <infra-preset> --help`
+- **THEN** the help identifies the selected infrastructure preset by the name given on the command line
+- **AND** the help shows that preset's description
+- **AND** the help shows the parameters that preset supports
+
+#### Scenario: Init help describes the selected infrastructure preset
+- **WHEN** a user runs `exasol init <infra-preset> --help`
+- **THEN** the help identifies the selected infrastructure preset by the name given on the command line
+- **AND** the help shows that preset's description
+
+#### Scenario: A preset selected by directory path is identified by that path
+- **WHEN** a user requests help with a preset directory path as the preset argument
+- **THEN** the help identifies the selected preset by the path the user wrote
+- **AND** the help shows the description recorded in that preset directory
+
+### Requirement: Help for a selected infrastructure preset names its compatible installation presets
+`exasol install` and `exasol init` SHALL name the installation presets that can be deployed on the selected infrastructure preset.
+
+#### Scenario: Compatible installation presets are named
+- **WHEN** a user requests help with an infrastructure preset that has compatible installation presets
+- **THEN** the help names each compatible installation preset
+
+#### Scenario: An infrastructure preset without compatible installation presets reports none
+- **WHEN** a user requests help with an infrastructure preset that has no compatible installation preset
+- **THEN** the help reports that no installation preset is compatible
+
+### Requirement: Help for a selected installation preset identifies and describes it
+`exasol install` and `exasol init` SHALL identify the installation preset selected by their second preset argument and describe it.
+
+#### Scenario: Both selected presets are described
+- **WHEN** a user runs `exasol install <infra-preset> <install-preset> --help`
+- **THEN** the help identifies the selected installation preset by the name given on the command line
+- **AND** the help shows that preset's description
+- **AND** the help describes the selected infrastructure preset
+
+### Requirement: Help with a preset selected describes only the selected presets
+When a preset argument selects a preset, `exasol install` and `exasol init` SHALL limit the presets their help describes to the selected ones.
+
+#### Scenario: One selected preset is the only preset described
+- **WHEN** a user runs `exasol install <infra-preset> --help`
+- **THEN** the only infrastructure preset the help describes is the selected one
+
+#### Scenario: Two selected presets are the only presets described
+- **WHEN** a user runs `exasol install <infra-preset> <install-preset> --help`
+- **THEN** the only presets the help describes are the two selected ones
+
+### Requirement: Help shows the usage and examples for the selected presets
+`exasol install` and `exasol init` SHALL show a usage line and examples that invoke the command with the presets selected on the command line.
+
+#### Scenario: Usage and examples use a selected infrastructure preset
+- **WHEN** a user requests help with an infrastructure preset selected
+- **THEN** the usage line names the selected preset in the position of the infrastructure preset argument
+- **AND** an example invokes the command with the selected preset
+
+#### Scenario: An example pairs the selected preset with a compatible installation preset
+- **WHEN** a user requests help with an infrastructure preset that has compatible installation presets
+- **THEN** an example invokes the command with the selected preset and one of those compatible installation presets
+
+#### Scenario: Usage and examples repeat the preset argument as the user wrote it
+- **WHEN** a user requests help with a preset selected by a path
+- **THEN** the usage line and the examples name that preset by the argument the user wrote
+- **AND** an argument containing spaces is quoted so that it stays one argument when an example is run
+
+#### Scenario: Examples use both selected presets
+- **WHEN** a user requests help with an infrastructure preset and an installation preset selected
+- **THEN** the usage line names both selected presets
+- **AND** an example invokes the command with both selected presets
+
+### Requirement: Help without a selected preset lists every built-in preset and how they combine
+`exasol install` and `exasol init` SHALL list the built-in infrastructure and installation presets and show which of them are compatible whenever no preset argument selects a preset.
+
+#### Scenario: Help without a preset argument lists every built-in preset
+- **WHEN** a user runs `exasol install --help` or `exasol init --help`
+- **THEN** the help lists the built-in infrastructure presets
+- **AND** the help lists the built-in installation presets
+- **AND** the help shows which infrastructure and installation presets are compatible with each other
+
+#### Scenario: Help with a preset argument that selects no preset lists every built-in preset
+- **WHEN** a user requests help with a preset argument that names neither a built-in preset nor a readable preset directory
+- **THEN** the command prints help and succeeds
+- **AND** the help lists the built-in presets and shows which of them are compatible with each other
+
+### Requirement: Command help points to preset discovery
+`exasol install` and `exasol init` SHALL point users to the command that lists and exports presets.
+
+#### Scenario: Help names the preset discovery command
+- **WHEN** a user requests help with or without a preset selected
+- **THEN** the help names the command that lists and exports presets

--- a/tests/tests/integration/helpers.py
+++ b/tests/tests/integration/helpers.py
@@ -85,6 +85,51 @@ def installation_preset_id_or_skip(exasol_path: str, preset_id: str) -> str:
     return preset_id_or_skip(exasol_path, "installations", preset_id)
 
 
+def preset_description_or_skip(
+    exasol_path: str, preset_type: str, preset_id: str
+) -> str:
+    """Return an embedded preset's description as reported by the preset listing."""
+    result = run_command([exasol_path, "presets", "list", "--json"])
+    data = json.loads(result.stdout)
+    presets_list = data.get(preset_type)
+    if not isinstance(presets_list, list):
+        pytest.skip(f"no presets found for type {preset_type!r}")
+
+    for preset in presets_list:
+        if preset.get("id") != preset_id:
+            continue
+        description = preset.get("description")
+        if isinstance(description, str) and description.strip() != "":
+            return description
+        pytest.skip(f"preset {preset_id!r} reports no description")
+
+    pytest.skip(f"preset {preset_id!r} not found for type {preset_type!r}")
+
+
+def compatible_preset_pair_or_skip(exasol_path: str) -> tuple[str, str]:
+    """Return a preset pair the generic compatibility matrix reports as compatible.
+
+    The pair is read from the generic help's matrix rather than from preset-specific
+    help, so a test asserting preset-specific output does not source its own input
+    from the output it verifies.
+    """
+    result = run_command([exasol_path, "install", "--help"])
+    lines = result.stdout.splitlines()
+    for index, line in enumerate(lines):
+        if "Compatibility matrix" not in line:
+            continue
+        installation_ids = lines[index + 1].split()[1:]
+        for row in lines[index + 2 :]:
+            cells = row.split()
+            if len(cells) != len(installation_ids) + 1:
+                break
+            for installation_id, cell in zip(installation_ids, cells[1:], strict=True):
+                if cell == "yes":
+                    return cells[0], installation_id
+
+    pytest.skip("the compatibility matrix reports no compatible preset pair")
+
+
 def export_preset(
     exasol_path: str, preset_id: str, preset_type: str, to_dir: str
 ) -> None:

--- a/tests/tests/integration/test_init.py
+++ b/tests/tests/integration/test_init.py
@@ -17,6 +17,7 @@ from .helpers import (
     export_preset,
     first_infrastructure_preset_id_or_skip,
     installation_preset_id_or_skip,
+    preset_description_or_skip,
     run_command,
 )
 
@@ -39,6 +40,33 @@ def test_init_defaults_and_help(exasol_path: str) -> None:
 
     # And the help nudges users towards presets discovery/export
     assert "exasol presets" in output
+
+    # Then I see how the presets can be combined
+    assert "Compatibility matrix" in output
+
+
+def test_init_help_describes_the_selected_infrastructure_preset(
+    exasol_path: str,
+) -> None:
+    # Given an infrastructure preset
+    infra_id = first_infrastructure_preset_id_or_skip(exasol_path)
+    description = preset_description_or_skip(exasol_path, "infrastructures", infra_id)
+
+    # When help is invoked for that preset
+    result = run_command([exasol_path, "init", infra_id, "--help"])
+    output: str = result.stdout.strip()
+
+    # Then the help describes the selected preset and how to combine it
+    assert f"Infrastructure preset `{infra_id}`:" in output
+    assert description in output
+    assert "Compatible installation presets:" in output
+
+    # Then the help exemplifies the command with the selected preset
+    assert f"exasol init {infra_id}" in output
+
+    # Then the help does not repeat the overview of every preset
+    assert "Available infrastructure presets:" not in output
+    assert "Compatibility matrix" not in output
 
 
 def test_init_requires_infra_preset_arg(exasol_path: str) -> None:

--- a/tests/tests/integration/test_install.py
+++ b/tests/tests/integration/test_install.py
@@ -13,7 +13,13 @@ from typing import Final
 
 import pytest
 
-from .helpers import first_infrastructure_preset_id_or_skip, run_command
+from .helpers import (
+    compatible_preset_pair_or_skip,
+    export_preset,
+    first_infrastructure_preset_id_or_skip,
+    preset_description_or_skip,
+    run_command,
+)
 
 LOCAL_TEST_DB_PORT = 28563
 LOCAL_MINIMUM_MEMORY_MB = 4096
@@ -182,6 +188,137 @@ def test_install_help(exasol_path: str) -> None:
     assert infra_id in output
     assert "Available installation presets:" in output
     assert "exasol presets" in output
+
+    # Then I see how the presets can be combined
+    assert "Compatibility matrix" in output
+
+
+def test_install_help_describes_the_selected_infrastructure_preset(
+    exasol_path: str,
+) -> None:
+    # Given an infrastructure preset
+    infra_id = first_infrastructure_preset_id_or_skip(exasol_path)
+    description = preset_description_or_skip(exasol_path, "infrastructures", infra_id)
+
+    # When help is invoked for that preset
+    result = run_command([exasol_path, "install", infra_id, "--help"])
+    output: str = result.stdout.strip()
+
+    # Then the help describes the selected preset and how to combine it
+    assert f"Infrastructure preset `{infra_id}`:" in output
+    assert description in output
+    assert "Compatible installation presets:" in output
+
+    # Then the help exemplifies the command with the selected preset
+    assert f"exasol install {infra_id}" in output
+
+    # Then the help does not repeat the overview of every preset
+    assert "Available infrastructure presets:" not in output
+    assert "Compatibility matrix" not in output
+
+    # Then preset discovery stays reachable
+    assert "exasol presets" in output
+
+
+def test_install_help_describes_both_selected_presets(exasol_path: str) -> None:
+    # Given a compatible infrastructure and installation preset pair
+    infra_id, install_id = compatible_preset_pair_or_skip(exasol_path)
+    install_description = preset_description_or_skip(
+        exasol_path, "installations", install_id
+    )
+
+    # When help is invoked for both presets
+    result = run_command([exasol_path, "install", infra_id, install_id, "--help"])
+    output: str = result.stdout.strip()
+
+    # Then the help describes both selected presets
+    assert f"Infrastructure preset `{infra_id}`:" in output
+    assert f"Installation preset `{install_id}`:" in output
+    assert install_description in output
+
+    # Then the help exemplifies the selected pair
+    assert f"exasol install {infra_id} {install_id}" in output
+
+    # Then the help does not repeat the overview of every preset
+    assert "Available installation presets:" not in output
+    assert "Compatibility matrix" not in output
+
+
+def test_install_help_describes_a_preset_selected_by_path(
+    exasol_path: str, tmp_path: Path
+) -> None:
+    # Given an infrastructure preset exported to a directory
+    infra_id = first_infrastructure_preset_id_or_skip(exasol_path)
+    description = preset_description_or_skip(exasol_path, "infrastructures", infra_id)
+    infra_dir = tmp_path / "infra_export"
+    infra_dir.mkdir()
+    export_preset(exasol_path, infra_id, "infrastructure", str(infra_dir))
+
+    # When help is invoked with that directory as the preset argument
+    result = run_command([exasol_path, "install", str(infra_dir), "--help"])
+    output: str = result.stdout.strip()
+
+    # Then the help identifies the preset by its path and describes it
+    assert f"Infrastructure preset `{infra_dir}`:" in output
+    assert description in output
+    assert "Compatible installation presets:" in output
+
+    # Then the help does not repeat the overview of every preset
+    assert "Available infrastructure presets:" not in output
+
+
+def test_install_help_quotes_a_preset_path_containing_spaces(
+    exasol_path: str, tmp_path: Path
+) -> None:
+    # Given an infrastructure preset exported to a directory whose path contains a space
+    infra_id = first_infrastructure_preset_id_or_skip(exasol_path)
+    infra_dir = tmp_path / "my preset"
+    infra_dir.mkdir()
+    export_preset(exasol_path, infra_id, "infrastructure", str(infra_dir))
+
+    # When help is invoked with that directory as the preset argument
+    result = run_command([exasol_path, "install", str(infra_dir), "--help"])
+    output: str = result.stdout.strip()
+
+    # Then the examples keep the path as a single argument
+    assert f'exasol install "{infra_dir}"' in output
+
+    # Then no example splits the path across two arguments
+    assert f"exasol install {infra_dir}\n" not in output
+
+
+def test_install_help_keeps_the_overview_for_an_unresolvable_installation_preset(
+    exasol_path: str,
+) -> None:
+    # Given a resolvable infrastructure preset, and an installation preset
+    # argument that names nothing
+    infra_id = first_infrastructure_preset_id_or_skip(exasol_path)
+
+    # When help is invoked for both
+    result = run_command([exasol_path, "install", infra_id, "no-such-preset", "--help"])
+    output: str = result.stdout.strip()
+
+    # Then the overview of every preset is shown, not a description of one of them
+    assert "Available infrastructure presets:" in output
+    assert "Compatibility matrix" in output
+
+    # Then no example advertises the preset that could not be described
+    assert "no-such-preset" not in output
+
+
+def test_install_help_keeps_the_overview_for_an_unresolvable_preset(
+    exasol_path: str,
+) -> None:
+    # Given a preset argument naming neither an embedded preset nor a preset directory
+
+    # When help is invoked for it
+    result = run_command([exasol_path, "install", "no-such-preset", "--help"])
+    output: str = result.stdout.strip()
+
+    # Then help is printed with the overview of every preset
+    assert "Available infrastructure presets:" in output
+    assert "Available installation presets:" in output
+    assert "Compatibility matrix" in output
 
 
 def test_install_executes_init_step(exasol_path: str, tmp_path: Path) -> None:


### PR DESCRIPTION
## Description

`exasol install local --help` rendered the generic introduction, the overview of every embedded preset, and the full compatibility matrix, so a user who had already selected a preset read mostly information about the other presets. With a preset argument present, the help now describes that preset instead. `exasol install --help` and `exasol init --help` are unchanged.

## Related Issue

SPOT-32435

## Type of Change

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Describe the selected infrastructure preset and the installation presets compatible with it, and describe an explicitly selected installation preset as well.
- Show the usage line and examples for the selected presets.
- Keep the generic preset overview and compatibility matrix for help without a resolvable preset argument.
- Record the preset selection separately from preset variable flag registration, which stops early for a preset that declares no variables and would otherwise leave such a preset looking unselected.
- Identify a preset by the argument the user wrote rather than by its resolved location, so a relative path stays relative and a remote preset is not shown as an artifact-cache directory.
- Quote a preset argument containing spaces in the usage line and examples, so an example stays a single argument when it is run.
- Scan for the preset selection only when help is requested, since resolving a preset argument reaches the resource manager, which re-fetches an artifact that carries no checksum.
- Fall back to the generic overview when a selected preset cannot be described, rather than omitting one description while the usage line still advertises that preset.

## User-visible behavior

Real output from `./bin/exasol`, excerpted around the change (the unchanged intro, deployment-directory help, and flag sections are elided; the home directory appears as `~`).

### Before: `exasol install local --help`

```
	Preset arguments:
	  - The first argument selects the infrastructure preset (required).
	  - The optional second argument selects the installation preset.

	Each argument can be either an embedded preset name (e.g. "aws") or a preset directory path.
	To force path selection, pass a path-like value such as "./my-preset" or "/abs/path/to/preset".

	Tip: use "exasol presets" to discover and export presets.

	Available infrastructure presets: aws, azure, exoscale, local, stackit
	Available installation presets: local, ubuntu

	Compatibility matrix (embedded presets):
	  infrastructure  local  ubuntu
	  aws             no     yes
	  azure           no     yes
	  exoscale        no     yes
	  local           yes    no
	  stackit         no     yes

Usage:
	exasol install <infra preset name-or-path> [install preset name-or-path] [flags]

[... Global Flags, preset variable flags, Flags ...]

Examples:
  exasol install aws
  exasol install aws ubuntu
```

### After: `exasol install local --help`

```
	Infrastructure preset `local`:
	  Exasol Local deployment using a macOS VM or Linux Podman.
	  Compatible installation presets: local

	Tip: use "exasol presets" to discover and export presets.

Usage:
	exasol install local [install preset name-or-path] [flags]

[... Global Flags, preset variable flags, Flags ...]

Examples:
  exasol install local
  exasol install local local
```

### After: both presets selected, `exasol install aws ubuntu --help`

```
	Infrastructure preset `aws`:
	  Provisioning in AWS. Ubuntu, S3 archive volume, dynamic IP.
	  Compatible installation presets: ubuntu

	Installation preset `ubuntu`:
	  Installs Exasol on Ubuntu distributions.

	Tip: use "exasol presets" to discover and export presets.

Usage:
	exasol install aws ubuntu [flags]
```

### Unchanged

`exasol install --help` and `exasol init --help` keep the generic overview; their output is byte-identical to `main` (verified with `diff` against output captured before the change). `exasol init local --help` gains the same preset-specific help as `install`. A preset argument that resolves to neither an embedded preset nor a readable preset directory still prints help successfully with the generic overview.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

`task all` passes: golangci-lint reports no issues, Go unit tests pass, 126 integration tests pass (6 platform-specific skips), and the binary builds.

New Go unit tests in `cmd/exasol/preset_help_test.go` cover the usage line, the examples, the compatible-preset list including the empty case, and the rendered preset entry with and without a description. New integration tests in `tests/tests/integration/test_install.py` and `test_init.py` run the built binary and assert that preset-specific help identifies and describes the selected preset, names its compatible installation presets, exemplifies the selected preset, and omits the overview of every preset — and that the generic overview is retained without a preset argument and for an unresolvable one. The integration tests read preset descriptions from `exasol presets list --json` and a compatible pair from the generic compatibility matrix, so they do not pin literal preset wording.

Further tests cover the behavior added in review: a preset argument echoed as typed rather than as resolved, a path containing spaces quoted in the usage line and examples, an unresolvable installation preset falling back to the generic overview, and no preset resolution happening without a help request.

Manually verified: `install local`, `init local`, `install local local`, `install aws ubuntu`, `install ./assets/infrastructure/local` (echoed as the relative path given), `install "/tmp/my preset"` (quoted in every example), `exasol help install local`, `install no-such-preset` and `install aws no-such-preset` (both fall back to the generic overview, exit code 0). Also verified on a cold artifact cache with a fresh `HOME` that preset-specific help renders on the first run.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

Developed as the OpenSpec change `add-preset-contextual-help`, archived in this branch under `openspec/changes/archive/` with the new `preset-contextual-help` capability spec.

Related: SPOT-32434 covers backend-owned CLI options and includes removing `--tofu-update-lockfile` from local preset help. That flag is still listed here, since this change only alters the descriptive help body, not which flags are registered.
