### PR TITLE
docs: Add troubleshooting entry for TLS security policy error in virtual schema guide

### DIFF
--- a/doc/virtual_schemas.md
+++ b/doc/virtual_schemas.md
@@ -307,3 +307,8 @@ and that the files were copied into the bucket directory.
 
 **Adapter execution or `IMPORT` reports no runtime** — confirm that the adapter's SLC is installed
 with `exasol slc list`. JDBC adapters require the Java SLC.
+
+**`ETL-5402` or `ETL-5: Your security policy has prevented the connection from being
+attempted`** — appears when the source database negotiates TLS, even though the message names
+`java.net.SocketPermission`. Append `?sslmode=disable` to the JDBC URL in `CREATE CONNECTION` to
+transfer data without TLS, which is only appropriate on a trusted network.


### PR DESCRIPTION
## Description

Adds a Troubleshooting entry to the virtual schema guide for the security policy error that JDBC
data transfer reports when the source database negotiates TLS, and gives users the workaround.

The error names `java.net.SocketPermission`, which sends users looking for a network or firewall
problem. Sockets are not restricted: the ETL JDBC layer runs with an empty Java policy grant set,
and the TLS handshake is the first operation that needs a permission, so the failure appears only
against sources that offer TLS. The driver wraps the resulting `SecurityException` in fixed
wording that blames socket permissions.

This affects most real sources, because a default Ubuntu package install and managed cloud
PostgreSQL instances have `ssl=on`, while the guide's own optional in-VM example uses a container
image with `ssl=off` and therefore never hits it.

## Related Issue

Documents the workaround for SPOT-32439, Symptom 3. The underlying defect is not fixed here.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Changes Made

- Added a fourth Troubleshooting entry to `doc/virtual_schemas.md` naming both observed error
  codes, `ETL-5402` and `ETL-5`, stating that the trigger is TLS rather than socket permissions,
  and pointing at `?sslmode=disable` on the JDBC URL in `CREATE CONNECTION`.
- Noted that the workaround transfers data without TLS and is only appropriate on a trusted
  network.

## Testing

- [x] Manually tested

### Test Details

Verified against a macOS local deployment (managed VM, single node) with the Java SLC and the
PostgreSQL adapter and driver staged per this guide:

- Reproduced the failure with an in-VM PostgreSQL container given a self-signed certificate and
  `ssl=on`. Holding address, network and credentials constant, `?sslmode=require` fails with the
  security policy error and `?sslmode=disable` transfers rows, which isolates TLS as the trigger.
- Confirmed the error is not a socket restriction: targets with nothing listening fail with an
  ordinary `The connection attempt failed`, on both private and public addresses.
- Applied the workaround to a real source. A virtual schema over an external PostgreSQL with
  `ssl=on` returns data through `?sslmode=disable`, including counts over 298,641 rows and a join
  across two virtual tables.
- Confirmed the guide is otherwise correct as written: its worked example now completes end to
  end, including a raw `IMPORT FROM JDBC`.

## Checklist

- [x] Code follows project style guidelines
- [ ] Self-review completed
- [x] Documentation updated
- [ ] Tests added/updated
- [ ] All tests pass locally

No `CHANGELOG.md` entry: this documents an existing failure and its workaround without changing
tool behaviour.

## Additional Notes

Both error codes appear because the same failure surfaced under `ETL-5402` when SPOT-32439 was
filed and under `ETL-5` in every reproduction since. The message text is identical, so users
searching either code find this entry.

The entry should be removed once the underlying defect is fixed. That fix is not in this
repository: `/var/lib/exa/jdbc/java.security` is generated by AdminI in the database image and is
loaded with a doubled `=`, which replaces the JDK's security properties instead of extending them,
leaving the policy provider with no `policy.url.*` entries and no `java.policy` to load.
