### PR TITLE
fix(build): Derive launcher version from release tags

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -102,7 +102,7 @@ tasks:
       CGO_ENABLED: "0"
     cmds:
       - |
-        version=$(git describe --tags --abbrev=0) # First character is "v".
+        version=$(git describe --tags --abbrev=0 --match 'v*') # First character is "v".
         go build \
           -tags=containers_image_openpgp \
           -o {{.BUILD_DIR_NAME}}/{{.BINARY_NAME}} \
@@ -128,7 +128,7 @@ tasks:
       CGO_ENABLED: "0"
     cmds:
       - |
-        version=$(git describe --tags --abbrev=0) # First character is "v".
+        version=$(git describe --tags --abbrev=0 --match 'v*') # First character is "v".
         go build -tags=containers_image_openpgp -o {{.BUILD_DIR_NAME}}/{{.OUTPUT_NAME}} \
           {{if eq .DEBUG_BUILD "true"}}-gcflags="all=-N -l"{{else}}-trimpath \
           -gcflags=all=-l{{end}} \

--- a/tests/tests/integration/test_cli.py
+++ b/tests/tests/integration/test_cli.py
@@ -77,7 +77,7 @@ def test_help_usage_section_is_indented_and_separated(exasol_path: str) -> None:
 def test_version(exasol_path: str) -> None:
     # Given the current version of the program based on the the latest git version tag
     git_describe_command_result = run_command(
-        ["git", "describe", "--tags", "--abbrev=0"],
+        ["git", "describe", "--tags", "--abbrev=0", "--match", "v*"],
     )
     git_tag_version_str = git_describe_command_result.stdout.strip()
 
@@ -87,19 +87,15 @@ def test_version(exasol_path: str) -> None:
     )
     version_command_output: str = version_command_result.stdout.strip()
 
-    # Then I expect that the git tag version starts with a "v"
-    version_expected_first_char = git_tag_version_str[0]
-    assert version_expected_first_char == "v"
-
-    # And I expect the version command output to be the same as the tagged version
-    tag_expected_str = git_tag_version_str[1:]
+    # Then I expect the version command output to be the same as the tagged version
+    tag_expected_str = git_tag_version_str.removeprefix("v")
     assert version_command_output == tag_expected_str
 
 
 def test_version_json(exasol_path: str) -> None:
     # Given the current version of the program based on the the latest git version tag
     git_describe_command_result = run_command(
-        ["git", "describe", "--tags", "--abbrev=0"],
+        ["git", "describe", "--tags", "--abbrev=0", "--match", "v*"],
     )
     git_tag_version_str = git_describe_command_result.stdout.strip()
 
@@ -110,7 +106,7 @@ def test_version_json(exasol_path: str) -> None:
     version_command_output = json.loads(version_command_result.stdout)
 
     # Then the version is returned as structured JSON
-    assert version_command_output == {"version": git_tag_version_str[1:]}
+    assert version_command_output == {"version": git_tag_version_str.removeprefix("v")}
 
 
 def test_info_command_exists(exasol_path: str) -> None:


### PR DESCRIPTION
## Description

Builds took their version from `git describe --tags --abbrev=0`, which returns the nearest reachable tag of any kind. Since the `docs/*` tags were introduced, that resolves to `docs/0.1`, and the build strips the leading character on the assumption of a `v` prefix, stamping the launcher `ocs/0.1`.

The result is a launcher that panics on `exasol version` and refuses every command with a deployment compatibility check:

```
$ exasol version
panic: semver: Parse(ocs/0.1): No Major.Minor.Patch elements found

$ exasol status --json
Error: invalid deployment version "ocs/0.1": No Major.Minor.Patch elements found
```

Restricting the tag match to `v*` makes builds use the latest release tag again.

## Type of Change

- [x] `fix`: Bug fix

## Changes Made

- Match only `v*` tags when deriving the launcher version in the `build` and `build-windows` tasks

## Testing

- [x] All existing tests pass (`task all`)
- [x] Manually tested the changes
