### PR TITLE
feat: Publish documentation release lines from release branches

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,11 +12,11 @@ on:
           - publish
           - delete
       source_ref:
-        description: "Tag, docs/ branch, or full 40-character SHA, e.g. v2.2.0 or docs/v2.2.0"
+        description: "Tag, release/ branch, or full 40-character SHA, e.g. v2.2.0 or release/v2.2"
         required: false
         type: string
       version:
-        description: "SemVer without v, e.g. 2.2.0; required for delete and optional for v-tags"
+        description: "Release line or full version without v, e.g. 2.2; required for delete"
         required: false
         type: string
       make_latest:
@@ -73,7 +73,7 @@ jobs:
           case "${SOURCE_REF}" in
             refs/heads/*) name="${SOURCE_REF#refs/heads/}"; kind="branch" ;;
             refs/tags/*) name="${SOURCE_REF#refs/tags/}"; kind="tag" ;;
-            refs/*) fail "source_ref must be a tag, a branch under docs/, or a full 40-character commit SHA" ;;
+            refs/*) fail "source_ref must be a tag, a branch under release/, or a full 40-character commit SHA" ;;
           esac
 
           branch_head=""
@@ -91,15 +91,15 @@ jobs:
 
           if [[ -n "${branch_head}" ]]; then
             case "${name}" in
-              docs/*) ;;
-              *) fail "a branch source must be a documentation branch under docs/, for example docs/v2.2.0" ;;
+              release/*) ;;
+              *) fail "a branch source must be a release branch under release/, for example release/v2.2" ;;
             esac
             [[ "${branch_head}" == "${commit}" ]] || fail "branch '${name}' moved during the run; rerun the workflow"
           elif [[ -n "${tag_object}" ]]; then
             tag_commit="$(git rev-parse --verify --end-of-options "refs/tags/${name}^{commit}")" || fail "tag '${name}' is not available"
             [[ "${tag_commit}" == "${commit}" ]] || fail "tag '${name}' does not name the checked-out commit"
           else
-            fail "source_ref must be an existing tag, an existing branch under docs/, or a full 40-character commit SHA"
+            fail "source_ref must be an existing tag, an existing branch under release/, or a full 40-character commit SHA"
           fi
           echo "commit=${commit}" >> "${GITHUB_OUTPUT}"
 

--- a/doc/ci.md
+++ b/doc/ci.md
@@ -79,25 +79,29 @@ workflow. GitHub Pages must be enabled with **GitHub Actions** as its source, an
 The workflow accepts four inputs:
 
 - `operation`: `publish` or `delete`.
-- `source_ref`: an existing Git tag, a branch under `docs/`, or a full 40-character commit SHA,
+- `source_ref`: an existing Git tag, a branch under `release/`, or a full 40-character commit SHA,
   required for publication.
-- `version`: the published semantic version. It is required for deletion and optional for
-  publication when `source_ref` is named `v<version>` or ends in `/v<version>`.
+- `version`: the published documentation version, either a release line such as `2.2` or a full
+  version such as `2.2.0-rc1`. It is required for deletion and optional for publication when
+  `source_ref` is named `v<version>` or ends in `/v<version>`.
 - `make_latest`: whether the published version takes the `latest` alias and the site root.
   `auto` grants it when no higher stable version is published, `yes` and `no` decide explicitly.
 
-An explicit version can map historical documentation content to an older release without changing
-an existing release tag. For example, publish a reviewed snapshot based on a current commit as
-`2.2.0`, or map its full commit SHA by supplying `2.2.0` explicitly.
+An explicit version can map historical documentation content to an older release line without
+changing an existing release tag. For example, publish a reviewed snapshot based on a current commit
+as `2.1`, or map its full commit SHA by supplying `2.1` explicitly.
 
-Documentation for a released version is revised on a branch under `docs/`, such as `docs/v2.2.0`.
-Publishing that branch replaces the version from its current tip, so content and styling can change
-after a release without moving the release tag. Branches outside `docs/` are rejected, which keeps
-publication from being requested against development work. Reserve `docs/` for branches: a name
-that exists as both a branch and a tag is rejected until `source_ref` is qualified with
-`refs/heads/` or `refs/tags/`, and documentation tags sharing the version namespace also interfere
-with release version derivation. Protect the `docs/*` branches with a ruleset, as described in
+Documentation is published per release line from that line's release branch, such as `release/v2.2`
+published as version `2.2`. Publishing the branch again replaces the line from its current tip, so
+content and styling can change after a release without moving any release tag, and a patch can be
+reviewed together with the documentation it changes. Branches outside `release/` are rejected, which
+keeps publication from being requested against development work. A name that exists as both a branch
+and a tag is rejected until `source_ref` is qualified with `refs/heads/` or `refs/tags/`. Protect the
+`release/*` branches with a ruleset, as described in
 [CI security best practices](ci_security_best_practices.md).
+
+Documentation for a line that is not released yet is published with `make_latest` set to `no`, and
+takes the alias on a later publication once the release is out.
 
 Publication shallow-checks out the source once and builds its self-contained `user-docs/` directory,
 including its content, configuration, scripts, and locked uv environment, before updating the

--- a/openspec/changes/archive/2026-09-04-publish-docs-from-release-branches/design.md
+++ b/openspec/changes/archive/2026-09-04-publish-docs-from-release-branches/design.md
@@ -1,0 +1,24 @@
+## Source namespace
+
+A release line already needs a branch to carry patches once the default branch has moved on. A
+separate documentation branch for the same line duplicates that role, keeps documentation away
+from the behavior it describes, and prevents reviewing a patch together with its documentation.
+Branch sources are therefore accepted under `release/` and nowhere else, which keeps publication
+from being requested against ordinary development work.
+
+Release publication selects a tag and never inspects a branch, so a release branch changes no
+release automation. Which commits reach a release branch is a release-process decision and is not
+settled here.
+
+## Version granularity
+
+A release branch covers a line rather than a single release, so its name yields a version such as
+`2.2`. Publishing per line also matches what readers select: consecutive patch versions differ
+little, and listing each one makes the version selector harder to use. Full versions stay valid,
+because mapping historical content to an exact version is still useful and pre-release
+documentation still needs its own entry.
+
+Ordering compares release components after padding a line to a full version, so `2.2` and `2.2.0`
+occupy one position and cannot both claim to be the higher version. Documentation for a line that
+is not released yet is published without the alias, which the explicit alias decision already
+covers.

--- a/openspec/changes/archive/2026-09-04-publish-docs-from-release-branches/proposal.md
+++ b/openspec/changes/archive/2026-09-04-publish-docs-from-release-branches/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Documentation branches and release branches describe the same release line. Maintaining both
+splits a line across two branches, so a patch and the documentation it changes cannot be reviewed
+together and can disagree. A release line also covers every patch it carries, which a version
+published per patch cannot express without listing near-identical entries.
+
+## What Changes
+
+- Accept a branch under `release/` as a documentation source, replacing the documentation branch
+  namespace.
+- Accept a release line such as `2.2` as a published documentation version alongside full
+  versions.
+- Order the `latest` alias by release line, treating a line and its first patch as the same
+  position.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `versioned-documentation-publishing`: Publish a release line from its release branch.
+
+## Impact
+
+The manual documentation workflow, its helper script and tests, the CI guide, and the versioned
+documentation publishing specification change. Publishing requires a release branch for the line
+being documented. No runtime product behavior or additional dependency is introduced.

--- a/openspec/changes/archive/2026-09-04-publish-docs-from-release-branches/specs/versioned-documentation-publishing/spec.md
+++ b/openspec/changes/archive/2026-09-04-publish-docs-from-release-branches/specs/versioned-documentation-publishing/spec.md
@@ -1,0 +1,138 @@
+## MODIFIED Requirements
+
+### Requirement: Maintainers can manually publish documentation from a selected source
+
+The documentation workflow SHALL allow a maintainer to select an existing Git tag, an existing
+branch whose name begins with `release/`, or a full 40-character commit SHA as the documentation
+source, and publish it under an independently selected documentation version. A documentation
+version SHALL be a release line such as `2.2` or a full version such as `2.2.0-rc1`. When the
+version is omitted, the workflow SHALL derive it from a source name that is `v<version>` or ends
+in `/v<version>`.
+
+#### Scenario: Publish a release line from its release branch
+
+- **WHEN** a maintainer publishes documentation from a branch such as `release/v2.3` without
+  supplying a version
+- **THEN** version `2.3` SHALL be published from the current tip of that branch
+
+#### Scenario: Revise a published release line
+
+- **WHEN** a maintainer adds commits to the release branch of an already published release line
+  and publishes that branch again
+- **THEN** that version SHALL be replaced from the new branch tip while every other published
+  version and every release tag SHALL remain unchanged
+
+#### Scenario: Publish a full version derived from a tag
+
+- **WHEN** a maintainer publishes documentation from a tag such as `v2.3.0` without supplying a
+  version
+- **THEN** version `2.3.0` SHALL be published
+
+#### Scenario: Publish a release-candidate version derived from a namespaced tag
+
+- **WHEN** a maintainer publishes documentation from a tag such as `docs/v2.3.0-rc1` without
+  supplying a version
+- **THEN** version `2.3.0-rc1` SHALL be published
+
+#### Scenario: Publish an explicitly mapped version
+
+- **WHEN** a maintainer publishes a source revision and supplies version `2.2`
+- **THEN** the selected source content SHALL be published as version `2.2` regardless of the
+  source name
+
+#### Scenario: Require an explicit version for an underivable source
+
+- **WHEN** a maintainer publishes a full commit SHA or a source name that does not end in
+  `v<version>` without supplying a version
+- **THEN** publication SHALL fail before changing any published version and explain that a version
+  is required
+
+#### Scenario: Reject a branch outside the release namespace
+
+- **WHEN** a maintainer selects a branch whose name does not begin with `release/`
+- **THEN** publication SHALL fail before changing any published version and explain that a branch
+  source must be a release branch
+
+#### Scenario: Reject an ambiguous source name
+
+- **WHEN** a maintainer selects a source name that exists as both a branch and a tag
+- **THEN** publication SHALL fail before changing any published version and explain that the
+  source must be selected as either a branch or a tag
+
+#### Scenario: Reject an unknown source
+
+- **WHEN** a maintainer selects a source name that is neither an existing tag, an existing branch,
+  nor the checked-out commit
+- **THEN** publication SHALL fail before changing any published version
+
+#### Scenario: Republish one version
+
+- **WHEN** a maintainer publishes a documentation version that already exists
+- **THEN** that version SHALL be replaced from the selected source and every other published
+  version SHALL remain unchanged
+
+### Requirement: The latest alias resolves to the highest published stable version
+
+Publication SHALL grant the `latest` alias and the site root to the requested stable version only
+when no higher stable version is published. A release line and its first patch version SHALL
+compare as the same position. A publication SHALL accept an explicit alias decision that overrides
+this comparison, and SHALL reject granting `latest` to a pre-release version.
+
+#### Scenario: Publish the highest stable version
+
+- **WHEN** a maintainer publishes stable version `2.3` while `2.2` is the highest published stable
+  version
+- **THEN** `latest` and the site root SHALL resolve to `2.3`
+
+#### Scenario: Publish documentation for an older release line
+
+- **WHEN** a maintainer publishes stable version `2.1` while `2.2` is the highest published stable
+  version
+- **THEN** `2.1` SHALL be published and `latest` and the site root SHALL continue to resolve to
+  `2.2`
+
+#### Scenario: Replace a full version with its release line
+
+- **WHEN** a maintainer publishes release line `2.2` while full version `2.2.0` is the highest
+  published stable version
+- **THEN** `latest` and the site root SHALL resolve to `2.2`
+
+#### Scenario: Publish a pre-release version
+
+- **WHEN** a maintainer publishes a pre-release version
+- **THEN** that version SHALL be published and `latest` and the site root SHALL remain unchanged
+
+#### Scenario: Force the alias onto a published version
+
+- **WHEN** a maintainer publishes a stable version and requests that it carry `latest`
+- **THEN** `latest` and the site root SHALL resolve to that version regardless of the published
+  version order
+
+#### Scenario: Withhold the alias from the highest stable version
+
+- **WHEN** a maintainer publishes the highest stable version and requests that it not carry
+  `latest`
+- **THEN** that version SHALL be published and `latest` and the site root SHALL remain unchanged
+
+#### Scenario: Reject forcing the alias onto a pre-release
+
+- **WHEN** a maintainer publishes a pre-release version and requests that it carry `latest`
+- **THEN** publication SHALL fail before changing any published version and explain that only a
+  stable version can carry `latest`
+
+### Requirement: Maintainers can manually delete one published version
+
+The documentation workflow SHALL allow a maintainer to select and delete one published
+documentation version while retaining the remaining versions and a valid stable default.
+
+#### Scenario: Delete a non-default version
+
+- **WHEN** a maintainer deletes a published version that does not carry the `latest` alias
+- **THEN** that version SHALL be removed and every other version, `latest`, and the site root SHALL
+  remain unchanged
+
+#### Scenario: Reject deletion of the current stable default
+
+- **WHEN** a maintainer selects the version that currently carries the `latest` alias for deletion
+- **THEN** publication SHALL fail before changing the published site and explain that a newer
+  stable version must be published first

--- a/openspec/changes/archive/2026-09-04-publish-docs-from-release-branches/tasks.md
+++ b/openspec/changes/archive/2026-09-04-publish-docs-from-release-branches/tasks.md
@@ -1,0 +1,7 @@
+## 1. Publish Release Lines
+
+- [x] 1.1 Implement and test release line versions and release branch sources.
+
+## 2. Document the Contract
+
+- [x] 2.1 Update the CI guide for release branch sources and release line versions.

--- a/openspec/specs/versioned-documentation-publishing/spec.md
+++ b/openspec/specs/versioned-documentation-publishing/spec.md
@@ -7,8 +7,8 @@ documentation through GitHub Pages.
 ## Requirements
 ### Requirement: Maintainers can manually delete one published version
 
-The documentation workflow SHALL allow a maintainer to select and delete one published version
-while retaining the remaining versions and a valid stable default.
+The documentation workflow SHALL allow a maintainer to select and delete one published
+documentation version while retaining the remaining versions and a valid stable default.
 
 #### Scenario: Delete a non-default version
 
@@ -79,21 +79,28 @@ catalog.
 ### Requirement: The latest alias resolves to the highest published stable version
 
 Publication SHALL grant the `latest` alias and the site root to the requested stable version only
-when no higher stable version is published. A publication SHALL accept an explicit alias decision
-that overrides this comparison, and SHALL reject granting `latest` to a pre-release version.
+when no higher stable version is published. A release line and its first patch version SHALL
+compare as the same position. A publication SHALL accept an explicit alias decision that overrides
+this comparison, and SHALL reject granting `latest` to a pre-release version.
 
 #### Scenario: Publish the highest stable version
 
-- **WHEN** a maintainer publishes stable version `2.3.0` while `2.2.0` is the highest published
-  stable version
-- **THEN** `latest` and the site root SHALL resolve to `2.3.0`
+- **WHEN** a maintainer publishes stable version `2.3` while `2.2` is the highest published stable
+  version
+- **THEN** `latest` and the site root SHALL resolve to `2.3`
 
-#### Scenario: Publish documentation for an older release
+#### Scenario: Publish documentation for an older release line
 
-- **WHEN** a maintainer publishes stable version `2.1.1` while `2.2.0` is the highest published
-  stable version
-- **THEN** `2.1.1` SHALL be published and `latest` and the site root SHALL continue to resolve to
-  `2.2.0`
+- **WHEN** a maintainer publishes stable version `2.1` while `2.2` is the highest published stable
+  version
+- **THEN** `2.1` SHALL be published and `latest` and the site root SHALL continue to resolve to
+  `2.2`
+
+#### Scenario: Replace a full version with its release line
+
+- **WHEN** a maintainer publishes release line `2.2` while full version `2.2.0` is the highest
+  published stable version
+- **THEN** `latest` and the site root SHALL resolve to `2.2`
 
 #### Scenario: Publish a pre-release version
 
@@ -121,12 +128,26 @@ that overrides this comparison, and SHALL reject granting `latest` to a pre-rele
 ### Requirement: Maintainers can manually publish documentation from a selected source
 
 The documentation workflow SHALL allow a maintainer to select an existing Git tag, an existing
-branch whose name begins with `docs/`, or a full 40-character commit SHA as the documentation
-source, and publish it under an independently selected semantic version. When the version is
-omitted, the workflow SHALL derive it from a source name that is `v<semver>` or ends in
-`/v<semver>`.
+branch whose name begins with `release/`, or a full 40-character commit SHA as the documentation
+source, and publish it under an independently selected documentation version. A documentation
+version SHALL be a release line such as `2.2` or a full version such as `2.2.0-rc1`. When the
+version is omitted, the workflow SHALL derive it from a source name that is `v<version>` or ends
+in `/v<version>`.
 
-#### Scenario: Publish a stable version derived from a tag
+#### Scenario: Publish a release line from its release branch
+
+- **WHEN** a maintainer publishes documentation from a branch such as `release/v2.3` without
+  supplying a version
+- **THEN** version `2.3` SHALL be published from the current tip of that branch
+
+#### Scenario: Revise a published release line
+
+- **WHEN** a maintainer adds commits to the release branch of an already published release line
+  and publishes that branch again
+- **THEN** that version SHALL be replaced from the new branch tip while every other published
+  version and every release tag SHALL remain unchanged
+
+#### Scenario: Publish a full version derived from a tag
 
 - **WHEN** a maintainer publishes documentation from a tag such as `v2.3.0` without supplying a
   version
@@ -138,37 +159,24 @@ omitted, the workflow SHALL derive it from a source name that is `v<semver>` or 
   supplying a version
 - **THEN** version `2.3.0-rc1` SHALL be published
 
-#### Scenario: Publish from a documentation branch
-
-- **WHEN** a maintainer publishes documentation from a branch such as `docs/v2.3.0` without
-  supplying a version
-- **THEN** version `2.3.0` SHALL be published from the current tip of that branch
-
-#### Scenario: Revise a published version from its documentation branch
-
-- **WHEN** a maintainer adds commits to the documentation branch of an already published version
-  and publishes that branch again
-- **THEN** that version SHALL be replaced from the new branch tip while every other published
-  version and the release tag of that version SHALL remain unchanged
-
 #### Scenario: Publish an explicitly mapped version
 
-- **WHEN** a maintainer publishes a source revision and supplies version `2.2.0`
-- **THEN** the selected source content SHALL be published as version `2.2.0` regardless of the
+- **WHEN** a maintainer publishes a source revision and supplies version `2.2`
+- **THEN** the selected source content SHALL be published as version `2.2` regardless of the
   source name
 
 #### Scenario: Require an explicit version for an underivable source
 
 - **WHEN** a maintainer publishes a full commit SHA or a source name that does not end in
-  `v<semver>` without supplying a version
+  `v<version>` without supplying a version
 - **THEN** publication SHALL fail before changing any published version and explain that a version
   is required
 
-#### Scenario: Reject a branch outside the documentation namespace
+#### Scenario: Reject a branch outside the release namespace
 
-- **WHEN** a maintainer selects a branch whose name does not begin with `docs/`
+- **WHEN** a maintainer selects a branch whose name does not begin with `release/`
 - **THEN** publication SHALL fail before changing any published version and explain that a branch
-  source must be a documentation branch
+  source must be a release branch
 
 #### Scenario: Reject an ambiguous source name
 

--- a/user-docs/scripts/versions.py
+++ b/user-docs/scripts/versions.py
@@ -8,14 +8,15 @@ import re
 import subprocess
 import sys
 
-SEMANTIC_VERSION = re.compile(
+DOCUMENTATION_VERSION = re.compile(
     r"^(0|[1-9][0-9]*)\."
-    r"(0|[1-9][0-9]*)\."
     r"(0|[1-9][0-9]*)"
+    r"(?:\.(0|[1-9][0-9]*))?"
     r"(?:-((?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)"
     r"(?:\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?"
     r"(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
 )
+RELEASE_COMPONENTS = 3
 FULL_COMMIT = re.compile(r"[0-9a-fA-F]{40}")
 VERSION_SOURCE = re.compile(r"(?:.*/)?v(?P<version>.+)")
 SOURCE_PREFIXES = ("refs/heads/", "refs/tags/")
@@ -23,14 +24,16 @@ MIKE_BRANCH = "gh-pages"
 MKDOCS_CONFIG = "user-docs/mkdocs.yml"
 LATEST_ALIAS = "latest"
 ALIAS_DECISIONS = ("auto", "yes", "no")
-PUBLISH_VERSION_ERROR = "version is required when source_ref does not end in v<semver>"
+PUBLISH_VERSION_ERROR = "version is required when source_ref does not end in v<version>"
 DELETE_TARGET_ERROR = (
-    "delete target must be a published semantic version such as 2.3.0-rc1"
+    "delete target must be a published documentation version such as 2.3 or 2.3.0-rc1"
 )
 DELETE_LATEST_ERROR = (
     "publish a newer stable version before deleting the version referenced by 'latest'"
 )
-VERSION_ERROR = "version must use semantic-version syntax such as 2.3.0 or 2.3.0-rc1"
+VERSION_ERROR = (
+    "version must be a release line such as 2.3 or a full version such as 2.3.0-rc1"
+)
 PRERELEASE_LATEST_ERROR = (
     "only a stable version can be published as the version referenced by 'latest'"
 )
@@ -58,7 +61,7 @@ def mike(
 
 
 def validate_delete(target: str) -> str:
-    if not SEMANTIC_VERSION.fullmatch(target):
+    if not DOCUMENTATION_VERSION.fullmatch(target):
         raise VersionError(DELETE_TARGET_ERROR)
     return target
 
@@ -86,7 +89,7 @@ def resolve_version(source_ref: str, version: str | None) -> str:
         else VERSION_SOURCE.fullmatch(selected)
     )
     derived = match.group("version") if match else ""
-    if not SEMANTIC_VERSION.fullmatch(derived):
+    if not DOCUMENTATION_VERSION.fullmatch(derived):
         raise VersionError(PUBLISH_VERSION_ERROR)
     return derived
 
@@ -96,7 +99,7 @@ def is_stable(version: str) -> bool:
 
 
 def require_version(version: str) -> None:
-    if not SEMANTIC_VERSION.fullmatch(version):
+    if not DOCUMENTATION_VERSION.fullmatch(version):
         raise VersionError(VERSION_ERROR)
 
 
@@ -106,7 +109,8 @@ def catalog() -> list[dict[str, object]]:
 
 
 def precedence(version: str) -> tuple[int, ...]:
-    return tuple(int(part) for part in version.partition("+")[0].split("."))
+    release = [int(part) for part in version.partition("+")[0].split(".")]
+    return tuple(release + [0] * (RELEASE_COMPONENTS - len(release)))
 
 
 def is_highest_stable(version: str) -> bool:
@@ -114,7 +118,7 @@ def is_highest_stable(version: str) -> bool:
     return all(
         precedence(other) <= precedence(version)
         for other in published
-        if SEMANTIC_VERSION.fullmatch(other) and is_stable(other)
+        if DOCUMENTATION_VERSION.fullmatch(other) and is_stable(other)
     )
 
 

--- a/user-docs/tests/test_versions.py
+++ b/user-docs/tests/test_versions.py
@@ -13,6 +13,7 @@ from scripts import versions
     "target",
     [
         "1.2.3",
+        "1.2",
         "1.2.3-alpha--1",
         "1.2.3--",
         "1.2.3+001.build",
@@ -30,6 +31,8 @@ def test_validate_delete_accepts_semantic_versions(target: str) -> None:
     "target",
     [
         "v1.2.3",
+        "1",
+        "1.2.3.4",
         "01.2.3",
         "1.02.3",
         "1.2.03",
@@ -50,9 +53,9 @@ def test_validate_delete_rejects_invalid_versions(target: str) -> None:
         ("v2.3.0", "2.3.0"),
         ("docs/v2.2.0-rc.1", "2.2.0-rc.1"),
         ("refs/tags/docs/v2.1.0", "2.1.0"),
-        ("docs/v2.4.0", "2.4.0"),
-        ("refs/heads/docs/v2.4.0", "2.4.0"),
-        ("refs/heads/docs/v2.5.0-rc.1", "2.5.0-rc.1"),
+        ("release/v2.4", "2.4"),
+        ("refs/heads/release/v2.4", "2.4"),
+        ("refs/heads/release/v2.5.0-rc.1", "2.5.0-rc.1"),
     ],
 )
 def test_validate_publish_derives_version_from_conventional_sources(
@@ -66,7 +69,7 @@ def test_validate_publish_derives_version_from_conventional_sources(
 
 
 @pytest.mark.parametrize(
-    "source_ref", ["a" * 40, "release-2.2.0", "refs/heads/docs/styling"]
+    "source_ref", ["a" * 40, "release-2.2.0", "refs/heads/release/styling"]
 )
 def test_validate_publish_requires_version_when_it_cannot_be_derived(
     source_ref: str,
@@ -86,7 +89,7 @@ def test_validate_publish_prefers_explicit_version() -> None:
 
 def test_validate_publish_rejects_invalid_explicit_version() -> None:
     # Given / When / Then
-    with pytest.raises(versions.VersionError, match="semantic-version syntax"):
+    with pytest.raises(versions.VersionError, match="must be a release line"):
         versions.validate_publish("v2.2.0", "release-2.2")
 
 
@@ -115,6 +118,66 @@ def test_validate_publish_rejects_forcing_latest_onto_a_prerelease() -> None:
     # Given / When / Then
     with pytest.raises(versions.VersionError, match="only a stable version"):
         versions.validate_publish("docs/v2.3.0-rc.1", None, "yes")
+
+
+def test_publish_release_line_supersedes_its_full_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Given
+    calls: list[tuple[str, ...]] = []
+    catalog = [{"version": "2.2.0", "aliases": ["latest"]}]
+    monkeypatch.setattr(versions, "mike", mike_with_versions(catalog, calls))
+
+    # When
+    versions.publish("2.2")
+
+    # Then
+    assert calls == [LIST, deploy("--update-aliases", "2.2", "latest"), SET_DEFAULT]
+
+
+def test_publish_release_line_preserves_a_higher_line(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Given
+    calls: list[tuple[str, ...]] = []
+    catalog = [{"version": "2.3", "aliases": ["latest"]}]
+    monkeypatch.setattr(versions, "mike", mike_with_versions(catalog, calls))
+
+    # When
+    versions.publish("2.2")
+
+    # Then
+    assert calls == [LIST, deploy("2.2")]
+
+
+def test_publish_higher_release_line_updates_latest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Given
+    calls: list[tuple[str, ...]] = []
+    catalog = [{"version": "2.2", "aliases": ["latest"]}]
+    monkeypatch.setattr(versions, "mike", mike_with_versions(catalog, calls))
+
+    # When
+    versions.publish("2.3")
+
+    # Then
+    assert calls == [LIST, deploy("--update-aliases", "2.3", "latest"), SET_DEFAULT]
+
+
+def test_publish_patch_does_not_supersede_its_release_line(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Given
+    calls: list[tuple[str, ...]] = []
+    catalog = [{"version": "2.3", "aliases": ["latest"]}]
+    monkeypatch.setattr(versions, "mike", mike_with_versions(catalog, calls))
+
+    # When
+    versions.publish("2.3.1")
+
+    # Then
+    assert calls == [LIST, deploy("--update-aliases", "2.3.1", "latest"), SET_DEFAULT]
 
 
 def test_publish_highest_stable_version_updates_latest(


### PR DESCRIPTION
## Description

Documentation branches and release branches describe the same release line. Keeping both splits a
line across two branches, so a patch and the documentation it changes cannot be reviewed together.
A release line also covers every patch it carries, which a version published per patch cannot
express without listing near-identical entries.

Branch sources move from `docs/` to `release/`, and a documentation version may now be a release
line such as `2.2` alongside full versions such as `2.2.0-rc1`.

## Related Issue

[SPOT-32456](https://exasol.atlassian.net/browse/SPOT-32456)

## Type of Change

- [x] `feat`: New feature
- [x] `docs`: Documentation update

## Changes Made

- Accept a branch under `release/` as a documentation source, replacing the `docs/` namespace.
- Accept a release line such as `2.2` as a documentation version alongside full versions.
- Order the `latest` alias by release line, treating a line and its first patch as one position.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

`task docs-check` and `task lint` pass, with 41 documentation tooling tests covering release line
versions, alias ordering across granularities, and derivation from release branches.

The publication script was exercised against a real `mike` catalog, following the migration from
the currently published `2.2.0`:

```
publish 2.2.0                  -> 2.2.0 [latest]
publish 2.2                    -> 2.2 [latest],  2.2.0 []
delete 2.2.0                   -> 2.2 [latest]
publish 2.3 --make-latest no   -> 2.3 [],        2.2 [latest]
publish 2.3                    -> 2.3 [latest],  2.2 []
publish 2.1                    -> 2.3 [latest],  2.2 [],  2.1 []
```

Source classification lives in the workflow, so it was verified by extracting that step's script
from `docs.yml` and running it against a fixture repository:

```
release/v2.2              (branch)        -> publishes
refs/heads/release/v2.3   (qualified)     -> publishes
v2.2.0                    (annotated tag) -> publishes
docs/v9.9.0               (tag)           -> publishes

docs/v2.2.0    (branch) -> a branch source must be a release branch under release/
```

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [ ] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
  (not applicable: this changes the documentation publishing pipeline, not how end users operate the tool)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

Release publication selects a tag and never inspects a branch, so release branches need no change
to `release.yml`. Which commits reach a release branch is a release-process decision and is not
settled here; `doc/release.md` still describes tagging from the default branch.

After merging:

- Create `release/v2.2` and delete the `docs/v2.2.0` branch.
- Publish `release/v2.2`, then delete the published `2.2.0`. That order matters: `2.2` takes the
  alias first, so deleting `2.2.0` is no longer blocked by the current-default guard.
- Protect `release/*` with a ruleset.


[SPOT-32456]: https://exasol.atlassian.net/browse/SPOT-32456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ