### PR TITLE
fix: SLC deployment test and macOS CI Python setup

### DIFF
--- a/.github/actions/tests-deployment/action.yml
+++ b/.github/actions/tests-deployment/action.yml
@@ -39,6 +39,16 @@ runs:
       uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1.4.2
       with:
         version: "2.4.1"
+    - name: Select Python 3.13 for Poetry
+      if: ${{ inputs.system-python == 'true' }}
+      shell: bash
+      working-directory: tests
+      run: |
+        python_path="$(uv python find 3.13)"
+        echo "Using Python: ${python_path}"
+        "${python_path}" --version
+        poetry env use "${python_path}"
+        poetry env info
     - name: Install test dependencies (system Python path)
       if: ${{ inputs.system-python == 'true' }}
       shell: bash

--- a/tests/tests/deployment/test_slc.py
+++ b/tests/tests/deployment/test_slc.py
@@ -260,7 +260,7 @@ def test_custom_slc_rejects_invalid_input(slc_deployment: Deployment) -> None:
     invalid = [
         ["--alias", CUSTOM_ALIAS, "--language", "python"],
         ["--source", "c.tar.gz", "--alias", "123bad", "--language", "python"],
-        ["--source", "c.tar.gz", "--alias", CUSTOM_ALIAS, "--language", "cobol"],
+        ["--source", "c.tar.gz", "--alias", CUSTOM_ALIAS, "--language", "cobol/"],
         [
             "--source",
             "http://example.com/c.tar.gz",

--- a/tests/tests/deployment/test_virtual_schema.py
+++ b/tests/tests/deployment/test_virtual_schema.py
@@ -279,17 +279,22 @@ def postgres_source(
     prepared_virtual_schema_deployment: Deployment,
     _local_infra: None,
 ) -> Iterator[PostgresSource]:
-    """Start PostgreSQL on an independent network and create a private schema."""
+    """Start PostgreSQL and create a private schema for the Virtual Schema test."""
     podman = _container_runtime(prepared_virtual_schema_deployment)
     config = json.loads(_ARTIFACT_CONFIG.read_text(encoding="utf-8"))
     container = "exasol-vs-postgres-" + uuid.uuid4().hex[:12]
-    network = "exasol-vs-network-" + uuid.uuid4().hex[:12]
     postgres_image = config["postgres_image"]
     deployment_container = _deployment_container(prepared_virtual_schema_deployment)
+    network: str | None = None
     schema_created = False
     try:
-        podman(["network", "create", network], None)
-        podman(["network", "connect", network, deployment_container], None)
+        if platform.system() == "Darwin":
+            network = "exasol-vs-network-" + uuid.uuid4().hex[:12]
+            podman(["network", "create", network], None)
+            podman(["network", "connect", network, deployment_container], None)
+            postgres_network = network
+        else:
+            postgres_network = "container:" + deployment_container
         run_args = [
             "run",
             "--detach",
@@ -297,7 +302,7 @@ def postgres_source(
             "--name",
             container,
             "--network",
-            network,
+            postgres_network,
         ]
         run_args.extend(
             [
@@ -316,7 +321,11 @@ def postgres_source(
         source = PostgresSource(
             podman=podman,
             container=container,
-            runtime_host=_container_ip(podman, container),
+            runtime_host=(
+                _container_ip(podman, container)
+                if platform.system() == "Darwin"
+                else "127.0.0.1"
+            ),
             port=5432,
             database=_POSTGRES_DATABASE,
             user=_POSTGRES_USER,
@@ -348,10 +357,13 @@ def postgres_source(
         finally:
             with suppress(subprocess.CalledProcessError):
                 podman(["rm", "--force", container], None)
-            with suppress(subprocess.CalledProcessError):
-                podman(["network", "disconnect", network, deployment_container], None)
-            with suppress(subprocess.CalledProcessError):
-                podman(["network", "rm", network], None)
+            if network is not None:
+                with suppress(subprocess.CalledProcessError):
+                    podman(
+                        ["network", "disconnect", network, deployment_container], None
+                    )
+                with suppress(subprocess.CalledProcessError):
+                    podman(["network", "rm", network], None)
 
 
 def _download_artifact(spec: ArtifactSpec, target: Path) -> Path:


### PR DESCRIPTION
## Description

Fix the SLC/VS deployment test and improve the macOS-specific CI setup required to run the deployment tests successfully on the self-hosted macOS ARM64 runner.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Fixed the invalid custom SLC language test input by using `cobol/`.
- Updated the Virtual Schema deployment test to handle Podman networking differently on macOS and non-macOS platforms.
- Configured Poetry to use the Python 3.13 interpreter installed by `uv` on the macOS self-hosted runner.

## Testing

- [ ] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

- Ran the deployment test workflow on GitHub Actions.
- Verified that the macOS-specific Python and Poetry setup step completes successfully.
- The Linux and Windows deployment test jobs continue to pass.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [ ] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [ ] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

Reference CI Jobs:

https://github.com/exasol/exasol-personal/actions/runs/33769343902
https://github.com/exasol/exasol-personal/actions/runs/33772258092
