### PR TITLE
docs: Align changelog and release process with release line publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,6 @@ Notable user-facing changes to Exasol Personal are documented here.
 
 ### Changed
 
-- Documentation publication now selects an immutable Git tag or full commit SHA independently
-  from the published version. Conventional version tags still derive the version automatically,
-  while an explicit version supports publishing reviewed documentation snapshots for older
-  releases without changing their release tags.
-
 - Custom SLC language identifiers are no longer limited to Python, Java, and R. The launcher now
   accepts any valid client-defined identifier, such as `rust`, for a custom SLC.
 

--- a/doc/release.md
+++ b/doc/release.md
@@ -20,6 +20,21 @@ Release safety gates:
 
 Tag governance controls (for example restricting who can create `v*` tags and what refs are allowed) are enforced through repository rulesets/settings.
 
+## Release Lines
+
+Each minor version has a release line branch named `release/v<major>.<minor>`, created from that
+line's first stable release tag. The line carries the user documentation published for that
+version, so content and styling can be corrected after the release without moving a release tag,
+and a fix can be reviewed together with the documentation it changes. Publishing documentation
+from a release line is described in the [CI guide](ci.md#documentation-publication-docsyml).
+
+Tagging is unchanged on a release line: the release workflow checks out the tag it is given and
+does not inspect branches, so a patch is tagged on its release branch exactly as a release is
+tagged on the default branch. Protect `release/*` with a ruleset, as described in
+[CI security best practices](ci_security_best_practices.md).
+
+Which changes reach a release line is decided per line and is not automated.
+
 ## Creating a Release
 
 Before tagging a release, ensure deployment directory compatibility constraints are up to date:
@@ -115,5 +130,6 @@ Before creating a stable release:
 - [ ] Changelog is finalized for this version and committed before the tag
 - [ ] Documentation is up to date
 - [ ] Version number follows semantic versioning
-- [ ] All changes merged to main branch
+- [ ] All changes merged to main branch, or to the release line for a patch release
 - [ ] Tag created with proper version format (`v1.2.3`)
+- [ ] Release line branch exists for the version, and its published documentation is current


### PR DESCRIPTION
## Description

Two corrections that follow from publishing documentation per release line.

The changelog carried an entry about how documentation publication selects its source. That is
development tooling and does not change how anyone operates the tool, so it does not belong in the
user-facing changelog. The release process, meanwhile, still described tagging only from the
default branch, although documentation for a released version is now maintained on that version's
release line.

## Related Issue

[SPOT-32456](https://exasol.atlassian.net/browse/SPOT-32456)

## Type of Change

- [x] `docs`: Documentation update

## Changes Made

- Remove the documentation publication entry from the changelog.
- Describe release line branches in the release process, including that tagging is unchanged on
  them.
- Extend the release checklist for patch releases tagged on a release line.

## Testing

- [x] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

`task docs-check` and `task lint` pass. Documentation only, so there is no behavior to test. The
cross-reference added to `doc/release.md` was checked against the generated anchor of the target
heading in `doc/ci.md`.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [ ] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
  (not applicable: this removes a non-user-facing entry and documents an internal process)
- [ ] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

Which changes reach a release line is stated as a per-line decision rather than a defined policy.
That policy is a maintainer decision and is deliberately not invented here; it is worth settling
before the first patch release is cut from a release line.


[SPOT-32456]: https://exasol.atlassian.net/browse/SPOT-32456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ