### PR TITLE
ci: Fix documentation workflow validation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,18 +5,18 @@ on:
   workflow_dispatch:
     inputs:
       operation:
-        description: Publish from a Git source or delete a published version
+        description: "Action to run: publish or delete"
         required: true
         type: choice
         options:
           - publish
           - delete
       source_ref:
-        description: Exact Git tag or full commit SHA (publish only)
+        description: "Exact tag, e.g. docs/v2.2.0 or docs/0.1; full 40-character SHA also accepted"
         required: false
         type: string
       version:
-        description: Published version (optional for conventional tags; required for delete)
+        description: "SemVer without v, e.g. 2.2.0; required for delete and optional for v-tags"
         required: false
         type: string
 
@@ -95,7 +95,7 @@ jobs:
 
       - name: Validate documentation
         if: inputs.operation == 'publish'
-        run: task docs-build
+        run: uv run --project user-docs --locked --no-build mkdocs build --strict --config-file user-docs/mkdocs.yml
 
       - name: Summarize request
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@ Notable user-facing changes to Exasol Personal are documented here.
 
 ### Fixed
 
+- Fixed documentation publication failing during validation because the GitHub Actions runner does
+  not provide the Task command.
+
 - Corrected the local Virtual Schema setup guide to use the active deployment's shared directory on
   macOS instead of obsolete SSH paths, and added the required deployment selection and PostgreSQL
   timezone configuration steps.


### PR DESCRIPTION
## Summary

- run the strict MkDocs build directly with uv instead of relying on an unavailable Task command
- show concrete legal examples in the manual workflow input descriptions

## Verification

- `task docs-check` (24 tests and strict MkDocs build)
- workflow YAML and embedded Bash syntax validation
- `git diff --check`

Fixes the failure observed in [documentation run 33845714456](https://github.com/exasol/exasol-personal/actions/runs/33845714456).

Relates to SPOT-32456.
