### PR TITLE
ci: Decouple documentation source and published version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,15 +5,19 @@ on:
   workflow_dispatch:
     inputs:
       operation:
-        description: Publish a Git tag or delete a published version
+        description: Publish from a Git source or delete a published version
         required: true
         type: choice
         options:
           - publish
           - delete
-      target:
-        description: Git tag for publish (v2.3.0-rc1) or version for delete (2.3.0-rc1)
-        required: true
+      source_ref:
+        description: Exact Git tag or full commit SHA (publish only)
+        required: false
+        type: string
+      version:
+        description: Published version (optional for conventional tags; required for delete)
+        required: false
         type: string
 
 permissions: {}
@@ -31,11 +35,35 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout trusted workflow source
+      - name: Checkout documentation snapshot
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
-          ref: refs/heads/main
+          fetch-depth: 1
+          ref: ${{ inputs.operation == 'publish' && inputs.source_ref || 'refs/heads/main' }}
+
+      - name: Validate documentation source
+        if: inputs.operation == 'publish'
+        id: source
+        env:
+          SOURCE_REF: ${{ inputs.source_ref }}
+        run: |
+          set -euo pipefail
+          fail() {
+            echo "::error::source_ref must be an exact Git tag or full 40-character commit SHA"
+            exit 1
+          }
+          commit="$(git rev-parse HEAD)"
+          if [[ "${SOURCE_REF}" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            [[ "${commit,,}" == "${SOURCE_REF,,}" ]] || fail
+          else
+            tag="${SOURCE_REF#refs/tags/}"
+            if [[ "${SOURCE_REF}" == refs/* && "${SOURCE_REF}" != refs/tags/* ]]; then
+              fail
+            fi
+            tag_commit="$(git rev-parse --verify --end-of-options "refs/tags/${tag}^{commit}")" || fail
+            [[ "${tag_commit}" == "${commit}" ]] || fail
+          fi
+          echo "commit=${commit}" >> "${GITHUB_OUTPUT}"
 
       - name: Set up uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
@@ -45,26 +73,47 @@ jobs:
           enable-cache: true
           cache-dependency-glob: user-docs/uv.lock
 
-      - name: Validate request
+      - name: Prepare publication request
         id: request
         env:
           OPERATION: ${{ inputs.operation }}
-          TARGET: ${{ inputs.target }}
+          SOURCE_REF: ${{ inputs.source_ref }}
+          REQUESTED_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          version="$(uv run --project user-docs --locked --no-build python user-docs/scripts/versions.py validate "${OPERATION}" "${TARGET}")"
-          echo "version=${version}" >> "${GITHUB_OUTPUT}"
-
-      - name: Checkout documentation tag
-        if: inputs.operation == 'publish'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          ref: refs/tags/v${{ steps.request.outputs.version }}
+          if [[ "${OPERATION}" == "publish" ]]; then
+            arguments=("${SOURCE_REF}")
+            if [[ -n "${REQUESTED_VERSION}" ]]; then
+              arguments+=(--version "${REQUESTED_VERSION}")
+            fi
+            version="$(uv run --project user-docs --locked --no-build python user-docs/scripts/versions.py validate-publish "${arguments[@]}")"
+            echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          else
+            version="$(uv run --project user-docs --locked --no-build python user-docs/scripts/versions.py validate-delete "${REQUESTED_VERSION}")"
+            echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          fi
 
       - name: Validate documentation
         if: inputs.operation == 'publish'
         run: task docs-build
+
+      - name: Summarize request
+        env:
+          OPERATION: ${{ inputs.operation }}
+          SOURCE_REF: ${{ inputs.source_ref }}
+          COMMIT: ${{ steps.source.outputs.commit }}
+          VERSION: ${{ steps.request.outputs.version }}
+        run: |
+          {
+            echo "## Documentation publication"
+            echo ""
+            echo "- Operation: \`${OPERATION}\`"
+            echo "- Version: \`${VERSION}\`"
+            if [[ "${OPERATION}" == "publish" ]]; then
+              echo "- Source: \`${SOURCE_REF}\`"
+              echo "- Commit: \`${COMMIT}\`"
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Configure publication identity
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ Notable user-facing changes to Exasol Personal are documented here.
 
 ### Changed
 
+- Documentation publication now selects an immutable Git tag or full commit SHA independently
+  from the published version. Conventional version tags still derive the version automatically,
+  while an explicit version supports publishing reviewed documentation snapshots for older
+  releases without changing their release tags.
+
 - Custom SLC language identifiers are no longer limited to Python, Java, and R. The launcher now
   accepts any valid client-defined identifier, such as `rust`, for a custom SLC.
 

--- a/doc/ci.md
+++ b/doc/ci.md
@@ -76,16 +76,23 @@ Maintainers publish versioned user documentation with the manually dispatched do
 workflow. GitHub Pages must be enabled with **GitHub Actions** as its source, and the existing
 `github-pages` environment must allow deployments only from `main`.
 
-The workflow accepts two inputs:
+The workflow accepts three inputs:
 
 - `operation`: `publish` or `delete`.
-- `target`: an existing Git tag for publication, such as `v2.3.0-rc1`, or a published version for
-  deletion, such as `2.3.0-rc1`.
+- `source_ref`: an exact Git tag or full 40-character commit SHA, required for publication.
+- `version`: the published semantic version. It is required for deletion and optional for
+  publication when `source_ref` is a tag named `v<version>` or ending in `/v<version>`.
 
-Publication builds the documentation and validates its internal links from the selected tag before
-updating the version catalog. Stable versions update `latest` and the site root; release candidates
-remain independently selectable. Deletion preserves all other versions and rejects removal of the
-version referenced by `latest` until a newer stable version is published.
+An explicit version can map historical documentation content to an older release without changing
+an existing release tag. For example, publish a reviewed `docs/v2.2.0` snapshot based on a current
+commit as `2.2.0`, or map its full commit SHA by supplying `2.2.0` explicitly. Branch references
+are not accepted.
+
+Publication shallow-checks out the source once and builds its self-contained `user-docs/` directory,
+including its content, configuration, scripts, and locked uv environment, before updating the
+version catalog. Stable versions update `latest` and the site root; release candidates remain
+independently selectable. Deletion preserves all other versions and rejects removal of the version
+referenced by `latest` until a newer stable version is published.
 
 All operations are serialized in request order. If Pages deployment fails after the version
 catalog is updated, rerun the same operation to deploy the complete stored catalog. A repeated

--- a/doc/development.md
+++ b/doc/development.md
@@ -74,9 +74,9 @@ The generated site is written to `user-docs/site/`. Warnings fail the build, inc
 internal documentation links. Run `task docs-check` to lint and test the publishing tooling before
 performing the strict build.
 
-Version-catalog operations are implemented by `user-docs/scripts/versions.py`. The script updates
-only a local `gh-pages` branch and never pushes; use a disposable clone when exercising publication
-operations manually.
+Publication-request validation and version-catalog operations are implemented by
+`user-docs/scripts/versions.py`. The script updates only a local `gh-pages` branch and never pushes;
+use a disposable clone when exercising catalog operations manually.
 
 ## Building
 

--- a/openspec/changes/archive/2026-09-03-decouple-doc-source-version/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-03-decouple-doc-source-version/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-03

--- a/openspec/changes/archive/2026-09-03-decouple-doc-source-version/design.md
+++ b/openspec/changes/archive/2026-09-03-decouple-doc-source-version/design.md
@@ -1,0 +1,56 @@
+## Context
+
+The manual workflow currently treats a release tag as both the source revision and published version. That prevents retroactive publication because immutable historical release tags do not contain the new documentation structure or tooling. A later documentation snapshot based on a current commit can contain the historical content and complete publishing environment without changing the original release tag.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Select a Git tag or full commit SHA independently from the published semantic version.
+- Publish a self-contained documentation snapshot with one shallow checkout.
+- Keep source and version validation locally testable with the catalog operations.
+
+**Non-Goals:**
+
+- Converting historical README content into the normalized documentation tree.
+- Accepting mutable branch references.
+- Integrating publication into the release workflow.
+
+## Decisions
+
+### D1. Publication has independent `source_ref` and `version` inputs
+
+`source_ref` identifies either an exact tag or a full 40-character commit SHA. An explicit `version` is authoritative; otherwise the version is derived from a tag named `v<semver>` or whose final path component is `v<semver>`. Delete operations use only the required `version` input.
+
+Separate inputs make retroactive mappings explicit without adding another workflow or moving release tags. Full SHAs and exact tags provide immutable source selection; branches remain outside the contract.
+
+### D2. The selected revision is a self-contained documentation snapshot
+
+Publication checks out the selected tag or commit once with shallow history. Its `user-docs/` directory supplies the content, MkDocs configuration, scripts, and locked uv environment used for the build and catalog operation.
+
+Keeping the snapshot complete makes it directly reviewable and reproducible. A retroactive tag such as `docs/v2.2.0` can point to a recent commit containing current tooling and the prepared historical content.
+
+### D3. The workflow validates the checked-out revision before running it
+
+Before invoking repository scripts, the workflow verifies that a full SHA matches the checked-out commit or that an exact tag resolves to it. Branch references therefore fail without executing their content.
+
+This retains the immutable-source contract without a second checkout, archive transport, or content-copying layer. Deletion selects `main` because it has no documentation source.
+
+### D4. Version catalog behavior remains version-based
+
+After strict validation, the existing mike operations publish the normalized version. Stable versions update `latest`; prereleases do not. Deletion remains independent of source content and accepts only a version.
+
+## Risks / Trade-offs
+
+- **A selected revision lacks a complete documentation environment** → Fail during setup or validation before changing the version catalog.
+- **A selected snapshot contains unreviewed tooling** → Require maintainers to publish only reviewed immutable tags or commits and validate the ref before executing repository code.
+- **A tag and explicit version describe different releases** → Treat the explicit mapping as intentional and show both the resolved commit and version in the workflow summary.
+- **Snapshot tooling eventually becomes stale** → Base retroactive snapshots on a current reviewed commit rather than on the original release tag.
+
+## Migration Plan
+
+Replace the manual workflow inputs and keep all existing published versions unchanged. Existing release tags continue to work when they contain the complete `user-docs/` setup; a reviewed documentation snapshot based on a current commit can supply an older published version. Reverting the workflow changes restores the previous input contract without changing `gh-pages` history.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-09-03-decouple-doc-source-version/proposal.md
+++ b/openspec/changes/archive/2026-09-03-decouple-doc-source-version/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+Release tags are immutable and older releases may need documentation published after their tags were created. Publication therefore needs to select historical content independently from the version shown to readers.
+
+## What Changes
+
+- Replace the single publication target with an immutable source revision and an independently selectable documentation version.
+- Derive the documentation version from conventional version tags when no explicit version is supplied.
+- Treat the selected revision as a self-contained documentation snapshot with its content and publishing environment.
+- Keep deletion version-based and preserve the existing version catalog behavior.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `versioned-documentation-publishing`: Select immutable source content independently from its published semantic version.
+
+## Impact
+
+The manual documentation workflow, its local helper scripts and tests, the CI guide, and the versioned documentation publishing specification change. No runtime product behavior or additional dependency is introduced.

--- a/openspec/changes/archive/2026-09-03-decouple-doc-source-version/specs/versioned-documentation-publishing/spec.md
+++ b/openspec/changes/archive/2026-09-03-decouple-doc-source-version/specs/versioned-documentation-publishing/spec.md
@@ -1,0 +1,75 @@
+## RENAMED Requirements
+
+- FROM: `### Requirement: Maintainers can manually publish documentation from a version tag`
+- TO: `### Requirement: Maintainers can manually publish documentation from an immutable source revision`
+
+## MODIFIED Requirements
+
+### Requirement: Maintainers can manually publish documentation from an immutable source revision
+
+The documentation workflow SHALL allow a maintainer to select an existing Git tag or full commit
+SHA as the documentation source and publish it under an independently selected semantic version.
+When the version is omitted, the workflow SHALL derive it from a tag named `v<semver>` or ending
+in `/v<semver>`.
+
+#### Scenario: Publish a stable version derived from a tag
+
+- **WHEN** a maintainer publishes documentation from a tag such as `v2.3.0` without supplying a
+  version
+- **THEN** version `2.3.0` SHALL be published, `latest` SHALL resolve to `2.3.0`, and the site root
+  SHALL resolve to `latest`
+
+#### Scenario: Publish a release-candidate version derived from a namespaced tag
+
+- **WHEN** a maintainer publishes documentation from a tag such as `docs/v2.3.0-rc1` without
+  supplying a version
+- **THEN** version `2.3.0-rc1` SHALL be published and the existing `latest` alias and site root
+  SHALL remain unchanged
+
+#### Scenario: Publish an explicitly mapped version
+
+- **WHEN** a maintainer publishes an immutable source revision and supplies version `2.2.0`
+- **THEN** the selected source content SHALL be published as version `2.2.0` regardless of the
+  source tag name
+
+#### Scenario: Require an explicit version for an underivable source
+
+- **WHEN** a maintainer publishes a full commit SHA or a tag that does not end in `v<semver>`
+  without supplying a version
+- **THEN** publication SHALL fail before changing any published version and explain that a version
+  is required
+
+#### Scenario: Reject a mutable source
+
+- **WHEN** a maintainer selects a branch as the documentation source
+- **THEN** publication SHALL fail before changing any published version and explain that only an
+  exact tag or full commit SHA is accepted
+
+#### Scenario: Republish one version
+
+- **WHEN** a maintainer publishes a documentation version that already exists
+- **THEN** that version SHALL be replaced from the selected source and every other published
+  version SHALL remain unchanged
+
+### Requirement: Documentation is validated before publication
+
+The workflow SHALL check out the selected source as an exact commit and complete a strict
+documentation build and internal-link validation using the content, configuration, scripts, and
+locked dependencies stored at that revision before it changes published version state.
+
+#### Scenario: Validation succeeds
+
+- **WHEN** the selected commit contains a valid self-contained `user-docs/` setup
+- **THEN** the workflow SHALL proceed with the requested publication using the exact resolved
+  commit
+
+#### Scenario: Selected source lacks a complete documentation setup
+
+- **WHEN** the selected commit lacks required documentation content, configuration, scripts, or
+  locked dependencies
+- **THEN** the workflow SHALL fail without changing any published version
+
+#### Scenario: Validation fails
+
+- **WHEN** the selected documentation snapshot has invalid navigation or internal links
+- **THEN** the workflow SHALL fail without changing any published version

--- a/openspec/changes/archive/2026-09-03-decouple-doc-source-version/tasks.md
+++ b/openspec/changes/archive/2026-09-03-decouple-doc-source-version/tasks.md
@@ -1,0 +1,11 @@
+## 1. Validate Documentation Sources
+
+- [x] 1.1 Implement and test version resolution for immutable documentation sources.
+
+## 2. Integrate Manual Publication
+
+- [x] 2.1 Update and test the manual workflow contract so one shallow checkout publishes the selected self-contained snapshot under the resolved version.
+
+## 3. Document the Contract
+
+- [x] 3.1 Update the development and CI guides and changelog for independent source and version selection.

--- a/openspec/specs/versioned-documentation-publishing/spec.md
+++ b/openspec/specs/versioned-documentation-publishing/spec.md
@@ -4,31 +4,7 @@
 
 Define how maintainers safely validate and manually publish, replace, or delete versioned user
 documentation through GitHub Pages.
-
 ## Requirements
-### Requirement: Maintainers can manually publish documentation from a version tag
-
-The documentation workflow SHALL allow a maintainer to select an existing semantic-version Git
-tag and publish the documentation stored at that exact tag under the corresponding version.
-
-#### Scenario: Publish a stable version
-
-- **WHEN** a maintainer publishes documentation from a stable tag such as `v2.3.0`
-- **THEN** version `2.3.0` SHALL be published, `latest` SHALL resolve to `2.3.0`, and the site root
-  SHALL resolve to `latest`
-
-#### Scenario: Publish a release-candidate version
-
-- **WHEN** a maintainer publishes documentation from a pre-release tag such as `v2.3.0-rc1`
-- **THEN** version `2.3.0-rc1` SHALL be published and the existing `latest` alias and site root
-  SHALL remain unchanged
-
-#### Scenario: Republish one version
-
-- **WHEN** a maintainer publishes a tag whose documentation version already exists
-- **THEN** that version SHALL be replaced from the selected tag and every other published version
-  SHALL remain unchanged
-
 ### Requirement: Maintainers can manually delete one published version
 
 The documentation workflow SHALL allow a maintainer to select and delete one published version
@@ -58,18 +34,25 @@ versions.
 
 ### Requirement: Documentation is validated before publication
 
-The workflow SHALL complete a strict documentation build and internal-link validation before it
-changes published version state.
+The workflow SHALL check out the selected source as an exact commit and complete a strict
+documentation build and internal-link validation using the content, configuration, scripts, and
+locked dependencies stored at that revision before it changes published version state.
 
 #### Scenario: Validation succeeds
 
-- **WHEN** the selected tag contains valid documentation and internal links
-- **THEN** the workflow SHALL proceed with the requested publication
+- **WHEN** the selected commit contains a valid self-contained `user-docs/` setup
+- **THEN** the workflow SHALL proceed with the requested publication using the exact resolved
+  commit
+
+#### Scenario: Selected source lacks a complete documentation setup
+
+- **WHEN** the selected commit lacks required documentation content, configuration, scripts, or
+  locked dependencies
+- **THEN** the workflow SHALL fail without changing any published version
 
 #### Scenario: Validation fails
 
-- **WHEN** the selected tag contains invalid documentation configuration, navigation, or internal
-  links
+- **WHEN** the selected documentation snapshot has invalid navigation or internal links
 - **THEN** the workflow SHALL fail without changing any published version
 
 ### Requirement: Publication operations preserve a consistent version catalog
@@ -87,3 +70,49 @@ catalog.
 
 - **WHEN** GitHub Pages deployment fails after the version catalog has been updated
 - **THEN** rerunning the same manual operation SHALL deploy the complete stored version catalog
+
+### Requirement: Maintainers can manually publish documentation from an immutable source revision
+
+The documentation workflow SHALL allow a maintainer to select an existing Git tag or full commit
+SHA as the documentation source and publish it under an independently selected semantic version.
+When the version is omitted, the workflow SHALL derive it from a tag named `v<semver>` or ending
+in `/v<semver>`.
+
+#### Scenario: Publish a stable version derived from a tag
+
+- **WHEN** a maintainer publishes documentation from a tag such as `v2.3.0` without supplying a
+  version
+- **THEN** version `2.3.0` SHALL be published, `latest` SHALL resolve to `2.3.0`, and the site root
+  SHALL resolve to `latest`
+
+#### Scenario: Publish a release-candidate version derived from a namespaced tag
+
+- **WHEN** a maintainer publishes documentation from a tag such as `docs/v2.3.0-rc1` without
+  supplying a version
+- **THEN** version `2.3.0-rc1` SHALL be published and the existing `latest` alias and site root
+  SHALL remain unchanged
+
+#### Scenario: Publish an explicitly mapped version
+
+- **WHEN** a maintainer publishes an immutable source revision and supplies version `2.2.0`
+- **THEN** the selected source content SHALL be published as version `2.2.0` regardless of the
+  source tag name
+
+#### Scenario: Require an explicit version for an underivable source
+
+- **WHEN** a maintainer publishes a full commit SHA or a tag that does not end in `v<semver>`
+  without supplying a version
+- **THEN** publication SHALL fail before changing any published version and explain that a version
+  is required
+
+#### Scenario: Reject a mutable source
+
+- **WHEN** a maintainer selects a branch as the documentation source
+- **THEN** publication SHALL fail before changing any published version and explain that only an
+  exact tag or full commit SHA is accepted
+
+#### Scenario: Republish one version
+
+- **WHEN** a maintainer publishes a documentation version that already exists
+- **THEN** that version SHALL be replaced from the selected source and every other published
+  version SHALL remain unchanged

--- a/user-docs/scripts/versions.py
+++ b/user-docs/scripts/versions.py
@@ -16,10 +16,12 @@ SEMANTIC_VERSION = re.compile(
     r"(?:\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?"
     r"(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
 )
+FULL_COMMIT = re.compile(r"[0-9a-fA-F]{40}")
+VERSION_TAG = re.compile(r"(?:.*/)?v(?P<version>.+)")
 MIKE_BRANCH = "gh-pages"
 MKDOCS_CONFIG = "user-docs/mkdocs.yml"
-PUBLISH_TARGET_ERROR = (
-    "publish target must be a semantic-version tag such as v2.3.0 or v2.3.0-rc1"
+PUBLISH_VERSION_ERROR = (
+    "version is required when source_ref is not a tag ending in v<semver>"
 )
 DELETE_TARGET_ERROR = (
     "delete target must be a published semantic version such as 2.3.0-rc1"
@@ -51,15 +53,27 @@ def mike(
     )
 
 
-def validate(operation: str, target: str) -> str:
-    if operation == "publish":
-        if not target.startswith("v") or not SEMANTIC_VERSION.fullmatch(target[1:]):
-            raise VersionError(PUBLISH_TARGET_ERROR)
-        return target[1:]
-
+def validate_delete(target: str) -> str:
     if not SEMANTIC_VERSION.fullmatch(target):
         raise VersionError(DELETE_TARGET_ERROR)
     return target
+
+
+def validate_publish(source_ref: str, version: str | None) -> str:
+    if version:
+        require_version(version)
+        return version
+
+    selected_tag = source_ref.removeprefix("refs/tags/")
+    match = (
+        None
+        if FULL_COMMIT.fullmatch(source_ref)
+        else VERSION_TAG.fullmatch(selected_tag)
+    )
+    derived = match.group("version") if match else ""
+    if not SEMANTIC_VERSION.fullmatch(derived):
+        raise VersionError(PUBLISH_VERSION_ERROR)
+    return derived
 
 
 def is_stable(version: str) -> bool:
@@ -114,11 +128,16 @@ def parse_args() -> argparse.Namespace:
     )
     commands = parser.add_subparsers(dest="command", required=True)
 
-    validate_parser = commands.add_parser(
-        "validate", help="Validate and normalize a request"
+    validate_delete_parser = commands.add_parser(
+        "validate-delete", help="Validate a deletion request"
     )
-    validate_parser.add_argument("operation", choices=("publish", "delete"))
-    validate_parser.add_argument("target")
+    validate_delete_parser.add_argument("target")
+
+    validate_publish_parser = commands.add_parser(
+        "validate-publish", help="Validate and normalize a publication request"
+    )
+    validate_publish_parser.add_argument("source_ref")
+    validate_publish_parser.add_argument("--version")
 
     publish_parser = commands.add_parser(
         "publish", help="Publish a version to the local catalog"
@@ -136,8 +155,10 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     try:
-        if args.command == "validate":
-            sys.stdout.write(f"{validate(args.operation, args.target)}\n")
+        if args.command == "validate-delete":
+            sys.stdout.write(f"{validate_delete(args.target)}\n")
+        elif args.command == "validate-publish":
+            sys.stdout.write(f"{validate_publish(args.source_ref, args.version)}\n")
         elif args.command == "publish":
             publish(args.version)
         else:

--- a/user-docs/tests/test_versions.py
+++ b/user-docs/tests/test_versions.py
@@ -10,38 +10,79 @@ from scripts import versions
 
 
 @pytest.mark.parametrize(
-    ("target", "expected"),
+    "target",
     [
-        ("v1.2.3", "1.2.3"),
-        ("v1.2.3-alpha--1", "1.2.3-alpha--1"),
-        ("v1.2.3--", "1.2.3--"),
-        ("v1.2.3+001.build", "1.2.3+001.build"),
+        "1.2.3",
+        "1.2.3-alpha--1",
+        "1.2.3--",
+        "1.2.3+001.build",
     ],
 )
-def test_validate_accepts_semantic_version_tags(target: str, expected: str) -> None:
+def test_validate_delete_accepts_semantic_versions(target: str) -> None:
     # Given / When
-    actual = versions.validate("publish", target)
+    actual = versions.validate_delete(target)
 
     # Then
-    assert actual == expected
+    assert actual == target
 
 
 @pytest.mark.parametrize(
     "target",
     [
-        "1.2.3",
-        "v01.2.3",
-        "v1.02.3",
-        "v1.2.03",
-        "v1.2.3-01",
-        "v1.2.3-alpha..1",
-        "v1.2.3-alpha_1",
+        "v1.2.3",
+        "01.2.3",
+        "1.02.3",
+        "1.2.03",
+        "1.2.3-01",
+        "1.2.3-alpha..1",
+        "1.2.3-alpha_1",
     ],
 )
-def test_validate_rejects_invalid_publish_targets(target: str) -> None:
+def test_validate_delete_rejects_invalid_versions(target: str) -> None:
     # Given / When / Then
-    with pytest.raises(versions.VersionError, match="publish target"):
-        versions.validate("publish", target)
+    with pytest.raises(versions.VersionError, match="delete target"):
+        versions.validate_delete(target)
+
+
+@pytest.mark.parametrize(
+    ("source_ref", "expected"),
+    [
+        ("v2.3.0", "2.3.0"),
+        ("docs/v2.2.0-rc.1", "2.2.0-rc.1"),
+        ("refs/tags/docs/v2.1.0", "2.1.0"),
+    ],
+)
+def test_validate_publish_derives_version_from_conventional_tags(
+    source_ref: str, expected: str
+) -> None:
+    # Given / When
+    actual = versions.validate_publish(source_ref, None)
+
+    # Then
+    assert actual == expected
+
+
+@pytest.mark.parametrize("source_ref", ["a" * 40, "release-2.2.0"])
+def test_validate_publish_requires_version_when_it_cannot_be_derived(
+    source_ref: str,
+) -> None:
+    # Given / When / Then
+    with pytest.raises(versions.VersionError, match="version is required"):
+        versions.validate_publish(source_ref, None)
+
+
+def test_validate_publish_prefers_explicit_version() -> None:
+    # Given / When
+    actual = versions.validate_publish("v9.9.9", "2.2.0")
+
+    # Then
+    assert actual == "2.2.0"
+
+
+def test_validate_publish_rejects_invalid_explicit_version() -> None:
+    # Given / When / Then
+    with pytest.raises(versions.VersionError, match="semantic-version syntax"):
+        versions.validate_publish("v2.2.0", "release-2.2")
 
 
 def test_publish_stable_version_updates_latest(


### PR DESCRIPTION
## Summary

- shallow-checkout the selected documentation tag or full commit SHA exactly once
- publish the snapshot under an independently supplied or derived semantic version
- keep each snapshot self-contained with its `user-docs/` content, configuration, scripts, and locked uv environment

## Verification

- `task docs-check` (24 tests and strict MkDocs build)
- `openspec validate versioned-documentation-publishing --strict`
- workflow YAML parsing and embedded Bash syntax validation
- `git diff --check main...HEAD`

Relates to SPOT-32456.
