### PR TITLE
fix: Ensure python dependencies are in sync

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -138,9 +138,7 @@ tasks:
     dir: '{{.TESTS_DIR}}'
     cmds:
       - poetry sync
-    status:
-      - poetry run ruff --version
-      - poetry run mypy --version
+    # There is no `poetry sync --status` to check if the venv is up-to-date, so no `status:` here
     deps:
       - deps-install-poetry
 


### PR DESCRIPTION
## Description

Small task fix, I was confused by some lint errors I got in another branch and it turns out we never run `poetry sync` if `ruff` or `mypy` are already in `PATH` or if we ever ran it before.

Always run it, when there's nothing to change it's quick enough (imo) and this way no-one has to chase these weird problems.

## Related Issue

none

Fixes #

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Always run `poetry sync` on tasks that need python stuff.

## Testing

<!-- Describe how you tested your changes -->

- [x] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [ ] Manually tested the changes

### Test Details

<!-- Describe your testing approach -->

## Checklist

<!-- Mark completed items with an "x" -->

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [ ] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [ ] Added/updated tests
- [ ] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

<!-- Any additional information, screenshots, or context -->
