### PR TITLE
fix: Determine and expose the latest documentation alias

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,15 @@ on:
         description: "SemVer without v, e.g. 2.2.0; required for delete and optional for v-tags"
         required: false
         type: string
+      make_latest:
+        description: "Give this version the 'latest' alias and the site root"
+        required: false
+        type: choice
+        default: auto
+        options:
+          - auto
+          - "yes"
+          - "no"
 
 permissions: {}
 
@@ -79,10 +88,11 @@ jobs:
           OPERATION: ${{ inputs.operation }}
           SOURCE_REF: ${{ inputs.source_ref }}
           REQUESTED_VERSION: ${{ inputs.version }}
+          MAKE_LATEST: ${{ inputs.make_latest }}
         run: |
           set -euo pipefail
           if [[ "${OPERATION}" == "publish" ]]; then
-            arguments=("${SOURCE_REF}")
+            arguments=("${SOURCE_REF}" --make-latest "${MAKE_LATEST}")
             if [[ -n "${REQUESTED_VERSION}" ]]; then
               arguments+=(--version "${REQUESTED_VERSION}")
             fi
@@ -103,6 +113,7 @@ jobs:
           SOURCE_REF: ${{ inputs.source_ref }}
           COMMIT: ${{ steps.source.outputs.commit }}
           VERSION: ${{ steps.request.outputs.version }}
+          MAKE_LATEST: ${{ inputs.make_latest }}
         run: |
           {
             echo "## Documentation publication"
@@ -112,6 +123,7 @@ jobs:
             if [[ "${OPERATION}" == "publish" ]]; then
               echo "- Source: \`${SOURCE_REF}\`"
               echo "- Commit: \`${COMMIT}\`"
+              echo "- Make latest: \`${MAKE_LATEST}\`"
             fi
           } >> "${GITHUB_STEP_SUMMARY}"
 
@@ -136,9 +148,14 @@ jobs:
         env:
           OPERATION: ${{ inputs.operation }}
           VERSION: ${{ steps.request.outputs.version }}
+          MAKE_LATEST: ${{ inputs.make_latest }}
         run: |
           set -euo pipefail
-          uv run --project user-docs --locked --no-build python user-docs/scripts/versions.py "${OPERATION}" "${VERSION}"
+          arguments=("${OPERATION}" "${VERSION}")
+          if [[ "${OPERATION}" == "publish" ]]; then
+            arguments+=(--make-latest "${MAKE_LATEST}")
+          fi
+          uv run --project user-docs --locked --no-build python user-docs/scripts/versions.py "${arguments[@]}"
           git push origin gh-pages
 
       - name: Export complete published site

--- a/doc/ci.md
+++ b/doc/ci.md
@@ -76,12 +76,14 @@ Maintainers publish versioned user documentation with the manually dispatched do
 workflow. GitHub Pages must be enabled with **GitHub Actions** as its source, and the existing
 `github-pages` environment must allow deployments only from `main`.
 
-The workflow accepts three inputs:
+The workflow accepts four inputs:
 
 - `operation`: `publish` or `delete`.
 - `source_ref`: an exact Git tag or full 40-character commit SHA, required for publication.
 - `version`: the published semantic version. It is required for deletion and optional for
   publication when `source_ref` is a tag named `v<version>` or ending in `/v<version>`.
+- `make_latest`: whether the published version takes the `latest` alias and the site root.
+  `auto` grants it when no higher stable version is published, `yes` and `no` decide explicitly.
 
 An explicit version can map historical documentation content to an older release without changing
 an existing release tag. For example, publish a reviewed `docs/v2.2.0` snapshot based on a current
@@ -90,9 +92,20 @@ are not accepted.
 
 Publication shallow-checks out the source once and builds its self-contained `user-docs/` directory,
 including its content, configuration, scripts, and locked uv environment, before updating the
-version catalog. Stable versions update `latest` and the site root; release candidates remain
-independently selectable. Deletion preserves all other versions and rejects removal of the version
+version catalog. Because the snapshot supplies the publishing script, a source revision predating a
+workflow input rejects the publication request before any published version changes.
+
+The highest published stable version carries `latest` and the site root, so publishing
+documentation for an older release leaves both untouched. Release candidates never take the alias
+and remain independently selectable. Set `make_latest` to `yes` to move the alias onto an older
+version, for example after withdrawing a release, or to `no` to publish a new stable version
+without fronting it yet. Deletion preserves all other versions and rejects removal of the version
 referenced by `latest` until a newer stable version is published.
+
+The version selector marks the version carrying `latest`. It reads the configuration built into
+each published version, so a version published before that configuration existed shows the marker
+only after it is republished. Readers may see a stale selector for up to ten minutes after a
+publication, because GitHub Pages caches the version catalog it fetches.
 
 All operations are serialized in request order. If Pages deployment fails after the version
 catalog is updated, rerun the same operation to deploy the complete stored catalog. A repeated

--- a/openspec/changes/archive/2026-09-04-control-latest-documentation-alias/design.md
+++ b/openspec/changes/archive/2026-09-04-control-latest-documentation-alias/design.md
@@ -1,0 +1,22 @@
+## Alias selection
+
+Publication order and version order diverge whenever documentation for an older release is
+published after a newer one. Version order is the property readers rely on, so automatic alias
+selection compares the requested version against the published catalog and grants `latest` only
+when no higher stable version exists. Comparison is limited to stable versions, whose precedence
+is the numeric order of their release components, so no version-parsing dependency is required.
+
+Automatic selection cannot express publishing documentation ahead of its announcement, or
+restoring `latest` to an earlier version after a withdrawn release. A publication input therefore
+overrides the comparison in either direction. Forcing `latest` onto a pre-release is rejected,
+because the site root resolves through `latest` and has to reach a stable version.
+
+## Alias exposure
+
+The version selector reads its configuration from the page it is served on, so the alias only
+becomes visible on versions built after the configuration changes. Existing versions show it once
+they are republished, which is a normal publication and needs no migration.
+
+Aliases stay redirects rather than copies. A `latest` URL therefore remains linkable but resolves
+to the versioned URL, which keeps one canonical address per page and avoids storing a second copy
+of the site for every stable release.

--- a/openspec/changes/archive/2026-09-04-control-latest-documentation-alias/proposal.md
+++ b/openspec/changes/archive/2026-09-04-control-latest-documentation-alias/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Readers cannot tell which published version is current, because the version selector never shows
+the `latest` alias. Publication also grants `latest` to every stable version, so publishing
+documentation for an older maintenance release moves the alias and the site root backwards.
+
+## What Changes
+
+- Show the `latest` alias next to the version that carries it in the published version selector.
+- Grant `latest` and the site root automatically only to the highest published stable version.
+- Add a publication input that forces or withholds `latest` for a single publication.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `versioned-documentation-publishing`: Determine the `latest` alias from published version order
+  and expose it to readers.
+
+## Impact
+
+The documentation configuration, the manual documentation workflow, its helper script and tests,
+the CI guide, and the versioned documentation publishing specification change. Versions published
+before this change keep their existing selector until they are republished. No runtime product
+behavior or additional dependency is introduced.

--- a/openspec/changes/archive/2026-09-04-control-latest-documentation-alias/specs/versioned-documentation-publishing/spec.md
+++ b/openspec/changes/archive/2026-09-04-control-latest-documentation-alias/specs/versioned-documentation-publishing/spec.md
@@ -1,0 +1,104 @@
+## ADDED Requirements
+
+### Requirement: The latest alias resolves to the highest published stable version
+
+Publication SHALL grant the `latest` alias and the site root to the requested stable version only
+when no higher stable version is published. A publication SHALL accept an explicit alias decision
+that overrides this comparison, and SHALL reject granting `latest` to a pre-release version.
+
+#### Scenario: Publish the highest stable version
+
+- **WHEN** a maintainer publishes stable version `2.3.0` while `2.2.0` is the highest published
+  stable version
+- **THEN** `latest` and the site root SHALL resolve to `2.3.0`
+
+#### Scenario: Publish documentation for an older release
+
+- **WHEN** a maintainer publishes stable version `2.1.1` while `2.2.0` is the highest published
+  stable version
+- **THEN** `2.1.1` SHALL be published and `latest` and the site root SHALL continue to resolve to
+  `2.2.0`
+
+#### Scenario: Publish a pre-release version
+
+- **WHEN** a maintainer publishes a pre-release version
+- **THEN** that version SHALL be published and `latest` and the site root SHALL remain unchanged
+
+#### Scenario: Force the alias onto a published version
+
+- **WHEN** a maintainer publishes a stable version and requests that it carry `latest`
+- **THEN** `latest` and the site root SHALL resolve to that version regardless of the published
+  version order
+
+#### Scenario: Withhold the alias from the highest stable version
+
+- **WHEN** a maintainer publishes the highest stable version and requests that it not carry
+  `latest`
+- **THEN** that version SHALL be published and `latest` and the site root SHALL remain unchanged
+
+#### Scenario: Reject forcing the alias onto a pre-release
+
+- **WHEN** a maintainer publishes a pre-release version and requests that it carry `latest`
+- **THEN** publication SHALL fail before changing any published version and explain that only a
+  stable version can carry `latest`
+
+## MODIFIED Requirements
+
+### Requirement: Published versions are discoverable from the site
+
+Every published page SHALL expose version navigation containing all retained documentation
+versions and identifying the version that carries the `latest` alias.
+
+#### Scenario: Navigate between retained versions
+
+- **WHEN** a reader opens a published documentation page and selects another retained version
+- **THEN** the site SHALL navigate to the corresponding page in that version
+
+#### Scenario: Recognize the current version
+
+- **WHEN** a reader opens a page of a version published with the `latest` alias
+- **THEN** version navigation SHALL show that the selected version is `latest`
+
+### Requirement: Maintainers can manually publish documentation from an immutable source revision
+
+The documentation workflow SHALL allow a maintainer to select an existing Git tag or full commit
+SHA as the documentation source and publish it under an independently selected semantic version.
+When the version is omitted, the workflow SHALL derive it from a tag named `v<semver>` or ending
+in `/v<semver>`.
+
+#### Scenario: Publish a stable version derived from a tag
+
+- **WHEN** a maintainer publishes documentation from a tag such as `v2.3.0` without supplying a
+  version
+- **THEN** version `2.3.0` SHALL be published
+
+#### Scenario: Publish a release-candidate version derived from a namespaced tag
+
+- **WHEN** a maintainer publishes documentation from a tag such as `docs/v2.3.0-rc1` without
+  supplying a version
+- **THEN** version `2.3.0-rc1` SHALL be published
+
+#### Scenario: Publish an explicitly mapped version
+
+- **WHEN** a maintainer publishes an immutable source revision and supplies version `2.2.0`
+- **THEN** the selected source content SHALL be published as version `2.2.0` regardless of the
+  source tag name
+
+#### Scenario: Require an explicit version for an underivable source
+
+- **WHEN** a maintainer publishes a full commit SHA or a tag that does not end in `v<semver>`
+  without supplying a version
+- **THEN** publication SHALL fail before changing any published version and explain that a version
+  is required
+
+#### Scenario: Reject a mutable source
+
+- **WHEN** a maintainer selects a branch as the documentation source
+- **THEN** publication SHALL fail before changing any published version and explain that only an
+  exact tag or full commit SHA is accepted
+
+#### Scenario: Republish one version
+
+- **WHEN** a maintainer publishes a documentation version that already exists
+- **THEN** that version SHALL be replaced from the selected source and every other published
+  version SHALL remain unchanged

--- a/openspec/changes/archive/2026-09-04-control-latest-documentation-alias/tasks.md
+++ b/openspec/changes/archive/2026-09-04-control-latest-documentation-alias/tasks.md
@@ -1,0 +1,12 @@
+## 1. Expose the Latest Alias
+
+- [x] 1.1 Show the alias carried by a published version in the version selector.
+
+## 2. Control Alias Selection
+
+- [x] 2.1 Implement and test automatic highest-stable alias selection with an explicit publication
+      override.
+
+## 3. Document the Contract
+
+- [x] 3.1 Update the CI guide for alias selection and exposure.

--- a/openspec/specs/versioned-documentation-publishing/spec.md
+++ b/openspec/specs/versioned-documentation-publishing/spec.md
@@ -25,12 +25,17 @@ while retaining the remaining versions and a valid stable default.
 ### Requirement: Published versions are discoverable from the site
 
 Every published page SHALL expose version navigation containing all retained documentation
-versions.
+versions and identifying the version that carries the `latest` alias.
 
 #### Scenario: Navigate between retained versions
 
 - **WHEN** a reader opens a published documentation page and selects another retained version
 - **THEN** the site SHALL navigate to the corresponding page in that version
+
+#### Scenario: Recognize the current version
+
+- **WHEN** a reader opens a page of a version published with the `latest` alias
+- **THEN** version navigation SHALL show that the selected version is `latest`
 
 ### Requirement: Documentation is validated before publication
 
@@ -82,15 +87,13 @@ in `/v<semver>`.
 
 - **WHEN** a maintainer publishes documentation from a tag such as `v2.3.0` without supplying a
   version
-- **THEN** version `2.3.0` SHALL be published, `latest` SHALL resolve to `2.3.0`, and the site root
-  SHALL resolve to `latest`
+- **THEN** version `2.3.0` SHALL be published
 
 #### Scenario: Publish a release-candidate version derived from a namespaced tag
 
 - **WHEN** a maintainer publishes documentation from a tag such as `docs/v2.3.0-rc1` without
   supplying a version
-- **THEN** version `2.3.0-rc1` SHALL be published and the existing `latest` alias and site root
-  SHALL remain unchanged
+- **THEN** version `2.3.0-rc1` SHALL be published
 
 #### Scenario: Publish an explicitly mapped version
 
@@ -116,3 +119,46 @@ in `/v<semver>`.
 - **WHEN** a maintainer publishes a documentation version that already exists
 - **THEN** that version SHALL be replaced from the selected source and every other published
   version SHALL remain unchanged
+
+### Requirement: The latest alias resolves to the highest published stable version
+
+Publication SHALL grant the `latest` alias and the site root to the requested stable version only
+when no higher stable version is published. A publication SHALL accept an explicit alias decision
+that overrides this comparison, and SHALL reject granting `latest` to a pre-release version.
+
+#### Scenario: Publish the highest stable version
+
+- **WHEN** a maintainer publishes stable version `2.3.0` while `2.2.0` is the highest published
+  stable version
+- **THEN** `latest` and the site root SHALL resolve to `2.3.0`
+
+#### Scenario: Publish documentation for an older release
+
+- **WHEN** a maintainer publishes stable version `2.1.1` while `2.2.0` is the highest published
+  stable version
+- **THEN** `2.1.1` SHALL be published and `latest` and the site root SHALL continue to resolve to
+  `2.2.0`
+
+#### Scenario: Publish a pre-release version
+
+- **WHEN** a maintainer publishes a pre-release version
+- **THEN** that version SHALL be published and `latest` and the site root SHALL remain unchanged
+
+#### Scenario: Force the alias onto a published version
+
+- **WHEN** a maintainer publishes a stable version and requests that it carry `latest`
+- **THEN** `latest` and the site root SHALL resolve to that version regardless of the published
+  version order
+
+#### Scenario: Withhold the alias from the highest stable version
+
+- **WHEN** a maintainer publishes the highest stable version and requests that it not carry
+  `latest`
+- **THEN** that version SHALL be published and `latest` and the site root SHALL remain unchanged
+
+#### Scenario: Reject forcing the alias onto a pre-release
+
+- **WHEN** a maintainer publishes a pre-release version and requests that it carry `latest`
+- **THEN** publication SHALL fail before changing any published version and explain that only a
+  stable version can carry `latest`
+

--- a/user-docs/mkdocs.yml
+++ b/user-docs/mkdocs.yml
@@ -16,5 +16,6 @@ extra:
   version:
     provider: mike
     default: latest
+    alias: true
 
 remote_branch: gh-pages

--- a/user-docs/scripts/versions.py
+++ b/user-docs/scripts/versions.py
@@ -20,6 +20,8 @@ FULL_COMMIT = re.compile(r"[0-9a-fA-F]{40}")
 VERSION_TAG = re.compile(r"(?:.*/)?v(?P<version>.+)")
 MIKE_BRANCH = "gh-pages"
 MKDOCS_CONFIG = "user-docs/mkdocs.yml"
+LATEST_ALIAS = "latest"
+ALIAS_DECISIONS = ("auto", "yes", "no")
 PUBLISH_VERSION_ERROR = (
     "version is required when source_ref is not a tag ending in v<semver>"
 )
@@ -30,6 +32,9 @@ DELETE_LATEST_ERROR = (
     "publish a newer stable version before deleting the version referenced by 'latest'"
 )
 VERSION_ERROR = "version must use semantic-version syntax such as 2.3.0 or 2.3.0-rc1"
+PRERELEASE_LATEST_ERROR = (
+    "only a stable version can be published as the version referenced by 'latest'"
+)
 
 
 class VersionError(Exception):
@@ -59,7 +64,16 @@ def validate_delete(target: str) -> str:
     return target
 
 
-def validate_publish(source_ref: str, version: str | None) -> str:
+def validate_publish(
+    source_ref: str, version: str | None, make_latest: str = "auto"
+) -> str:
+    resolved = resolve_version(source_ref, version)
+    if make_latest == "yes" and not is_stable(resolved):
+        raise VersionError(PRERELEASE_LATEST_ERROR)
+    return resolved
+
+
+def resolve_version(source_ref: str, version: str | None) -> str:
     if version:
         require_version(version)
         return version
@@ -85,41 +99,60 @@ def require_version(version: str) -> None:
         raise VersionError(VERSION_ERROR)
 
 
-def publish(version: str) -> None:
+def catalog() -> list[dict[str, object]]:
+    listed = mike("list", "--branch", MIKE_BRANCH, "--json", capture_output=True)
+    return json.loads(listed.stdout)
+
+
+def precedence(version: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in version.partition("+")[0].split("."))
+
+
+def is_highest_stable(version: str) -> bool:
+    published = (str(entry.get("version", "")) for entry in catalog())
+    return all(
+        precedence(other) <= precedence(version)
+        for other in published
+        if SEMANTIC_VERSION.fullmatch(other) and is_stable(other)
+    )
+
+
+def takes_latest(version: str, make_latest: str) -> bool:
+    if make_latest != "auto":
+        return make_latest == "yes"
+    return is_stable(version) and is_highest_stable(version)
+
+
+def publish(version: str, make_latest: str = "auto") -> None:
     require_version(version)
+    if make_latest == "yes" and not is_stable(version):
+        raise VersionError(PRERELEASE_LATEST_ERROR)
     arguments = [
         "--branch",
         MIKE_BRANCH,
         "--alias-type",
         "redirect",
     ]
-    if is_stable(version):
-        mike("deploy", *arguments, "--update-aliases", version, "latest")
-        mike("set-default", "--branch", MIKE_BRANCH, "latest")
+    if takes_latest(version, make_latest):
+        mike("deploy", *arguments, "--update-aliases", version, LATEST_ALIAS)
+        mike("set-default", "--branch", MIKE_BRANCH, LATEST_ALIAS)
     else:
         mike("deploy", *arguments, version)
 
 
 def delete(version: str) -> None:
     require_version(version)
-    listed = mike(
-        "list",
-        "--branch",
-        MIKE_BRANCH,
-        "--json",
-        capture_output=True,
-    )
     metadata = next(
-        (item for item in json.loads(listed.stdout) if item.get("version") == version),
+        (item for item in catalog() if item.get("version") == version),
         None,
     )
     if metadata is None:
         return
-    if "latest" in metadata.get("aliases", []):
+    if LATEST_ALIAS in metadata.get("aliases", []):
         raise VersionError(DELETE_LATEST_ERROR)
 
     mike("delete", "--branch", MIKE_BRANCH, version)
-    mike("set-default", "--branch", MIKE_BRANCH, "latest")
+    mike("set-default", "--branch", MIKE_BRANCH, LATEST_ALIAS)
 
 
 def parse_args() -> argparse.Namespace:
@@ -138,11 +171,17 @@ def parse_args() -> argparse.Namespace:
     )
     validate_publish_parser.add_argument("source_ref")
     validate_publish_parser.add_argument("--version")
+    validate_publish_parser.add_argument(
+        "--make-latest", choices=ALIAS_DECISIONS, default="auto"
+    )
 
     publish_parser = commands.add_parser(
         "publish", help="Publish a version to the local catalog"
     )
     publish_parser.add_argument("version")
+    publish_parser.add_argument(
+        "--make-latest", choices=ALIAS_DECISIONS, default="auto"
+    )
 
     delete_parser = commands.add_parser(
         "delete", help="Delete a version from the local catalog"
@@ -158,9 +197,11 @@ def main() -> int:
         if args.command == "validate-delete":
             sys.stdout.write(f"{validate_delete(args.target)}\n")
         elif args.command == "validate-publish":
-            sys.stdout.write(f"{validate_publish(args.source_ref, args.version)}\n")
+            sys.stdout.write(
+                f"{validate_publish(args.source_ref, args.version, args.make_latest)}\n"
+            )
         elif args.command == "publish":
-            publish(args.version)
+            publish(args.version, args.make_latest)
         else:
             delete(args.version)
     except VersionError as error:

--- a/user-docs/tests/test_versions.py
+++ b/user-docs/tests/test_versions.py
@@ -85,53 +85,6 @@ def test_validate_publish_rejects_invalid_explicit_version() -> None:
         versions.validate_publish("v2.2.0", "release-2.2")
 
 
-def test_publish_stable_version_updates_latest(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    # Given
-    calls: list[tuple[str, ...]] = []
-    monkeypatch.setattr(versions, "mike", lambda *args, **_kwargs: calls.append(args))
-
-    # When
-    versions.publish("2.3.0")
-
-    # Then
-    assert calls == [
-        (
-            "deploy",
-            "--branch",
-            "gh-pages",
-            "--alias-type",
-            "redirect",
-            "--update-aliases",
-            "2.3.0",
-            "latest",
-        ),
-        ("set-default", "--branch", "gh-pages", "latest"),
-    ]
-
-
-def test_publish_prerelease_preserves_latest(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Given
-    calls: list[tuple[str, ...]] = []
-    monkeypatch.setattr(versions, "mike", lambda *args, **_kwargs: calls.append(args))
-
-    # When
-    versions.publish("2.3.0-rc.1")
-
-    # Then
-    assert calls == [
-        (
-            "deploy",
-            "--branch",
-            "gh-pages",
-            "--alias-type",
-            "redirect",
-            "2.3.0-rc.1",
-        )
-    ]
-
-
 def mike_with_versions(
     catalog: list[dict[str, object]], calls: list[tuple[str, ...]]
 ) -> Callable[..., subprocess.CompletedProcess[str]]:
@@ -145,6 +98,132 @@ def mike_with_versions(
     return fake_mike
 
 
+def deploy(*arguments: str) -> tuple[str, ...]:
+    return ("deploy", "--branch", "gh-pages", "--alias-type", "redirect", *arguments)
+
+
+LIST = ("list", "--branch", "gh-pages", "--json")
+SET_DEFAULT = ("set-default", "--branch", "gh-pages", "latest")
+
+
+def test_validate_publish_rejects_forcing_latest_onto_a_prerelease() -> None:
+    # Given / When / Then
+    with pytest.raises(versions.VersionError, match="only a stable version"):
+        versions.validate_publish("docs/v2.3.0-rc.1", None, "yes")
+
+
+def test_publish_highest_stable_version_updates_latest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Given
+    calls: list[tuple[str, ...]] = []
+    catalog = [{"version": "2.2.0", "aliases": ["latest"]}]
+    monkeypatch.setattr(versions, "mike", mike_with_versions(catalog, calls))
+
+    # When
+    versions.publish("2.3.0")
+
+    # Then
+    assert calls == [
+        LIST,
+        deploy("--update-aliases", "2.3.0", "latest"),
+        SET_DEFAULT,
+    ]
+
+
+def test_publish_republished_highest_version_keeps_latest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Given
+    calls: list[tuple[str, ...]] = []
+    catalog = [{"version": "2.3.0", "aliases": ["latest"]}]
+    monkeypatch.setattr(versions, "mike", mike_with_versions(catalog, calls))
+
+    # When
+    versions.publish("2.3.0")
+
+    # Then
+    assert calls == [
+        LIST,
+        deploy("--update-aliases", "2.3.0", "latest"),
+        SET_DEFAULT,
+    ]
+
+
+def test_publish_older_stable_version_preserves_latest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Given
+    calls: list[tuple[str, ...]] = []
+    catalog = [
+        {"version": "2.3.0", "aliases": ["latest"]},
+        {"version": "2.2.0", "aliases": []},
+    ]
+    monkeypatch.setattr(versions, "mike", mike_with_versions(catalog, calls))
+
+    # When
+    versions.publish("2.2.1")
+
+    # Then
+    assert calls == [LIST, deploy("2.2.1")]
+
+
+def test_publish_prerelease_preserves_latest(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Given
+    calls: list[tuple[str, ...]] = []
+    catalog = [{"version": "2.3.0", "aliases": ["latest"]}]
+    monkeypatch.setattr(versions, "mike", mike_with_versions(catalog, calls))
+
+    # When
+    versions.publish("2.3.0-rc.1")
+
+    # Then
+    assert calls == [deploy("2.3.0-rc.1")]
+
+
+def test_publish_forces_latest_onto_an_older_stable_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Given
+    calls: list[tuple[str, ...]] = []
+    catalog = [{"version": "2.3.0", "aliases": ["latest"]}]
+    monkeypatch.setattr(versions, "mike", mike_with_versions(catalog, calls))
+
+    # When
+    versions.publish("2.2.0", "yes")
+
+    # Then
+    assert calls == [deploy("--update-aliases", "2.2.0", "latest"), SET_DEFAULT]
+
+
+def test_publish_withholds_latest_from_the_highest_stable_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Given
+    calls: list[tuple[str, ...]] = []
+    catalog = [{"version": "2.2.0", "aliases": ["latest"]}]
+    monkeypatch.setattr(versions, "mike", mike_with_versions(catalog, calls))
+
+    # When
+    versions.publish("2.3.0", "no")
+
+    # Then
+    assert calls == [deploy("2.3.0")]
+
+
+def test_publish_rejects_forcing_latest_onto_a_prerelease(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Given
+    calls: list[tuple[str, ...]] = []
+    monkeypatch.setattr(versions, "mike", mike_with_versions([], calls))
+
+    # When / Then
+    with pytest.raises(versions.VersionError, match="only a stable version"):
+        versions.publish("2.3.0-rc.1", "yes")
+    assert calls == []
+
+
 def test_delete_rejects_version_referenced_by_latest(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -156,7 +235,7 @@ def test_delete_rejects_version_referenced_by_latest(
     # When / Then
     with pytest.raises(versions.VersionError, match="newer stable version"):
         versions.delete("2.3.0")
-    assert calls == [("list", "--branch", "gh-pages", "--json")]
+    assert calls == [LIST]
 
 
 def test_delete_removes_only_selected_version(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -173,9 +252,9 @@ def test_delete_removes_only_selected_version(monkeypatch: pytest.MonkeyPatch) -
 
     # Then
     assert calls == [
-        ("list", "--branch", "gh-pages", "--json"),
+        LIST,
         ("delete", "--branch", "gh-pages", "2.4.0-rc.1"),
-        ("set-default", "--branch", "gh-pages", "latest"),
+        SET_DEFAULT,
     ]
 
 
@@ -191,7 +270,7 @@ def test_delete_retry_accepts_an_already_absent_version(
     versions.delete("2.4.0-rc.1")
 
     # Then
-    assert calls == [("list", "--branch", "gh-pages", "--json")]
+    assert calls == [LIST]
 
 
 def test_publish_retry_reapplies_the_same_catalog_update(
@@ -199,19 +278,13 @@ def test_publish_retry_reapplies_the_same_catalog_update(
 ) -> None:
     # Given
     calls: list[tuple[str, ...]] = []
-    monkeypatch.setattr(versions, "mike", lambda *args, **_kwargs: calls.append(args))
-    expected = (
-        "deploy",
-        "--branch",
-        "gh-pages",
-        "--alias-type",
-        "redirect",
-        "2.3.0-rc.1",
-    )
+    catalog = [{"version": "2.3.0", "aliases": ["latest"]}]
+    monkeypatch.setattr(versions, "mike", mike_with_versions(catalog, calls))
+    expected = [LIST, deploy("--update-aliases", "2.3.0", "latest"), SET_DEFAULT]
 
     # When
-    versions.publish("2.3.0-rc.1")
-    versions.publish("2.3.0-rc.1")
+    versions.publish("2.3.0")
+    versions.publish("2.3.0")
 
     # Then
-    assert calls == [expected, expected]
+    assert calls == expected + expected


### PR DESCRIPTION
## Description

Published user documentation never showed which version was current, and the `latest` alias
followed publication order instead of version order. Publishing documentation for an older release
therefore moved `latest` and the site root backwards without warning.

The version selector now marks the version carrying `latest`, and the alias follows the highest
published stable version. A `make_latest` input overrides that decision for a single publication.

## Related Issue

[SPOT-32456](https://exasol.atlassian.net/browse/SPOT-32456)

## Type of Change

- [x] `fix`: Bug fix
- [x] `docs`: Documentation update

## Changes Made

- Set `alias: true` in the documentation configuration so the version selector shows the alias
  carried by the selected version.
- Grant `latest` and the site root to a published stable version only when no higher stable
  version exists.
- Add the `make_latest` workflow input (`auto`, `yes`, `no`) and reject granting `latest` to a
  pre-release version.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

`task docs-check` and `task lint` pass. The documentation tooling suite covers alias selection,
both overrides, and the pre-release rejection.

The publication script was additionally exercised against a real `mike` catalog in a scratch
repository, confirming every specified outcome:

```
publish 2.2.0                    -> 2.2.0 [latest]
publish 2.1.1                    -> 2.1.1 [],        2.2.0 [latest]
publish 2.3.0-rc.1               -> 2.3.0-rc.1 [],   2.2.0 [latest]
publish 2.3.0                    -> 2.3.0 [latest],  2.2.0 []
publish 2.2.0 --make-latest yes  -> 2.2.0 [latest],  2.3.0 []
publish 2.4.0 --make-latest no   -> 2.4.0 [],        2.2.0 [latest]
publish 2.5.0-rc.1 --make-latest yes
  error: only a stable version can be published as the version referenced by 'latest'
  exit 1, catalog unchanged
```

The generated pages carry `"version": {"alias": true, "default": "latest", "provider": "mike"}`
and the site root resolves to `latest/`.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [ ] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
  (not applicable: this changes the documentation publishing pipeline, not how end users operate the tool)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

Two consequences of the self-contained snapshot model:

- Material builds its configuration into each version's pages, so an already published version
  shows the alias marker only after it is republished. Version 2.2.0 needs a republish from a new
  documentation tag.
- Publication runs the script stored in the selected snapshot, so a source revision predating the
  `make_latest` input rejects the request. This fails during request preparation, before any
  published version changes.

Separately, the version selector can lag a publication by up to ten minutes because GitHub Pages
caches the version catalog it fetches. This is documented rather than changed.


[SPOT-32456]: https://exasol.atlassian.net/browse/SPOT-32456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ