### PR TITLE
feat(local): Store Nano data in host-visible deployment storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ Notable user-facing changes to Exasol Personal are documented here.
 
 ### Changed
 
+- macOS local deployments now store Nano data in host-visible deployment
+  storage, making persistent `/exa` files available to host tools.
+
+- macOS local deployments now run the VM guest that belongs to the launcher's
+  runner. A deployment created by an earlier launcher rebuilds its guest on the
+  next `exasol start`, which takes longer than usual once and keeps its
+  database contents.
+
 - Custom SLC language identifiers are no longer limited to Python, Java, and R. The launcher now
   accepts any valid client-defined identifier, such as `rust`, for a custom SLC.
 

--- a/assets/resources/resources.yaml
+++ b/assets/resources/resources.yaml
@@ -42,8 +42,8 @@ exasol-local-runner:
   embed: true
   artifact:
     darwin/arm64:
-      url: https://github.com/exasol/exasol-local-vm/releases/download/v2.0.0-alpha.1/mac-launcher-aarch64.zip
-      sha256: 8386bc7f1816ac6994bf6bc0ac0d2067670de9ff5039acea923cef55c4b6dc40
+      url: https://github.com/exasol/exasol-local-vm/releases/download/v2.0.0/mac-launcher-aarch64.zip
+      sha256: 0396aaa409e3ee925726a9c5dae6b7eafb4c27c29382f6e51b0e0502e26a563a
       resource_path: launcher
 exasol-nano-image:
   extract: false

--- a/doc/virtual_schemas.md
+++ b/doc/virtual_schemas.md
@@ -85,16 +85,11 @@ DEPLOY_DIR=$(exasol info --json --deployment demo | jq -r '.deploymentDir')
 DEPLOY_DIR=$(exasol info --json --deployment-dir /path/to/deployment | jq -r '.deploymentDir')
 ```
 
-On Linux, Nano's `/exa` is the persistent Podman data directory on the host:
+Nano's `/exa` files are available at `local/runtime/exa` in the deployment directory:
 
 ```bash
 EXA_DATA="$DEPLOY_DIR/local/runtime/exa"
 ```
-
-On macOS, the database runs inside a managed VM. The deployment's
-`local/runtime/vm-shared` directory is mounted in the VM as `/mnt/host`. Use
-`exasol shell host` to copy staged files into the database directories; do not rely on VM IP
-addresses, SSH keys, or SSH ports.
 
 ## Worked example: PostgreSQL JDBC adapter
 
@@ -138,8 +133,6 @@ directory because the adapter reads it for metadata and the ETL layer uses it fo
 
 ### 2. Copy the files into the database
 
-On Linux:
-
 ```bash
 mkdir -p "$EXA_DATA/bucketfs/bfsdefault/default/vs"
 cp "$VS_DIR/$ADAPTER_JAR" "$VS_DIR/$DRIVER_JAR" \
@@ -148,28 +141,8 @@ mkdir -p "$EXA_DATA/jdbc/POSTGRESQL"
 cp "$VS_DIR/$DRIVER_JAR" "$VS_DIR/settings.cfg" "$EXA_DATA/jdbc/POSTGRESQL/"
 ```
 
-On macOS:
-
-```bash
-exasol shell host --deployment-dir "$DEPLOY_DIR"
-```
-
-Inside the VM shell, run:
-
-```bash
-mkdir -p /var/lib/exa/bucketfs/bfsdefault/default/vs /var/lib/exa/jdbc/POSTGRESQL && \
-cp /mnt/host/vs/virtual-schema-dist-14.0.2-postgresql-4.0.0.jar \
-   /mnt/host/vs/postgresql-42.7.13.jar \
-   /var/lib/exa/bucketfs/bfsdefault/default/vs/ && \
-cp /mnt/host/vs/postgresql-42.7.13.jar \
-   /mnt/host/vs/settings.cfg \
-   /var/lib/exa/jdbc/POSTGRESQL/ && \
-ls -lh /var/lib/exa/bucketfs/bfsdefault/default/vs /var/lib/exa/jdbc/POSTGRESQL
-```
-
-Then run `exit` to return to the macOS shell. `DRIVERNAME` is the name used in
-`IMPORT ... DRIVER = '...'`. If either example filename changes, use the resulting filenames for
-`JAR` and the `%jar` lines in the adapter script.
+`DRIVERNAME` is the name used in `IMPORT ... DRIVER = '...'`. If either example filename changes,
+use the resulting filenames for `JAR` and the `%jar` lines in the adapter script.
 
 ### 3. Apply the setup
 
@@ -182,8 +155,9 @@ This activates the SLC and makes the JDBC driver configuration available to the 
 
 ### Optional: run PostgreSQL inside the macOS VM
 
-For a self-contained test, PostgreSQL can run inside the managed VM. Put it on a dedicated Podman
-network and attach Nano to that network:
+For a self-contained test, PostgreSQL can run inside the managed VM. The deployment's
+`local/runtime/vm-shared` directory is mounted in the VM as `/mnt/host`. Put PostgreSQL on a
+dedicated Podman network and attach Nano to that network:
 
 ```bash
 exasol shell host --deployment-dir "$DEPLOY_DIR"

--- a/internal/deploy/local_backend.go
+++ b/internal/deploy/local_backend.go
@@ -412,7 +412,7 @@ func localConfigVariableDefinitionsForPlatform(
 	}
 	definitions[localDataSizeGBConfigName] = ConfigVariableDefinition{
 		Name:           localDataSizeGBConfigName,
-		Description:    "Data disk size in GB for the Exasol Local VM",
+		Description:    "VM runtime disk size in GB for Podman images and runtime state.",
 		Type:           ConfigVariableTypeNumber,
 		DefaultDisplay: strconv.Itoa(runtimeConfig.dataSizeGB),
 	}

--- a/internal/deploy/local_backend_test.go
+++ b/internal/deploy/local_backend_test.go
@@ -359,6 +359,27 @@ func TestLocalBackendReadConfiguration_ExposesSizingValues(t *testing.T) {
 	assertConfigValue(t, values, localDataSizeGBConfigName, 250, localDefaultDataSizeGB)
 }
 
+func TestLocalBackendDescribesMacOSRuntimeDisk(t *testing.T) {
+	t.Parallel()
+
+	backend := newLocalBackendForPlatform(
+		config.NewDeploymentDir(t.TempDir()),
+		&presets.InfrastructureManifest{},
+		nil,
+		localMacOS,
+		localMacArch,
+	)
+	definitions, err := backend.ReadDeploymentConfigVariables()
+	if err != nil {
+		t.Fatalf("expected local configuration definitions, got %v", err)
+	}
+	definition := definitions[localDataSizeGBConfigName]
+	const wantDescription = "VM runtime disk size in GB for Podman images and runtime state."
+	if definition.Description != wantDescription {
+		t.Fatalf("runtime disk description = %q, want %q", definition.Description, wantDescription)
+	}
+}
+
 func TestLocalBackendReadConfiguration_LinuxExposesOnlyPorts(t *testing.T) {
 	t.Parallel()
 

--- a/internal/localruntime/mac_data_migration.go
+++ b/internal/localruntime/mac_data_migration.go
@@ -1,0 +1,297 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package localruntime
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+
+	"github.com/exasol/exasol-personal/internal/localinstall"
+)
+
+const (
+	vmSharedNanoDataDir        = "/mnt/host/exa"
+	vmNanoDataBackupDir        = "/var/lib/exa.migrated-backup"
+	vmSharedNanoDataStagingDir = "/mnt/host/.exa-migration"
+	hostLayoutMarkerName       = ".exasol-personal-host-layout"
+	hostLayoutMarkerContents   = "1\n"
+)
+
+type macDataMigration struct {
+	environment localinstall.ExecutionEnvironment
+	sourceDir   string
+	targetDir   string
+	stagingDir  string
+	backupDir   string
+}
+
+func newMacDataMigration(environment localinstall.ExecutionEnvironment) *macDataMigration {
+	return &macDataMigration{
+		environment: environment,
+		sourceDir:   vmNanoDataDir,
+		targetDir:   vmSharedNanoDataDir,
+		stagingDir:  vmSharedNanoDataStagingDir,
+		backupDir:   vmNanoDataBackupDir,
+	}
+}
+
+func (migration *macDataMigration) prepare(
+	ctx context.Context,
+	out, outErr io.Writer,
+	stopNano func() error,
+) error {
+	targetComplete, err := migration.markerMatches(
+		ctx, path.Join(migration.targetDir, hostLayoutMarkerName),
+	)
+	if err != nil {
+		return err
+	}
+	sourceExists, err := migration.environment.PathExists(ctx, migration.sourceDir)
+	if err != nil {
+		return fmt.Errorf("failed to inspect legacy Nano data at %s: %w", migration.sourceDir, err)
+	}
+	sourcePopulated, err := migration.environment.DirectoryHasEntries(ctx, migration.sourceDir)
+	if err != nil {
+		return fmt.Errorf("failed to inspect legacy Nano data at %s: %w", migration.sourceDir, err)
+	}
+	if targetComplete {
+		if sourceExists {
+			if err := stopNano(); err != nil {
+				return fmt.Errorf("failed to stop Nano before using host data at %s: %w",
+					migration.targetDir, err)
+			}
+		}
+
+		return nil
+	}
+
+	targetPopulated, err := migration.environment.DirectoryHasEntries(ctx, migration.targetDir)
+	if err != nil {
+		return fmt.Errorf("failed to inspect host Nano data at %s: %w", migration.targetDir, err)
+	}
+	if sourcePopulated && targetPopulated {
+		return fmt.Errorf(
+			"refusing to migrate Nano data because both %s and %s contain data; "+
+				"leave one location empty and retry",
+			migration.sourceDir,
+			migration.targetDir,
+		)
+	}
+	if !sourcePopulated {
+		if sourceExists {
+			if err := stopNano(); err != nil {
+				return fmt.Errorf("failed to stop Nano before using host data at %s: %w",
+					migration.targetDir, err)
+			}
+		}
+
+		return nil
+	}
+	if err := stopNano(); err != nil {
+		return fmt.Errorf("failed to stop Nano before migrating %s to %s: %w",
+			migration.sourceDir, migration.targetDir, err)
+	}
+
+	return migration.copyAndPublish(ctx, out, outErr)
+}
+
+func (migration *macDataMigration) copyAndPublish(
+	ctx context.Context,
+	out, outErr io.Writer,
+) error {
+	readyToPublish, err := migration.resetOrResumeStaging(ctx)
+	if err != nil {
+		return err
+	}
+	if readyToPublish {
+		return migration.publish(ctx)
+	}
+	if err := migration.environment.MkdirAll(ctx, migration.stagingDir, dirMode); err != nil {
+		return fmt.Errorf("failed to create migration staging directory %s: %w",
+			migration.stagingDir, err)
+	}
+	if err := migration.environment.Run(
+		ctx,
+		nil,
+		out,
+		outErr,
+		"cp",
+		"-a",
+		"--sparse=always",
+		migration.sourceDir+"/.",
+		migration.stagingDir+"/",
+	); err != nil {
+		return fmt.Errorf(
+			"failed to copy legacy Nano data from %s to %s: %w",
+			migration.sourceDir,
+			migration.targetDir,
+			err,
+		)
+	}
+	if err := migration.environment.Sync(ctx, out, outErr); err != nil {
+		return fmt.Errorf("failed to flush migrated Nano data from %s to %s: %w",
+			migration.sourceDir, migration.targetDir, err)
+	}
+	if err := migration.environment.WriteFileAtomically(
+		ctx,
+		path.Join(migration.stagingDir, hostLayoutMarkerName),
+		[]byte(hostLayoutMarkerContents),
+		dirMode,
+		markerFileMode,
+	); err != nil {
+		return fmt.Errorf("failed to mark migrated Nano data at %s: %w",
+			migration.stagingDir, err)
+	}
+	if err := migration.environment.Sync(ctx, out, outErr); err != nil {
+		return fmt.Errorf("failed to flush completed migration at %s: %w",
+			migration.stagingDir, err)
+	}
+
+	return migration.publish(ctx)
+}
+
+func (migration *macDataMigration) resetOrResumeStaging(ctx context.Context) (bool, error) {
+	stagingExists, err := migration.environment.PathExists(ctx, migration.stagingDir)
+	if err != nil {
+		return false, fmt.Errorf("failed to inspect migration staging directory %s: %w",
+			migration.stagingDir, err)
+	}
+	if !stagingExists {
+		return false, nil
+	}
+	complete, err := migration.markerMatches(
+		ctx, path.Join(migration.stagingDir, hostLayoutMarkerName),
+	)
+	if err != nil {
+		return false, err
+	}
+	if complete {
+		return true, nil
+	}
+	if err := migration.environment.RemoveAll(ctx, migration.stagingDir); err != nil {
+		return false, fmt.Errorf("failed to reset migration staging directory %s: %w",
+			migration.stagingDir, err)
+	}
+
+	return false, nil
+}
+
+func (migration *macDataMigration) publish(ctx context.Context) error {
+	targetExists, err := migration.environment.PathExists(ctx, migration.targetDir)
+	if err != nil {
+		return fmt.Errorf("failed to inspect host Nano data at %s: %w", migration.targetDir, err)
+	}
+	if targetExists {
+		targetPopulated, inspectErr := migration.environment.DirectoryHasEntries(
+			ctx, migration.targetDir,
+		)
+		if inspectErr != nil {
+			return fmt.Errorf("failed to inspect host Nano data at %s: %w",
+				migration.targetDir, inspectErr)
+		}
+		if targetPopulated {
+			return fmt.Errorf("refusing to publish migrated Nano data because %s contains data",
+				migration.targetDir)
+		}
+		if err := migration.environment.RemoveDir(ctx, migration.targetDir); err != nil {
+			return fmt.Errorf("failed to remove empty host Nano directory %s: %w",
+				migration.targetDir, err)
+		}
+	}
+	if err := migration.environment.Rename(
+		ctx, migration.stagingDir, migration.targetDir,
+	); err != nil {
+		return fmt.Errorf("failed to publish migrated Nano data from %s to %s: %w",
+			migration.sourceDir, migration.targetDir, err)
+	}
+
+	return nil
+}
+
+func (migration *macDataMigration) finalize(
+	ctx context.Context,
+	out, outErr io.Writer,
+) error {
+	complete, err := migration.markerMatches(
+		ctx, path.Join(migration.targetDir, hostLayoutMarkerName),
+	)
+	if err != nil {
+		return err
+	}
+	if !complete {
+		if err := migration.environment.WriteFileAtomically(
+			ctx,
+			path.Join(migration.targetDir, hostLayoutMarkerName),
+			[]byte(hostLayoutMarkerContents),
+			dirMode,
+			markerFileMode,
+		); err != nil {
+			return fmt.Errorf("failed to record host Nano layout at %s: %w",
+				migration.targetDir, err)
+		}
+	}
+	sourceExists, err := migration.environment.PathExists(ctx, migration.sourceDir)
+	if err != nil {
+		return fmt.Errorf("failed to inspect legacy Nano data at %s: %w", migration.sourceDir, err)
+	}
+	if sourceExists {
+		backupExists, inspectErr := migration.environment.PathExists(ctx, migration.backupDir)
+		if inspectErr != nil {
+			return fmt.Errorf("failed to inspect migration backup at %s: %w",
+				migration.backupDir, inspectErr)
+		}
+		if backupExists {
+			return fmt.Errorf(
+				"refusing to replace migration backup %s while retiring legacy Nano data at %s",
+				migration.backupDir,
+				migration.sourceDir,
+			)
+		}
+		if err := migration.environment.Rename(
+			ctx, migration.sourceDir, migration.backupDir,
+		); err != nil {
+			return fmt.Errorf("failed to retain legacy Nano data from %s at %s: %w",
+				migration.sourceDir, migration.backupDir, err)
+		}
+	}
+	if err := migration.environment.Sync(ctx, out, outErr); err != nil {
+		return fmt.Errorf("failed to flush completed host Nano layout at %s: %w",
+			migration.targetDir, err)
+	}
+
+	return nil
+}
+
+func (migration *macDataMigration) markerMatches(
+	ctx context.Context,
+	markerPath string,
+) (bool, error) {
+	exists, err := migration.environment.PathExists(ctx, markerPath)
+	if err != nil || !exists {
+		return false, err
+	}
+	err = migration.environment.Run(
+		ctx,
+		nil,
+		io.Discard,
+		io.Discard,
+		"sh",
+		"-c",
+		`actual=$(cat "$1"); [ "$actual" = "$2" ]`,
+		"sh",
+		markerPath,
+		strings.TrimSuffix(hostLayoutMarkerContents, "\n"),
+	)
+	if err == nil {
+		return true, nil
+	}
+	if commandExitedWith(err, 1) {
+		return false, nil
+	}
+
+	return false, fmt.Errorf("failed to read migration marker %s: %w", markerPath, err)
+}

--- a/internal/localruntime/mac_data_migration_test.go
+++ b/internal/localruntime/mac_data_migration_test.go
@@ -1,0 +1,307 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package localruntime
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/exasol/exasol-personal/internal/localinstall"
+)
+
+const migrationSparseFileSize = int64(64 * 1024 * 1024)
+
+func TestMacDataMigrationCopiesAndRetainsLegacyData(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	migration := newTestMacDataMigration(t)
+	wantTime := time.Unix(1577934245, 0)
+	writeMigrationFixture(t, migration.sourceDir, wantTime)
+	if err := os.MkdirAll(migration.targetDir, dirMode); err != nil {
+		t.Fatal(err)
+	}
+	stopCalls := 0
+
+	// When
+	err := migration.prepare(context.Background(), io.Discard, io.Discard, func() error {
+		stopCalls++
+
+		return nil
+	})
+	// Then
+	if err != nil {
+		t.Fatalf("prepare migration failed: %v", err)
+	}
+	if stopCalls != 1 {
+		t.Fatalf("stop calls = %d, want 1", stopCalls)
+	}
+	assertMigrationFixture(t, migration.targetDir, wantTime)
+	if _, err := os.Stat(filepath.Join(migration.sourceDir, "sparse")); err != nil {
+		t.Fatalf("legacy source changed before finalization: %v", err)
+	}
+	assertFileContents(
+		t, filepath.Join(migration.targetDir, hostLayoutMarkerName), hostLayoutMarkerContents,
+	)
+
+	// When
+	err = migration.finalize(context.Background(), io.Discard, io.Discard)
+	// Then
+	if err != nil {
+		t.Fatalf("finalize migration failed: %v", err)
+	}
+	if _, err := os.Stat(migration.sourceDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("legacy source still active after finalization: %v", err)
+	}
+	assertMigrationFixture(t, migration.backupDir, wantTime)
+}
+
+func TestMacDataMigrationRetriesInterruptedCopy(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	migration := newTestMacDataMigration(t)
+	writeMigrationFixture(t, migration.sourceDir, time.Unix(1577934245, 0))
+	failing := &copyFailingEnvironment{
+		ExecutionEnvironment: migration.environment,
+		failNextCopy:         true,
+	}
+	migration.environment = failing
+	stopCalls := 0
+	stopNano := func() error {
+		stopCalls++
+
+		return nil
+	}
+
+	// When
+	firstErr := migration.prepare(context.Background(), io.Discard, io.Discard, stopNano)
+	failing.failNextCopy = false
+	secondErr := migration.prepare(context.Background(), io.Discard, io.Discard, stopNano)
+
+	// Then
+	if firstErr == nil || !strings.Contains(firstErr.Error(), migration.sourceDir) ||
+		!strings.Contains(firstErr.Error(), migration.targetDir) {
+		t.Fatalf("copy failure does not identify both locations: %v", firstErr)
+	}
+	if secondErr != nil {
+		t.Fatalf("migration retry failed: %v", secondErr)
+	}
+	if stopCalls != 2 {
+		t.Fatalf("stop calls = %d, want 2", stopCalls)
+	}
+	if failing.copyCalls != 2 {
+		t.Fatalf("copy calls = %d, want 2", failing.copyCalls)
+	}
+	if _, err := os.Stat(filepath.Join(migration.sourceDir, "sparse")); err != nil {
+		t.Fatalf("legacy source changed during retry: %v", err)
+	}
+}
+
+func TestMacDataMigrationResumesAfterPublication(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	migration := newTestMacDataMigration(t)
+	writeMigrationFixture(t, migration.sourceDir, time.Unix(1577934245, 0))
+	counting := &copyFailingEnvironment{ExecutionEnvironment: migration.environment}
+	migration.environment = counting
+	if err := migration.prepare(context.Background(), io.Discard, io.Discard, func() error {
+		return nil
+	}); err != nil {
+		t.Fatalf("initial migration failed: %v", err)
+	}
+	stopCalls := 0
+
+	// When
+	err := migration.prepare(context.Background(), io.Discard, io.Discard, func() error {
+		stopCalls++
+
+		return nil
+	})
+	// Then
+	if err != nil {
+		t.Fatalf("migration resume failed: %v", err)
+	}
+	if stopCalls != 1 {
+		t.Fatalf("stop calls = %d, want 1", stopCalls)
+	}
+	if counting.copyCalls != 1 {
+		t.Fatalf("copy calls = %d, want the published data to be reused", counting.copyCalls)
+	}
+}
+
+func TestMacDataMigrationRejectsPopulatedSourceAndTarget(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	migration := newTestMacDataMigration(t)
+	writeTestPath(t, filepath.Join(migration.sourceDir, "source"), "source")
+	writeTestPath(t, filepath.Join(migration.targetDir, "target"), "target")
+	stopCalled := false
+
+	// When
+	err := migration.prepare(context.Background(), io.Discard, io.Discard, func() error {
+		stopCalled = true
+
+		return nil
+	})
+
+	// Then
+	if err == nil || !strings.Contains(err.Error(), migration.sourceDir) ||
+		!strings.Contains(err.Error(), migration.targetDir) {
+		t.Fatalf("conflict error does not identify both locations: %v", err)
+	}
+	if stopCalled {
+		t.Fatal("Nano was stopped before the data conflict was rejected")
+	}
+	assertFileContents(t, filepath.Join(migration.sourceDir, "source"), "source")
+	assertFileContents(t, filepath.Join(migration.targetDir, "target"), "target")
+}
+
+func TestMacDataMigrationMarksFreshHostLayoutAfterReadiness(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	migration := newTestMacDataMigration(t)
+	writeTestPath(t, filepath.Join(migration.targetDir, "exasol.conf"), "fresh")
+
+	// When
+	err := migration.finalize(context.Background(), io.Discard, io.Discard)
+	// Then
+	if err != nil {
+		t.Fatalf("finalizing fresh host layout failed: %v", err)
+	}
+	assertFileContents(
+		t, filepath.Join(migration.targetDir, hostLayoutMarkerName), hostLayoutMarkerContents,
+	)
+}
+
+type copyFailingEnvironment struct {
+	localinstall.ExecutionEnvironment
+
+	failNextCopy bool
+	copyCalls    int
+}
+
+func (environment *copyFailingEnvironment) Run(
+	ctx context.Context,
+	stdin io.Reader,
+	stdout, stderr io.Writer,
+	command ...string,
+) error {
+	if len(command) > 0 && command[0] == "cp" {
+		environment.copyCalls++
+		if environment.failNextCopy {
+			return errors.New("injected copy failure")
+		}
+	}
+
+	return environment.ExecutionEnvironment.Run(ctx, stdin, stdout, stderr, command...)
+}
+
+func newTestMacDataMigration(t *testing.T) *macDataMigration {
+	t.Helper()
+	root := t.TempDir()
+
+	migration := newMacDataMigration(localinstall.NewDirectExecutionEnvironment(nil))
+	migration.sourceDir = filepath.Join(root, "guest", "exa")
+	migration.targetDir = filepath.Join(root, "host", "exa")
+	migration.stagingDir = filepath.Join(root, "host", ".exa-migration")
+	migration.backupDir = filepath.Join(root, "guest", "exa.migrated-backup")
+
+	return migration
+}
+
+func writeMigrationFixture(t *testing.T, directory string, modificationTime time.Time) {
+	t.Helper()
+	if err := os.MkdirAll(directory, dirMode); err != nil {
+		t.Fatal(err)
+	}
+	sparsePath := filepath.Join(directory, "sparse")
+	file, err := os.OpenFile(sparsePath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Truncate(migrationSparseFileSize); err != nil {
+		_ = file.Close()
+		t.Fatal(err)
+	}
+	if _, err := file.WriteAt([]byte("x"), migrationSparseFileSize-1); err != nil {
+		_ = file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(sparsePath, modificationTime, modificationTime); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("sparse", filepath.Join(directory, "link")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertMigrationFixture(t *testing.T, directory string, modificationTime time.Time) {
+	t.Helper()
+	fileInfo, err := os.Stat(filepath.Join(directory, "sparse"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fileInfo.Size() != migrationSparseFileSize {
+		t.Fatalf("copied file size = %d, want %d", fileInfo.Size(), migrationSparseFileSize)
+	}
+	if fileInfo.Mode().Perm() != 0o600 {
+		t.Fatalf("copied file mode = %o, want 600", fileInfo.Mode().Perm())
+	}
+	if !fileInfo.ModTime().Equal(modificationTime) {
+		t.Fatalf(
+			"copied file modification time = %v, want %v",
+			fileInfo.ModTime(), modificationTime,
+		)
+	}
+	stat, ok := fileInfo.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatal("unexpected stat type for copied sparse file")
+	}
+	if allocated := stat.Blocks * 512; allocated >= migrationSparseFileSize/2 {
+		t.Fatalf("copied file allocated %d bytes for logical size %d",
+			allocated, migrationSparseFileSize)
+	}
+	linkTarget, err := os.Readlink(filepath.Join(directory, "link"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if linkTarget != "sparse" {
+		t.Fatalf("copied symbolic link target = %q, want sparse", linkTarget)
+	}
+}
+
+func writeTestPath(t *testing.T, filePath, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(filePath), dirMode); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filePath, []byte(contents), markerFileMode); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertFileContents(t *testing.T, filePath, want string) {
+	t.Helper()
+	contents, err := os.ReadFile(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(contents) != want {
+		t.Fatalf("file %s = %q, want %q", filePath, contents, want)
+	}
+}

--- a/internal/localruntime/mac_vm_runtime.go
+++ b/internal/localruntime/mac_vm_runtime.go
@@ -84,11 +84,17 @@ type runnerState struct {
 }
 
 type MacVMRuntime struct {
-	deployment     config.DeploymentDir
-	paths          vmRuntimePaths
-	manager        *runtimeartifacts.Manager
-	endpoint       *RuntimeEndpoint
-	installFactory func(string) (localinstall.LocalInstall, error)
+	deployment       config.DeploymentDir
+	paths            vmRuntimePaths
+	manager          *runtimeartifacts.Manager
+	endpoint         *RuntimeEndpoint
+	installFactory   func(string) (localinstall.LocalInstall, error)
+	migrationFactory func(localinstall.ExecutionEnvironment) macDataMigrator
+}
+
+type macDataMigrator interface {
+	prepare(ctx context.Context, out, outErr io.Writer, stopNano func() error) error
+	finalize(ctx context.Context, out, outErr io.Writer) error
 }
 
 // NewMacVMRuntime creates a VM runtime. manager may be nil when no runner invocation is needed.
@@ -117,6 +123,9 @@ func (runtime *MacVMRuntime) Prepare(
 	if err := os.MkdirAll(runtime.paths.WorkDir, dirMode); err != nil {
 		return fmt.Errorf("failed to create local runtime directory: %w", err)
 	}
+	if err := ensureMacHostDataLink(runtime.paths); err != nil {
+		return err
+	}
 	runnerPath, err := runtime.resolveRunnerPath(ctx)
 	if err != nil {
 		return err
@@ -126,6 +135,42 @@ func (runtime *MacVMRuntime) Prepare(
 	}
 
 	return runtime.initializeVMIfNeeded(ctx, runnerPath, out, outErr)
+}
+
+func ensureMacHostDataLink(paths vmRuntimePaths) error {
+	wantTarget := filepath.Join(sharedDirName, nanoDataDirName)
+	info, err := os.Lstat(paths.HostNanoDataDir)
+	if errors.Is(err, os.ErrNotExist) {
+		if err := os.Symlink(wantTarget, paths.HostNanoDataDir); err != nil {
+			return fmt.Errorf("failed to create host Nano data link: %w", err)
+		}
+
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to inspect host Nano data path: %w", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return fmt.Errorf(
+			"host Nano data path %s already exists and is not the managed symlink to %s",
+			paths.HostNanoDataDir,
+			wantTarget,
+		)
+	}
+	target, err := os.Readlink(paths.HostNanoDataDir)
+	if err != nil {
+		return fmt.Errorf("failed to read host Nano data link: %w", err)
+	}
+	if target != wantTarget {
+		return fmt.Errorf(
+			"host Nano data path %s points to %s instead of the managed target %s",
+			paths.HostNanoDataDir,
+			target,
+			wantTarget,
+		)
+	}
+
+	return nil
 }
 
 func (runtime *MacVMRuntime) Start(
@@ -168,9 +213,15 @@ func (runtime *MacVMRuntime) Start(
 	if err != nil {
 		return runtime.stopAfterStartFailure(ctx, runnerPath, out, outErr, err)
 	}
+	migration := runtime.dataMigration(runnerPath)
+	if err := migration.prepare(ctx, out, outErr, func() error {
+		return install.Stop(ctx, out, outErr)
+	}); err != nil {
+		return runtime.stopAfterStartFailure(ctx, runnerPath, out, outErr, err)
+	}
 	startConfig := localinstall.StartConfig{
 		ContainerDBPort:      nanoDBPort,
-		DataDir:              vmNanoDataDir,
+		DataDir:              vmSharedNanoDataDir,
 		InitParams:           append([]string(nil), nanoInitParams...),
 		VersionCheck:         runtimeConfig.VersionCheck,
 		SLCs:                 runtimeConfig.SLCs,
@@ -339,9 +390,8 @@ func (runtime *MacVMRuntime) WorkaroundNanoStartupDurability(
 	if err != nil {
 		return err
 	}
-	environment := newRunnerExecutionEnvironment(runnerPath, runtime.paths.WorkDir)
-	if err := environment.Sync(ctx, out, outErr); err != nil {
-		return fmt.Errorf("failed to apply Nano startup durability workaround: %w", err)
+	if err := runtime.dataMigration(runnerPath).finalize(ctx, out, outErr); err != nil {
+		return fmt.Errorf("failed to finalize Nano data migration: %w", err)
 	}
 
 	return nil
@@ -452,6 +502,15 @@ func (runtime *MacVMRuntime) install(
 		slcStagingDir,
 		slcStatusPath,
 	), nil
+}
+
+func (runtime *MacVMRuntime) dataMigration(runnerPath string) macDataMigrator {
+	environment := newRunnerExecutionEnvironment(runnerPath, runtime.paths.WorkDir)
+	if runtime.migrationFactory != nil {
+		return runtime.migrationFactory(environment)
+	}
+
+	return newMacDataMigration(environment)
 }
 
 func materializeFileAtomically(sourcePath, targetPath string) error {

--- a/internal/localruntime/mac_vm_runtime.go
+++ b/internal/localruntime/mac_vm_runtime.go
@@ -130,11 +130,24 @@ func (runtime *MacVMRuntime) Prepare(
 	if err != nil {
 		return err
 	}
-	if err := runtime.reconcileRunnerVersion(ctx, runnerPath); err != nil {
+	reconciliation, err := runtime.reconcileRunnerVersion(ctx, runnerPath)
+	if err != nil {
 		return err
 	}
+	if err := runtime.initializeVM(
+		ctx, runnerPath, reconciliation.GuestStale, out, outErr,
+	); err != nil {
+		return err
+	}
+	if !reconciliation.Recordable {
+		return nil
+	}
 
-	return runtime.initializeVMIfNeeded(ctx, runnerPath, out, outErr)
+	// Recording only now leaves an interrupted replacement visible as a
+	// mismatch, so the next start retries it.
+	return writeRunnerVersionMarker(
+		runtime.paths.RunnerVersionMarkerPath, reconciliation.Version,
+	)
 }
 
 func ensureMacHostDataLink(paths vmRuntimePaths) error {
@@ -186,7 +199,7 @@ func (runtime *MacVMRuntime) Start(
 	if err != nil {
 		return err
 	}
-	if err := runtime.reconcileRunnerVersion(ctx, runnerPath); err != nil {
+	if _, err := runtime.reconcileRunnerVersion(ctx, runnerPath); err != nil {
 		return err
 	}
 
@@ -640,23 +653,66 @@ func (runtime *MacVMRuntime) resolveRunnerPath(ctx context.Context) (string, err
 	return runtime.manager.Request(ctx, exasolLocalRunnerResourceID)
 }
 
-func (runtime *MacVMRuntime) initializeVMIfNeeded(
+func (runtime *MacVMRuntime) initializeVM(
 	ctx context.Context,
 	runnerPath string,
+	guestStale bool,
 	out, outErr io.Writer,
 ) error {
-	if _, err := os.Stat(runtime.paths.VMDir); err == nil {
-		return nil
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("failed to inspect local VM directory: %w", err)
+	initialized := true
+	if _, err := os.Stat(runtime.paths.VMDir); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("failed to inspect local VM directory: %w", err)
+		}
+		initialized = false
+	}
+	if initialized {
+		if !guestStale {
+			return nil
+		}
+		if err := runtime.stopVMBeforeGuestReplacement(
+			ctx, runnerPath, out, outErr,
+		); err != nil {
+			return err
+		}
+		slog.Info("replacing the local VM guest to match the resolved runner")
 	}
 
 	return runtime.runnerCommand(ctx, runnerPath, []string{"init"}, out, outErr)
 }
 
-// reconcileRunnerVersion enforces the VM-only v2 contract and records the
-// resolved runner version for deployment diagnostics.
-func (runtime *MacVMRuntime) reconcileRunnerVersion(ctx context.Context, runnerPath string) error {
+// stopVMBeforeGuestReplacement guards the guest disk, which the runner rewrites
+// in place while a booted VM still has it open.
+func (runtime *MacVMRuntime) stopVMBeforeGuestReplacement(
+	ctx context.Context,
+	runnerPath string,
+	out, outErr io.Writer,
+) error {
+	vmStatus, err := runnerCommandJSON[RuntimeStatus](ctx, runtime, "status")
+	if err != nil {
+		return err
+	}
+	if !vmStatus.Running {
+		return nil
+	}
+
+	return runtime.stopVM(ctx, runnerPath, out, outErr)
+}
+
+// runnerReconciliation reports what the version check learned, so the guest can
+// be replaced before the resolved version is recorded.
+type runnerReconciliation struct {
+	Version    semver.Version
+	Recordable bool
+	GuestStale bool
+}
+
+// reconcileRunnerVersion enforces the VM-only v2 contract and compares the
+// resolved runner against the one that produced this deployment's guest.
+func (runtime *MacVMRuntime) reconcileRunnerVersion(
+	ctx context.Context,
+	runnerPath string,
+) (runnerReconciliation, error) {
 	resolvedVersion, err := readRunnerVersion(ctx, runnerPath)
 	forceReconciliation := strings.TrimSpace(os.Getenv(forceRunnerReconciliationEnv)) == "1"
 	if err != nil {
@@ -667,22 +723,28 @@ func (runtime *MacVMRuntime) reconcileRunnerVersion(ctx context.Context, runnerP
 				"versionError", err,
 			)
 
-			return nil
+			return runnerReconciliation{}, nil
 		}
 
-		return fmt.Errorf("resolved local runner does not report a valid version: %w", err)
+		return runnerReconciliation{}, fmt.Errorf(
+			"resolved local runner does not report a valid version: %w", err,
+		)
 	}
 	if resolvedVersion.Major < minimumRunnerMajor {
-		return fmt.Errorf(
+		return runnerReconciliation{}, fmt.Errorf(
 			"resolved local runner %s uses the legacy application-owning contract; "+
 				"version 2 or newer is required",
 			resolvedVersion,
 		)
 	}
 
-	markerVersion, err := readRunnerVersionMarker(runtime.paths.RunnerVersionMarkerPath)
-	if err != nil {
-		return writeRunnerVersionMarker(runtime.paths.RunnerVersionMarkerPath, resolvedVersion)
+	reconciliation := runnerReconciliation{Version: resolvedVersion, Recordable: true}
+	markerVersion, recorded := runtime.recordedRunnerVersion()
+	if !recorded {
+		// Unknown provenance is replaced rather than trusted.
+		reconciliation.GuestStale = true
+
+		return reconciliation, nil
 	}
 
 	switch {
@@ -707,8 +769,24 @@ func (runtime *MacVMRuntime) reconcileRunnerVersion(ctx context.Context, runnerP
 	default:
 		// Identical versions require no diagnostic message.
 	}
+	reconciliation.GuestStale = !resolvedVersion.EQ(markerVersion)
 
-	return writeRunnerVersionMarker(runtime.paths.RunnerVersionMarkerPath, resolvedVersion)
+	return reconciliation, nil
+}
+
+// A deployment predating version tracking carries no record, which for deciding
+// whether to trust its guest is the same as a record that cannot be read.
+func (runtime *MacVMRuntime) recordedRunnerVersion() (semver.Version, bool) {
+	version, err := readRunnerVersionMarker(runtime.paths.RunnerVersionMarkerPath)
+	if err != nil {
+		slog.Debug(
+			"no usable local runner version recorded for this deployment", "error", err,
+		)
+
+		return semver.Version{}, false
+	}
+
+	return version, true
 }
 
 func readRunnerVersion(ctx context.Context, runnerPath string) (semver.Version, error) {

--- a/internal/localruntime/mac_vm_runtime_test.go
+++ b/internal/localruntime/mac_vm_runtime_test.go
@@ -5,7 +5,6 @@ package localruntime
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -13,6 +12,7 @@ import (
 	"time"
 
 	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/localinstall"
 )
 
 func TestReadRunnerStateUsesLabeledForwardsWithoutTransportMetadata(t *testing.T) {
@@ -93,6 +93,77 @@ func TestResolveMacHostDBPort(t *testing.T) {
 		if _, err := resolveMacHostDBPort(ports); err == nil {
 			t.Fatalf("expected invalid mapping %q to fail", ports)
 		}
+	}
+}
+
+//nolint:paralleltest // test runner scripts fork executable fixtures.
+func TestMacVMRuntimePrepareCreatesAndReusesManagedHostDataLink(t *testing.T) {
+	requirePOSIXRunnerTest(t)
+
+	// Given
+	eventsPath := filepath.Join(t.TempDir(), "events")
+	runtime := NewMacVMRuntime(
+		config.NewDeploymentDir(t.TempDir()),
+		newTestManagerForRunner(t, []byte(fakeV2RunnerScript(eventsPath))),
+	)
+
+	// When
+	if err := runtime.Prepare(context.Background(), nil, nil, PrepareOptions{}); err != nil {
+		t.Fatalf("failed to prepare runtime: %v", err)
+	}
+	if err := runtime.Prepare(context.Background(), nil, nil, PrepareOptions{}); err != nil {
+		t.Fatalf("failed to prepare runtime again: %v", err)
+	}
+
+	// Then
+	target, err := os.Readlink(runtime.paths.HostNanoDataDir)
+	if err != nil {
+		t.Fatalf("failed to read host data link: %v", err)
+	}
+	wantTarget := filepath.Join(sharedDirName, nanoDataDirName)
+	if target != wantTarget {
+		t.Fatalf("host data link target = %q, want %q", target, wantTarget)
+	}
+}
+
+func TestMacVMRuntimePrepareRejectsConflictingHostDataPath(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]func(t *testing.T, path string){
+		"directory": func(t *testing.T, path string) {
+			t.Helper()
+			if err := os.Mkdir(path, dirMode); err != nil {
+				t.Fatalf("failed to create conflicting directory: %v", err)
+			}
+		},
+		"file": func(t *testing.T, path string) {
+			t.Helper()
+			if err := os.WriteFile(path, []byte("data"), markerFileMode); err != nil {
+				t.Fatalf("failed to create conflicting file: %v", err)
+			}
+		},
+		"different symlink": func(t *testing.T, path string) {
+			t.Helper()
+			if err := os.Symlink("somewhere-else", path); err != nil {
+				t.Fatalf("failed to create conflicting symlink: %v", err)
+			}
+		},
+	}
+	for name, createConflict := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			runtime := NewMacVMRuntime(config.NewDeploymentDir(t.TempDir()), nil)
+			if err := os.MkdirAll(runtime.paths.WorkDir, dirMode); err != nil {
+				t.Fatalf("failed to create runtime directory: %v", err)
+			}
+			createConflict(t, runtime.paths.HostNanoDataDir)
+
+			err := runtime.Prepare(context.Background(), nil, nil, PrepareOptions{})
+
+			if err == nil || !strings.Contains(err.Error(), runtime.paths.HostNanoDataDir) {
+				t.Fatalf("expected path-rich conflict error, got %v", err)
+			}
+		})
 	}
 }
 
@@ -192,18 +263,17 @@ func TestMaterializeFileAtomicallyRejectsDirectorySource(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // test runner scripts fork executable fixtures.
-func TestMacVMRuntimeWorkaroundNanoStartupDurabilityDelegatesToRunner(t *testing.T) {
-	requirePOSIXRunnerTest(t)
+func TestMacVMRuntimeWorkaroundNanoStartupDurabilityFinalizesMigration(t *testing.T) {
+	t.Parallel()
 
 	deployment := config.NewDeploymentDir(t.TempDir())
-	logPath := filepath.Join(t.TempDir(), "runner-args")
-	runnerScript := fmt.Sprintf(`#!/bin/sh
-printf '%%s' "$*" > %q
-`, logPath)
 	localRuntime := NewMacVMRuntime(
-		deployment, newTestManagerForRunner(t, []byte(runnerScript)),
+		deployment, newTestManagerForRunner(t, []byte("#!/bin/sh\n")),
 	)
+	migration := &recordingMacDataMigrator{}
+	localRuntime.migrationFactory = func(localinstall.ExecutionEnvironment) macDataMigrator {
+		return migration
+	}
 	if err := os.MkdirAll(localRuntime.paths.WorkDir, dirMode); err != nil {
 		t.Fatalf("failed to create runtime work dir: %v", err)
 	}
@@ -211,11 +281,10 @@ printf '%%s' "$*" > %q
 	if err := localRuntime.WorkaroundNanoStartupDurability(
 		context.Background(), nil, nil,
 	); err != nil {
-		t.Fatalf("expected VM sync to succeed, got %v", err)
+		t.Fatalf("expected migration finalization to succeed, got %v", err)
 	}
-	args, err := os.ReadFile(logPath)
-	if err != nil || string(args) != "run -- sync" {
-		t.Fatalf("expected sync through runner, got %q, %v", string(args), err)
+	if migration.finalizeCalls != 1 {
+		t.Fatalf("migration finalize calls = %d, want 1", migration.finalizeCalls)
 	}
 }
 

--- a/internal/localruntime/mac_vm_runtime_test.go
+++ b/internal/localruntime/mac_vm_runtime_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -123,6 +124,132 @@ func TestMacVMRuntimePrepareCreatesAndReusesManagedHostDataLink(t *testing.T) {
 	wantTarget := filepath.Join(sharedDirName, nanoDataDirName)
 	if target != wantTarget {
 		t.Fatalf("host data link target = %q, want %q", target, wantTarget)
+	}
+}
+
+//nolint:paralleltest // test runner scripts fork executable fixtures.
+func TestMacVMRuntimePrepareReplacesGuestWhenRunnerChanged(t *testing.T) {
+	requirePOSIXRunnerTest(t)
+
+	// Given a deployment whose guest came from a different runner
+	eventsPath := filepath.Join(t.TempDir(), "events")
+	runtime := newPreparedGuestRuntime(t, eventsPath, "2.0.0-dev", "1.1.0")
+
+	// When
+	if err := runtime.Prepare(context.Background(), nil, nil, PrepareOptions{}); err != nil {
+		t.Fatalf("failed to prepare runtime: %v", err)
+	}
+
+	// Then the guest is replaced and the resolved runner recorded
+	assertRunnerEvents(t, eventsPath, "runner-init")
+	assertMarkerVersion(t, runtime, "2.0.0-dev")
+}
+
+//nolint:paralleltest // test runner scripts fork executable fixtures.
+func TestMacVMRuntimePrepareKeepsGuestOfRecordedRunner(t *testing.T) {
+	requirePOSIXRunnerTest(t)
+
+	// Given a deployment whose guest came from the resolved runner
+	eventsPath := filepath.Join(t.TempDir(), "events")
+	runtime := newPreparedGuestRuntime(t, eventsPath, "2.0.0-dev", "2.0.0-dev")
+
+	// When
+	if err := runtime.Prepare(context.Background(), nil, nil, PrepareOptions{}); err != nil {
+		t.Fatalf("failed to prepare runtime: %v", err)
+	}
+
+	// Then the guest is left alone
+	assertRunnerEvents(t, eventsPath)
+}
+
+//nolint:paralleltest // test runner scripts fork executable fixtures.
+func TestMacVMRuntimePrepareStopsRunningVMBeforeReplacingGuest(t *testing.T) {
+	requirePOSIXRunnerTest(t)
+
+	// Given a running VM whose guest came from a different runner
+	eventsPath := filepath.Join(t.TempDir(), "events")
+	runtime := newPreparedGuestRuntime(t, eventsPath, "2.0.0-dev", "1.1.0")
+	if err := os.WriteFile(
+		filepath.Join(runtime.paths.WorkDir, "running"), nil, markerFileMode,
+	); err != nil {
+		t.Fatalf("failed to mark the VM as running: %v", err)
+	}
+
+	// When
+	if err := runtime.Prepare(context.Background(), nil, nil, PrepareOptions{}); err != nil {
+		t.Fatalf("failed to prepare runtime: %v", err)
+	}
+
+	// Then the VM stops before its guest disk is rewritten
+	assertRunnerEvents(t, eventsPath, "runner-stop", "runner-init")
+}
+
+//nolint:paralleltest // test runner scripts fork executable fixtures.
+func TestMacVMRuntimePrepareKeepsRecordedVersionWhenReplacementFails(t *testing.T) {
+	requirePOSIXRunnerTest(t)
+
+	// Given a runner that cannot rebuild the guest
+	eventsPath := filepath.Join(t.TempDir(), "events")
+	script := strings.Replace(
+		fakeV2RunnerScriptWithVersion(eventsPath, "2.0.0-dev"),
+		"    mkdir -p vm vm-shared\n",
+		"    exit 3\n",
+		1,
+	)
+	runtime := NewMacVMRuntime(
+		config.NewDeploymentDir(t.TempDir()), newTestManagerForRunner(t, []byte(script)),
+	)
+	seedPreparedGuest(t, runtime, "1.1.0")
+
+	// When
+	err := runtime.Prepare(context.Background(), nil, nil, PrepareOptions{})
+
+	// Then the recorded version still reports the guest that is actually there
+	if err == nil {
+		t.Fatal("expected guest replacement to fail")
+	}
+	assertMarkerVersion(t, runtime, "1.1.0")
+}
+
+func newPreparedGuestRuntime(
+	t *testing.T,
+	eventsPath, runnerVersion, recordedVersion string,
+) *MacVMRuntime {
+	t.Helper()
+
+	runtime := NewMacVMRuntime(
+		config.NewDeploymentDir(t.TempDir()),
+		newTestManagerForRunner(
+			t, []byte(fakeV2RunnerScriptWithVersion(eventsPath, runnerVersion)),
+		),
+	)
+	seedPreparedGuest(t, runtime, recordedVersion)
+
+	return runtime
+}
+
+func seedPreparedGuest(t *testing.T, runtime *MacVMRuntime, recordedVersion string) {
+	t.Helper()
+
+	if err := os.MkdirAll(runtime.paths.VMDir, dirMode); err != nil {
+		t.Fatalf("failed to seed VM directory: %v", err)
+	}
+	seedVersionMarker(t, runtime, recordedVersion)
+}
+
+func assertRunnerEvents(t *testing.T, eventsPath string, expected ...string) {
+	t.Helper()
+
+	content, err := os.ReadFile(eventsPath)
+	if err != nil {
+		if os.IsNotExist(err) && len(expected) == 0 {
+			return
+		}
+		t.Fatalf("failed to read runner events: %v", err)
+	}
+	actual := strings.Fields(string(content))
+	if !slices.Equal(actual, expected) {
+		t.Fatalf("runner events = %v, want %v", actual, expected)
 	}
 }
 

--- a/internal/localruntime/runner_environment.go
+++ b/internal/localruntime/runner_environment.go
@@ -107,7 +107,9 @@ func (environment *runnerExecutionEnvironment) MkdirAll(
 ) error {
 	return environment.Run(
 		ctx, nil, nil, nil,
-		"sh", "-c", `umask 0; mkdir -p -- "$2"; chmod "$1" "$2"`,
+		// Leaving an existing directory's mode alone keeps this usable on the
+		// host share's mount point, which the guest cannot chmod.
+		"sh", "-c", `umask 0; [ -d "$2" ] || { mkdir -p -- "$2" && chmod "$1" "$2"; }`,
 		"sh", formatFileMode(mode), directory,
 	)
 }

--- a/internal/localruntime/runner_environment_test.go
+++ b/internal/localruntime/runner_environment_test.go
@@ -91,6 +91,9 @@ func TestRunnerExecutionEnvironmentFilesystemOperations(t *testing.T) {
 	if err := os.Chmod(directory, 0o700); err != nil { //nolint:gosec
 		t.Fatalf("failed to set existing directory mode: %v", err)
 	}
+	if err := environment.MkdirAll(ctx, directory, 0o750); err != nil {
+		t.Fatalf("mkdir all on existing directory failed: %v", err)
+	}
 
 	filePath := filepath.Join(directory, "state file")
 	if err := environment.WriteFileAtomically(

--- a/internal/localruntime/runner_reconciliation_test.go
+++ b/internal/localruntime/runner_reconciliation_test.go
@@ -63,33 +63,61 @@ func writeRunnerScript(t *testing.T, version string) string {
 }
 
 //nolint:paralleltest // tests set process environment and fork executable fixtures.
-func TestReconcileRunnerVersionRecordsCompatibleV2Runner(t *testing.T) {
+func TestReconcileRunnerVersionTreatsUnrecordedGuestAsStale(t *testing.T) {
 	testRuntime := newTestRuntimeForReconciliation(t)
 	runnerPath := writeRunnerScript(t, "2.1.3")
 
-	if err := testRuntime.reconcileRunnerVersion(context.Background(), runnerPath); err != nil {
+	reconciliation, err := testRuntime.reconcileRunnerVersion(context.Background(), runnerPath)
+	if err != nil {
 		t.Fatalf("expected v2 runner reconciliation: %v", err)
 	}
-	assertMarkerVersion(t, testRuntime, "2.1.3")
+	if reconciliation.Version.String() != "2.1.3" || !reconciliation.Recordable {
+		t.Fatalf("reconciliation = %+v, want recordable 2.1.3", reconciliation)
+	}
+	if !reconciliation.GuestStale {
+		t.Fatal("expected an unrecorded guest to be replaced")
+	}
+}
+
+//nolint:paralleltest // tests set process environment and fork executable fixtures.
+func TestReconcileRunnerVersionKeepsGuestForRecordedRunner(t *testing.T) {
+	testRuntime := newTestRuntimeForReconciliation(t)
+	seedVersionMarker(t, testRuntime, "2.1.3")
+
+	reconciliation, err := testRuntime.reconcileRunnerVersion(
+		context.Background(), writeRunnerScript(t, "2.1.3"),
+	)
+	if err != nil {
+		t.Fatalf("expected v2 runner reconciliation: %v", err)
+	}
+	if reconciliation.GuestStale {
+		t.Fatal("expected a guest matching the resolved runner to be kept")
+	}
 }
 
 //nolint:paralleltest // tests set process environment and fork executable fixtures.
 func TestReconcileRunnerVersionUpdatesCompatibleUpgradeAndDowngrade(t *testing.T) {
 	testRuntime := newTestRuntimeForReconciliation(t)
 	seedVersionMarker(t, testRuntime, "2.1.0")
-	if err := testRuntime.reconcileRunnerVersion(
+	upgrade, err := testRuntime.reconcileRunnerVersion(
 		context.Background(), writeRunnerScript(t, "2.2.0"),
-	); err != nil {
+	)
+	if err != nil {
 		t.Fatalf("expected compatible upgrade: %v", err)
 	}
-	assertMarkerVersion(t, testRuntime, "2.2.0")
+	if upgrade.Version.String() != "2.2.0" || !upgrade.GuestStale {
+		t.Fatalf("upgrade reconciliation = %+v, want stale 2.2.0", upgrade)
+	}
 
-	if err := testRuntime.reconcileRunnerVersion(
+	downgrade, err := testRuntime.reconcileRunnerVersion(
 		context.Background(), writeRunnerScript(t, "2.1.9"),
-	); err != nil {
+	)
+	if err != nil {
 		t.Fatalf("expected compatible downgrade: %v", err)
 	}
-	assertMarkerVersion(t, testRuntime, "2.1.9")
+	if downgrade.Version.String() != "2.1.9" || !downgrade.GuestStale {
+		t.Fatalf("downgrade reconciliation = %+v, want stale 2.1.9", downgrade)
+	}
 }
 
 //nolint:paralleltest // tests set process environment and fork executable fixtures.
@@ -97,12 +125,15 @@ func TestReconcileRunnerVersionAcceptsNewerContractMajor(t *testing.T) {
 	testRuntime := newTestRuntimeForReconciliation(t)
 	seedVersionMarker(t, testRuntime, "2.1.0")
 
-	if err := testRuntime.reconcileRunnerVersion(
+	reconciliation, err := testRuntime.reconcileRunnerVersion(
 		context.Background(), writeRunnerScript(t, "3.0.0"),
-	); err != nil {
+	)
+	if err != nil {
 		t.Fatalf("expected newer runner contract: %v", err)
 	}
-	assertMarkerVersion(t, testRuntime, "3.0.0")
+	if reconciliation.Version.String() != "3.0.0" || !reconciliation.GuestStale {
+		t.Fatalf("reconciliation = %+v, want stale 3.0.0", reconciliation)
+	}
 }
 
 //nolint:paralleltest // tests set process environment and fork executable fixtures.
@@ -110,7 +141,7 @@ func TestReconcileRunnerVersionRejectsLegacyV1BeforeUpdatingMarker(t *testing.T)
 	testRuntime := newTestRuntimeForReconciliation(t)
 	seedVersionMarker(t, testRuntime, "2.1.0")
 
-	err := testRuntime.reconcileRunnerVersion(
+	_, err := testRuntime.reconcileRunnerVersion(
 		context.Background(), writeRunnerScript(t, "1.9.9"),
 	)
 	if err == nil || !strings.Contains(err.Error(), "legacy application-owning contract") {
@@ -125,7 +156,7 @@ func TestReconcileRunnerVersionRejectsInvalidVersion(t *testing.T) {
 	runnerPath := filepath.Join(t.TempDir(), "launcher")
 	writeExecutableTestFile(t, runnerPath, []byte("#!/bin/sh\nprintf 'invalid-version\\n'\n"))
 
-	err := testRuntime.reconcileRunnerVersion(context.Background(), runnerPath)
+	_, err := testRuntime.reconcileRunnerVersion(context.Background(), runnerPath)
 	if err == nil || !strings.Contains(err.Error(), "does not report a valid version") {
 		t.Fatalf("expected invalid version error, got %v", err)
 	}
@@ -138,8 +169,12 @@ func TestReconcileRunnerVersionForcedBypassAllowsUnversionedDevelopmentRunner(t 
 	runnerPath := filepath.Join(t.TempDir(), "launcher")
 	writeExecutableTestFile(t, runnerPath, []byte("#!/bin/sh\nprintf 'dev\\n'\n"))
 
-	if err := testRuntime.reconcileRunnerVersion(context.Background(), runnerPath); err != nil {
+	reconciliation, err := testRuntime.reconcileRunnerVersion(context.Background(), runnerPath)
+	if err != nil {
 		t.Fatalf("expected forced development runner: %v", err)
+	}
+	if reconciliation.Recordable || reconciliation.GuestStale {
+		t.Fatalf("reconciliation = %+v, want an unrecordable version", reconciliation)
 	}
 }
 

--- a/internal/localruntime/runtime.go
+++ b/internal/localruntime/runtime.go
@@ -187,6 +187,7 @@ type vmRuntimePaths struct {
 
 	VMDir                   string
 	SharedDir               string
+	HostNanoDataDir         string
 	StatePath               string
 	RunnerVersionMarkerPath string
 }
@@ -198,6 +199,7 @@ func newVMRuntimePaths(deployment config.DeploymentDir) vmRuntimePaths {
 		runtimePaths:            rtPaths,
 		VMDir:                   filepath.Join(rtPaths.WorkDir, vmDirName),
 		SharedDir:               filepath.Join(rtPaths.WorkDir, sharedDirName),
+		HostNanoDataDir:         filepath.Join(rtPaths.WorkDir, nanoDataDirName),
 		StatePath:               filepath.Join(rtPaths.WorkDir, vmStateFileName),
 		RunnerVersionMarkerPath: filepath.Join(rtPaths.WorkDir, runnerVersionMarkerFileName),
 	}

--- a/internal/localruntime/runtime_test.go
+++ b/internal/localruntime/runtime_test.go
@@ -79,11 +79,14 @@ func TestMacVMRuntimeLifecycleUsesV2RunnerThenSharedInstall(t *testing.T) {
 
 	deployment := config.NewDeploymentDir(t.TempDir())
 	eventsPath := filepath.Join(t.TempDir(), "events")
-	runnerScript := fakeV2RunnerScript(eventsPath, 28563)
+	runnerScript := fakeV2RunnerScript(eventsPath)
 	localRuntime := NewMacVMRuntime(deployment, newTestManagerForRunner(t, []byte(runnerScript)))
 	install := &recordingLocalInstall{eventsPath: eventsPath, running: true}
 	localRuntime.installFactory = func(string) (localinstall.LocalInstall, error) {
 		return install, nil
+	}
+	localRuntime.migrationFactory = func(localinstall.ExecutionEnvironment) macDataMigrator {
+		return &recordingMacDataMigrator{eventsPath: eventsPath}
 	}
 
 	if err := localRuntime.Prepare(context.Background(), nil, nil, PrepareOptions{}); err != nil {
@@ -98,7 +101,7 @@ func TestMacVMRuntimeLifecycleUsesV2RunnerThenSharedInstall(t *testing.T) {
 		t.Fatalf("start failed: %v", err)
 	}
 	if install.startConfig.ContainerDBPort != nanoDBPort ||
-		install.startConfig.DataDir != vmNanoDataDir {
+		install.startConfig.DataDir != vmSharedNanoDataDir {
 		t.Fatalf("unexpected guest Podman config: %#v", install.startConfig)
 	}
 	if install.startConfig.ContainerDBBindHost != "" {
@@ -124,7 +127,10 @@ func TestMacVMRuntimeLifecycleUsesV2RunnerThenSharedInstall(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read lifecycle events: %v", err)
 	}
-	want := []string{"runner-init", "runner-start", "install-start", "install-stop", "runner-stop"}
+	want := []string{
+		"runner-init", "runner-start", "migration-prepare", "install-start",
+		"install-stop", "runner-stop",
+	}
 	for _, event := range want {
 		if !strings.Contains(string(events), event+"\n") {
 			t.Fatalf("missing %q in lifecycle events:\n%s", event, events)
@@ -152,13 +158,16 @@ func TestMacVMRuntimeStartStopsVMWhenInstallFails(t *testing.T) {
 	eventsPath := filepath.Join(t.TempDir(), "events")
 	localRuntime := NewMacVMRuntime(
 		deployment,
-		newTestManagerForRunner(t, []byte(fakeV2RunnerScript(eventsPath, 28563))),
+		newTestManagerForRunner(t, []byte(fakeV2RunnerScript(eventsPath))),
 	)
 	localRuntime.installFactory = func(string) (localinstall.LocalInstall, error) {
 		return &recordingLocalInstall{
 			eventsPath: eventsPath,
 			startErr:   errors.New("podman failed"),
 		}, nil
+	}
+	localRuntime.migrationFactory = func(localinstall.ExecutionEnvironment) macDataMigrator {
+		return &recordingMacDataMigrator{eventsPath: eventsPath}
 	}
 	if err := localRuntime.Prepare(context.Background(), nil, nil, PrepareOptions{}); err != nil {
 		t.Fatalf("prepare failed: %v", err)
@@ -176,6 +185,48 @@ func TestMacVMRuntimeStartStopsVMWhenInstallFails(t *testing.T) {
 	}
 	if !strings.Contains(string(events), "install-start\nrunner-stop\n") {
 		t.Fatalf("expected failed installation to stop VM, got:\n%s", events)
+	}
+}
+
+//nolint:paralleltest // test runner scripts fork executable files.
+func TestMacVMRuntimeStartStopsVMWhenMigrationFails(t *testing.T) {
+	requirePOSIXRunnerTest(t)
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	eventsPath := filepath.Join(t.TempDir(), "events")
+	localRuntime := NewMacVMRuntime(
+		deployment,
+		newTestManagerForRunner(t, []byte(fakeV2RunnerScript(eventsPath))),
+	)
+	install := &recordingLocalInstall{eventsPath: eventsPath}
+	localRuntime.installFactory = func(string) (localinstall.LocalInstall, error) {
+		return install, nil
+	}
+	localRuntime.migrationFactory = func(localinstall.ExecutionEnvironment) macDataMigrator {
+		return &recordingMacDataMigrator{
+			eventsPath: eventsPath,
+			prepareErr: errors.New("migration failed"),
+		}
+	}
+	if err := localRuntime.Prepare(context.Background(), nil, nil, PrepareOptions{}); err != nil {
+		t.Fatalf("prepare failed: %v", err)
+	}
+
+	err := localRuntime.Start(context.Background(), nil, nil, VMConfig{
+		CPUCount: 2, MemoryMB: 4096, DataSizeGB: 100,
+	})
+	if err == nil || !strings.Contains(err.Error(), "migration failed") {
+		t.Fatalf("expected migration failure, got %v", err)
+	}
+	events, readErr := os.ReadFile(eventsPath)
+	if readErr != nil {
+		t.Fatalf("failed to read lifecycle events: %v", readErr)
+	}
+	if !strings.Contains(string(events), "migration-prepare\nrunner-stop\n") {
+		t.Fatalf("expected failed migration to stop VM, got:\n%s", events)
+	}
+	if strings.Contains(string(events), "install-start") {
+		t.Fatalf("Nano started after failed migration:\n%s", events)
 	}
 }
 
@@ -353,7 +404,7 @@ func TestMacVMRuntimeOpenHostShellPreservesRunnerFailure(t *testing.T) {
 	}
 }
 
-func fakeV2RunnerScript(eventsPath string, hostDBPort int) string {
+func fakeV2RunnerScript(eventsPath string) string {
 	return fmt.Sprintf(`#!/bin/sh
 set -eu
 events=%q
@@ -393,7 +444,7 @@ EOF
     exit 2
     ;;
 esac
-`, eventsPath, hostDBPort)
+`, eventsPath, 28563)
 }
 
 type recordingLocalInstall struct {
@@ -401,6 +452,35 @@ type recordingLocalInstall struct {
 	startConfig localinstall.StartConfig
 	startErr    error
 	running     bool
+}
+
+type recordingMacDataMigrator struct {
+	eventsPath    string
+	prepareErr    error
+	finalizeErr   error
+	finalizeCalls int
+}
+
+func (migration *recordingMacDataMigrator) prepare(
+	context.Context,
+	io.Writer,
+	io.Writer,
+	func() error,
+) error {
+	recordTestEvent(migration.eventsPath, "migration-prepare")
+
+	return migration.prepareErr
+}
+
+func (migration *recordingMacDataMigrator) finalize(
+	context.Context,
+	io.Writer,
+	io.Writer,
+) error {
+	migration.finalizeCalls++
+	recordTestEvent(migration.eventsPath, "migration-finalize")
+
+	return migration.finalizeErr
 }
 
 func (install *recordingLocalInstall) Start(
@@ -437,8 +517,12 @@ func (install *recordingLocalInstall) Destroy(ctx context.Context, out, outErr i
 }
 
 func (install *recordingLocalInstall) record(event string) {
+	recordTestEvent(install.eventsPath, event)
+}
+
+func recordTestEvent(eventsPath, event string) {
 	file, err := os.OpenFile(
-		install.eventsPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600,
+		eventsPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600,
 	)
 	if err != nil {
 		return

--- a/internal/localruntime/runtime_test.go
+++ b/internal/localruntime/runtime_test.go
@@ -405,12 +405,16 @@ func TestMacVMRuntimeOpenHostShellPreservesRunnerFailure(t *testing.T) {
 }
 
 func fakeV2RunnerScript(eventsPath string) string {
+	return fakeV2RunnerScriptWithVersion(eventsPath, "2.0.0-dev")
+}
+
+func fakeV2RunnerScriptWithVersion(eventsPath, version string) string {
 	return fmt.Sprintf(`#!/bin/sh
 set -eu
 events=%q
 case "$1" in
   version)
-    printf 'v2.0.0-dev\n'
+    printf 'v%s\n'
     ;;
   init)
     mkdir -p vm vm-shared
@@ -444,7 +448,7 @@ EOF
     exit 2
     ;;
 esac
-`, eventsPath, 28563)
+`, eventsPath, version, 28563)
 }
 
 type recordingLocalInstall struct {

--- a/openspec/changes/archive/2026-09-02-share-exa-with-host/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-02-share-exa-with-host/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-02

--- a/openspec/changes/archive/2026-09-02-share-exa-with-host/design.md
+++ b/openspec/changes/archive/2026-09-02-share-exa-with-host/design.md
@@ -1,0 +1,169 @@
+## Context
+
+Linux and Windows local deployments already bind a directory below the
+deployment runtime into Nano at `/exa`. macOS instead binds `/var/lib/exa`
+from the VM's ext4 data disk. The VM also exposes a launcher-managed host
+directory at `/mnt/host` through VirtioFS.
+
+The Nano image documents one persistent mount at `/exa` and supports a writable
+absolute host directory as its source. The full tree includes database storage,
+configuration, logs, SLCs, JDBC drivers, and BucketFS content.
+
+The macOS VM data disk mounts at `/var`, so it also holds Podman's image store
+and other guest runtime state. Moving Nano data does not remove the need for
+that disk. Existing macOS deployments need both the old disk and the host share
+available during their first start with the new layout.
+
+The spike found no material database-workload regression on macOS. Synthetic
+VirtioFS writes were about 31% to 33% slower than ext4, which is accepted in
+exchange for host access and a self-contained deployment directory. Windows
+already uses Podman-machine filesystem passthrough but still needs explicit
+lifecycle and data-visibility coverage.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep the complete Nano `/exa` tree in host-visible deployment storage on
+  Linux, macOS, and Windows.
+- Preserve existing macOS databases while moving them from the guest disk.
+- Make migration atomic, conflict-safe, interruption-safe, and retryable.
+- Preserve sparse database files and relevant filesystem metadata.
+- Keep the macOS VM data disk for Podman and guest runtime state.
+- Make host visibility and persistence part of macOS and Windows lifecycle
+  verification.
+
+**Non-Goals:**
+
+- Split Nano-managed subdirectories into separate mounts.
+- Add user-configurable shared-directory settings.
+- Eliminate the macOS VM data disk or move Podman's image store to the host.
+- Guarantee identical filesystem performance across platforms.
+- Migrate arbitrary user-created data when both source and destination contain
+  unrelated Nano runtimes.
+
+## Decisions
+
+1. Expose one stable host path as the complete Nano runtime root.
+
+   Linux and Windows continue using the runtime's host-side `exa` directory.
+   On macOS, `local/runtime/exa` is a launcher-managed relative symlink to the
+   `exa` directory below the runner's private host share. The VM uses the
+   corresponding `/mnt/host` path. This keeps the user-facing host layout the
+   same on every platform without mixing runner coordination files into Nano's
+   `/exa` tree.
+
+2. Keep platform-specific path selection outside installation policy.
+
+   The local runtimes select the host and execution-environment paths. The
+   shared Podman installation continues to receive one data directory and bind
+   it at `/exa`. This keeps Nano lifecycle behavior common while leaving
+   VirtioFS and Windows path translation in their platform boundaries.
+
+3. Migrate macOS data before the shared installation starts Nano.
+
+   After the runner starts with the existing data disk attached, the macOS
+   runtime checks the host layout marker and the legacy `/var/lib/exa` source.
+   A populated legacy source and an empty host destination trigger migration.
+   Nano remains stopped throughout the copy. Windows and Linux do not run this
+   migration because their managed data is already host-side.
+
+   Reusing only the current overlay migration was considered. It is rejected
+   because that migration treats every bind-mounted `/exa` as persistent and
+   skips it. The old macOS container has a valid bind mount whose source is the
+   guest disk, which is exactly the source that must move.
+
+4. Copy into a host-side staging directory and publish it atomically.
+
+   The fixed staging path is private launcher state outside Nano's `/exa` tree.
+   The launcher may replace incomplete staging on retry. The VM copies the
+   entire legacy tree there while preserving modes, links, timestamps, and
+   sparse allocation. It flushes the copy, writes and flushes one versioned
+   completion marker, and then renames staging into place atomically. The marker
+   travels with the data, so marked staging can be published on retry and a
+   marked host destination is authoritative.
+
+   The VM image provides GNU `cp`, which the launcher invokes through the
+   runner's existing arbitrary guest-command interface with archive and sparse
+   preservation enabled. This avoids adding a migration-specific runner API.
+
+   `podman cp` was considered because the existing overlay migration uses it.
+   The guest filesystem copy is preferred because the source and destination
+   are both visible in the VM and the copy tool can explicitly preserve sparse
+   files. The runner image will provide the required copy behavior as part of
+   its contract.
+
+5. Refuse ambiguous data rather than selecting a winner.
+
+   If both the legacy source and an unmarked host destination are populated,
+   startup fails with both locations and manual recovery guidance. A marked
+   host destination is authoritative and makes later starts idempotent. Marked
+   staging is ready to publish, while incomplete staging is replaced from the
+   unchanged source.
+
+6. Retain a recoverable guest backup until host startup succeeds.
+
+   The legacy tree remains untouched while copying and while Nano first starts
+   from the host. After the database becomes ready, the legacy tree is renamed
+   to a migration backup outside `/var/lib/exa`, then host data and the backup
+   rename are flushed before startup succeeds. This prevents an older launcher
+   from silently starting a stale database at the old path while leaving a
+   manual rollback source on the VM disk. Destroy removes the backup with the
+   VM runtime.
+
+7. Keep `data_size_gb` for the macOS VM runtime disk.
+
+   The setting continues to size the disk mounted at `/var`, which Podman still
+   needs for container images. Its user-facing description becomes "VM runtime
+   disk size in GB for Podman images and runtime state," because the host
+   filesystem now determines the space available to `/exa`.
+
+8. Treat Windows passthrough as a supported storage contract.
+
+   Windows keeps the existing host directory and Podman-machine passthrough.
+   Tests must prove that host-created and Nano-created files are mutually
+   visible, database state survives normal and forced lifecycle recovery, and
+   destroy removes deployment-owned data without removing the shared Podman
+   machine. Performance is observed for diagnostics, not used as a release
+   threshold.
+
+## Risks / Trade-offs
+
+- **[Risk] VirtioFS and Windows passthrough have slower or different filesystem
+  semantics than native ext4.** → Keep durability flushes, exercise restart and
+  forced recovery on both platforms, and retain platform-specific diagnostics.
+- **[Risk] Copying sparse database files expands them and exhausts host
+  storage.** → Use a copy operation with explicit sparse-file preservation and
+  verify allocated size in migration tests.
+- **[Risk] The host runs out of space during migration.** → Copy into staging,
+  leave the source untouched, and report both paths so the user can free space
+  and retry.
+- **[Risk] Migration is interrupted.** → Keep the source unchanged until host
+  startup succeeds. Replace incomplete staging, publish marked staging, and
+  reuse a marked host destination on retry.
+- **[Risk] A user has independently populated both locations.** → Refuse the
+  migration without changing either tree.
+- **[Risk] Downgrading starts a stale guest copy.** → Move the legacy tree away
+  from `/var/lib/exa` only after successful host startup and document manual
+  rollback from the retained backup.
+- **[Trade-off] The VM data disk remains even though Nano data moves out.** → It
+  continues to provide writable `/var` and persistent Podman runtime state.
+
+## Migration Plan
+
+1. Start the existing VM with its current data disk and managed host share.
+2. Refuse conflicting legacy and unmarked host data.
+3. Copy legacy data through reserved staging and publish the marked tree.
+4. Start Nano from host storage and wait for database readiness.
+5. Retain the legacy tree as a backup and flush the completed state.
+6. On retry, replace incomplete staging or resume from marked staging or host
+   data.
+
+Before the first successful host-backed start, retry replaces incomplete staging
+from the retained guest tree. Afterwards, manual rollback requires stopping Nano
+and restoring the retained guest backup to `/var/lib/exa`. A normal deployment
+destroy removes host data, the VM disk, and any migration backup.
+
+Fresh macOS deployments create the managed host alias and never put Nano data
+at `/var/lib/exa`. Linux and Windows deployments retain their current host-side
+data in place without copying.

--- a/openspec/changes/archive/2026-09-02-share-exa-with-host/proposal.md
+++ b/openspec/changes/archive/2026-09-02-share-exa-with-host/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+VM-backed local deployments keep durable Nano data inside a guest disk, which
+makes the deployment harder to inspect, back up, and exchange with host tools.
+Nano supports an absolute, writable host directory mounted at `/exa`, and the
+measured macOS database workload remained correct with acceptable performance,
+so local deployments should use that more flexible layout consistently.
+
+## What Changes
+
+- Expose the complete persistent Nano `/exa` tree at `local/runtime/exa` in the
+  deployment directory on Linux, macOS, and Windows.
+- Mount the deployment's host-side `exa` directory at `/exa` in Nano across all
+  supported local platforms.
+- Migrate existing macOS `/exa` data from the guest data disk into the host
+  deployment directory before starting Nano with the new mount.
+- Replace a macOS deployment's guest operating system when the resolved runner
+  differs from the one recorded for it, so migration runs against the guest the
+  launcher expects.
+- Make migration conflict-safe, interruption-safe, and retryable, while
+  retaining the guest copy until the host copy has started successfully.
+- Treat the host filesystem as the source of database storage capacity while
+  retaining the macOS data disk and its existing sizing setting for Podman and
+  other VM runtime state.
+- Verify host visibility, persistence, restart, recovery, and migration on
+  macOS and Windows, with Linux as the existing host-mounted reference.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `exasol-local-deployment`: Make the deployment directory the owner of Nano
+  data on every supported local platform, define its lifecycle and visibility,
+  and clarify the remaining purpose of macOS VM data-disk sizing.
+- `vm-backed-podman-runtime`: Mount macOS Nano data from the managed host share
+  and preserve existing data while migrating it from the former guest disk.
+
+## Impact
+
+The change affects local deployment configuration, macOS VM startup, guest
+replacement and data migration, shared Podman installation behavior,
+deployment destruction,
+Windows filesystem-passthrough validation, local lifecycle and migration tests,
+documentation, and release notes. The Exasol Local VM runner image must provide
+a sparse-preserving copy utility, keep its data disk accessible during
+migration, and continue using it for Podman runtime state.

--- a/openspec/changes/archive/2026-09-02-share-exa-with-host/specs/exasol-local-deployment/spec.md
+++ b/openspec/changes/archive/2026-09-02-share-exa-with-host/specs/exasol-local-deployment/spec.md
@@ -1,0 +1,195 @@
+## MODIFIED Requirements
+
+### Requirement: Launcher-owned local runtime
+
+The system SHALL own host-side Nano data, the macOS VM runtime disk, and the
+managed deployment share inside the deployment directory, and SHALL resolve the
+Exasol Local VM runner through the resource manager on every use rather than
+maintaining a per-deployment copy of it.
+
+#### Scenario: Runner is resolved without a per-deployment copy
+
+- **WHEN** the launcher initializes or starts a local deployment
+- **THEN** it resolves the Exasol Local runner through the resource manager and
+  invokes it directly from the resolved location, without copying it into the
+  deployment directory
+
+#### Scenario: Missing version marker is initialized
+
+- **WHEN** the launcher prepares a local deployment that has no persisted
+  runner-version marker, or an invalid one, and the resolved runner reports a
+  valid semantic version
+- **THEN** it records the resolved runner's version as the deployment's
+  persisted marker before invoking the runner
+
+#### Scenario: Compatible runner update is recorded
+
+- **WHEN** the resolved runner is a newer patch or minor version within the
+  persisted marker's major version
+- **THEN** the launcher updates the persisted marker to the resolved runner's
+  version before starting the local deployment
+
+#### Scenario: Release-candidate runner update is recorded
+
+- **WHEN** a `v`-prefixed resolved runner release candidate has greater semantic
+  precedence than the persisted marker's release candidate within the same
+  major version
+- **THEN** the launcher updates the persisted marker to the resolved runner's
+  version before starting the local deployment
+
+#### Scenario: Unsafe version relationship proceeds with a warning
+
+- **WHEN** the resolved runner's version differs in major version from the
+  persisted marker, or is older than the persisted marker within the same major
+  version
+- **THEN** the launcher proceeds using the resolved runner, logs a warning
+  describing the version relationship, and updates the persisted marker to the
+  resolved runner's version
+
+#### Scenario: Version reconciliation is skipped for non-starting lifecycle behavior
+
+- **WHEN** the launcher performs status, stop, or destroy behavior for a local
+  deployment
+- **THEN** it resolves and invokes the runner without comparing or updating the
+  persisted version marker
+
+#### Scenario: Resolved runner version is invalid
+
+- **WHEN** the resolved runner does not report a valid semantic version during
+  preparation
+- **THEN** the launcher fails before invoking it, unless forced reconciliation
+  is enabled
+
+#### Scenario: Internal forced-reconciliation bypass is enabled
+
+- **WHEN** development explicitly enables forced reconciliation and the
+  resolved runner does not report a valid semantic version
+- **THEN** the launcher proceeds with the resolved runner without version
+  compatibility checks and warns that reconciliation was forced
+
+#### Scenario: Runner VM sizing is prepared
+
+- **WHEN** the launcher initializes or starts a local deployment
+- **THEN** it exposes VM CPU, VM memory, and VM runtime-disk sizing through the
+  runner start command
+
+#### Scenario: Managed share is prepared
+
+- **WHEN** the launcher initializes a local deployment
+- **THEN** it creates a launcher-managed share for guest coordination, SSH key
+  import, and host-visible Nano data
+
+#### Scenario: User shares are not exposed
+
+- **WHEN** the user initializes or starts a local deployment
+- **THEN** the launcher does not require or expose user-configurable shared
+  folder settings
+
+### Requirement: Local lifecycle commands
+
+The system SHALL support standard lifecycle commands for local deployments and
+preserve host-backed Nano data until the deployment is destroyed.
+
+#### Scenario: Stop local deployment
+
+- **WHEN** a macOS local deployment is running and the user runs `exasol stop`
+- **THEN** the launcher removes the disposable Nano container, stops the VM,
+  preserves host-backed Nano data, and records the deployment as stopped
+
+#### Scenario: Start local deployment
+
+- **WHEN** a local deployment is stopped and the user runs `exasol start`
+- **THEN** the launcher starts its execution environment with the existing
+  host-backed Nano data, starts the shared Podman installation, waits up to a
+  bounded timeout until the database accepts connections, refreshes connection
+  artifacts, and records the deployment as running
+
+#### Scenario: Start local deployment times out
+
+- **WHEN** a local deployment is stopped, the user runs `exasol start`, and the
+  database does not become ready within the bounded timeout
+- **THEN** the launcher fails the command rather than waiting indefinitely
+
+#### Scenario: Local execution environment stops unexpectedly
+
+- **WHEN** a local execution environment stops without a graceful Nano shutdown
+  and the deployment is started again
+- **THEN** the launcher recovers the runtime with the same host-backed Nano data
+
+#### Scenario: Destroy local deployment
+
+- **WHEN** a user runs `exasol destroy` for a local deployment
+- **THEN** the launcher removes the disposable container, stops its execution
+  environment if needed, deletes deployment-owned host-backed Nano data, any
+  macOS migration backup, and connection artifacts, and records the deployment
+  as initialized
+
+### Requirement: Local configuration is platform-specific
+
+The system SHALL expose and validate VM CPU, memory, and runtime-disk sizing
+only for the macOS VM runtime, while direct-host platforms SHALL ignore
+persisted VM sizing and use host-managed resources.
+
+#### Scenario: Linux local configuration contains VM sizing
+
+- **WHEN** a Linux deployment contains shared VM CPU, memory, or data-size
+  values
+- **THEN** local validation and startup ignore those values and do not advertise
+  them as effective Linux settings
+
+#### Scenario: Windows local configuration contains VM sizing
+
+- **WHEN** a Windows deployment contains shared VM CPU, memory, or data-size
+  values
+- **THEN** local validation and startup ignore those values and do not advertise
+  them as effective Windows settings
+
+#### Scenario: macOS local configuration contains invalid VM sizing
+
+- **WHEN** a macOS Apple Silicon deployment contains invalid VM sizing
+- **THEN** validation fails as before
+
+#### Scenario: macOS data-size configuration is inspected
+
+- **WHEN** a user inspects local configuration on macOS
+- **THEN** the data-size setting describes VM runtime-disk capacity for Podman
+  images and runtime state
+
+
+## ADDED Requirements
+
+### Requirement: Local Nano data is host-visible
+
+The system SHALL expose the complete persistent Nano `/exa` tree at
+`local/runtime/exa` in the deployment directory on every supported local
+platform.
+
+#### Scenario: Fresh local deployment starts
+
+- **WHEN** a user installs a fresh local deployment on Linux, macOS, or Windows
+- **THEN** Nano stores its persistent `/exa` content in
+  `local/runtime/exa`
+
+#### Scenario: Host creates a runtime file
+
+- **WHEN** a file is created below `local/runtime/exa` while the local runtime
+  is available
+- **THEN** the file is visible at the corresponding path below Nano's `/exa`
+
+#### Scenario: Nano creates a runtime file
+
+- **WHEN** Nano creates a file below `/exa`
+- **THEN** the file is visible at the corresponding path below
+  `local/runtime/exa`
+
+#### Scenario: Nano runs an SLC
+
+- **WHEN** Nano initializes or runs an SLC in a local deployment
+- **THEN** persistent SLC files remain visible below
+  `local/runtime/exa/slc`
+
+#### Scenario: Existing direct-host deployment starts
+
+- **WHEN** an existing Linux or Windows deployment has managed host-side Nano
+  data
+- **THEN** the launcher continues using that data at `local/runtime/exa`

--- a/openspec/changes/archive/2026-09-02-share-exa-with-host/specs/vm-backed-podman-runtime/spec.md
+++ b/openspec/changes/archive/2026-09-02-share-exa-with-host/specs/vm-backed-podman-runtime/spec.md
@@ -1,77 +1,39 @@
-# vm-backed-podman-runtime Specification
-
-## Purpose
-Defines how macOS local deployments run the shared Podman installation inside a VM without exposing VM transport details to installation code.
-## Requirements
-### Requirement: macOS uses a VM-only runner contract
-The system SHALL require a VM runner that provides VM lifecycle, labeled forwarding, shared-path exchange, and guest command execution without owning application containers.
-
-#### Scenario: Compatible runner is used
-- **WHEN** a macOS local deployment prepares a runner implementing the VM-only contract
-- **THEN** the system initializes and starts the VM before invoking the shared Podman installation inside it
-
-#### Scenario: Legacy runner is resolved
-- **WHEN** a macOS local deployment resolves a runner that does not implement the VM-only contract
-- **THEN** preparation fails before the runner can start a legacy database container
+## MODIFIED Requirements
 
 ### Requirement: macOS installs Nano through guest Podman
+
 The system SHALL perform Nano image loading, SLC materialization, container
 creation, status inspection, diagnostics, and cleanup through Podman commands
 executed inside the VM while storing Nano's complete `/exa` tree in the managed
 host share.
 
 #### Scenario: Fresh macOS deployment starts
+
 - **WHEN** the VM is running and the deployment has no running Nano container
 - **THEN** the same persistent Podman installation behavior used by the Linux
   host runtime runs inside the VM with the managed host directory mounted at
   `/exa`
 
 #### Scenario: macOS deployment stops
+
 - **WHEN** a running macOS deployment is stopped
 - **THEN** its disposable Nano container is removed before the VM is stopped
   and persistent host-side data remains
 
 #### Scenario: macOS host path is prepared
+
 - **WHEN** the launcher prepares a macOS local deployment
 - **THEN** `local/runtime/exa` resolves to Nano data in the runner's private
   host share
 
 #### Scenario: macOS host path conflicts
+
 - **WHEN** the macOS `local/runtime/exa` path conflicts with the
   launcher-managed host path
 - **THEN** preparation fails and preserves the existing path
 
-### Requirement: macOS maps staged artifacts into the VM
-The system SHALL stage host artifacts below the VM shared directory and provide both host and guest paths to installation behavior.
-
-#### Scenario: Nano image is loaded
-- **WHEN** the shared installation loads the embedded Nano image on macOS
-- **THEN** it invokes `podman load -i` with the corresponding path below `/mnt/host`
-
-#### Scenario: Custom SLC package is imported
-- **WHEN** a configured custom SLC package is available on the macOS host
-- **THEN** it is staged in the VM share and imported using its guest path
-
-#### Scenario: Path is outside the VM share
-- **WHEN** a host artifact cannot be represented below the VM shared directory
-- **THEN** installation fails before a guest command receives an unusable host path
-
-### Requirement: macOS endpoints come from labeled VM forwards
-The system SHALL request labeled VM forwards for application services before VM startup and derive connection endpoints from the effective mappings reported by the runner.
-
-#### Scenario: Dynamic database host port is requested
-- **WHEN** the configured database host port is zero
-- **THEN** the runtime requests a `db` forward to guest port `8563` and publishes the assigned loopback port as the database endpoint
-
-#### Scenario: Admin UI is enabled
-- **WHEN** the local installation exposes its Admin UI guest port
-- **THEN** the runtime requests a labeled UI forward and publishes the effective loopback endpoint
-
-#### Scenario: Requested host port is occupied
-- **WHEN** the runner cannot bind a requested nonzero service port
-- **THEN** local startup fails without substituting another host port
-
 ### Requirement: legacy runner database assets are retired safely
+
 The system SHALL remove obsolete host-shared runner database payloads, preserve
 existing Nano data while migrating it from the macOS guest disk to managed host
 storage, allow failed or interrupted migrations to be retried safely, retain a
@@ -79,46 +41,57 @@ recoverable guest backup until deployment destruction, and run a deployment on
 the guest operating system of the runner that drives it.
 
 #### Scenario: Existing deployment contains legacy shared payloads
+
 - **WHEN** a deployment starts with VM-only runner support
-- **THEN** obsolete shared Nano payload and runner configuration files are removed before installation
+- **THEN** obsolete shared Nano payload and runner configuration files are
+  removed before installation
 
 #### Scenario: Existing guest data is present
-- **WHEN** a deployment created by an earlier runner has persistent database data in the VM data disk
+
+- **WHEN** a deployment created by an earlier runner has persistent database
+  data in the VM data disk
 - **THEN** the data remains available after the deployment starts from managed
   host storage and a recoverable guest backup remains available
 
 #### Scenario: Data migration cannot complete
+
 - **WHEN** migration fails or is interrupted before the deployment starts from
   managed host storage
 - **THEN** the existing data remains unchanged and a later start can retry
   migration safely
 
 #### Scenario: Guest and host data conflict
+
 - **WHEN** both the legacy guest location and the managed host location contain
   different Nano data
 - **THEN** startup fails, reports both locations, and preserves both data sets
 
 #### Scenario: Migrated deployment starts again
+
 - **WHEN** a deployment has started successfully from migrated host data
 - **THEN** later starts reuse that host data without replacing it from the guest
   backup
 
 #### Scenario: Deployment was created by a different runner
+
 - **WHEN** a deployment starts and the runner recorded for it differs from the
   resolved runner, or no runner is recorded
 - **THEN** the deployment runs the resolved runner's guest operating system and
   keeps its database and container state
 
 #### Scenario: Deployment already matches the resolved runner
+
 - **WHEN** a deployment starts and the runner recorded for it matches the
   resolved runner
 - **THEN** the deployment keeps its guest operating system
 
 #### Scenario: Guest replacement cannot complete
+
 - **WHEN** replacing the guest operating system fails
 - **THEN** startup fails and a later start replaces the guest again
 
 #### Scenario: VM runtime state is present
+
 - **WHEN** Nano data has moved to the managed host share
 - **THEN** the runner continues using the VM data disk for Podman and other
   guest runtime state

--- a/openspec/changes/archive/2026-09-02-share-exa-with-host/tasks.md
+++ b/openspec/changes/archive/2026-09-02-share-exa-with-host/tasks.md
@@ -1,0 +1,47 @@
+## 1. VM Copy Support
+
+- [x] 1.1 Add GNU `cp` to the Exasol Local VM image so the existing guest
+  command interface can copy directory trees to VirtioFS while preserving
+  modes, links, timestamps, and sparse allocation, and cover the copy behavior
+  in runner tests
+
+## 2. Host Layout and Migration
+
+- [x] 2.1 Add one host-layout completion marker and a macOS migration
+  transaction with reserved staging, atomic publication, conflict detection,
+  interrupted-copy recovery, path-rich errors, and focused unit tests
+- [x] 2.2 Switch macOS Nano startup to the host-shared `exa` path, retain and
+  finalize the guest backup only after durable database readiness, expose it
+  through the managed `local/runtime/exa` symlink, and cover fresh, migrated,
+  repeated, conflicting, failed, stopped, and destroyed lifecycle behavior
+- [x] 2.3 Replace a macOS deployment's guest operating system when the resolved
+  runner differs from the one recorded for it, stopping a running VM first,
+  recording the runner only after the replacement succeeds, and covering the
+  differing, matching, running, and failed cases
+
+## 3. Configuration Semantics
+
+- [x] 3.1 Keep macOS `data_size_gb` as VM runtime-disk sizing, update its
+  user-facing description, and cover existing manifest compatibility and
+  direct-host behavior
+
+## 4. Cross-Platform Verification
+
+- [x] 4.1 Extend macOS deployment tests to verify complete guest-to-host data
+  migration, bidirectional file visibility, committed rows, sparse allocation,
+  normal restart, forced VM recovery, conflict handling, retry, and destroy
+- [x] 4.2 Extend Windows deployment tests to verify bidirectional `/exa` file
+  visibility, committed rows, normal restart, forced Podman-machine recovery,
+  adoption without copying into the machine, and deployment-owned data removal
+
+## 5. User Guidance
+
+- [x] 5.1 Document the host-side `/exa` layout, macOS migration and rollback,
+  Windows passthrough, VM runtime-disk sizing, and accepted performance
+  trade-off, and add the user-visible change to the changelog
+
+## 6. OpenSpec Completion
+
+- [x] 6.1 Verify the proposal, design, specifications, tests, and implementation
+  agree, then archive the change and sync every delta into the main specs before
+  committing the OpenSpec artifacts

--- a/openspec/specs/exasol-local-deployment/spec.md
+++ b/openspec/specs/exasol-local-deployment/spec.md
@@ -29,7 +29,10 @@ The system SHALL provide the standard local deployment option through a VM-backe
 
 ### Requirement: Launcher-owned local runtime
 
-The system SHALL own the local VM disk/data and managed deployment share inside the deployment directory, and SHALL resolve the Exasol Local VM runner through the resource manager on every use rather than maintaining a per-deployment copy of it.
+The system SHALL own host-side Nano data, the macOS VM runtime disk, and the
+managed deployment share inside the deployment directory, and SHALL resolve the
+Exasol Local VM runner through the resource manager on every use rather than
+maintaining a per-deployment copy of it.
 
 #### Scenario: Runner is resolved without a per-deployment copy
 
@@ -74,17 +77,55 @@ The system SHALL own the local VM disk/data and managed deployment share inside 
 #### Scenario: Runner VM sizing is prepared
 
 - **WHEN** the launcher initializes or starts a local deployment
-- **THEN** it exposes VM CPU, VM memory, and Exasol Local data disk sizing through the runner start command
+- **THEN** it exposes VM CPU, VM memory, and VM runtime-disk sizing through the
+  runner start command
 
 #### Scenario: Managed share is prepared
 
 - **WHEN** the launcher initializes a local deployment
-- **THEN** it creates a launcher-managed share for guest coordination and SSH key import
+- **THEN** it creates a launcher-managed share for guest coordination, SSH key
+  import, and host-visible Nano data
 
 #### Scenario: User shares are not exposed
 
 - **WHEN** the user initializes or starts a local deployment
 - **THEN** the launcher does not require or expose user-configurable shared folder settings
+
+### Requirement: Local Nano data is host-visible
+
+The system SHALL expose the complete persistent Nano `/exa` tree at
+`local/runtime/exa` in the deployment directory on every supported local
+platform.
+
+#### Scenario: Fresh local deployment starts
+
+- **WHEN** a user installs a fresh local deployment on Linux, macOS, or Windows
+- **THEN** Nano stores its persistent `/exa` content in
+  `local/runtime/exa`
+
+#### Scenario: Host creates a runtime file
+
+- **WHEN** a file is created below `local/runtime/exa` while the local runtime
+  is available
+- **THEN** the file is visible at the corresponding path below Nano's `/exa`
+
+#### Scenario: Nano creates a runtime file
+
+- **WHEN** Nano creates a file below `/exa`
+- **THEN** the file is visible at the corresponding path below
+  `local/runtime/exa`
+
+#### Scenario: Nano runs an SLC
+
+- **WHEN** Nano initializes or runs an SLC in a local deployment
+- **THEN** persistent SLC files remain visible below
+  `local/runtime/exa/slc`
+
+#### Scenario: Existing direct-host deployment starts
+
+- **WHEN** an existing Linux or Windows deployment has managed host-side Nano
+  data
+- **THEN** the launcher continues using that data at `local/runtime/exa`
 
 ### Requirement: Local deployment artifacts
 
@@ -120,23 +161,36 @@ The system SHALL allow `exasol connect` to connect to the Exasol Local database 
 - **THEN** the metadata marks certificate validation as insecure for that local deployment
 
 ### Requirement: Local lifecycle commands
-The system SHALL support standard lifecycle commands for local deployments.
+The system SHALL support standard lifecycle commands for local deployments and
+preserve host-backed Nano data until the deployment is destroyed.
 
 #### Scenario: Stop local deployment
 - **WHEN** a macOS local deployment is running and the user runs `exasol stop`
-- **THEN** the launcher removes the disposable Nano container, stops the VM, preserves persistent data, and records the deployment as stopped
+- **THEN** the launcher removes the disposable Nano container, stops the VM,
+  preserves host-backed Nano data, and records the deployment as stopped
 
 #### Scenario: Start local deployment
 - **WHEN** a local deployment is stopped and the user runs `exasol start`
-- **THEN** the launcher starts its execution environment, starts the shared Podman installation, waits up to a bounded timeout until the database accepts connections, refreshes connection artifacts, and records the deployment as running
+- **THEN** the launcher starts its execution environment with the existing
+  host-backed Nano data, starts the shared Podman installation, waits up to a
+  bounded timeout until the database accepts connections, refreshes connection
+  artifacts, and records the deployment as running
 
 #### Scenario: Start local deployment times out
 - **WHEN** a local deployment is stopped, the user runs `exasol start`, and the database does not become ready within the bounded timeout
 - **THEN** the launcher fails the command rather than waiting indefinitely
 
+#### Scenario: Local execution environment stops unexpectedly
+- **WHEN** a local execution environment stops without a graceful Nano shutdown
+  and the deployment is started again
+- **THEN** the launcher recovers the runtime with the same host-backed Nano data
+
 #### Scenario: Destroy local deployment
 - **WHEN** a user runs `exasol destroy` for a local deployment
-- **THEN** the launcher removes the disposable container, stops its execution environment if needed, deletes runtime data and connection artifacts, and records the deployment as initialized
+- **THEN** the launcher removes the disposable container, stops its execution
+  environment if needed, deletes deployment-owned host-backed Nano data, any
+  macOS migration backup, and connection artifacts, and records the deployment
+  as initialized
 
 ### Requirement: Local shell access
 
@@ -183,15 +237,29 @@ The system SHALL fail local deployment on macOS when detected host memory is bel
 - **THEN** the launcher fails before starting the local deployment and explains the required and detected host memory
 
 ### Requirement: Local configuration is platform-specific
-The system SHALL expose and validate VM CPU, memory, and data-size configuration only for the macOS VM runtime, while Linux SHALL ignore persisted VM sizing and use unrestricted host resources.
+The system SHALL expose and validate VM CPU, memory, and runtime-disk sizing
+only for the macOS VM runtime, while direct-host platforms SHALL ignore
+persisted VM sizing and use host-managed resources.
 
 #### Scenario: Linux local configuration contains VM sizing
 - **WHEN** a Linux deployment contains shared VM CPU, memory, or data-size values
 - **THEN** local validation and startup ignore those values and do not advertise them as effective Linux settings
 
+#### Scenario: Windows local configuration contains VM sizing
+- **WHEN** a Windows deployment contains shared VM CPU, memory, or data-size
+  values
+- **THEN** local validation and startup ignore those values and do not advertise
+  them as effective Windows settings
+
 #### Scenario: macOS local configuration contains invalid VM sizing
 - **WHEN** a macOS Apple Silicon deployment contains invalid VM sizing
 - **THEN** validation fails as before
+
+#### Scenario: macOS data-size configuration is inspected
+- **WHEN** a user inspects local configuration on macOS
+- **THEN** the data-size setting describes VM runtime-disk capacity for Podman
+  images and runtime state
+
 
 ### Requirement: Linux local status and health reflect the published database endpoint
 The system SHALL derive Linux runtime status from the exact Podman deployment container, recover missing in-memory endpoints from deployment information, and probe the published database port for health.

--- a/tests/tests/deployment/test_local_vm.py
+++ b/tests/tests/deployment/test_local_vm.py
@@ -4,7 +4,11 @@
 """Local runtime lifecycle and macOS VM-specific configuration."""
 
 import json
+import os
+import shutil
+import signal
 import subprocess
+import time
 from pathlib import Path
 from typing import Final
 
@@ -14,6 +18,7 @@ from tests.testcase_helpers import (
     IS_MACOS_ARM,
     requires_macos_arm,
     run_command,
+    run_in_local_vm,
 )
 
 
@@ -91,6 +96,59 @@ OLD_FIXED_DEFAULT_MB: Final = 2048
 
 LOCAL_MINIMUM_MEMORY_MB: Final = 4096
 
+HOST_LAYOUT_MARKER: Final = ".exasol-personal-host-layout"
+HOST_DATA_SETUP_SQL: Final = (
+    "CREATE SCHEMA HOST_DATA; OPEN SCHEMA HOST_DATA; "
+    "CREATE TABLE SMOKE (ID DECIMAL(18,0)); INSERT INTO SMOKE VALUES 424242;"
+)
+
+
+def _run_vm_script(
+    exasol_path: str,
+    deployment_dir: Path,
+    script: str,
+) -> subprocess.CompletedProcess[str]:
+    return run_in_local_vm(exasol_path, deployment_dir, script)
+
+
+def _create_legacy_guest_data(
+    exasol_path: str,
+    deployment_dir: Path,
+    host_exa: Path,
+    base: list[str],
+) -> tuple[Path, Path]:
+    host_file = host_exa / "host-visible"
+    host_file.write_text("from-host")
+    _run_vm_script(
+        exasol_path,
+        deployment_dir,
+        'test "$(cat /mnt/host/exa/host-visible)" = from-host\n'
+        "printf from-guest > /mnt/host/exa/guest-visible\n",
+    )
+    assert (host_exa / "guest-visible").read_text() == "from-guest"
+
+    sparse_path = host_exa / "migration-sparse"
+    with sparse_path.open("wb") as sparse_file:
+        sparse_file.seek(64 * 1024 * 1024 - 1)
+        sparse_file.write(b"x")
+
+    run_command([exasol_path, "connect", "-c", HOST_DATA_SETUP_SQL, *base])
+    deployment_data = json.loads((deployment_dir / "deployment.json").read_text())
+    container_name = f"exasol-db-{deployment_data['deploymentId']}"
+    _run_vm_script(
+        exasol_path,
+        deployment_dir,
+        f"podman pause {container_name}\n"
+        "rm -rf /var/lib/exa /var/lib/exa.migrated-backup\n"
+        "mkdir -p /var/lib/exa\n"
+        "cp -a --sparse=always /mnt/host/exa/. /var/lib/exa/\n"
+        f"podman unpause {container_name}\n"
+        "sync\n",
+    )
+    run_command([exasol_path, "stop", *base])
+
+    return host_file, sparse_path
+
 
 @pytest.mark.local_e2e
 @requires_macos_arm
@@ -110,3 +168,101 @@ def test_memory_default_is_half_host_ram(exasol_path: str, tmp_path: Path) -> No
     # Then it is no longer the old fixed default and honours the minimum
     assert memory_mb != OLD_FIXED_DEFAULT_MB
     assert memory_mb >= LOCAL_MINIMUM_MEMORY_MB
+
+
+@pytest.mark.local_e2e
+@pytest.mark.installation_e2e
+@requires_macos_arm
+def test_macos_host_data_migration_and_recovery(
+    exasol_path: str,
+    tmp_path: Path,
+) -> None:
+    # Given a fresh host-backed deployment with data written from both sides
+    deployment_dir = tmp_path / "macos-host-data"
+    deployment_dir.mkdir()
+    base = ["--deployment-dir", str(deployment_dir)]
+    host_exa = deployment_dir / "local" / "runtime" / "exa"
+    state_path = deployment_dir / "local" / "runtime" / "vm-state.json"
+    destroyed = False
+
+    try:
+        run_command([exasol_path, "install", "local", *base])
+        assert (host_exa / HOST_LAYOUT_MARKER).read_text() == "1\n"
+
+        # When the host tree is turned into a legacy guest-disk deployment
+        host_file, sparse_path = _create_legacy_guest_data(
+            exasol_path, deployment_dir, host_exa, base
+        )
+
+        # Then ambiguous source and destination data is refused unchanged
+        (host_exa / HOST_LAYOUT_MARKER).unlink()
+        conflict = subprocess.run(
+            [exasol_path, "start", *base],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=False,
+        )
+        assert conflict.returncode != 0
+        assert "/var/lib/exa" in conflict.stderr
+        assert "/mnt/host/exa" in conflict.stderr
+        assert host_file.read_text() == "from-host"
+
+        # When the empty destination condition is restored and start is retried
+        shutil.rmtree(host_exa.resolve())
+        run_command([exasol_path, "start", *base])
+
+        # Then the full tree was migrated and the guest source became a backup
+        persisted = run_command(
+            [
+                exasol_path,
+                "connect",
+                "-c",
+                "SELECT ID FROM HOST_DATA.SMOKE;",
+                *base,
+            ]
+        )
+        assert "424242" in persisted.stdout
+        assert host_file.read_text() == "from-host"
+        assert (host_exa / "guest-visible").read_text() == "from-guest"
+        assert (host_exa / HOST_LAYOUT_MARKER).read_text() == "1\n"
+        sparse_stat = sparse_path.stat()
+        assert sparse_stat.st_blocks * 512 < sparse_stat.st_size // 2
+        _run_vm_script(
+            exasol_path,
+            deployment_dir,
+            "test ! -e /var/lib/exa\ntest -e /var/lib/exa.migrated-backup\n",
+        )
+
+        # When Nano is restarted normally and the VM is then killed out of band
+        run_command([exasol_path, "stop", *base])
+        run_command([exasol_path, "start", *base])
+        vm_pid = int(json.loads(state_path.read_text())["pid"])
+        os.kill(vm_pid, signal.SIGKILL)
+        time.sleep(2)
+        run_command([exasol_path, "start", *base])
+
+        # Then both recovery paths reuse the same committed host data
+        recovered = run_command(
+            [
+                exasol_path,
+                "connect",
+                "-c",
+                "SELECT ID FROM HOST_DATA.SMOKE;",
+                *base,
+            ]
+        )
+        assert "424242" in recovered.stdout
+
+        # When the deployment is destroyed, both host data and the VM are removed
+        run_command([exasol_path, "destroy", "--auto-approve", *base])
+        destroyed = True
+        assert not (deployment_dir / "local").exists()
+    finally:
+        if not destroyed and state_path.exists():
+            subprocess.run(
+                [exasol_path, "destroy", "--auto-approve", *base],
+                capture_output=True,
+                text=True,
+                check=False,
+            )

--- a/tests/tests/deployment/test_virtual_schema.py
+++ b/tests/tests/deployment/test_virtual_schema.py
@@ -11,10 +11,8 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import platform
 import re
-import secrets
 import shlex
 import shutil
 import subprocess
@@ -32,6 +30,7 @@ import pytest
 
 from framework.deployment import Deployment
 from framework.launcher import DeploymentConfig, Launcher
+from tests.testcase_helpers import run_in_local_vm
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -104,76 +103,12 @@ def _run_in_local_vm(
     command: str,
     input_text: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    """Run a command through the interactive local VM shell with check=True."""
-    import pty  # noqa: PLC0415 - only available on the macOS VM path
-
-    shared = Path(deployment.deployment_dir.name) / "local/runtime/vm-shared"
-    shared.mkdir(parents=True, exist_ok=True)
-    input_file = None
-    if input_text is not None:
-        input_file = shared / ("input-" + secrets.token_hex(16))
-        input_file.write_text(input_text, encoding="utf-8")
-        command += " < " + shlex.quote("/mnt/host/" + input_file.name)
-
-    marker = "__VM_COMMAND_RESULT_" + secrets.token_hex(16) + "__"
-    script = "\n".join(
-        [
-            "stty -echo",
-            f"printf '%s\\n' {shlex.quote(marker)}",
-            command,
-            "status=$?",
-            f"printf '%s:%s\\n' {shlex.quote(marker)} \"$status\"",
-            'exit "$status"',
-        ]
-    )
-    launcher_command = [
+    return run_in_local_vm(
         deployment.launcher.launcher_path,
-        "shell",
-        "host",
-        "--deployment-dir",
         deployment.deployment_dir.name,
-    ]
-    output = bytearray()
-    input_data = (script + "\n").encode()
-    input_sent = False
-
-    def read_input(_fd: int) -> bytes:
-        nonlocal input_sent
-        if input_sent:
-            return b""
-        input_sent = True
-        return input_data
-
-    def read_output(fd: int) -> bytes:
-        try:
-            data = os.read(fd, 4096)
-        except OSError:
-            return b""
-        output.extend(data)
-        return data
-
-    try:
-        pty.spawn(launcher_command, master_read=read_output, stdin_read=read_input)
-    finally:
-        if input_file is not None:
-            input_file.unlink(missing_ok=True)
-
-    decoded = output.decode(errors="replace").replace("\r", "")
-    result_start = decoded.rfind(marker + "\n")
-    result_end = decoded.rfind(marker + ":")
-    if result_start < 0 or result_end < result_start:
-        message = "Local VM command did not return a result marker"
-        raise AssertionError(message)
-    command_output = decoded[result_start + len(marker) + 1 : result_end]
-    returncode = int(decoded[result_end + len(marker) + 1 :].splitlines()[0])
-    result = subprocess.CompletedProcess(
-        launcher_command, returncode, command_output, ""
+        command,
+        input_text,
     )
-    if returncode != 0:
-        raise subprocess.CalledProcessError(
-            returncode, launcher_command, output=command_output
-        )
-    return result
 
 
 def _run_podman(
@@ -437,41 +372,11 @@ JAR={driver.name}
 
 def _stage_artifacts(deployment: Deployment, artifacts: VirtualSchemaArtifacts) -> None:
     deployment_dir = Path(deployment.deployment_dir.name)
-    bucketfs_relative = Path("local/runtime/exa/bucketfs/bfsdefault/default/vs")
-    jdbc_relative = Path("local/runtime/exa/jdbc/POSTGRESQL")
+    runtime_relative = Path("local/runtime/exa")
+    bucketfs = deployment_dir / runtime_relative / "bucketfs/bfsdefault/default/vs"
+    jdbc = deployment_dir / runtime_relative / "jdbc/POSTGRESQL"
     settings_name = "settings.cfg"
 
-    if platform.system() == "Darwin":
-        shared = deployment_dir / "local/runtime/vm-shared/vs"
-        shared.mkdir(parents=True, exist_ok=True)
-        settings = shared / settings_name
-        for artifact in (artifacts.adapter, artifacts.driver):
-            shutil.copy2(artifact, shared / artifact.name)
-        _write_settings(settings, artifacts.driver)
-        remote_bucketfs = "/var/lib/exa/bucketfs/bfsdefault/default/vs"
-        remote_jdbc = "/var/lib/exa/jdbc/POSTGRESQL"
-        shared_path = "/mnt/host/vs"
-        shell_script = "\n".join(
-            [
-                "set -eu",
-                f"mkdir -p {remote_bucketfs} {remote_jdbc}",
-                (
-                    f"cp {shared_path}/{shlex.quote(artifacts.adapter.name)} "
-                    f"{remote_bucketfs}/"
-                ),
-                (
-                    f"cp {shared_path}/{shlex.quote(artifacts.driver.name)} "
-                    f"{remote_bucketfs}/"
-                ),
-                f"cp {shared_path}/{shlex.quote(artifacts.driver.name)} {remote_jdbc}/",
-                f"cp {shared_path}/{settings_name} {remote_jdbc}/",
-            ]
-        )
-        _run_in_local_vm(deployment, shell_script)
-        return
-
-    bucketfs = deployment_dir / bucketfs_relative
-    jdbc = deployment_dir / jdbc_relative
     bucketfs.mkdir(parents=True, exist_ok=True)
     jdbc.mkdir(parents=True, exist_ok=True)
     for artifact in (artifacts.adapter, artifacts.driver):

--- a/tests/tests/integration/test_install.py
+++ b/tests/tests/integration/test_install.py
@@ -693,6 +693,15 @@ def _podman_query(podman_path: Path, *args: str) -> str:
     ).stdout
 
 
+def _run_podman(podman_path: Path, *args: str) -> None:
+    subprocess.run(
+        [str(podman_path), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
 def _windows_machine_state(podman_path: Path) -> str:
     return (
         _podman_query(
@@ -710,6 +719,48 @@ def _windows_machine_state(podman_path: Path) -> str:
 
 def _windows_container_names(podman_path: Path) -> list[str]:
     return _podman_query(podman_path, "ps", "-a", "--format", "{{.Names}}").splitlines()
+
+
+def _assert_windows_host_data_passthrough(
+    podman_path: Path,
+    container_name: str,
+    host_exa: Path,
+    tmp_path: Path,
+) -> None:
+    mounts = json.loads(
+        _podman_query(
+            podman_path,
+            "inspect",
+            "--format",
+            "{{json .Mounts}}",
+            container_name,
+        )
+    )
+    exa_mounts = [mount for mount in mounts if mount["Destination"] == "/exa"]
+    assert len(exa_mounts) == 1
+    assert exa_mounts[0]["Type"] == "bind"
+    assert host_exa.is_dir()
+
+    host_file = host_exa / "host-visible"
+    host_file.write_text("from-host")
+    host_roundtrip = tmp_path / "host-roundtrip"
+    _run_podman(
+        podman_path,
+        "cp",
+        f"{container_name}:/exa/host-visible",
+        str(host_roundtrip),
+    )
+    assert host_roundtrip.read_text() == "from-host"
+
+    guest_source = tmp_path / "guest-source"
+    guest_source.write_text("from-guest")
+    _run_podman(
+        podman_path,
+        "cp",
+        str(guest_source),
+        f"{container_name}:/exa/guest-visible",
+    )
+    assert (host_exa / "guest-visible").read_text() == "from-guest"
 
 
 # The flags the Windows lifecycle test drives, kept next to it so the two stay
@@ -784,6 +835,12 @@ def test_install_local_windows_lifecycle(exasol_path: str, tmp_path: Path) -> No
 
         deployment_data = json.loads((deployment_dir / "deployment.json").read_text())
         container_name = f"exasol-db-{deployment_data['deploymentId']}"
+        host_exa = deployment_dir / "local" / "runtime" / "exa"
+
+        # Then Nano uses one host bind at /exa with visibility in both directions
+        _assert_windows_host_data_passthrough(
+            podman_path, container_name, host_exa, tmp_path
+        )
 
         # Then the database accepts SQL over the published loopback port
         run_command(
@@ -902,6 +959,7 @@ def test_install_local_windows_lifecycle(exasol_path: str, tmp_path: Path) -> No
         # Then the container and local runtime files are gone
         assert container_name not in _windows_container_names(podman_path)
         assert not (deployment_dir / "local").exists()
+        assert not host_exa.exists()
 
         # Then the shared Podman machine is left running: it is host-wide
         # state the launcher borrows, not deployment state it owns.

--- a/tests/tests/testcase_helpers.py
+++ b/tests/tests/testcase_helpers.py
@@ -16,7 +16,11 @@ etc.).
 
 import os
 import platform
+import secrets
+import shlex
+import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -43,6 +47,7 @@ __all__ = [
     "requires_macos_arm",
     "requires_posix_pty",
     "run_command",
+    "run_in_local_vm",
     "skip_unless_infra",
     "skip_without_cloud_deploy_optin",
 ]
@@ -92,3 +97,82 @@ def skip_without_cloud_deploy_optin() -> None:
 def local_deploy_base_args(deployment_dir: str) -> list[str]:
     """Return the trailing args that point a command at a local deployment dir."""
     return ["--deployment-dir", deployment_dir, "--no-launcher-version-check"]
+
+
+def run_in_local_vm(
+    exasol_path: str,
+    deployment_dir: str | Path,
+    command: str,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run a checked command through the interactive local VM shell."""
+    import pty  # noqa: PLC0415 - only available on the macOS VM path
+
+    deployment_path = Path(deployment_dir)
+    shared = deployment_path / "local/runtime/vm-shared"
+    shared.mkdir(parents=True, exist_ok=True)
+    input_file = None
+    if input_text is not None:
+        input_file = shared / ("input-" + secrets.token_hex(16))
+        input_file.write_text(input_text, encoding="utf-8")
+        command += " < " + shlex.quote("/mnt/host/" + input_file.name)
+
+    marker = "__VM_COMMAND_RESULT_" + secrets.token_hex(16) + "__"
+    script = "\n".join(
+        [
+            "stty -echo",
+            f"printf '%s\\n' {shlex.quote(marker)}",
+            command,
+            "status=$?",
+            f"printf '%s:%s\\n' {shlex.quote(marker)} \"$status\"",
+            'exit "$status"',
+        ]
+    )
+    launcher_command = [
+        exasol_path,
+        "shell",
+        "host",
+        "--deployment-dir",
+        str(deployment_path),
+    ]
+    output = bytearray()
+    input_data = (script + "\n").encode()
+    input_sent = False
+
+    def read_input(_fd: int) -> bytes:
+        nonlocal input_sent
+        if input_sent:
+            return b""
+        input_sent = True
+        return input_data
+
+    def read_output(fd: int) -> bytes:
+        try:
+            data = os.read(fd, 4096)
+        except OSError:
+            return b""
+        output.extend(data)
+        return data
+
+    try:
+        pty.spawn(launcher_command, master_read=read_output, stdin_read=read_input)
+    finally:
+        if input_file is not None:
+            input_file.unlink(missing_ok=True)
+
+    decoded = output.decode(errors="replace").replace("\r", "")
+    result_start = decoded.rfind(marker + "\n")
+    result_end = decoded.rfind(marker + ":")
+    if result_start < 0 or result_end < result_start:
+        message = "Local VM command did not return a result marker"
+        raise AssertionError(message)
+    command_output = decoded[result_start + len(marker) + 1 : result_end]
+    returncode = int(decoded[result_end + len(marker) + 1 :].splitlines()[0])
+    result = subprocess.CompletedProcess(
+        launcher_command, returncode, command_output, ""
+    )
+    if returncode != 0:
+        raise subprocess.CalledProcessError(
+            returncode, launcher_command, output=command_output
+        )
+    return result


### PR DESCRIPTION
## Description

macOS local deployments now keep the Nano `/exa` tree at `local/runtime/exa`, making persistent database files visible to host tools. Linux and Windows keep their existing host-side storage.

Existing deployments migrate on their first start with this launcher. That start also rebuilds the VM guest when it came from a different runner, so the migration and later starts run on the guest the launcher expects.

## Related Issue

[SPOT-32427](https://exasol.atlassian.net/browse/SPOT-32427)

## Type of Change

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [x] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Store macOS Nano data at `local/runtime/exa` on the host, migrating existing data on first start and preserving metadata and sparse files.
- Rebuild a deployment's VM guest when the resolved runner differs from the one recorded for it, stopping a running VM first and recording the new runner only once the rebuild succeeds.
- Describe the macOS data-size setting as VM runtime disk size for Podman images and runtime state, since the host filesystem now determines the space available to `/exa`.
- Cover macOS and Windows host-data behavior with tests, and document the host path for virtual-schema setup.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

Verified on a macOS Apple Silicon host against deployments installed by released launchers:

- A v2.2.0 deployment started on this branch rebuilds its guest, migrates `/exa` to the host, and keeps committed rows. Volume files stay sparse: two 1 GiB files occupy 33 MB and 16 KB on the host.
- A v2.1.0 deployment records no runner version at all and is rebuilt on that basis, also keeping committed rows.
- Restarting a migrated deployment rebuilds nothing and keeps its data.
- A rebuild that fails leaves the recorded runner version untouched, and a later start retries it and succeeds.
- After migration the guest keeps a recoverable backup and no longer has the legacy `/var/lib/exa` path.

`exasol start` reports the one-time rebuild:

```
INFO msg="replacing the local VM guest to match the resolved runner"
```

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation
- [x] Updated `CHANGELOG.md`
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

[SPOT-32427]: https://exasol.atlassian.net/browse/SPOT-32427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

