### PR TITLE
fix: use correct dial error codes on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Notable user-facing changes to Exasol Personal are documented here.
 
 ### Fixed
 
+- Fixed Windows local deployments blaming the host-to-VM network path for a database that failed to start. When the forwarded port refused the connection, `exasol start` and `exasol deploy` reported that the network path appeared blocked, listing Windows Firewall and port conflict causes, instead of reporting the underlying failure. `exasol diag local` reported such a port as `blocked` rather than `refused`.
 - `exasol deployments list` now reports the same live status as `exasol status` instead of treating persisted workflow state as current state. Deployment checks run concurrently under one five-second bound.
 - `exasol status` now stops waiting after five seconds by default instead of hanging indefinitely on an unresponsive deployment. Use `--timeout <seconds>` to select another positive limit, for example `exasol status --timeout 10`.
 - Fixed infrastructure and installation presets being unavailable. `exasol presets list` reported no presets, and commands that resolve one, such as `exasol install local` and `exasol presets export`, could not find it. Embedded preset archives are now extracted completely.

--- a/internal/localruntime/host_runtime.go
+++ b/internal/localruntime/host_runtime.go
@@ -287,17 +287,48 @@ func classifyHostPortHealth(err error) PortState {
 	if errors.As(err, &netError) && netError.Timeout() {
 		return PortStateTimeout
 	}
-	if errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.ECONNRESET) {
+	if isPeerReachedDialError(err) {
 		return PortStateRefused
 	}
-	// The error slipped past every well-known classifier. This is where
-	// Windows-specific errnos (WSAENOTCONN, WSAECONNABORTED, etc.) end
-	// up today; logging the underlying error keeps future occurrences
-	// diagnosable from deployment.log alone.
+	// The error slipped past every well-known classifier, so the network
+	// path cannot be shown to work; logging the underlying error keeps
+	// future occurrences diagnosable from deployment.log alone.
 	slog.Debug("classifying host port dial error as blocked",
 		"error", err.Error(), "errorType", fmt.Sprintf("%T", err))
 
 	return PortStateBlocked
+}
+
+// Winsock error codes for the dial outcomes that prove a peer answered.
+// syscall's POSIX-named errnos are unusable for this on Windows: there they
+// are invented APPLICATION_ERROR placeholders that Winsock never returns,
+// and Errno.Is bridges only the os.Err* sentinels, so matching them silently
+// misses every real Windows dial error. The numeric codes are matched on
+// every platform because no other platform issues errnos in this range,
+// which keeps the Windows path exercisable by tests that do not run there.
+const (
+	wsaeConnAborted = 10053
+	wsaeConnReset   = 10054
+	wsaeNotConn     = 10057
+	wsaeConnRefused = 10061
+)
+
+// isPeerReachedDialError reports whether a failed dial still proves the
+// host-to-container network path carries traffic: the peer refused the
+// connection or tore it down, rather than the packets going unanswered. A
+// port with no listener yet, as during database startup, lands here.
+func isPeerReachedDialError(err error) bool {
+	if errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.ECONNRESET) {
+		return true
+	}
+
+	var errno syscall.Errno
+	if !errors.As(err, &errno) {
+		return false
+	}
+
+	return errno == wsaeConnRefused || errno == wsaeConnReset ||
+		errno == wsaeConnAborted || errno == wsaeNotConn
 }
 
 func (runtime *HostRuntime) install() *localinstall.PodmanInstall {

--- a/internal/localruntime/host_runtime_test.go
+++ b/internal/localruntime/host_runtime_test.go
@@ -295,22 +295,79 @@ func TestLinuxHostHealthCheck_ProbesRecoveredPublishedPort(t *testing.T) {
 	}
 }
 
-func TestClassifyHostPortHealth_ConnectionResetIsRefused(t *testing.T) {
+// The Winsock cases are asserted with the numeric codes Windows actually
+// reports rather than syscall's POSIX-named errnos, whose Windows values are
+// placeholders no dial ever returns.
+func TestClassifyHostPortHealth_ClassifiesDialOutcomes(t *testing.T) {
 	t.Parallel()
 
-	// Given
-	dialError := &net.OpError{
-		Op:  "dial",
-		Net: "tcp",
-		Err: os.NewSyscallError("connect", syscall.ECONNRESET),
+	for name, testCase := range map[string]struct {
+		dialError error
+		expected  PortState
+	}{
+		"connection refused": {
+			dialError: syscall.ECONNREFUSED,
+			expected:  PortStateRefused,
+		},
+		"connection reset": {
+			dialError: syscall.ECONNRESET,
+			expected:  PortStateRefused,
+		},
+		"winsock connection refused": {
+			dialError: syscall.Errno(10061),
+			expected:  PortStateRefused,
+		},
+		"winsock connection reset": {
+			dialError: syscall.Errno(10054),
+			expected:  PortStateRefused,
+		},
+		"winsock connection aborted": {
+			dialError: syscall.Errno(10053),
+			expected:  PortStateRefused,
+		},
+		"winsock not connected": {
+			dialError: syscall.Errno(10057),
+			expected:  PortStateRefused,
+		},
+		"deadline exceeded": {
+			dialError: context.DeadlineExceeded,
+			expected:  PortStateTimeout,
+		},
+		"unrecognised failure": {
+			dialError: errors.New("no route to host"),
+			expected:  PortStateBlocked,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// Given
+			dialError := &net.OpError{
+				Op:  "dial",
+				Net: "tcp",
+				Err: os.NewSyscallError("connect", testCase.dialError),
+			}
+
+			// When
+			state := classifyHostPortHealth(dialError)
+
+			// Then
+			if state != testCase.expected {
+				t.Fatalf("expected %q, got %q", testCase.expected, state)
+			}
+		})
 	}
+}
+
+func TestClassifyHostPortHealth_ReachableWithoutError(t *testing.T) {
+	t.Parallel()
 
 	// When
-	state := classifyHostPortHealth(dialError)
+	state := classifyHostPortHealth(nil)
 
 	// Then
-	if state != PortStateRefused {
-		t.Fatalf("expected a connection reset to be refused, got %q", state)
+	if state != PortStateReachable {
+		t.Fatalf("expected a successful dial to be reachable, got %q", state)
 	}
 }
 


### PR DESCRIPTION
## Description

On Windows, a local database that fails to become reachable was blamed on the host-to-VM network path. `exasol start` and `exasol deploy` answered a startup failure with the podman-for-windows reachability guidance, listing Windows Firewall and port conflict causes, when the forwarded port had in fact refused the connection and the real fault lay with the database or the container. `exasol diag local` reported such a port as `blocked` rather than `refused`.

The reachability diagnosis is meant to stay silent when a port is reachable or refused, because a refused connection proves the network path carries traffic. On Windows the `refused` state was unreachable, so only the `reachable` half of that rule ever applied.

Supporting detail: the POSIX-named errnos in `syscall` are, on Windows, placeholders in the `APPLICATION_ERROR` range that Winsock never returns, and `syscall.Errno.Is` bridges only the `os.Err*` sentinels. `errors.Is(err, syscall.ECONNREFUSED)` therefore never matched a real dial error, and every refused connection fell through to `blocked`. Winsock reports 10061 instead. The same defect is recorded upstream in [golang/go#45621](https://github.com/golang/go/issues/45621) and produced the equivalent container-port symptom in [testcontainers-go#159](https://github.com/testcontainers/testcontainers-go/issues/159).

User-visible behavior on Windows amd64, when a local database does not accept connections within the wait timeout.

Before, the failure is answered with guidance that does not apply, and the real error is pushed below it:

```
Error: could not reach the local database endpoint published by podman-for-windows.

On Windows the database port is forwarded from the Nano container, through the WSL2 podman
machine, out to 127.0.0.1 on the host. If every forwarded port is unreachable the break is
almost always in that host-to-VM path rather than in the database itself.

Likely causes, in decreasing order of frequency:
  1. Windows Firewall or a third-party security product is blocking loopback traffic to the
forwarded port. Temporarily allow the port and retry.
  2. Another process (Docker Desktop, a running server, an older Exasol container) is
already bound to the configured port. ...
...

Underlying failure: <the actual database startup failure>
```

After, the database failure is reported on its own. A genuinely unreachable endpoint, such as a firewall dropping loopback traffic to the published port, still produces the guidance above.

## Related Issue

Fixes #

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Classify the Winsock dial outcomes that prove a peer answered (10061 refused, 10054 reset, 10053 aborted, 10057 not connected) as `refused`, alongside the existing POSIX errnos, so a refused endpoint lets the failure be reported on its own terms.
- Match those codes on every platform rather than behind a `windows` build constraint, so the Windows classification path is exercised by the unit tests that run on Linux CI. No other supported platform issues errnos in that range.
- Replace the classifier test that constructed its dial error from the same constant the classifier compared against. It passed everywhere while the real Windows path was broken. The replacement table covers both errno families plus timeout, unrecognised-error, and success cases.
- Add a `CHANGELOG.md` entry under `Unreleased`.

## Testing

- [ ] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

### Test Details

- Full Go unit suite with the race detector passes after rebasing onto the current readiness-wait design: `go test -tags=containers_image_openpgp -race ./...`.
- `task fmt-golang` and `task lint-golang` report 1 issues.
- The new tests were confirmed to be load-bearing by stubbing the Winsock branch back out. The four Winsock cases then fail with `expected "refused", got "blocked"`, which is the reported production behavior.
- `task all` was not run to completion. `task fmt` and `task lint-ruff-check` fail on a pre-existing ruff error at `tests/chaos/test_lifecycle_faults.py:245`, which is unrelated to this change and reproduces with these changes stashed.
- Not yet verified on a Windows host. Reproducing the corrected behavior needs a local deployment on Windows amd64 whose database does not become reachable within the wait timeout, which should now report the database failure alone, plus one run with the published port blocked by a firewall rule, which should still report the reachability guidance.

Existing coverage did not catch this, which is worth a reviewer's attention: the reachability tests inject port states as runner JSON and skip on Windows, so they never crossed the errno to state boundary where the defect lived.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [x] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

Scope note after the rebase onto `032635cd`. An earlier revision of this branch also touched `internal/deploy/ready.go`, where a pre-wait reachability check could abort a local start within about three seconds while the database was still coming up. The bounded readiness wait now on main removed that check and moved the diagnosis after the wait, so the premature failure is already fixed there and this branch no longer changes that file. What remains, and what this PR fixes, is the misdiagnosis of a failure that has genuinely occurred.

No documentation change: the Windows local deployment guidance in `README.md` and the reachability troubleshooting text stay accurate, since the diagnostic itself is unchanged and only the condition that triggers it is corrected.

Two follow-ups are deliberately left out:

1. An unrecognised errno is still classified as `blocked`, which attaches the network guidance to a failure that has not been shown to be network-related. Deferring to the underlying cause instead would make the next unmapped errno harmless rather than misleading, and is the general form of the defect fixed here.
2. `WSAETIMEDOUT` (10060), which a dropped SYN produces, is classified as `blocked` rather than `timeout` for the same upstream reason: `syscall.Errno.Timeout` compares against the placeholder `ETIMEDOUT`. Both states produce the same verdict, so the only effect is the state string printed by `exasol diag local`.
