### PR TITLE
docs: Add Exasol Personal 2.2 user documentation

### DIFF
--- a/user-docs/content/cloud-deployment.md
+++ b/user-docs/content/cloud-deployment.md
@@ -1,0 +1,47 @@
+# Deploy to the cloud
+
+Exasol Personal 2.2 can provision a database in your own AWS, Azure, Exoscale, or STACKIT account.
+Cloud deployments are useful when you need more capacity, multiple nodes, or a shared database.
+
+## Prepare your account
+
+Follow the setup guide for your provider before starting the installation:
+
+- [Amazon Web Services](cloud/aws.md)
+- [Microsoft Azure](cloud/azure.md)
+- [Exoscale](cloud/exoscale.md)
+- [STACKIT](cloud/stackit.md)
+
+Cloud resources incur charges in your account until you destroy them.
+
+## Install the database
+
+Run the command for your provider:
+
+```bash
+exasol install aws
+exasol install azure --location westeurope
+exasol install exoscale
+exasol install stackit --project-id "<your-project-uuid>"
+```
+
+The launcher generates the deployment files, provisions the infrastructure, starts it, and installs
+Exasol Personal. A cloud installation normally takes 10 to 20 minutes.
+
+When installation finishes, the command prints connection instructions. Run `exasol info` later to
+display them again.
+
+## Choose the cluster size and compute type
+
+The default is a single-node cluster on a memory-optimized compute instance. Default types include
+`r6i.xlarge` on AWS, `Standard_E4s_v3` on Azure, `standard.extra-large` on Exoscale, and `m2i.4` on
+STACKIT.
+
+Use `--cluster-size` and `--instance-type` to override the defaults:
+
+```bash
+exasol install <provider> --cluster-size <number> --instance-type <type>
+```
+
+If an installation is interrupted, resources already created are not removed automatically. Follow
+the cleanup guidance in [Troubleshooting](troubleshooting.md) to avoid ongoing charges.

--- a/user-docs/content/cloud/aws.md
+++ b/user-docs/content/cloud/aws.md
@@ -1,0 +1,44 @@
+# Set up Amazon Web Services
+
+Prepare an AWS account and a named AWS CLI profile before deploying Exasol Personal.
+
+## Prerequisites
+
+You need an AWS account with the permissions and service quotas required to launch large compute
+instances. This procedure assumes basic familiarity with AWS Identity and Access Management (IAM).
+See the [AWS documentation](https://docs.aws.amazon.com/) for background information.
+
+## Configure IAM access
+
+In the AWS IAM console:
+
+1. Create a user for Exasol Personal.
+2. Attach the
+   [Exasol Personal AWS policy](https://github.com/exasol/exasol-personal/blob/v2.2.0/assets/infrastructure/aws/iam-policy.broad.json)
+   to the user.
+3. Generate an access key for the user and store its ID and secret securely.
+
+Additional configuration may be necessary if your organization requires multi-factor authentication
+or another authentication method.
+
+## Configure your computer
+
+1. Install the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
+2. Configure a named profile called `exasol`:
+
+   ```bash
+   aws configure --profile exasol
+   ```
+
+3. Enter the access key ID, secret access key, region, and optional output format when prompted:
+
+   ```text
+   AWS Access Key ID [None]: <your-key-id>
+   AWS Secret Access Key [None]: <your-secret-key>
+   Default region name [None]: eu-west-1
+   Default output format [None]: json
+   ```
+
+For details, see [Named profiles for the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html).
+
+You can now [deploy Exasol Personal to AWS](../cloud-deployment.md).

--- a/user-docs/content/cloud/azure.md
+++ b/user-docs/content/cloud/azure.md
@@ -1,0 +1,69 @@
+# Set up Microsoft Azure
+
+Prepare an Azure subscription and authenticate the Azure CLI before deploying Exasol Personal.
+
+## Prerequisites
+
+You need an Azure subscription with sufficient permissions and quota for virtual machines,
+networking, managed disks, and storage accounts in the target region. This procedure assumes basic
+familiarity with Microsoft Entra ID and Azure role-based access control (RBAC). See the
+[Azure documentation](https://learn.microsoft.com/azure/) for background information.
+
+## Configure subscription access
+
+In the Azure portal:
+
+1. Open the target subscription and its **Access control (IAM)** page.
+2. Give the user who will run Exasol Personal one of these roles at subscription scope:
+   - the built-in **Contributor** role;
+   - a custom role based on the
+     [broad example](https://github.com/exasol/exasol-personal/blob/v2.2.0/assets/infrastructure/azure/rbac-role.broad.json); or
+   - a custom role based on the
+     [minimal example](https://github.com/exasol/exasol-personal/blob/v2.2.0/assets/infrastructure/azure/rbac-role.minimal.json).
+
+Use only one option. The built-in Contributor role is usually the simplest. When creating a custom
+role from an example, replace `<subscription-id>` in the JSON first.
+
+The role must allow the launcher to create and delete resource groups, networks, virtual machines,
+managed disks, and storage accounts, and to read storage account keys. Conditional access,
+multi-factor authentication, or organizational approval flows may require additional steps.
+
+## Configure your computer
+
+1. Install the [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli).
+2. Sign in:
+
+   ```bash
+   az login
+   ```
+
+3. If you can access multiple subscriptions, select the one to use:
+
+   ```bash
+   az account set --subscription "<subscription-id-or-name>"
+   ```
+
+4. Verify the selection:
+
+   ```bash
+   az account show
+   ```
+
+5. For a new subscription, register these resource providers if Azure reports registration errors:
+
+   ```bash
+   az provider register --namespace Microsoft.Compute
+   az provider register --namespace Microsoft.Network
+   az provider register --namespace Microsoft.Storage
+   az provider register --namespace Microsoft.Resources
+   ```
+
+Azure requires an explicit deployment location:
+
+```bash
+exasol install azure --location westeurope
+```
+
+For more details, see the Azure CLI guides for
+[authentication](https://learn.microsoft.com/cli/azure/authenticate-azure-cli) and
+[subscription selection](https://learn.microsoft.com/cli/azure/manage-azure-subscriptions-azure-cli).

--- a/user-docs/content/cloud/exoscale.md
+++ b/user-docs/content/cloud/exoscale.md
@@ -1,0 +1,61 @@
+# Set up Exoscale
+
+Prepare an Exoscale organization and API credentials before deploying Exasol Personal.
+
+## Prerequisites
+
+You need an active Exoscale organization with billing configured and sufficient quota for compute
+instances, block storage volumes, and private networks in the target zone. This procedure assumes
+basic familiarity with Exoscale IAM. See the
+[Exoscale documentation](https://community.exoscale.com/documentation/) for background information.
+
+## Configure IAM access
+
+In the Exoscale portal:
+
+1. Open **IAM** > **Roles** and create a role for Exasol Personal.
+2. Grant the permissions described by the
+   [minimal example policy](https://github.com/exasol/exasol-personal/blob/v2.2.0/assets/infrastructure/exoscale/iam-policy.minimal.json)
+   or the
+   [broad example policy](https://github.com/exasol/exasol-personal/blob/v2.2.0/assets/infrastructure/exoscale/iam-policy.broad.json).
+   The minimal policy is recommended. Use the JSON as a reference when entering the permissions in
+   the portal; Exoscale does not import the file directly.
+3. Open **IAM** > **API Keys**, create an API key, and assign the new role.
+4. Copy the key and secret. The secret is displayed only once.
+
+## Configure your computer
+
+Set the credentials as environment variables.
+
+On Linux or macOS:
+
+```bash
+export EXOSCALE_API_KEY=<your-api-key>
+export EXOSCALE_API_SECRET=<your-api-secret>
+```
+
+In Windows PowerShell:
+
+```powershell
+$env:EXOSCALE_API_KEY = "<your-api-key>"
+$env:EXOSCALE_API_SECRET = "<your-api-secret>"
+```
+
+In Windows Command Prompt:
+
+```batch
+set EXOSCALE_API_KEY=<your-api-key>
+set EXOSCALE_API_SECRET=<your-api-secret>
+```
+
+The default zone is `ch-gva-2`. Select another zone with `--zone`:
+
+```bash
+exasol install exoscale
+exasol install exoscale --zone de-fra-1
+exasol install exoscale --zone at-vie-1
+```
+
+Release 2.2 supports `ch-gva-2`, `de-fra-1`, `de-muc-1`, `at-vie-1`, `at-vie-2`, and `bg-sof-1`.
+See the Exoscale guides for [IAM](https://community.exoscale.com/documentation/iam/) and
+[API keys](https://community.exoscale.com/documentation/iam/quick-start/) for more information.

--- a/user-docs/content/cloud/stackit.md
+++ b/user-docs/content/cloud/stackit.md
@@ -1,0 +1,50 @@
+# Set up STACKIT
+
+Prepare a STACKIT project and service account before deploying Exasol Personal.
+
+## Prerequisites
+
+You need an active STACKIT organization with billing configured and permission to create projects.
+See the [STACKIT documentation](https://docs.stackit.cloud/) for background information.
+
+## Configure a service account
+
+In the STACKIT Portal:
+
+1. Open **Resource manager**, create a project, and enter it.
+2. Open **IAM** > **Service Accounts** and create a service account.
+3. Copy the service account email.
+4. Create a service account key and download the JSON credentials file.
+5. Open **IAM** > **Access**.
+6. Add the service account email as the subject and grant the **Editor** role from the **Basic**
+   section.
+7. Copy the project UUID from the Resource manager or the project URL.
+
+## Configure your computer
+
+Set `STACKIT_SERVICE_ACCOUNT_KEY_PATH` to the downloaded credentials file.
+
+On Linux or macOS:
+
+```bash
+export STACKIT_SERVICE_ACCOUNT_KEY_PATH=/path/to/credentials.json
+```
+
+In Windows PowerShell:
+
+```powershell
+$env:STACKIT_SERVICE_ACCOUNT_KEY_PATH = "C:\path\to\credentials.json"
+```
+
+In Windows Command Prompt:
+
+```batch
+set STACKIT_SERVICE_ACCOUNT_KEY_PATH=C:\path\to\credentials.json
+```
+
+Install with the project UUID. The default region is `eu01`; use `--region` to select another:
+
+```bash
+exasol install stackit --project-id "<your-project-uuid>"
+exasol install stackit --region eu02 --project-id "<your-project-uuid>"
+```

--- a/user-docs/content/connect.md
+++ b/user-docs/content/connect.md
@@ -1,0 +1,81 @@
+# Connect to the database
+
+Run `exasol info` after installation to display database connection details. The deployment's
+`secrets.json` contains the credentials needed by database clients.
+
+See [Connect to Exasol](https://docs.exasol.com/db/latest/connect_exasol.htm) for supported drivers and
+client applications.
+
+## Use the built-in SQL client
+
+Start an interactive SQL session:
+
+```bash
+exasol connect
+```
+
+Run one or more semicolon-separated statements without opening an interactive session:
+
+```bash
+exasol connect -c "SELECT 1; SELECT 2"
+```
+
+Run statements from a file:
+
+```bash
+exasol connect -f script.sql
+```
+
+`--command` and `--file` are mutually exclusive. Non-interactive execution stops at the first failed
+statement and exits with a non-zero status.
+
+## Select the output format
+
+Use `--csv` for CSV output:
+
+```bash
+exasol connect --csv -c "SELECT * FROM PRODUCTS" > products.csv
+```
+
+Use `--json` for machine-readable output. A non-interactive invocation writes one JSON document for
+all statements, including SQL errors. An interactive `exasol connect --json` session writes one JSON
+document per statement.
+
+## Limit query output
+
+Interactive query output is limited to 100 rows by default. Piped input and `--command` or `--file`
+return the full result unless you set a limit.
+
+```bash
+exasol connect --max-rows 0
+echo "SELECT * FROM PRODUCTS;" | exasol connect --max-rows 1000
+```
+
+Use `--max-rows 0` for unlimited interactive output.
+
+For SQL syntax, functions, and data types, see the
+[Exasol SQL reference](https://docs.exasol.com/db/latest/sql_reference.htm).
+
+## Use Exasol Admin
+
+Exasol Admin is available for cloud deployments in release 2.2. The installation output and
+`exasol info` show its URL. Its credentials are stored in `secrets.json`.
+
+The browser can display a warning because Exasol Admin uses a self-signed certificate. Verify that
+you are connecting to your deployment before accepting the certificate warning.
+
+Exasol Admin is not available for local deployments in release 2.2.
+
+## Open a shell
+
+Open a shell on the compute instance or local virtual machine:
+
+```bash
+exasol shell host
+```
+
+Open a shell inside the database container:
+
+```bash
+exasol shell container
+```

--- a/user-docs/content/getting-started.md
+++ b/user-docs/content/getting-started.md
@@ -1,0 +1,57 @@
+# Install the launcher
+
+The Exasol Launcher (`exasol`) is the command-line tool that deploys and manages Exasol Personal.
+The launcher runs on macOS, Linux, and Windows.
+
+## Before you begin
+
+Choose where the database will run:
+
+- For a local deployment, use an Apple Silicon Mac running macOS 15 or later with at least 8 GB of
+  memory. Local deployments in release 2.2 are not available on Linux or Windows.
+- For a cloud deployment, prepare an account with permission to provision compute resources. See
+  the account setup guide for [AWS](cloud/aws.md), [Azure](cloud/azure.md),
+  [Exoscale](cloud/exoscale.md), or [STACKIT](cloud/stackit.md).
+
+See [System requirements](system-requirements.md) for the complete supported-platform summary.
+
+## Install on macOS or Linux
+
+Run:
+
+```bash
+curl https://www.exasol.com/install/ | sh
+```
+
+The installer places the `exasol` binary in `~/.local/bin`. If that directory is not in `PATH`,
+follow the instructions printed by the installer.
+
+## Install on Windows
+
+Download the launcher from the [Exasol Download Portal](https://downloads.exasol.com/exasol-personal)
+and copy the binary into a directory in `PATH`.
+
+## Verify the installation
+
+```bash
+exasol version
+```
+
+Continue with a [local deployment](local-deployment.md) or a
+[cloud deployment](cloud-deployment.md).
+
+## Install with an AI agent
+
+Exasol publishes [agent skills](https://github.com/exasol-labs/exasol-agent-skills) that teach
+compatible coding agents how to install Exasol Personal, connect to it, load data, and write Exasol
+SQL. For example:
+
+```bash
+claude "Install skills from https://github.com/exasol-labs/exasol-agent-skills/ and use these skills to set up Exasol Personal"
+```
+
+```bash
+codex "Install skills from https://github.com/exasol-labs/exasol-agent-skills/ and use these skills to set up Exasol Personal"
+```
+
+The agent installs the launcher and asks before making changes to your computer or cloud account.

--- a/user-docs/content/index.md
+++ b/user-docs/content/index.md
@@ -1,3 +1,29 @@
-# Exasol Personal
+# Exasol Personal 2.2
 
-Versioned Exasol Personal user documentation will be available here.
+Exasol Personal gives you a full Exasol database for personal use. Run it locally on a supported
+Mac or deploy it into your own AWS, Azure, Exoscale, or STACKIT account.
+
+The Exasol Launcher (`exasol`) installs and manages the database from the command line. It can
+provision infrastructure, start and stop deployments, display connection details, and open SQL or
+shell sessions.
+
+These pages document Exasol Personal 2.2. Commands and capabilities introduced after release 2.2
+are intentionally not included.
+
+## Start here
+
+- [Install the launcher](getting-started.md), then [run Exasol locally](local-deployment.md) or
+  [deploy it to the cloud](cloud-deployment.md).
+- [Connect to the database](connect.md) and [load the sample data](load-data.md).
+- Learn how to [manage one or more deployments](manage-deployments.md).
+- Check the [system requirements](system-requirements.md) and [2.2 limitations](limitations.md).
+
+## Key capabilities
+
+- Start a local database on macOS in seconds.
+- Provision single-node or multi-node deployments in supported clouds.
+- Connect AI agents and automation through the scriptable CLI.
+- Run analytics with Exasol's in-memory, massively parallel database engine.
+- Use the full Exasol Database feature set without an artificial data-size limit.
+
+Exasol Personal is free for personal use under the applicable [license terms](privacy-and-licensing.md).

--- a/user-docs/content/limitations.md
+++ b/user-docs/content/limitations.md
@@ -1,0 +1,15 @@
+# Limitations
+
+Local deployments are intended for development and exploration. Release 2.2 has these differences
+from cloud deployments:
+
+- **Script languages:** UDFs are supported, but no script language container is installed by
+  default. Install one with `exasol slc install <language>`. Cloud deployments include the standard
+  containers.
+- **Virtual schemas:** Virtual schemas are not available on local deployments.
+- **Administration UI:** Exasol Admin is not available on local deployments.
+- **Cluster size:** A local deployment always runs as a single node.
+- **Host platforms:** A local deployment requires a supported Apple Silicon Mac. The launcher itself
+  can run on the other supported platforms to manage cloud deployments.
+
+Cloud deployments support UDFs, virtual schemas, Exasol Admin, and multiple database nodes.

--- a/user-docs/content/load-data.md
+++ b/user-docs/content/load-data.md
@@ -1,0 +1,39 @@
+# Load sample data
+
+Exasol provides sample product and review data in Parquet files hosted on Amazon S3.
+
+Run the bundled sample script from a deployment directory:
+
+```bash
+exasol connect -f sample.sql
+```
+
+For a named deployment, add `-d <name>`.
+
+Alternatively, connect with a SQL client and run:
+
+```sql
+CREATE OR REPLACE TABLE PRODUCTS AS (
+    IMPORT FROM PARQUET
+    AT 'https://exasol-easy-data-access.s3.eu-central-1.amazonaws.com/sample-data/'
+    FILE 'online_products.parquet'
+);
+```
+
+```sql
+CREATE OR REPLACE TABLE PRODUCT_REVIEWS AS (
+    IMPORT FROM PARQUET
+    AT 'https://exasol-easy-data-access.s3.eu-central-1.amazonaws.com/sample-data/'
+    FILE 'product_reviews.parquet'
+);
+```
+
+Exasol infers the table schemas from the Parquet files.
+
+| Table | Rows | Size |
+| --- | ---: | ---: |
+| `PRODUCTS` | 1,000,000 | 27.3 MiB |
+| `PRODUCT_REVIEWS` | 1,822,007 | 154.5 MiB |
+
+See [Load data](https://docs.exasol.com/db/latest/loading_data.htm) for the other supported import
+methods.

--- a/user-docs/content/local-deployment.md
+++ b/user-docs/content/local-deployment.md
@@ -1,0 +1,39 @@
+# Run Exasol locally
+
+Release 2.2 supports local deployments on Apple Silicon Macs running macOS 15 or later with at
+least 8 GB of memory.
+
+After [installing the launcher](getting-started.md), run:
+
+```bash
+exasol install local
+```
+
+The launcher creates a managed local virtual machine and starts a single-node Exasol database. Run
+`exasol info` at any time to display connection information.
+
+The virtual machine uses about half of the detected host memory by default. An explicitly configured
+memory value must be at least 4096 MB. The initial local database credentials are `sys` / `exasol`.
+
+## Open a shell
+
+Open a shell in the managed virtual machine:
+
+```bash
+exasol shell host
+```
+
+Open a shell inside the database container:
+
+```bash
+exasol shell container
+```
+
+## Next steps
+
+- [Connect to the database](connect.md).
+- [Load sample data](load-data.md).
+- [Install a script language container](udfs.md) to run UDFs.
+- [Manage the deployment lifecycle](manage-deployments.md).
+
+If the local deployment does not behave as expected, see [Troubleshooting](troubleshooting.md).

--- a/user-docs/content/manage-deployments.md
+++ b/user-docs/content/manage-deployments.md
@@ -1,0 +1,119 @@
+# Manage deployments
+
+Each local or cloud deployment keeps its configuration, state, and credentials in a deployment
+directory. Keep this directory until you have destroyed the deployment resources.
+
+## Select a deployment
+
+The default deployment is stored in `~/.exasol/personal/deployments/default`. When you run a command
+from an existing deployment directory, the launcher selects that deployment automatically.
+
+To maintain multiple deployments, give each one a case-sensitive name with `--deployment` or `-d`:
+
+```bash
+exasol install local -d demo
+exasol install aws -d staging
+exasol status -d demo
+exasol connect -d demo -c "SELECT 1"
+```
+
+Named deployments live below `~/.exasol/personal/deployments/<name>`. Names that differ only by case
+may collide on the case-insensitive filesystems commonly used by macOS and Windows.
+
+Alternatively, select an arbitrary path with `--deployment-dir <path>`. You cannot combine
+`--deployment-dir` and `--deployment`.
+
+List the launcher-managed default and named deployments with:
+
+```bash
+exasol deployments list
+```
+
+Example output:
+
+```text
+default status=running preset=local/local path=/Users/me/.exasol/personal/deployments/default
+staging status=stopped preset=aws/ubuntu path=/Users/me/.exasol/personal/deployments/staging
+```
+
+The list does not include deployments selected through an arbitrary `--deployment-dir` path.
+
+## Inspect or change configuration
+
+An initialized deployment directory is tied to its infrastructure and installation presets. Retry a
+failed installation with the same presets, or use these commands to inspect and change their
+parameters:
+
+```bash
+exasol config get
+exasol config set
+exasol config reset
+```
+
+To select different presets in the same directory, first run `exasol destroy --remove`. If the
+deployment resources have already been removed outside the launcher, run `exasol remove` instead.
+
+## Inspect or clean the runtime cache
+
+The launcher downloads runtime tools such as OpenTofu on demand and reuses them from a per-user
+cache. Use:
+
+```bash
+exasol cache list
+exasol cache clean
+exasol cache clean --invalid
+exasol cache clean --partial-downloads
+exasol cache clean --all
+exasol diag cache
+```
+
+Add `--dry-run` to a cleanup command to preview the files it would remove.
+
+## Stop and start
+
+Stop a deployment when you do not need its compute resources:
+
+```bash
+exasol stop
+```
+
+For cloud deployments, networking and data volumes can continue to incur costs while compute
+instances are stopped.
+
+Restart the deployment with:
+
+```bash
+exasol start
+```
+
+Node IP addresses can change after a restart. Check the command output or run `exasol info` before
+connecting again.
+
+## Destroy a deployment
+
+Destroying removes the deployment resources and their data:
+
+```bash
+exasol destroy
+```
+
+By default, the launcher retains the deployment directory for inspection or recreation. Remove it
+after successful destruction with:
+
+```bash
+exasol destroy --remove
+```
+
+If the resources were already deleted manually or are no longer accessible, remove only the local
+deployment directory with:
+
+```bash
+exasol remove
+```
+
+`exasol remove` does not destroy resources. Deleting a deployment directory or the launcher itself
+also does not remove provisioned resources. If the directory is lost before destruction, you must
+remove the remaining resources directly through the target environment.
+
+For local deployments, `exasol destroy` removes the managed virtual-machine data and launcher-managed
+share for the selected deployment.

--- a/user-docs/content/presets.md
+++ b/user-docs/content/presets.md
@@ -1,0 +1,49 @@
+# Presets
+
+Exasol Personal uses presets to provision infrastructure and install the database. A preset is a
+self-contained directory of templates and configuration files.
+
+Each deployment combines:
+
+- an infrastructure preset, which provisions a cloud or local environment; and
+- an installation preset, which installs and configures Exasol on that environment.
+
+Release 2.2 includes the `aws`, `azure`, `exoscale`, `stackit`, and `local` infrastructure presets.
+The built-in `ubuntu` installation preset is selected by default where applicable.
+
+List the built-in presets with:
+
+```bash
+exasol presets list
+```
+
+## Select a preset source
+
+The `install` command accepts built-in names, filesystem paths, Git repositories, and archives:
+
+```bash
+exasol install <infrastructure-preset> [installation-preset]
+
+exasol install aws
+exasol install ./my-preset
+exasol install https://github.com/org/preset.git
+exasol install https://github.com/org/preset.git@v1.0
+exasol install https://example.com/preset.tar.gz
+exasol install file:///path/to/preset-dir
+exasol install file:///path/to/preset.tar.gz
+```
+
+A local path starts with `.`, `/`, or `~`, or otherwise contains a path separator. Local directory
+URIs are used directly. Local archives are extracted again on each run.
+
+Git sources support HTTPS and SSH URLs. Append `@<branch-or-tag>` to select a ref. The launcher
+caches a Git source by commit and reuses it on later runs.
+
+Remote `.tar.gz`, `.tgz`, and `.zip` archives can use HTTP or HTTPS. They are downloaded on each run
+because the source does not supply a checksum.
+
+## Develop a preset
+
+The preset manifest schemas, required output artifacts, caching rules, and reference implementations
+are documented in the
+[2.2 preset development guide](https://github.com/exasol/exasol-personal/blob/v2.2.0/doc/presets.md).

--- a/user-docs/content/privacy-and-licensing.md
+++ b/user-docs/content/privacy-and-licensing.md
@@ -1,0 +1,30 @@
+# Privacy and licensing
+
+## Version checks
+
+Exasol Personal periodically checks whether newer launcher and database versions are available. The
+request includes limited information such as the installed version, operating system, and
+architecture. See the [Exasol Privacy Policy](https://www.exasol.com/privacy-policy/) for details.
+
+Both checks are optional. See [Troubleshooting](troubleshooting.md#check-for-newer-versions) for the
+installation flags that disable them.
+
+## Launcher license
+
+The Exasol Launcher source code is available under the
+[MIT License](https://github.com/exasol/exasol-personal/blob/v2.2.0/LICENSE). You may use, modify, and
+distribute it under those terms.
+
+## Database license
+
+Exasol Database is proprietary software provided by Exasol AG and is free for personal use. By
+deploying it with `exasol install`, you accept the
+[Exasol Personal End User License Agreement](https://www.exasol.com/terms-and-conditions/#h-exasol-personal-end-user-license-agreement).
+
+## More resources
+
+- [Exasol Database documentation](https://docs.exasol.com/db/latest/home.htm)
+- [Connect to Exasol](https://docs.exasol.com/db/latest/connect_exasol.htm)
+- [Load data](https://docs.exasol.com/db/latest/loading_data.htm)
+- [SQL reference](https://docs.exasol.com/db/latest/sql_reference.htm)
+- [Exasol Community](https://community.exasol.com)

--- a/user-docs/content/system-requirements.md
+++ b/user-docs/content/system-requirements.md
@@ -1,0 +1,31 @@
+# System requirements
+
+## Launcher platforms
+
+The Exasol Launcher in release 2.2 runs on:
+
+- macOS 12 Monterey or later;
+- Linux on AMD64 or ARM64; and
+- Windows 10 or later on AMD64.
+
+The launcher platform and the database deployment target are separate. A launcher running on any
+supported platform can manage a cloud deployment.
+
+## Local database
+
+A local database requires:
+
+- macOS 15 Sequoia or later;
+- Apple Silicon; and
+- at least 8 GB of host memory.
+
+The database runs as a single node in a launcher-managed virtual machine. Local deployments are not
+available on Linux or Windows in release 2.2.
+
+## Cloud database
+
+Cloud deployments run on AWS, Azure, Exoscale, or STACKIT infrastructure. The launcher provisions
+Ubuntu 22.04 LTS on x86-64 compute instances.
+
+The cloud account must have permission and quota for the selected compute, storage, and networking
+resources. See the provider-specific account setup pages for details.

--- a/user-docs/content/troubleshooting.md
+++ b/user-docs/content/troubleshooting.md
@@ -1,0 +1,73 @@
+# Troubleshooting
+
+## Inspect a local deployment
+
+Run the local diagnostic command whether the deployment is running or stopped:
+
+```bash
+exasol diag local
+```
+
+It returns a JSON snapshot containing platform support, virtual-machine state, port reachability,
+and database readiness.
+
+Use `exasol info` to display the current connection details after a successful start. Node addresses
+can change whenever a deployment restarts.
+
+## Inspect the runtime cache
+
+The launcher downloads runtime tools on demand. Inspect their cached state without changing it:
+
+```bash
+exasol diag cache
+```
+
+Remove artifacts with invalid checksums or partial downloads:
+
+```bash
+exasol cache clean --invalid --dry-run
+exasol cache clean --invalid
+exasol cache clean --partial-downloads --dry-run
+exasol cache clean --partial-downloads
+```
+
+## Recover from an interrupted installation
+
+Cloud resources created before an interruption are not removed automatically and can continue to
+incur charges. Keep the deployment directory and retry the same installation command. The directory
+records the selected presets and deployment state.
+
+If you do not want to retry, remove the provisioned resources with:
+
+```bash
+exasol destroy
+```
+
+After successful destruction, add `--remove` to remove the local deployment directory as well.
+
+## Recover when resources were removed manually
+
+If deployment resources no longer exist or cannot be reached through the launcher, remove only the
+local deployment directory with:
+
+```bash
+exasol remove
+```
+
+This command does not destroy resources. If you deleted the deployment directory before destroying
+the resources, remove the remaining resources through the cloud provider or local environment.
+
+## Check for newer versions
+
+Exasol Personal periodically checks for a newer launcher version. Cloud deployments also check for a
+newer database version. Disable these checks during installation when required:
+
+```bash
+exasol install <preset> --no-launcher-version-check
+exasol install <preset> --no-db-version-check
+```
+
+The database-version option applies to cloud deployments.
+
+For help with an individual command, run `exasol <command> --help`. For further assistance, ask in
+the [Exasol Community](https://community.exasol.com) using the `exasol-personal` tag.

--- a/user-docs/content/udfs.md
+++ b/user-docs/content/udfs.md
@@ -1,0 +1,31 @@
+# UDFs and script language containers
+
+User-defined functions (UDFs) execute in a script language container (SLC), which supplies a runtime
+such as Python, Java, or R.
+
+Cloud deployments include the standard SLCs. Local deployments in release 2.2 do not install one by
+default. Install the language you need with `exasol slc`:
+
+```bash
+exasol slc list
+exasol slc install python3
+exasol slc install java
+exasol slc install r
+exasol slc update python3
+exasol slc remove python3
+```
+
+The language argument is an alias used by `CREATE ... SCRIPT` and is matched case-insensitively. For
+example, the Python container enables the `PYTHON3` and `PYTHON312` aliases, the Java container
+enables `JAVA` and `JAVA17`, and the R container enables `R` and `R44`.
+
+`exasol slc list` displays each available container's flavor, aliases, version, and installation
+state.
+
+Installing, updating, or removing an SLC normally restarts the local database. This drops open
+connections and aborts running statements. The command asks for confirmation first:
+
+- Use `--auto-approve` to skip the prompt. This is required for non-interactive use.
+- Use `--no-restart` to record the change and activate it the next time the deployment starts.
+
+The `install`, `update`, and `remove` SLC operations apply only to local deployments.

--- a/user-docs/mkdocs.yml
+++ b/user-docs/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: Exasol Personal
+site_description: Install, deploy, and use Exasol Personal
 site_url: https://exasol.github.io/exasol-personal/
 repo_url: https://github.com/exasol/exasol-personal
 repo_name: exasol/exasol-personal
@@ -8,6 +9,29 @@ site_dir: site
 
 theme:
   name: material
+
+nav:
+  - Home: index.md
+  - Get started:
+      - Install the launcher: getting-started.md
+      - Run Exasol locally: local-deployment.md
+      - Deploy to the cloud: cloud-deployment.md
+  - Cloud account setup:
+      - Amazon Web Services: cloud/aws.md
+      - Microsoft Azure: cloud/azure.md
+      - Exoscale: cloud/exoscale.md
+      - STACKIT: cloud/stackit.md
+  - Use Exasol Personal:
+      - Manage deployments: manage-deployments.md
+      - Connect to the database: connect.md
+      - Load sample data: load-data.md
+      - UDFs and script languages: udfs.md
+      - Presets: presets.md
+  - Help and reference:
+      - Troubleshooting: troubleshooting.md
+      - System requirements: system-requirements.md
+      - Limitations: limitations.md
+      - Privacy and licensing: privacy-and-licensing.md
 
 plugins:
   - search


### PR DESCRIPTION
## Description

Create a complete MkDocs documentation snapshot for Exasol Personal 2.2 so the released product can be documented independently from ongoing development on `main`.

## Related Issue

[SPOT-32457](https://exasol.atlassian.net/browse/SPOT-32457)

## Type of Change

- [x] `docs`: Documentation update

## Changes Made

- Structure the Exasol Personal 2.2 user guidance as 17 navigable MkDocs pages.
- Migrate the release-appropriate README guidance and cloud-account setup procedures.
- Exclude platforms, commands, and capabilities introduced after 2.2.
- Keep the snapshot self-contained under `user-docs/` for immutable versioned publication.

## Testing

- [x] Manually tested the changes

### Test Details

- `env UV_CACHE_DIR=/tmp/exasol-personal-docs-uv-cache task docs-check`
  - Ruff checks passed.
  - 24 publishing-tool tests passed.
  - The strict MkDocs build passed without documentation warnings.
- `git diff --check`
- Audited the content against the v2.2.0 sources and the binary-verified corrections from PR #330.

## Checklist

- [x] Code follows the project's coding guidelines
- [x] Updated documentation
- [x] All relevant tests pass locally
- [x] Commit messages follow Conventional Commits

No changelog entry is needed because this creates documentation for already released behavior without changing the product or its operating instructions.

## Additional Notes

After merge, tag the resulting immutable revision as `docs/v2.2.0` and publish it as documentation version `2.2.0` before merging the follow-up PR for current `main`.

[SPOT-32457]: https://exasol.atlassian.net/browse/SPOT-32457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ