### PR TITLE
feat: Publish documentation from documentation branches

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ on:
           - publish
           - delete
       source_ref:
-        description: "Exact tag, e.g. docs/v2.2.0 or docs/0.1; full 40-character SHA also accepted"
+        description: "Tag, docs/ branch, or full 40-character SHA, e.g. v2.2.0 or docs/v2.2.0"
         required: false
         type: string
       version:
@@ -58,19 +58,48 @@ jobs:
         run: |
           set -euo pipefail
           fail() {
-            echo "::error::source_ref must be an exact Git tag or full 40-character commit SHA"
+            echo "::error::$1"
             exit 1
           }
           commit="$(git rev-parse HEAD)"
           if [[ "${SOURCE_REF}" =~ ^[0-9a-fA-F]{40}$ ]]; then
-            [[ "${commit,,}" == "${SOURCE_REF,,}" ]] || fail
+            [[ "${commit,,}" == "${SOURCE_REF,,}" ]] || fail "source_ref must name the checked-out commit"
+            echo "commit=${commit}" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          name="${SOURCE_REF}"
+          kind="any"
+          case "${SOURCE_REF}" in
+            refs/heads/*) name="${SOURCE_REF#refs/heads/}"; kind="branch" ;;
+            refs/tags/*) name="${SOURCE_REF#refs/tags/}"; kind="tag" ;;
+            refs/*) fail "source_ref must be a tag, a branch under docs/, or a full 40-character commit SHA" ;;
+          esac
+
+          branch_head=""
+          tag_object=""
+          if [[ "${kind}" != "tag" ]]; then
+            branch_head="$(git ls-remote --heads origin "refs/heads/${name}" | cut -f1)"
+          fi
+          if [[ "${kind}" != "branch" ]]; then
+            tag_object="$(git ls-remote --tags origin "refs/tags/${name}" | cut -f1)"
+          fi
+
+          if [[ -n "${branch_head}" && -n "${tag_object}" ]]; then
+            fail "'${name}' is both a branch and a tag; qualify source_ref with refs/heads/ or refs/tags/"
+          fi
+
+          if [[ -n "${branch_head}" ]]; then
+            case "${name}" in
+              docs/*) ;;
+              *) fail "a branch source must be a documentation branch under docs/, for example docs/v2.2.0" ;;
+            esac
+            [[ "${branch_head}" == "${commit}" ]] || fail "branch '${name}' moved during the run; rerun the workflow"
+          elif [[ -n "${tag_object}" ]]; then
+            tag_commit="$(git rev-parse --verify --end-of-options "refs/tags/${name}^{commit}")" || fail "tag '${name}' is not available"
+            [[ "${tag_commit}" == "${commit}" ]] || fail "tag '${name}' does not name the checked-out commit"
           else
-            tag="${SOURCE_REF#refs/tags/}"
-            if [[ "${SOURCE_REF}" == refs/* && "${SOURCE_REF}" != refs/tags/* ]]; then
-              fail
-            fi
-            tag_commit="$(git rev-parse --verify --end-of-options "refs/tags/${tag}^{commit}")" || fail
-            [[ "${tag_commit}" == "${commit}" ]] || fail
+            fail "source_ref must be an existing tag, an existing branch under docs/, or a full 40-character commit SHA"
           fi
           echo "commit=${commit}" >> "${GITHUB_OUTPUT}"
 

--- a/doc/ci.md
+++ b/doc/ci.md
@@ -79,16 +79,25 @@ workflow. GitHub Pages must be enabled with **GitHub Actions** as its source, an
 The workflow accepts four inputs:
 
 - `operation`: `publish` or `delete`.
-- `source_ref`: an exact Git tag or full 40-character commit SHA, required for publication.
+- `source_ref`: an existing Git tag, a branch under `docs/`, or a full 40-character commit SHA,
+  required for publication.
 - `version`: the published semantic version. It is required for deletion and optional for
-  publication when `source_ref` is a tag named `v<version>` or ending in `/v<version>`.
+  publication when `source_ref` is named `v<version>` or ends in `/v<version>`.
 - `make_latest`: whether the published version takes the `latest` alias and the site root.
   `auto` grants it when no higher stable version is published, `yes` and `no` decide explicitly.
 
 An explicit version can map historical documentation content to an older release without changing
-an existing release tag. For example, publish a reviewed `docs/v2.2.0` snapshot based on a current
-commit as `2.2.0`, or map its full commit SHA by supplying `2.2.0` explicitly. Branch references
-are not accepted.
+an existing release tag. For example, publish a reviewed snapshot based on a current commit as
+`2.2.0`, or map its full commit SHA by supplying `2.2.0` explicitly.
+
+Documentation for a released version is revised on a branch under `docs/`, such as `docs/v2.2.0`.
+Publishing that branch replaces the version from its current tip, so content and styling can change
+after a release without moving the release tag. Branches outside `docs/` are rejected, which keeps
+publication from being requested against development work. Reserve `docs/` for branches: a name
+that exists as both a branch and a tag is rejected until `source_ref` is qualified with
+`refs/heads/` or `refs/tags/`, and documentation tags sharing the version namespace also interfere
+with release version derivation. Protect the `docs/*` branches with a ruleset, as described in
+[CI security best practices](ci_security_best_practices.md).
 
 Publication shallow-checks out the source once and builds its self-contained `user-docs/` directory,
 including its content, configuration, scripts, and locked uv environment, before updating the

--- a/openspec/changes/archive/2026-09-04-publish-docs-from-branches/design.md
+++ b/openspec/changes/archive/2026-09-04-publish-docs-from-branches/design.md
@@ -1,0 +1,28 @@
+## Source namespace
+
+Revising released documentation needs a source that accumulates commits, which no immutable
+reference provides. Accepting any branch would allow publication from development branches, so
+branches are accepted only under `docs/`. The prefix states the intent of the branch, keeps the
+existing guarantee that publication cannot be requested from ordinary development work, and can be
+widened later without changing published state.
+
+Reserving `docs/` for branches also removes an existing conflict. Release version derivation
+selects the most recent version tag, so a documentation tag sharing the version namespace is
+indistinguishable from a release tag and has to be filtered out explicitly. Branch names never
+participate in that selection.
+
+A source name that exists as both a branch and a tag resolves silently to the branch during
+checkout, which would let an unchanged request publish different content once a branch appears.
+Such a name is therefore rejected, and a fully qualified reference selects one deliberately.
+
+## Validation placement
+
+Source classification stays in the workflow and runs before the selected snapshot supplies any
+executable content, so a rejected source never reaches the publishing environment. Version
+derivation stays in the helper script, where it is covered by the documentation tooling tests.
+
+## Provenance
+
+A branch tip moves, so the published version no longer identifies its source by name alone. The
+resolved commit is recorded in the run summary and in the published version's commit message,
+which keeps every published version traceable to exact content.

--- a/openspec/changes/archive/2026-09-04-publish-docs-from-branches/proposal.md
+++ b/openspec/changes/archive/2026-09-04-publish-docs-from-branches/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Content and styling of documentation for an already released version need to change after that
+release. Publication currently accepts only immutable sources, and a release tag cannot move, so a
+revision has no source to publish from.
+
+## What Changes
+
+- Accept a branch under `docs/` as a documentation source alongside tags and commit SHAs.
+- Reject branches outside that namespace, so publication cannot be requested from a development
+  branch.
+- Derive the published version from a documentation branch ending in `v<semver>`, matching the
+  existing derivation from tags.
+- Reject a source name that exists as both a branch and a tag.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `versioned-documentation-publishing`: Publish from a revisable documentation branch within a
+  reserved namespace.
+
+## Impact
+
+The manual documentation workflow, its helper script and tests, the CI guide, and the versioned
+documentation publishing specification change. No runtime product behavior or additional
+dependency is introduced.

--- a/openspec/changes/archive/2026-09-04-publish-docs-from-branches/specs/versioned-documentation-publishing/spec.md
+++ b/openspec/changes/archive/2026-09-04-publish-docs-from-branches/specs/versioned-documentation-publishing/spec.md
@@ -1,0 +1,76 @@
+## RENAMED Requirements
+
+- FROM: `### Requirement: Maintainers can manually publish documentation from an immutable source revision`
+- TO: `### Requirement: Maintainers can manually publish documentation from a selected source`
+
+## MODIFIED Requirements
+
+### Requirement: Maintainers can manually publish documentation from a selected source
+
+The documentation workflow SHALL allow a maintainer to select an existing Git tag, an existing
+branch whose name begins with `docs/`, or a full 40-character commit SHA as the documentation
+source, and publish it under an independently selected semantic version. When the version is
+omitted, the workflow SHALL derive it from a source name that is `v<semver>` or ends in
+`/v<semver>`.
+
+#### Scenario: Publish a stable version derived from a tag
+
+- **WHEN** a maintainer publishes documentation from a tag such as `v2.3.0` without supplying a
+  version
+- **THEN** version `2.3.0` SHALL be published
+
+#### Scenario: Publish a release-candidate version derived from a namespaced tag
+
+- **WHEN** a maintainer publishes documentation from a tag such as `docs/v2.3.0-rc1` without
+  supplying a version
+- **THEN** version `2.3.0-rc1` SHALL be published
+
+#### Scenario: Publish from a documentation branch
+
+- **WHEN** a maintainer publishes documentation from a branch such as `docs/v2.3.0` without
+  supplying a version
+- **THEN** version `2.3.0` SHALL be published from the current tip of that branch
+
+#### Scenario: Revise a published version from its documentation branch
+
+- **WHEN** a maintainer adds commits to the documentation branch of an already published version
+  and publishes that branch again
+- **THEN** that version SHALL be replaced from the new branch tip while every other published
+  version and the release tag of that version SHALL remain unchanged
+
+#### Scenario: Publish an explicitly mapped version
+
+- **WHEN** a maintainer publishes a source revision and supplies version `2.2.0`
+- **THEN** the selected source content SHALL be published as version `2.2.0` regardless of the
+  source name
+
+#### Scenario: Require an explicit version for an underivable source
+
+- **WHEN** a maintainer publishes a full commit SHA or a source name that does not end in
+  `v<semver>` without supplying a version
+- **THEN** publication SHALL fail before changing any published version and explain that a version
+  is required
+
+#### Scenario: Reject a branch outside the documentation namespace
+
+- **WHEN** a maintainer selects a branch whose name does not begin with `docs/`
+- **THEN** publication SHALL fail before changing any published version and explain that a branch
+  source must be a documentation branch
+
+#### Scenario: Reject an ambiguous source name
+
+- **WHEN** a maintainer selects a source name that exists as both a branch and a tag
+- **THEN** publication SHALL fail before changing any published version and explain that the
+  source must be selected as either a branch or a tag
+
+#### Scenario: Reject an unknown source
+
+- **WHEN** a maintainer selects a source name that is neither an existing tag, an existing branch,
+  nor the checked-out commit
+- **THEN** publication SHALL fail before changing any published version
+
+#### Scenario: Republish one version
+
+- **WHEN** a maintainer publishes a documentation version that already exists
+- **THEN** that version SHALL be replaced from the selected source and every other published
+  version SHALL remain unchanged

--- a/openspec/changes/archive/2026-09-04-publish-docs-from-branches/tasks.md
+++ b/openspec/changes/archive/2026-09-04-publish-docs-from-branches/tasks.md
@@ -1,0 +1,7 @@
+## 1. Accept Documentation Branches
+
+- [x] 1.1 Implement and test source selection for branches within the documentation namespace.
+
+## 2. Document the Contract
+
+- [x] 2.1 Update the CI guide for documentation branch sources.

--- a/openspec/specs/versioned-documentation-publishing/spec.md
+++ b/openspec/specs/versioned-documentation-publishing/spec.md
@@ -76,50 +76,6 @@ catalog.
 - **WHEN** GitHub Pages deployment fails after the version catalog has been updated
 - **THEN** rerunning the same manual operation SHALL deploy the complete stored version catalog
 
-### Requirement: Maintainers can manually publish documentation from an immutable source revision
-
-The documentation workflow SHALL allow a maintainer to select an existing Git tag or full commit
-SHA as the documentation source and publish it under an independently selected semantic version.
-When the version is omitted, the workflow SHALL derive it from a tag named `v<semver>` or ending
-in `/v<semver>`.
-
-#### Scenario: Publish a stable version derived from a tag
-
-- **WHEN** a maintainer publishes documentation from a tag such as `v2.3.0` without supplying a
-  version
-- **THEN** version `2.3.0` SHALL be published
-
-#### Scenario: Publish a release-candidate version derived from a namespaced tag
-
-- **WHEN** a maintainer publishes documentation from a tag such as `docs/v2.3.0-rc1` without
-  supplying a version
-- **THEN** version `2.3.0-rc1` SHALL be published
-
-#### Scenario: Publish an explicitly mapped version
-
-- **WHEN** a maintainer publishes an immutable source revision and supplies version `2.2.0`
-- **THEN** the selected source content SHALL be published as version `2.2.0` regardless of the
-  source tag name
-
-#### Scenario: Require an explicit version for an underivable source
-
-- **WHEN** a maintainer publishes a full commit SHA or a tag that does not end in `v<semver>`
-  without supplying a version
-- **THEN** publication SHALL fail before changing any published version and explain that a version
-  is required
-
-#### Scenario: Reject a mutable source
-
-- **WHEN** a maintainer selects a branch as the documentation source
-- **THEN** publication SHALL fail before changing any published version and explain that only an
-  exact tag or full commit SHA is accepted
-
-#### Scenario: Republish one version
-
-- **WHEN** a maintainer publishes a documentation version that already exists
-- **THEN** that version SHALL be replaced from the selected source and every other published
-  version SHALL remain unchanged
-
 ### Requirement: The latest alias resolves to the highest published stable version
 
 Publication SHALL grant the `latest` alias and the site root to the requested stable version only
@@ -161,4 +117,74 @@ that overrides this comparison, and SHALL reject granting `latest` to a pre-rele
 - **WHEN** a maintainer publishes a pre-release version and requests that it carry `latest`
 - **THEN** publication SHALL fail before changing any published version and explain that only a
   stable version can carry `latest`
+
+### Requirement: Maintainers can manually publish documentation from a selected source
+
+The documentation workflow SHALL allow a maintainer to select an existing Git tag, an existing
+branch whose name begins with `docs/`, or a full 40-character commit SHA as the documentation
+source, and publish it under an independently selected semantic version. When the version is
+omitted, the workflow SHALL derive it from a source name that is `v<semver>` or ends in
+`/v<semver>`.
+
+#### Scenario: Publish a stable version derived from a tag
+
+- **WHEN** a maintainer publishes documentation from a tag such as `v2.3.0` without supplying a
+  version
+- **THEN** version `2.3.0` SHALL be published
+
+#### Scenario: Publish a release-candidate version derived from a namespaced tag
+
+- **WHEN** a maintainer publishes documentation from a tag such as `docs/v2.3.0-rc1` without
+  supplying a version
+- **THEN** version `2.3.0-rc1` SHALL be published
+
+#### Scenario: Publish from a documentation branch
+
+- **WHEN** a maintainer publishes documentation from a branch such as `docs/v2.3.0` without
+  supplying a version
+- **THEN** version `2.3.0` SHALL be published from the current tip of that branch
+
+#### Scenario: Revise a published version from its documentation branch
+
+- **WHEN** a maintainer adds commits to the documentation branch of an already published version
+  and publishes that branch again
+- **THEN** that version SHALL be replaced from the new branch tip while every other published
+  version and the release tag of that version SHALL remain unchanged
+
+#### Scenario: Publish an explicitly mapped version
+
+- **WHEN** a maintainer publishes a source revision and supplies version `2.2.0`
+- **THEN** the selected source content SHALL be published as version `2.2.0` regardless of the
+  source name
+
+#### Scenario: Require an explicit version for an underivable source
+
+- **WHEN** a maintainer publishes a full commit SHA or a source name that does not end in
+  `v<semver>` without supplying a version
+- **THEN** publication SHALL fail before changing any published version and explain that a version
+  is required
+
+#### Scenario: Reject a branch outside the documentation namespace
+
+- **WHEN** a maintainer selects a branch whose name does not begin with `docs/`
+- **THEN** publication SHALL fail before changing any published version and explain that a branch
+  source must be a documentation branch
+
+#### Scenario: Reject an ambiguous source name
+
+- **WHEN** a maintainer selects a source name that exists as both a branch and a tag
+- **THEN** publication SHALL fail before changing any published version and explain that the
+  source must be selected as either a branch or a tag
+
+#### Scenario: Reject an unknown source
+
+- **WHEN** a maintainer selects a source name that is neither an existing tag, an existing branch,
+  nor the checked-out commit
+- **THEN** publication SHALL fail before changing any published version
+
+#### Scenario: Republish one version
+
+- **WHEN** a maintainer publishes a documentation version that already exists
+- **THEN** that version SHALL be replaced from the selected source and every other published
+  version SHALL remain unchanged
 

--- a/user-docs/scripts/versions.py
+++ b/user-docs/scripts/versions.py
@@ -17,14 +17,13 @@ SEMANTIC_VERSION = re.compile(
     r"(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
 )
 FULL_COMMIT = re.compile(r"[0-9a-fA-F]{40}")
-VERSION_TAG = re.compile(r"(?:.*/)?v(?P<version>.+)")
+VERSION_SOURCE = re.compile(r"(?:.*/)?v(?P<version>.+)")
+SOURCE_PREFIXES = ("refs/heads/", "refs/tags/")
 MIKE_BRANCH = "gh-pages"
 MKDOCS_CONFIG = "user-docs/mkdocs.yml"
 LATEST_ALIAS = "latest"
 ALIAS_DECISIONS = ("auto", "yes", "no")
-PUBLISH_VERSION_ERROR = (
-    "version is required when source_ref is not a tag ending in v<semver>"
-)
+PUBLISH_VERSION_ERROR = "version is required when source_ref does not end in v<semver>"
 DELETE_TARGET_ERROR = (
     "delete target must be a published semantic version such as 2.3.0-rc1"
 )
@@ -78,11 +77,13 @@ def resolve_version(source_ref: str, version: str | None) -> str:
         require_version(version)
         return version
 
-    selected_tag = source_ref.removeprefix("refs/tags/")
+    selected = source_ref
+    for prefix in SOURCE_PREFIXES:
+        selected = selected.removeprefix(prefix)
     match = (
         None
         if FULL_COMMIT.fullmatch(source_ref)
-        else VERSION_TAG.fullmatch(selected_tag)
+        else VERSION_SOURCE.fullmatch(selected)
     )
     derived = match.group("version") if match else ""
     if not SEMANTIC_VERSION.fullmatch(derived):

--- a/user-docs/tests/test_versions.py
+++ b/user-docs/tests/test_versions.py
@@ -50,9 +50,12 @@ def test_validate_delete_rejects_invalid_versions(target: str) -> None:
         ("v2.3.0", "2.3.0"),
         ("docs/v2.2.0-rc.1", "2.2.0-rc.1"),
         ("refs/tags/docs/v2.1.0", "2.1.0"),
+        ("docs/v2.4.0", "2.4.0"),
+        ("refs/heads/docs/v2.4.0", "2.4.0"),
+        ("refs/heads/docs/v2.5.0-rc.1", "2.5.0-rc.1"),
     ],
 )
-def test_validate_publish_derives_version_from_conventional_tags(
+def test_validate_publish_derives_version_from_conventional_sources(
     source_ref: str, expected: str
 ) -> None:
     # Given / When
@@ -62,7 +65,9 @@ def test_validate_publish_derives_version_from_conventional_tags(
     assert actual == expected
 
 
-@pytest.mark.parametrize("source_ref", ["a" * 40, "release-2.2.0"])
+@pytest.mark.parametrize(
+    "source_ref", ["a" * 40, "release-2.2.0", "refs/heads/docs/styling"]
+)
 def test_validate_publish_requires_version_when_it_cannot_be_derived(
     source_ref: str,
 ) -> None:


### PR DESCRIPTION
## Description

Documentation content and styling for an already released version need to change after the
release. Publication accepted only immutable sources, and a release tag must not move, so a
revision had no source to publish from.

`source_ref` now also accepts a branch under `docs/`. Publishing such a branch replaces the
version from its current tip, leaving the release tag untouched.

## Related Issue

[SPOT-32456](https://exasol.atlassian.net/browse/SPOT-32456)

## Type of Change

- [x] `feat`: New feature
- [x] `docs`: Documentation update

## Changes Made

- Accept an existing branch under `docs/` as a documentation source, alongside tags and full
  commit SHAs.
- Reject branches outside `docs/`, so publication cannot be requested against development work.
- Derive the published version from a branch ending in `v<semver>`, matching tag derivation.
- Reject a source name that exists as both a branch and a tag until it is qualified with
  `refs/heads/` or `refs/tags/`.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

`task docs-check` and `task lint` pass. Version derivation from branch references is covered by
the documentation tooling tests.

Source classification lives in the workflow, so it was verified by extracting the step's script
from `docs.yml` and running it against a fixture repository containing an annotated tag, a
lightweight tag, documentation branches, a development branch, and a deliberate branch/tag
collision:

```
docs/v8.8.0              (branch only)      -> publishes
refs/heads/docs/v8.8.0   (qualified)        -> publishes
docs/v9.9.0              (annotated tag)    -> publishes
v9.9.0                   (lightweight tag)  -> publishes
refs/tags/docs/v9.9.0    (qualified)        -> publishes
<full SHA of HEAD>                          -> publishes

feature/x                (branch)  -> a branch source must be a documentation branch under docs/
refs/heads/feature/x               -> a branch source must be a documentation branch under docs/
docs/v7.7.0    (branch AND tag)    -> is both a branch and a tag; qualify source_ref
refs/heads/docs/v7.7.0             -> publishes the branch
nope/missing                       -> must be an existing tag, an existing branch under docs/, ...
refs/remotes/origin/x              -> must be a tag, a branch under docs/, or a full SHA
<mismatched SHA>                   -> must name the checked-out commit
```

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [ ] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
  (not applicable: this changes the documentation publishing pipeline, not how end users operate the tool)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

`actions/checkout` resolves a bare name to a branch in preference to a same-named tag, so without
the ambiguity guard an unchanged request would silently publish different content once a matching
branch appeared. Nothing changes today: with only the `docs/v2.2.0` tag present, the bare name
still resolves to that tag.

Reserving `docs/` for branches also removes an existing conflict. Release version derivation picks
the most recent version tag, which is why `git describe` needs `--match 'v*'` to skip
`docs/v2.2.0`. Branch names never take part in that selection.

After merging:

- Delete the `docs/v2.2.0` tag before creating a `docs/v2.2.0` branch.
- Protect `docs/*` with a ruleset, as the CI guide now states.
- Republish 2.2.0 from its documentation branch so it picks up the `latest` marker added in #342.


[SPOT-32456]: https://exasol.atlassian.net/browse/SPOT-32456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ