### PR TITLE
docs: Align user documentation and README with main

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,10 @@
 
 **The Analytics Database for Agentic AI — Free for Personal Use**
 
-*Run a full Exasol database locally on macOS, Linux, or Windows, or deploy to your own cloud*
+*Deploy and explore Exasol Database on your own computer or in your cloud account.*
 
-[![Documentation](https://img.shields.io/badge/docs-exasol.com-blue)](https://docs.exasol.com/db/latest/home.htm)
+[![User documentation](https://img.shields.io/badge/user%20docs-latest-blue)](https://exasol.github.io/exasol-personal/latest/)
+[![Exasol documentation](https://img.shields.io/badge/database%20docs-exasol.com-blue)](https://docs.exasol.com/db/latest/home.htm)
 [![Community](https://img.shields.io/badge/community-exasol-green)](https://community.exasol.com)
 [![Downloads](https://img.shields.io/badge/downloads-exasol.com-orange)](https://downloads.exasol.com/exasol-personal)
 
@@ -19,436 +20,48 @@
 
 </div>
 
-## 🔥 Key Features
+## About Exasol Personal
 
-- 💻 **Runs Locally in Seconds** — Spin up a full Exasol database on macOS, Linux, or Windows with one command
-- 🤖 **Built for Agentic AI** — Connect AI agents and LLM tools directly through a scriptable CLI
-- 🧠 **Built-in AI Functions** — Leverage native AI/ML capabilities with GPU acceleration, right where your data lives
-- 🏎️ **In-Memory Performance** — Run complex analytics at in-memory speed with Exasol's industry-leading analytics engine
-- 🏢 **Full Enterprise Features** — Access all enterprise-scale capabilities of the Exasol database, completely free for personal use
-- ♾️ **Unlimited Data** — Store and analyze unlimited amounts of data with no artificial limits
-- 📈 **Scalable Architecture** — Scale up to any number of nodes using Exasol's MPP (Massively Parallel Processing) architecture
-- ☁️ **Or Deploy to Your Cloud** — Provision to AWS, Azure, Exoscale, or STACKIT with just a few commands when you need scale or a shared instance
-- 🖥️ **Cross-Platform CLI** — Install and manage Exasol using the Exasol Launcher on macOS, Linux, or Windows
+Exasol Personal gives individual users a complete Exasol database for development, exploration,
+analytics, and AI-assisted workflows. The Exasol Launcher is a scriptable command-line application
+that installs and manages the database locally or on supported cloud infrastructure.
 
+The database combines Exasol's in-memory, massively parallel analytics engine with the SQL,
+integration, AI, and extensibility capabilities of Exasol Database. Exasol Personal is free for
+personal use and does not impose an artificial data-size limit.
 
-## ✅ Prerequisites
+## Get started
 
-**Local deployment (recommended — fastest):**
+The [latest user documentation](https://exasol.github.io/exasol-personal/latest/) contains the
+current system requirements, installation instructions, supported deployment targets, tutorials,
+command guidance, and troubleshooting information. Use its version selector when working with an
+earlier release.
 
-- **macOS:** Apple Silicon with at least 8 GB RAM. Podman is included in the managed VM; no host Podman installation is required.
-- **Linux:** amd64 or arm64 with Podman installed and available on `PATH`.
-- **Windows:** amd64 with Windows Package Manager (`winget`) and the prerequisites for a Podman machine. If Podman is missing, the launcher offers to install it; that installation may request administrator approval.
+Download the launcher from the
+[Exasol Download Portal](https://downloads.exasol.com/exasol-personal), or follow the
+[installation guide](https://exasol.github.io/exasol-personal/latest/getting-started/).
 
-On Windows the launcher also creates or starts Podman's default machine, and leaves an existing machine's configuration alone. Installing Podman changes state shared beyond the deployment, so the launcher shows the exact command and asks first. Pass `--auto-approve` to `install`, `deploy`, or `start` for unattended setup; without it, commands that cannot prompt refuse the change rather than assuming consent. Windows arm64 is not supported for local deployments.
+AI coding agents can use the published
+[Exasol agent skills](https://github.com/exasol-labs/exasol-agent-skills) to install Exasol Personal,
+connect to it, load data, and write Exasol SQL.
 
-**Cloud deployment:** an account on one of the supported providers, with permission to provision compute instances:
+## Development and contributions
 
-- **AWS** — [Set up an AWS account for Exasol Personal](./HOWTO_SETUP_AWS_ACCOUNT.md)
-- **Azure** — [Set up an Azure account for Exasol Personal](./HOWTO_SETUP_AZURE_ACCOUNT.md)
-- **Exoscale** — [Set up an Exoscale account for Exasol Personal](./HOWTO_SETUP_EXOSCALE_ACCOUNT.md)
-- **STACKIT** — [Set up a STACKIT account for Exasol Personal](./HOWTO_SETUP_STACKIT_ACCOUNT.md)
+This repository contains the Exasol Launcher, its built-in deployment presets, tests, and user
+documentation sources. To build or contribute:
 
+- Read the [contribution guidelines](CONTRIBUTING.md).
+- Set up the project with the [development guide](doc/development.md).
+- Follow the [testing guide](tests/README.md).
+- Review the high-level [architecture](doc/architecture.md) and
+  [project-specific best practices](doc/best_practices.md).
 
-## ⬇️ Install the Launcher
+## License
 
-The **Exasol Launcher** (`exasol`) is the command-line tool that deploys and manages your Exasol database, locally or in the cloud. It runs on macOS, Linux, and Windows.
+The Exasol Launcher source code is licensed under the [MIT License](LICENSE). Exasol Database is
+proprietary software provided by Exasol AG and is free for personal use. Installing the database
+means accepting the
+[Exasol Personal End User License Agreement](https://www.exasol.com/terms-and-conditions/#h-exasol-personal-end-user-license-agreement).
 
-On macOS and Linux, install it with:
-```bash
-curl https://www.exasol.com/install/ | sh
-```
-This places the `exasol` binary in `~/.local/bin`. On most Linux distributions this directory is already in your `PATH`; on macOS, or if the installer reports that `~/.local/bin` is not in your `PATH`, follow the instructions it prints.
-
-On Windows, download the launcher from the [Exasol Download Portal](https://downloads.exasol.com/exasol-personal) and copy the `exasol` binary to a directory in your `PATH`.
-
-Verify the installation with `exasol version`.
-
-
-## 🏎️ Quick Start — Run Exasol Locally
-
-The fastest way to try Exasol: a full database running on your own macOS, Linux, or Windows machine.
-
-With the launcher installed (see **Install the Launcher** above), start a local Exasol database:
-```bash
-exasol install local
-```
-
-In a few seconds you'll have a local Exasol instance running. Run `exasol info` at any time to see how to connect, then head to the **Load Sample Data** section to start querying.
-
-To run UDFs locally, install a script language container — see **UDFs and Script Language Containers** below. To run several local databases side by side, see **Deployments and Named Deployments**.
-
-Prefer to run in your own cloud? See the **Deploy to the Cloud** section below.
-
-
-## 🤖 Install with AI Agent
-
-If you work with an AI coding agent, it can set up and run Exasol Personal for you. Exasol publishes [agent skills](https://github.com/exasol-labs/exasol-agent-skills) that teach agents how to deploy Exasol Personal, connect to it, load data, and write Exasol SQL.
-
-One command is enough — the agent installs the skills itself, then uses them:
-
-```bash
-# Claude Code
-claude "Install skills from https://github.com/exasol-labs/exasol-agent-skills/ and use these skills to set up Exasol Personal"
-
-# Codex
-codex "Install skills from https://github.com/exasol-labs/exasol-agent-skills/ and use these skills to set up Exasol Personal"
-```
-
-The agent takes it from there, including installing the launcher, and asks before it makes changes to your machine or cloud account.
-
-
-## ☁️ Deploy to the Cloud
-
-Deploy Exasol Personal to your own cloud account when you need more scale or a shared instance. Supported providers: AWS, Azure, Exoscale, and STACKIT.
-
-With the launcher installed (see **Install the Launcher** above):
-
-1. Configure authentication for your provider. See the relevant account setup guide in the **Prerequisites** section for the environment variables and credentials required.
-
-2. To install Exasol Personal, run the following command with the preset for your cloud provider:
-   ```bash
-   exasol install aws        # Amazon Web Services
-   exasol install azure      # Microsoft Azure
-   exasol install exoscale   # Exoscale
-   exasol install stackit    # STACKIT
-   ```
-   The `exasol install` command does the following:
-   - Generates backend files in the deployment directory
-   - Provisions the necessary deployment resources
-   - Starts the deployment
-   - Downloads and installs Exasol Personal on that infrastructure
-
-   The whole process normally takes about 10 to 20 minutes to complete.
-
-   When the deployment process has finished, you will see instructions on how to connect to your Exasol database using a client of your choice. You can also find this information at any time by using `exasol info` in the terminal.
-
-
-## 🗂️ Deployments and Named Deployments
-
-Each Exasol Personal deployment — local or cloud — keeps its state in a **deployment directory**. This section applies to both deployment types.
-
-By default, Exasol Personal stores deployment state in `~/.exasol/personal/deployments/default`. If you run a command from an existing deployment directory, Exasol Personal uses that directory instead.
-
-To run more than one deployment side by side, give each one a **name** with `--deployment <name>` (`-d <name>`). Named deployments live under `~/.exasol/personal/deployments/<name>`, so you can address them by name from any working directory:
-
-```bash
-exasol install local -d demo             # a local deployment named "demo"
-exasol install aws -d staging            # a cloud deployment named "staging"
-exasol status -d demo                    # check on it from anywhere
-exasol connect -d demo -c "SELECT 1"
-```
-
-Names are matched case-sensitively, but may collide on case-insensitive filesystems (the default on macOS and Windows).
-
-Named deployments are optional — choosing a deployment directory by path still works. Pass `--deployment-dir <path>` to use a directory of your choice. `--deployment-dir` and `--deployment` cannot be used together.
-
-Use `exasol deployments list` to see every default and named deployment directory together with its status, presets, and path:
-
-```bash
-$ exasol deployments list
-default status=database_ready preset=local/ubuntu path=/Users/me/.exasol/personal/deployments/default
-staging status=stopped preset=aws/ubuntu path=/Users/me/.exasol/personal/deployments/staging
-```
-
-The listing covers launcher-managed deployment directories only; deployments selected with an arbitrary `--deployment-dir` path are not included.
-
-Keep a deployment directory until its deployment resources have been destroyed. Deleting the directory does not remove those resources and can make cleanup harder.
-
-An initialized deployment directory is tied to the selected infrastructure and installation presets. Rerun `exasol install <preset>` with the same presets to retry a failed deployment safely, or use `exasol config get`, `exasol config set`, and `exasol config reset` to inspect or change parameters for the existing presets without deleting local state. To switch presets in the same deployment directory, run `exasol destroy --remove` before initializing again, or run `exasol remove` if the deployment resources are already gone.
-
-Runtime tools such as OpenTofu are downloaded on demand and reused from a per-user runtime artifact cache. Use `exasol cache list` to inspect cached artifacts, `exasol cache clean` to remove stale artifacts, `exasol cache clean --invalid` to remove artifacts that fail integrity checks, `exasol cache clean --partial-downloads` to remove staged partial downloads, `exasol cache clean --all` to wipe cached artifacts, and `exasol diag cache` to inspect cache health without changing it. Add `--dry-run` to a cleanup command to preview what would be removed.
-
-## 📊 Load Sample Data
-
-To get started quickly, Exasol provides a sample dataset hosted on S3 that you can import using SQL.
-
-You can load it directly by executing this command in your deployment directory (e.g. `~/.exasol/personal/deployments/default` for a default deployment), or from anywhere by adding `-d <name>` for a named deployment:
-
-```bash
-exasol connect -f sample.sql
-```
-
-Alternatively, connect with a SQL client of your choice and paste the statements below:
-
-```sql
-CREATE OR REPLACE TABLE PRODUCTS AS (
-    IMPORT FROM PARQUET
-    AT 'https://exasol-easy-data-access.s3.eu-central-1.amazonaws.com/sample-data/'
-    FILE 'online_products.parquet'
-);
-```
-
-```sql
-CREATE OR REPLACE TABLE PRODUCT_REVIEWS AS (
-    IMPORT FROM PARQUET
-    AT 'https://exasol-easy-data-access.s3.eu-central-1.amazonaws.com/sample-data/'
-    FILE 'product_reviews.parquet'
-);
-```
-
-Exasol infers the table schema directly from the Parquet files, so there's no need to define columns up front.
-
-For a Parquet file on your computer, use the bundled SQL client and the `LOCAL` form:
-
-```sql
-CREATE TABLE LOCAL_PRODUCTS AS (
-    IMPORT FROM LOCAL PARQUET FILE '/path/to/products.parquet'
-);
-```
-
-Run this statement with `exasol connect -c` or from a SQL file passed to `exasol connect -f`. The file is read from the client machine and the local import supports one Parquet file per statement. This launcher support does not change engine-side Parquet semantics or add cloud/object-storage import behavior.
-
-| Table | Rows | Size |
-|---|---|---|
-| `PRODUCTS` | 1,000,000 | 27.3 MiB |
-| `PRODUCT_REVIEWS` | 1,822,007 | 154.5 MiB |
-
-## 🐍 UDFs and Script Language Containers
-
-User-defined functions (UDFs) run inside a **script language container** (SLC), which provides the language runtime for a script language such as `PYTHON3`, `JAVA`, or `R`.
-
-**Cloud deployments** come with the standard script language containers, so UDFs work out of the box.
-
-**Local deployments** ship without any SLC installed. Install the one you need with `exasol slc`, and UDFs in that language start working:
-
-```bash
-exasol slc list                 # available containers and which are installed
-exasol slc install python3      # enables PYTHON3 / PYTHON312 UDFs
-exasol slc install java         # enables JAVA / JAVA17 UDFs
-exasol slc install r            # enables R / R44 UDFs
-exasol slc update python3       # update an installed container
-exasol slc remove python3
-```
-
-The argument is a language alias as used in `CREATE ... SCRIPT`, matched case-insensitively. `exasol slc list` shows each container's flavor, its aliases, its version, and whether it is installed.
-
-Script language containers are also used by features that execute script language code, such as virtual schema adapter scripts. Install the SLC required by the adapter language before creating the adapter script. For JDBC-based virtual schemas on local deployments, see [Virtual schemas on local deployments](doc/virtual_schemas.md).
-
-Operations that restart the local database — official `install`, `update`, and `remove`, plus `slc custom install` and `slc custom update` — drop open connections and abort running statements. The command asks for confirmation first; pass `--auto-approve` to skip the prompt (required for non-interactive use), or `--no-restart` to record the change and activate it on the next start.
-
-### Custom containers
-
-When the official catalog does not ship what you need — for example a Python container with extra packages — install your own container with `exasol slc custom`:
-
-```bash
-exasol slc custom install --source ./my-python.tar.gz --alias MYPY3 --language python
-exasol slc custom update  --source ./my-python-v2.tar.gz --alias MYPY3
-exasol slc remove MYPY3
-```
-
-`--source` takes a local tarball path or an `https` URL, `--alias` is the name you then use in `CREATE <alias> SCALAR SCRIPT`, and `--language` is the language identifier passed to the custom SLC client. Leading and trailing whitespace is trimmed and the identifier is normalized to lowercase. It must start with an ASCII letter or digit and contain only ASCII letters, digits, dots, hyphens, or underscores. Custom clients can use identifiers such as `rust` when they implement the Exasol UDF protocol. `custom install` and `custom update` restart the database and accept `--auto-approve` and `--no-restart` just like the official commands. If the container cannot be made available, the database still starts but the command fails, reporting that the container is recorded but not active.
-
-Removing a custom container works differently: it takes effect immediately without a restart, so `--auto-approve` and `--no-restart` do not apply. Because the alias is cleared through the database, the deployment must be running to remove an active container; one that was recorded but never activated can be removed while stopped.
-
-`exasol slc list` lists custom containers in their own table below the official ones, showing each alias, its language, its status (`active` or `pending`), and its source; under `--json` they carry a `custom` type and an `available` field. Use `exasol slc remove <alias>` to remove either kind.
-
-`exasol slc` applies to local deployments only.
-
-## ⏯️ Start and stop Exasol Personal
-
-To save costs, you can temporarily stop Exasol Personal by using the following command:
-```bash
-exasol stop
-```
-This stops the compute instance(s) that Exasol Personal is running on.
-
-Networking and the data volumes where the database data is stored will continue to incur costs when compute instances are stopped.
-
-To start Exasol Personal again, use the following command:
-```bash
-exasol start
-```
-The IP addresses of the nodes will change when you restart Exasol Personal. Check the output of the `start` command to know how to connect to the deployment after a restart.
-
-On macOS, the launcher manages a local VM and runs the same Podman-based database installation used on the other platforms inside it. If you do not configure VM memory explicitly, it defaults to about 50% of detected host memory; configured VM memory must be at least 4096 MB. On Linux and Windows, the database runs directly through host Podman and uses host-managed resources, so VM sizing options do not apply. On Windows those containers run inside Podman's default machine, which is shared host-wide: stopping or destroying a deployment leaves that machine running. The initial local database credentials are `sys` / `exasol`. The `exasol shell host` and `exasol shell container` commands are available for macOS local deployments but are not supported on Linux or Windows.
-
-If a local deployment does not behave as expected, `exasol diag local` prints a JSON snapshot of its runtime state, bound host ports, reachability, and database readiness. It is safe to run whether or not the deployment is currently running.
-
-## 🗑️ Remove Exasol Personal
-
-To completely remove an Exasol Personal deployment, use `exasol destroy`. This command deletes the deployment resources and all associated data.
-
-To learn more about this command, use `exasol destroy --help`.
-
-By default, `exasol destroy` keeps the local deployment files so you can inspect the deployment or recreate the same preset. To also remove the local deployment directory after deployment resources have been destroyed, run:
-```bash
-exasol destroy --remove
-```
-
-If deployment resources were already deleted manually or you no longer have access to destroy them through the launcher, use the local recovery command:
-```bash
-exasol remove
-```
-This removes the local deployment directory. It does not destroy deployment resources.
-
-Deleting the deployment directory and the Exasol Launcher will not remove the resources that were created in the target environment. To completely remove a deployment, you must use the `exasol destroy` command before deleting the deployment directory.
-
-If you have already deleted the deployment directory and the Exasol Launcher, you must remove the resources manually in the target environment.
-
-For local deployments, `exasol destroy` deletes the launcher-managed runtime and database data for that deployment.
-
-## ⚙️ Cloud: Choosing cluster size and compute instance types
-
-By default the launcher deploys a single-node cluster on a memory-optimized instance in the cloud (e.g. `r6i.xlarge` on AWS, `Standard_E4s_v3` on Azure, `standard.extra-large` on Exoscale, `m2i.4` on STACKIT). To change the number of nodes or the instance type, use the `--cluster-size` and `--instance-type` options:
-```bash
-exasol install <preset> --cluster-size <number> --instance-type <string>
-```
-If the deployment process is interrupted, resources that were already created will not be removed automatically and cloud resources may continue to accrue cost. In that case, use `exasol destroy` to clean up the deployment, or remove the resources manually in the target environment.
-
-
-## 🔜 Next steps
-
-Once the deployment process is complete, use `exasol info` for information about how to connect to your Exasol database. The credentials for connecting to the database from a client are stored in the file `secrets.json` in the deployment directory.
-
-You can also use the built-in SQL client in Exasol Launcher to connect directly to the database from the command line:
-```bash
-exasol connect
-```
-
-To run SQL without entering the interactive shell, pass it directly. Both flags accept multiple `;`-separated statements and exit when done, which is convenient for scripting and automation:
-```bash
-exasol connect -c "SELECT 1; SELECT 2"   # run inline statement(s)
-exasol connect -f script.sql             # run statements from a file
-```
-`--command` and `--file` are mutually exclusive. In this non-interactive mode, execution stops at the first failing statement and `connect` exits with a non-zero status so scripts can detect errors. Combine with `--json` for machine-readable output, or use `--csv` for CSV output:
-```bash
-exasol connect --csv -c "SELECT * FROM PRODUCTS" > products.csv
-```
-With `--json`, non-interactive execution writes exactly one JSON document to stdout for the full invocation, including multi-statement runs and SQL errors. Interactive `exasol connect --json` continues to emit one JSON document per executed statement.
-
-In an interactive session, query output is capped at 100 rows by default so a large `SELECT` doesn't flood the terminal; a note is printed when output is truncated. Piped or `--command`/`--file` (non-interactive) execution returns the full result set. Use `--max-rows N` to set the cap explicitly, or `--max-rows 0` for unlimited:
-```bash
-exasol connect --max-rows 0        # return all rows, even interactively
-echo "SELECT * FROM PRODUCTS;" | exasol connect --max-rows 1000
-```
-
-See also...
-- To learn more about how you can connect to your Exasol database and start loading data using the many supported tools and integrations, see [Connect to Exasol](https://docs.exasol.com/db/latest/connect_exasol.htm) and [Load Data](https://docs.exasol.com/db/latest/loading_data.htm).
-- To learn how to use the SQL statements, data types, functions, and other SQL language elements that are supported in Exasol, see [SQL reference](https://docs.exasol.com/db/latest/sql_reference.htm).
-
-## 🧑‍💻 Exasol Admin
-
-Exasol Admin is an easy-to-use web interface that you can use to administer your new Exasol database. Instructions on how to access Exasol Admin are shown in the terminal output at the end of the install process.
-
-- To find the Exasol Admin URL after the installation has completed, use `exasol info`.
-- The credentials for connecting to Exasol Admin are stored in the file `secrets.json` in the deployment directory.
-
-Your browser may show a security warning when connecting to Exasol Admin because of the self-signed certificate. Accept this warning and continue.
-
-Currently, Exasol Admin is only available on cloud deployments.
-
-## 🔒 Shell access
-
-Use the runtime-managed shell commands without needing to know how the deployment is reached:
-
-```bash
-# Connect to the compute instance your database is running on:
-exasol shell host
-```
-
-```bash
-# Connect to the COS container your node is running on:
-exasol shell container
-```
-
-## 📦 Presets
-
-Exasol Personal uses **presets** — self-contained directories of templates and config files — to provision infrastructure and install Exasol. Each deployment combines two presets:
-
-- **Infrastructure preset** — provisions deployment resources for a cloud provider or local system. Built-in: `aws`, `azure`, `exoscale`, `stackit`, `local`.
-- **Installation preset** — installs and configures Exasol on the provisioned nodes. Built-in: `ubuntu` (used by default).
-
-```bash
-exasol install <infra-preset> [install-preset]
-
-exasol install aws                                       # built-in preset by name
-exasol install ./my-preset                               # local preset by path (starts with . / ~ or contains /)
-exasol install https://github.com/org/preset.git         # git repository (HEAD)
-exasol install https://github.com/org/preset.git@v1.0    # git repository at branch or tag
-exasol install https://example.com/preset.tar.gz         # remote archive (re-fetched on every run)
-exasol install file:///path/to/preset-dir                # local directory via URI
-exasol install file:///path/to/preset.tar.gz             # local archive (re-extracted on every run)
-```
-
-List all available built-in presets, including cloud and local targets:
-
-```bash
-exasol presets
-```
-
-### Local presets
-
-You can store your own preset directories anywhere on your filesystem and pass the path directly to `exasol install`. This lets you target additional infrastructure platforms or customize provisioning without modifying the launcher.
-
-### External presets
-
-In addition to built-in names and local paths, `exasol install` accepts external sources:
-
-- **Git repository** — `https://github.com/org/preset.git` or `git@github.com:org/preset.git`. Append `@branch-or-tag` to pin a specific ref. The repository is cloned once per commit and cached; repeated runs at the same commit reuse the cache.
-- **Remote archive** — An `https://` or `http://` URL ending in `.tar.gz`, `.tgz`, or `.zip`. The archive is re-downloaded on every run because no checksum is provided.
-- **Local directory via URI** — `file:///absolute/path`. The directory is used directly without copying.
-- **Local archive via URI** — `file:///absolute/path/to/preset.tar.gz`. The archive is re-extracted on every run.
-
-Git repositories and archives also accept an optional `#<subpath>` fragment (e.g. `repo.git@v1#infra/aws`) to select a preset from a subdirectory of a monorepo or multi-preset archive.
-
-See [doc/presets.md](doc/presets.md) for the full preset contract, caching behavior, and troubleshooting.
-
-### Building your own preset
-
-See [doc/presets.md](doc/presets.md) for the full preset contract: manifest schema, required output artifacts, variable channels, and the reference implementations in `assets/infrastructure`.
-
-## 🖥️ System Requirements
-
-The Exasol Launcher runs on:
-
-- **macOS** — 12 (Monterey) or later.
-- **Linux** — amd64 or arm64.
-- **Windows** — 10 or later, amd64.
-
-Where the database runs depends on the deployment type:
-
-- **Cloud deployments** — the database runs on your provider's infrastructure, so any supported launcher platform above works. The launcher provisions **Ubuntu 24.04 LTS (x86-64)** compute instances on all cloud providers.
-- **Local deployments on macOS** — the database runs with the bundled Podman installation in a managed VM and requires macOS 15 (Sequoia) or later on Apple Silicon, with at least 8 GB RAM.
-- **Local deployments on Linux** — the database runs in Podman on amd64 or arm64 and uses host resources without launcher-managed limits.
-- **Local deployments on Windows** — the database runs through host Podman on amd64, inside Podman's default machine. The launcher can install Podman and prepare that machine, asking before it changes the host.
-
-## 🚧 Limitations
-
-Local deployments are intended for development and exploration and do not yet support every feature of a cloud deployment:
-
-- **UDFs** — supported, but no script language container is installed by default. Install one with `exasol slc install <language>` (see **UDFs and Script Language Containers** above); on cloud deployments UDFs work out of the box.
-- **Virtual schemas** — supported when the required adapter runtime and dependencies are installed. Depending on the adapter, this may require installing an SLC and staging adapter or driver files. See [Virtual schemas on local deployments](doc/virtual_schemas.md).
-- **Admin UI** — the Administration UI is not available yet (coming soon).
-- **Multi-node clusters** — a local deployment runs as a single node by design.
-
-Cloud deployments support all of the above.
-
-## 🔎 Version Check
-
-Exasol Personal periodically checks for newer versions so it can let you know when an update is available. The launcher checks for a newer `exasol` binary, and cloud deployments additionally check for a newer database version. These checks send a small amount of information (such as the current version, operating system, and architecture) to Exasol.
-
-Both checks are opt-out. Pass the flags to `exasol install` to disable them:
-
-```bash
-exasol install <preset> --no-launcher-version-check   # disable the launcher update check
-exasol install <preset> --no-db-version-check         # disable the database version check (cloud deployments)
-```
-
-For details on what data is collected and how it is used, see the [Exasol Privacy Policy](https://www.exasol.com/privacy-policy/).
-
-## ⚖️ Licensing
-
-The Exasol Launcher source code in this repository is open-source software licensed under the [MIT License](./LICENSE). You are free to use, modify, and distribute it. Contributions are made under the same terms.
-
-The launcher installs the **Exasol Database**, which is proprietary software provided by Exasol AG, free for personal use. By deploying it with `exasol install`, you accept the [Exasol Personal End User License Agreement (EULA)](https://www.exasol.com/terms-and-conditions/#h-exasol-personal-end-user-license-agreement).
-
-## 📚 Resources & Documentation
-
-Get the most out of Exasol with these resources:
-
-- [Exasol Documentation](https://docs.exasol.com/db/latest/home.htm) — Complete database documentation
-- [Connect to Exasol](https://docs.exasol.com/db/latest/connect_exasol.htm) — Driver downloads and client setup
-- [Load Data](https://docs.exasol.com/db/latest/loading_data.htm) — Import data into your database
-- [SQL Reference](https://docs.exasol.com/db/latest/sql_reference.htm) — Complete SQL syntax reference
-- [Exasol Community](https://community.exasol.com) — Ask questions and share knowledge (use tag `exasol-personal`)
+For help and discussion, visit the [Exasol Community](https://community.exasol.com) and use the
+`exasol-personal` tag.

--- a/user-docs/content/cloud-deployment.md
+++ b/user-docs/content/cloud-deployment.md
@@ -1,6 +1,6 @@
 # Deploy to the cloud
 
-Exasol Personal 2.2 can provision a database in your own AWS, Azure, Exoscale, or STACKIT account.
+Exasol Personal can provision a database in your own AWS, Azure, Exoscale, or STACKIT account.
 Cloud deployments are useful when you need more capacity, multiple nodes, or a shared database.
 
 ## Prepare your account

--- a/user-docs/content/cloud/aws.md
+++ b/user-docs/content/cloud/aws.md
@@ -14,7 +14,7 @@ In the AWS IAM console:
 
 1. Create a user for Exasol Personal.
 2. Attach the
-   [Exasol Personal AWS policy](https://github.com/exasol/exasol-personal/blob/v2.2.0/assets/infrastructure/aws/iam-policy.broad.json)
+   [Exasol Personal AWS policy](https://github.com/exasol/exasol-personal/blob/main/assets/infrastructure/aws/iam-policy.broad.json)
    to the user.
 3. Generate an access key for the user and store its ID and secret securely.
 

--- a/user-docs/content/cloud/azure.md
+++ b/user-docs/content/cloud/azure.md
@@ -17,9 +17,9 @@ In the Azure portal:
 2. Give the user who will run Exasol Personal one of these roles at subscription scope:
    - the built-in **Contributor** role;
    - a custom role based on the
-     [broad example](https://github.com/exasol/exasol-personal/blob/v2.2.0/assets/infrastructure/azure/rbac-role.broad.json); or
+     [broad example](https://github.com/exasol/exasol-personal/blob/main/assets/infrastructure/azure/rbac-role.broad.json); or
    - a custom role based on the
-     [minimal example](https://github.com/exasol/exasol-personal/blob/v2.2.0/assets/infrastructure/azure/rbac-role.minimal.json).
+     [minimal example](https://github.com/exasol/exasol-personal/blob/main/assets/infrastructure/azure/rbac-role.minimal.json).
 
 Use only one option. The built-in Contributor role is usually the simplest. When creating a custom
 role from an example, replace `<subscription-id>` in the JSON first.

--- a/user-docs/content/cloud/exoscale.md
+++ b/user-docs/content/cloud/exoscale.md
@@ -15,9 +15,9 @@ In the Exoscale portal:
 
 1. Open **IAM** > **Roles** and create a role for Exasol Personal.
 2. Grant the permissions described by the
-   [minimal example policy](https://github.com/exasol/exasol-personal/blob/v2.2.0/assets/infrastructure/exoscale/iam-policy.minimal.json)
+   [minimal example policy](https://github.com/exasol/exasol-personal/blob/main/assets/infrastructure/exoscale/iam-policy.minimal.json)
    or the
-   [broad example policy](https://github.com/exasol/exasol-personal/blob/v2.2.0/assets/infrastructure/exoscale/iam-policy.broad.json).
+   [broad example policy](https://github.com/exasol/exasol-personal/blob/main/assets/infrastructure/exoscale/iam-policy.broad.json).
    The minimal policy is recommended. Use the JSON as a reference when entering the permissions in
    the portal; Exoscale does not import the file directly.
 3. Open **IAM** > **API Keys**, create an API key, and assign the new role.
@@ -56,6 +56,6 @@ exasol install exoscale --zone de-fra-1
 exasol install exoscale --zone at-vie-1
 ```
 
-Release 2.2 supports `ch-gva-2`, `de-fra-1`, `de-muc-1`, `at-vie-1`, `at-vie-2`, and `bg-sof-1`.
+The supported zones are `ch-gva-2`, `de-fra-1`, `de-muc-1`, `at-vie-1`, `at-vie-2`, and `bg-sof-1`.
 See the Exoscale guides for [IAM](https://community.exoscale.com/documentation/iam/) and
 [API keys](https://community.exoscale.com/documentation/iam/quick-start/) for more information.

--- a/user-docs/content/connect.md
+++ b/user-docs/content/connect.md
@@ -58,17 +58,17 @@ For SQL syntax, functions, and data types, see the
 
 ## Use Exasol Admin
 
-Exasol Admin is available for cloud deployments in release 2.2. The installation output and
-`exasol info` show its URL. Its credentials are stored in `secrets.json`.
+Exasol Admin is available for cloud deployments. The installation output and `exasol info` show its
+URL. Its credentials are stored in `secrets.json`.
 
 The browser can display a warning because Exasol Admin uses a self-signed certificate. Verify that
 you are connecting to your deployment before accepting the certificate warning.
 
-Exasol Admin is not available for local deployments in release 2.2.
+Exasol Admin is not available for local deployments.
 
 ## Open a shell
 
-Open a shell on the compute instance or local virtual machine:
+Open a shell on a cloud compute instance or in the managed macOS virtual machine:
 
 ```bash
 exasol shell host
@@ -79,3 +79,5 @@ Open a shell inside the database container:
 ```bash
 exasol shell container
 ```
+
+The runtime-managed shell commands are not available for local deployments on Linux or Windows.

--- a/user-docs/content/getting-started.md
+++ b/user-docs/content/getting-started.md
@@ -7,13 +7,12 @@ The launcher runs on macOS, Linux, and Windows.
 
 Choose where the database will run:
 
-- For a local deployment, use an Apple Silicon Mac running macOS 15 or later with at least 8 GB of
-  memory. Local deployments in release 2.2 are not available on Linux or Windows.
+- For a local deployment, use a supported macOS, Linux, or Windows computer. Linux requires Podman.
+  Windows requires Windows Package Manager and the prerequisites for a Podman machine. See
+  [System requirements](system-requirements.md) for platform-specific details.
 - For a cloud deployment, prepare an account with permission to provision compute resources. See
   the account setup guide for [AWS](cloud/aws.md), [Azure](cloud/azure.md),
   [Exoscale](cloud/exoscale.md), or [STACKIT](cloud/stackit.md).
-
-See [System requirements](system-requirements.md) for the complete supported-platform summary.
 
 ## Install on macOS or Linux
 

--- a/user-docs/content/index.md
+++ b/user-docs/content/index.md
@@ -1,14 +1,14 @@
-# Exasol Personal 2.2
+# Exasol Personal
 
-Exasol Personal gives you a full Exasol database for personal use. Run it locally on a supported
-Mac or deploy it into your own AWS, Azure, Exoscale, or STACKIT account.
+Exasol Personal gives you a full Exasol database for personal use. Run it locally on macOS, Linux,
+or Windows, or deploy it into your own AWS, Azure, Exoscale, or STACKIT account.
 
 The Exasol Launcher (`exasol`) installs and manages the database from the command line. It can
 provision infrastructure, start and stop deployments, display connection details, and open SQL or
 shell sessions.
 
-These pages document Exasol Personal 2.2. Commands and capabilities introduced after release 2.2
-are intentionally not included.
+These pages describe the product version selected in the version menu. Choose the version that
+matches your installed launcher when commands or supported capabilities differ between releases.
 
 ## Start here
 
@@ -16,11 +16,11 @@ are intentionally not included.
   [deploy it to the cloud](cloud-deployment.md).
 - [Connect to the database](connect.md) and [load the sample data](load-data.md).
 - Learn how to [manage one or more deployments](manage-deployments.md).
-- Check the [system requirements](system-requirements.md) and [2.2 limitations](limitations.md).
+- Check the [system requirements](system-requirements.md) and [product limitations](limitations.md).
 
 ## Key capabilities
 
-- Start a local database on macOS in seconds.
+- Start a local database on macOS, Linux, or Windows in seconds.
 - Provision single-node or multi-node deployments in supported clouds.
 - Connect AI agents and automation through the scriptable CLI.
 - Run analytics with Exasol's in-memory, massively parallel database engine.

--- a/user-docs/content/limitations.md
+++ b/user-docs/content/limitations.md
@@ -1,15 +1,16 @@
 # Limitations
 
-Local deployments are intended for development and exploration. Release 2.2 has these differences
-from cloud deployments:
+Local deployments are intended for development and exploration. They have these differences from
+cloud deployments:
 
 - **Script languages:** UDFs are supported, but no script language container is installed by
   default. Install one with `exasol slc install <language>`. Cloud deployments include the standard
   containers.
-- **Virtual schemas:** Virtual schemas are not available on local deployments.
+- **Virtual schemas:** Virtual schemas require an adapter runtime and dependencies. JDBC adapters
+  need a Java SLC and staged adapter and driver files. See [Virtual schemas](virtual-schemas.md).
 - **Administration UI:** Exasol Admin is not available on local deployments.
 - **Cluster size:** A local deployment always runs as a single node.
-- **Host platforms:** A local deployment requires a supported Apple Silicon Mac. The launcher itself
-  can run on the other supported platforms to manage cloud deployments.
+- **Shell access:** The runtime-managed `shell` commands for local deployments are available only on
+  macOS.
 
 Cloud deployments support UDFs, virtual schemas, Exasol Admin, and multiple database nodes.

--- a/user-docs/content/load-data.md
+++ b/user-docs/content/load-data.md
@@ -30,6 +30,20 @@ CREATE OR REPLACE TABLE PRODUCT_REVIEWS AS (
 
 Exasol infers the table schemas from the Parquet files.
 
+## Import a local Parquet file
+
+The bundled SQL client can upload one Parquet file per statement from the client computer:
+
+```sql
+CREATE TABLE LOCAL_PRODUCTS AS (
+    IMPORT FROM LOCAL PARQUET FILE '/path/to/products.parquet'
+);
+```
+
+Run the statement through `exasol connect -c` or place it in a file passed to `exasol connect -f`.
+The `LOCAL` form reads the file from the computer running the client. It does not change the
+database engine's object-storage Parquet behavior.
+
 | Table | Rows | Size |
 | --- | ---: | ---: |
 | `PRODUCTS` | 1,000,000 | 27.3 MiB |

--- a/user-docs/content/local-deployment.md
+++ b/user-docs/content/local-deployment.md
@@ -1,7 +1,13 @@
 # Run Exasol locally
 
-Release 2.2 supports local deployments on Apple Silicon Macs running macOS 15 or later with at
-least 8 GB of memory.
+Local deployments run on supported macOS, Linux, and Windows computers.
+
+- On macOS, the launcher manages a virtual machine containing Podman and the database. An Apple
+  Silicon Mac with at least 8 GB of memory is required.
+- On Linux, the database runs directly in Podman on the host. Install Podman and make sure it is
+  available in `PATH`.
+- On Windows, the database runs through Podman's default machine. Windows Package Manager
+  (`winget`) and the prerequisites for a Podman machine are required.
 
 After [installing the launcher](getting-started.md), run:
 
@@ -9,15 +15,28 @@ After [installing the launcher](getting-started.md), run:
 exasol install local
 ```
 
-The launcher creates a managed local virtual machine and starts a single-node Exasol database. Run
-`exasol info` at any time to display connection information.
+The launcher starts a single-node Exasol database. Run `exasol info` at any time to display
+connection information.
 
-The virtual machine uses about half of the detected host memory by default. An explicitly configured
-memory value must be at least 4096 MB. The initial local database credentials are `sys` / `exasol`.
+On macOS, the managed virtual machine uses about half of the detected host memory by default. An
+explicitly configured memory value must be at least 4096 MB. Linux and Windows use host-managed
+resources, so the virtual-machine sizing options do not apply. The initial local database credentials
+are `sys` / `exasol`.
+
+## Windows host preparation
+
+If Podman is missing, the launcher can offer to install it. It also creates or starts Podman's
+default machine when necessary, without changing the configuration of an existing machine. Because
+installing Podman changes shared host state, the launcher displays the exact command and asks for
+approval.
+
+Use `--auto-approve` with `install`, `deploy`, or `start` for unattended preparation. A command that
+cannot prompt refuses the host change unless this option is present. Stopping or destroying an
+Exasol deployment leaves the shared Podman machine running.
 
 ## Open a shell
 
-Open a shell in the managed virtual machine:
+On macOS, open a shell in the managed virtual machine:
 
 ```bash
 exasol shell host
@@ -28,6 +47,8 @@ Open a shell inside the database container:
 ```bash
 exasol shell container
 ```
+
+These shell commands are not available for local deployments on Linux or Windows.
 
 ## Next steps
 

--- a/user-docs/content/manage-deployments.md
+++ b/user-docs/content/manage-deployments.md
@@ -32,7 +32,7 @@ exasol deployments list
 Example output:
 
 ```text
-default status=running preset=local/local path=/Users/me/.exasol/personal/deployments/default
+default status=database_ready preset=local/ubuntu path=/Users/me/.exasol/personal/deployments/default
 staging status=stopped preset=aws/ubuntu path=/Users/me/.exasol/personal/deployments/staging
 ```
 
@@ -115,5 +115,5 @@ exasol remove
 also does not remove provisioned resources. If the directory is lost before destruction, you must
 remove the remaining resources directly through the target environment.
 
-For local deployments, `exasol destroy` removes the managed virtual-machine data and launcher-managed
-share for the selected deployment.
+For local deployments, `exasol destroy` removes the launcher-managed runtime and database data for
+the selected deployment. On Windows, it leaves Podman's shared default machine running.

--- a/user-docs/content/presets.md
+++ b/user-docs/content/presets.md
@@ -8,8 +8,8 @@ Each deployment combines:
 - an infrastructure preset, which provisions a cloud or local environment; and
 - an installation preset, which installs and configures Exasol on that environment.
 
-Release 2.2 includes the `aws`, `azure`, `exoscale`, `stackit`, and `local` infrastructure presets.
-The built-in `ubuntu` installation preset is selected by default where applicable.
+The built-in infrastructure presets are `aws`, `azure`, `exoscale`, `stackit`, and `local`. The
+built-in `ubuntu` installation preset is selected by default where applicable.
 
 List the built-in presets with:
 
@@ -42,8 +42,15 @@ caches a Git source by commit and reuses it on later runs.
 Remote `.tar.gz`, `.tgz`, and `.zip` archives can use HTTP or HTTPS. They are downloaded on each run
 because the source does not supply a checksum.
 
+Git repositories and archives accept an optional `#<subpath>` fragment. Use it to select a preset
+from a subdirectory in a repository or multi-preset archive:
+
+```bash
+exasol install https://github.com/org/presets.git@v1#infra/aws
+```
+
 ## Develop a preset
 
 The preset manifest schemas, required output artifacts, caching rules, and reference implementations
 are documented in the
-[2.2 preset development guide](https://github.com/exasol/exasol-personal/blob/v2.2.0/doc/presets.md).
+[preset development guide](https://github.com/exasol/exasol-personal/blob/main/doc/presets.md).

--- a/user-docs/content/privacy-and-licensing.md
+++ b/user-docs/content/privacy-and-licensing.md
@@ -12,7 +12,7 @@ installation flags that disable them.
 ## Launcher license
 
 The Exasol Launcher source code is available under the
-[MIT License](https://github.com/exasol/exasol-personal/blob/v2.2.0/LICENSE). You may use, modify, and
+[MIT License](https://github.com/exasol/exasol-personal/blob/main/LICENSE). You may use, modify, and
 distribute it under those terms.
 
 ## Database license

--- a/user-docs/content/system-requirements.md
+++ b/user-docs/content/system-requirements.md
@@ -2,7 +2,7 @@
 
 ## Launcher platforms
 
-The Exasol Launcher in release 2.2 runs on:
+The Exasol Launcher runs on:
 
 - macOS 12 Monterey or later;
 - Linux on AMD64 or ARM64; and
@@ -13,19 +13,19 @@ supported platform can manage a cloud deployment.
 
 ## Local database
 
-A local database requires:
+A local database always runs as a single node. Platform-specific requirements are:
 
-- macOS 15 Sequoia or later;
-- Apple Silicon; and
-- at least 8 GB of host memory.
-
-The database runs as a single node in a launcher-managed virtual machine. Local deployments are not
-available on Linux or Windows in release 2.2.
+- **macOS:** macOS 15 Sequoia or later on Apple Silicon with at least 8 GB of host memory. The
+  launcher supplies Podman in a managed virtual machine.
+- **Linux:** AMD64 or ARM64 with Podman installed and available in `PATH`. The database uses host
+  resources directly.
+- **Windows:** Windows 10 or later on AMD64, Windows Package Manager (`winget`), and the prerequisites
+  for a Podman machine. Windows on ARM64 is not supported for local deployments.
 
 ## Cloud database
 
 Cloud deployments run on AWS, Azure, Exoscale, or STACKIT infrastructure. The launcher provisions
-Ubuntu 22.04 LTS on x86-64 compute instances.
+Ubuntu 24.04 LTS on x86-64 compute instances.
 
 The cloud account must have permission and quota for the selected compute, storage, and networking
 resources. See the provider-specific account setup pages for details.

--- a/user-docs/content/troubleshooting.md
+++ b/user-docs/content/troubleshooting.md
@@ -8,8 +8,8 @@ Run the local diagnostic command whether the deployment is running or stopped:
 exasol diag local
 ```
 
-It returns a JSON snapshot containing platform support, virtual-machine state, port reachability,
-and database readiness.
+It returns a JSON snapshot containing runtime state, bound host ports, reachability, and database
+readiness.
 
 Use `exasol info` to display the current connection details after a successful start. Node addresses
 can change whenever a deployment restarts.

--- a/user-docs/content/udfs.md
+++ b/user-docs/content/udfs.md
@@ -3,8 +3,8 @@
 User-defined functions (UDFs) execute in a script language container (SLC), which supplies a runtime
 such as Python, Java, or R.
 
-Cloud deployments include the standard SLCs. Local deployments in release 2.2 do not install one by
-default. Install the language you need with `exasol slc`:
+Cloud deployments include the standard SLCs. Local deployments do not install one by default.
+Install the language you need with `exasol slc`:
 
 ```bash
 exasol slc list
@@ -28,4 +28,36 @@ connections and aborts running statements. The command asks for confirmation fir
 - Use `--auto-approve` to skip the prompt. This is required for non-interactive use.
 - Use `--no-restart` to record the change and activate it the next time the deployment starts.
 
-The `install`, `update`, and `remove` SLC operations apply only to local deployments.
+Official `install`, `update`, and `remove` operations and custom SLC management apply only to local
+deployments.
+
+Script language containers also provide runtimes for features such as virtual schema adapter
+scripts. Install the language required by the adapter before creating it. See
+[Virtual schemas](virtual-schemas.md) for a JDBC example.
+
+## Install a custom container
+
+Install a custom SLC when the official catalog does not provide the language or packages you need:
+
+```bash
+exasol slc custom install --source ./my-python.tar.gz --alias MYPY3 --language python
+exasol slc custom update --source ./my-python-v2.tar.gz --alias MYPY3
+exasol slc remove MYPY3
+```
+
+`--source` accepts a local tar archive or an HTTPS URL. `--alias` defines the name used in
+`CREATE <alias> ... SCRIPT`. `--language` identifies the custom client language. The launcher trims
+whitespace, converts the identifier to lowercase, and requires it to start with an ASCII letter or
+digit and contain only ASCII letters, digits, dots, hyphens, or underscores. A custom client can use
+another identifier, such as `rust`, when it implements the Exasol UDF protocol.
+
+Custom `install` and `update` restart the database and support `--auto-approve` and `--no-restart`.
+If the container cannot be activated, the database still starts but the command reports that the
+container is recorded as pending.
+
+Removing a custom container takes effect immediately and does not accept the restart options. The
+deployment must be running to remove an active alias through the database. A container recorded but
+never activated can be removed while the deployment is stopped.
+
+`exasol slc list` shows custom containers separately, including their alias, language, status, and
+source. JSON output marks them as custom and includes availability information.

--- a/user-docs/content/virtual-schemas.md
+++ b/user-docs/content/virtual-schemas.md
@@ -1,0 +1,264 @@
+# Virtual schemas on local deployments
+
+Virtual schemas let you query another database as if its objects were an Exasol schema. Cloud
+deployments already include the standard script language containers and driver locations, so follow
+the [Exasol virtual schema documentation](https://docs.exasol.com/db/latest/database_concepts/virtual_schemas.htm)
+for those deployments.
+
+Local deployments require you to install the adapter runtime and stage its dependencies. This guide
+uses the PostgreSQL JDBC adapter as an example.
+
+## Install the adapter runtime
+
+JDBC adapters execute as Java UDFs and JDBC data transfer needs a Java runtime. Install the Java SLC
+without restarting yet:
+
+```bash
+DEPLOY_DIR=$(exasol info --json | jq -r '.deploymentDir')
+exasol slc install java --no-restart --deployment-dir "$DEPLOY_DIR"
+```
+
+This command requires `jq`. Use the same `--deployment` or `--deployment-dir` selector with `info`
+when working with a named or explicitly selected deployment. Skip the installation if the required
+SLC is already present. For an adapter implemented in another language, install that runtime. A
+[custom SLC](udfs.md#install-a-custom-container) can supply packages missing from the official one.
+
+## Understand the required files
+
+A JDBC virtual schema needs the adapter JAR, the source database's JDBC driver JAR, and a
+`settings.cfg` describing the driver.
+
+| Files | Container location | Used by |
+| --- | --- | --- |
+| Adapter and driver JARs | `/exa/bucketfs/<service>/<bucket>/<dir>/` | Adapter script through `/buckets/...` |
+| Driver JAR and `settings.cfg` | `/exa/jdbc/<DRIVERNAME>/` | ETL layer for `IMPORT` and `EXPORT` |
+
+The driver JAR is present in both locations because the adapter reads it for metadata and the ETL
+layer uses the registered copy for data transfer. A BucketFS file stored at
+`/exa/bucketfs/bfsdefault/default/vs/example.jar` is addressed by an adapter script as
+`/buckets/bfsdefault/default/vs/example.jar`.
+
+## Select the deployment and staging directory
+
+Resolve the deployment directory and prepare a staging location:
+
+```bash
+DEPLOY_DIR=$(exasol info --json | jq -r '.deploymentDir')
+VS_DIR="$DEPLOY_DIR/local/runtime/vm-shared/vs"
+mkdir -p "$VS_DIR"
+```
+
+For another deployment selection:
+
+```bash
+DEPLOY_DIR=$(exasol info --json --deployment demo | jq -r '.deploymentDir')
+# or
+DEPLOY_DIR=$(exasol info --json --deployment-dir /path/to/deployment | jq -r '.deploymentDir')
+```
+
+On Linux, the persistent database data is directly accessible on the host:
+
+```bash
+EXA_DATA="$DEPLOY_DIR/local/runtime/exa"
+```
+
+On macOS, `local/runtime/vm-shared` is mounted inside the managed virtual machine as `/mnt/host`.
+Use `exasol shell host` to copy staged files into database directories. Do not depend on the virtual
+machine's IP address, SSH key, or SSH port.
+
+## PostgreSQL JDBC example
+
+Check the [PostgreSQL virtual schema releases](https://github.com/exasol/postgresql-virtual-schema)
+and [PostgreSQL JDBC downloads](https://jdbc.postgresql.org/download/) for current versions. The
+versions below are examples and should be updated together when newer compatible artifacts are used.
+
+### Download the adapter and driver
+
+```bash
+DEPLOY_DIR=$(exasol info --json | jq -r '.deploymentDir')
+VS_DIR="$DEPLOY_DIR/local/runtime/vm-shared/vs"
+mkdir -p "$VS_DIR"
+
+ADAPTER_VERSION=4.0.0
+ADAPTER_JAR=virtual-schema-dist-14.0.2-postgresql-4.0.0.jar
+DRIVER_JAR=postgresql-42.7.13.jar
+
+curl -L -o "$VS_DIR/$ADAPTER_JAR" \
+  "https://github.com/exasol/postgresql-virtual-schema/releases/download/$ADAPTER_VERSION/$ADAPTER_JAR"
+curl -L -o "$VS_DIR/$DRIVER_JAR" \
+  "https://repo.maven.apache.org/maven2/org/postgresql/postgresql/42.7.13/$DRIVER_JAR"
+```
+
+Create `$VS_DIR/settings.cfg` with an empty final line:
+
+```text
+DRIVERNAME=POSTGRESQL
+PREFIX=jdbc:postgresql:
+DRIVERMAIN=org.postgresql.Driver
+FETCHSIZE=100000
+INSERTSIZE=-1
+JAR=postgresql-42.7.13.jar
+
+```
+
+### Copy the files on Linux
+
+```bash
+mkdir -p "$EXA_DATA/bucketfs/bfsdefault/default/vs"
+cp "$VS_DIR/$ADAPTER_JAR" "$VS_DIR/$DRIVER_JAR" \
+  "$EXA_DATA/bucketfs/bfsdefault/default/vs/"
+mkdir -p "$EXA_DATA/jdbc/POSTGRESQL"
+cp "$VS_DIR/$DRIVER_JAR" "$VS_DIR/settings.cfg" "$EXA_DATA/jdbc/POSTGRESQL/"
+```
+
+### Copy the files on macOS
+
+Open the virtual-machine shell:
+
+```bash
+exasol shell host --deployment-dir "$DEPLOY_DIR"
+```
+
+Then run inside it:
+
+```bash
+mkdir -p /var/lib/exa/bucketfs/bfsdefault/default/vs /var/lib/exa/jdbc/POSTGRESQL
+cp /mnt/host/vs/virtual-schema-dist-14.0.2-postgresql-4.0.0.jar \
+   /mnt/host/vs/postgresql-42.7.13.jar \
+   /var/lib/exa/bucketfs/bfsdefault/default/vs/
+cp /mnt/host/vs/postgresql-42.7.13.jar \
+   /mnt/host/vs/settings.cfg \
+   /var/lib/exa/jdbc/POSTGRESQL/
+ls -lh /var/lib/exa/bucketfs/bfsdefault/default/vs /var/lib/exa/jdbc/POSTGRESQL
+```
+
+Exit the shell after verifying the files. If you selected other artifact versions, substitute their
+filenames throughout the setup.
+
+### Restart once
+
+Apply the pending SLC and JDBC driver configuration:
+
+```bash
+exasol stop --deployment-dir "$DEPLOY_DIR"
+exasol start --deployment-dir "$DEPLOY_DIR"
+```
+
+### Optional: run PostgreSQL inside the macOS virtual machine
+
+For a self-contained test, run PostgreSQL on a dedicated Podman network inside the managed virtual
+machine and connect the Exasol container to that network.
+
+Open the virtual-machine shell:
+
+```bash
+exasol shell host --deployment-dir "$DEPLOY_DIR"
+```
+
+Then run:
+
+```bash
+EXASOL_CONTAINER=$(podman ps --format '{{.Names}}' | sed -n '/^exasol-db-/p' | head -n 1)
+VS_NETWORK="vs-net-${EXASOL_CONTAINER#exasol-db-}"
+podman network create "$VS_NETWORK"
+podman network connect "$VS_NETWORK" "$EXASOL_CONTAINER"
+podman run -d --rm \
+  --name exasol-vs-postgres \
+  --network "$VS_NETWORK" \
+  --env POSTGRES_DB=vs_test \
+  --env POSTGRES_USER=vs_test \
+  --env POSTGRES_PASSWORD=vs_test \
+  docker.io/library/postgres@sha256:c1b3783309b6499c795eed7c20135a1a4d25cae1b575c3d52c6f536129a1b109 \
+  -c timezone=UTC
+until podman exec exasol-vs-postgres pg_isready --username vs_test --dbname vs_test; do
+  sleep 1
+done
+podman exec exasol-vs-postgres psql --no-password --username vs_test --dbname vs_test \
+  -c "CREATE SCHEMA source_schema"
+podman exec exasol-vs-postgres psql --no-password --username vs_test --dbname vs_test \
+  -c "CREATE TABLE source_schema.source_data (id INTEGER PRIMARY KEY, payload TEXT)"
+podman exec exasol-vs-postgres psql --no-password --username vs_test --dbname vs_test \
+  -c "INSERT INTO source_schema.source_data VALUES (1, 'before-refresh')"
+podman inspect exasol-vs-postgres \
+  --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' \
+  > /mnt/host/vs/postgres-ip
+exit
+```
+
+The dedicated network gives Exasol a route to PostgreSQL while keeping the containers independent.
+Do not use `--network container:<Exasol-container>` because that dependency can prevent
+`exasol destroy` from removing the deployment. The example writes PostgreSQL's address into the
+shared staging directory because Podman DNS aliases are not reliable in every managed environment.
+
+Read the address on the macOS host:
+
+```bash
+PG_HOST=$(tr -d '\r\n' < "$VS_DIR/postgres-ip")
+```
+
+Remove the test container with `podman rm --force exasol-vs-postgres` from `exasol shell host` when
+it is no longer needed. Destroying the virtual machine also removes it.
+
+### Create the connection and virtual schema
+
+The PostgreSQL host must be reachable from the database container or managed virtual machine.
+`localhost` refers to that environment, not necessarily to the computer running PostgreSQL. For an
+external database, use an address reachable from the Exasol runtime. When PostgreSQL runs on a Mac
+host, do not use `127.0.0.1`; publish it on a reachable host interface and verify connectivity from
+`exasol shell host`.
+
+Create `$DEPLOY_DIR/create-vs.sql` and replace the host, credentials, and source schema:
+
+```sql
+CREATE OR REPLACE CONNECTION POSTGRES_CONN
+  TO 'jdbc:postgresql://192.168.1.20:5432/vs_test'
+  USER 'vs_test' IDENTIFIED BY 'vs_test';
+
+CREATE SCHEMA IF NOT EXISTS VS;
+
+CREATE OR REPLACE JAVA ADAPTER SCRIPT VS.POSTGRES_ADAPTER AS
+  %scriptclass com.exasol.adapter.RequestDispatcher;
+  %jvmoption -Duser.timezone=UTC;
+  %jar /buckets/bfsdefault/default/vs/virtual-schema-dist-14.0.2-postgresql-4.0.0.jar;
+  %jar /buckets/bfsdefault/default/vs/postgresql-42.7.13.jar;
+/
+
+CREATE VIRTUAL SCHEMA VS_POSTGRES
+  USING VS.POSTGRES_ADAPTER
+  WITH CONNECTION_NAME = 'POSTGRES_CONN'
+       SCHEMA_NAME = 'source_schema';
+
+SELECT * FROM VS_POSTGRES.source_data;
+```
+
+Run it against the selected deployment:
+
+```bash
+exasol connect --deployment-dir "$DEPLOY_DIR" -f "$DEPLOY_DIR/create-vs.sql"
+```
+
+Refresh the virtual schema after the source schema changes:
+
+```sql
+ALTER VIRTUAL SCHEMA VS_POSTGRES REFRESH;
+```
+
+## Other adapters
+
+For another JDBC dialect, substitute the adapter JAR, driver JAR, and the `DRIVERNAME`, `PREFIX`,
+`DRIVERMAIN`, and `JAR` settings. For a non-JDBC adapter, install its required SLC and follow the
+adapter's dependency and script-definition instructions. The
+[Exasol virtual schema documentation](https://docs.exasol.com/db/latest/database_concepts/virtual_schemas.htm)
+lists available adapters and their properties.
+
+## Troubleshooting
+
+**`ETL-1014: No default DRIVER registered`**: Check that `/exa/jdbc/<DRIVERNAME>/` contains the JAR
+and `settings.cfg`, that the configuration ends with an empty line, and that you restarted the
+deployment.
+
+**The adapter script cannot find its class**: Check that every `%jar` path resolves below `/buckets`
+and that the files exist in the corresponding BucketFS directory.
+
+**Adapter execution or `IMPORT` reports no runtime**: Run `exasol slc list` and confirm that the
+adapter's SLC is installed. JDBC adapters require the Java SLC.

--- a/user-docs/mkdocs.yml
+++ b/user-docs/mkdocs.yml
@@ -26,6 +26,7 @@ nav:
       - Connect to the database: connect.md
       - Load sample data: load-data.md
       - UDFs and script languages: udfs.md
+      - Virtual schemas: virtual-schemas.md
       - Presets: presets.md
   - Help and reference:
       - Troubleshooting: troubleshooting.md


### PR DESCRIPTION
## Description

Move changing product guidance out of the README and align the versioned user documentation with the current capabilities on `main`.

This PR is stacked on #339 so its diff contains only the changes from the publishable 2.2 snapshot to the current-development documentation. It must not be merged until #339 is merged and its immutable revision has been published as documentation version 2.2.0.

## Related Issue

[SPOT-32457](https://exasol.atlassian.net/browse/SPOT-32457)

## Type of Change

- [x] `docs`: Documentation update

## Changes Made

- Refocus the README as a release-neutral product introduction and contributor entry point.
- Point README users to the latest versioned user documentation.
- Document the capabilities currently available on `main`, including cross-platform local deployments, local Parquet import, custom script language containers, virtual schemas, and preset subpaths.
- Keep platform matrices, command details, tutorials, and troubleshooting in `user-docs/`.

## Testing

- [x] Manually tested the changes

### Test Details

- `env UV_CACHE_DIR=/tmp/exasol-personal-docs-uv-cache task docs-check`
  - Ruff checks passed.
  - 24 publishing-tool tests passed.
  - The strict MkDocs build passed without documentation warnings.
- `git diff --check`
- Compared the current documentation against the `main` README and linked user-facing guidance.

## Checklist

- [x] Code follows the project's coding guidelines
- [x] Updated documentation
- [x] All relevant tests pass locally
- [x] Commit messages follow Conventional Commits

No changelog entry is needed because the product behavior and operating instructions are unchanged; this reorganizes existing guidance into its versioned documentation home.

## Additional Notes

Depends on #339. After #339 is merged and version 2.2.0 is published, retarget this PR to `main` before merging.

[SPOT-32457]: https://exasol.atlassian.net/browse/SPOT-32457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ