### PR TITLE
feat: Publish documentation as part of a release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]    
+    branches: [main, "release/**"]
 
 permissions: {}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,26 @@
 name: Publish documentation
 
 on:
+  workflow_call:
+    inputs:
+      operation:
+        description: "Action to run: publish or delete"
+        required: false
+        default: publish
+        type: string
+      source_ref:
+        description: "Tag, release/ branch, or full 40-character SHA, e.g. v2.2.0 or release/v2.2"
+        required: false
+        type: string
+      version:
+        description: "Release line or full version without v, e.g. 2.2; required for delete"
+        required: false
+        type: string
+      make_latest:
+        description: "Give this version the 'latest' alias and the site root"
+        required: false
+        default: auto
+        type: string
   workflow_dispatch:
     inputs:
       operation:
@@ -120,17 +140,23 @@ jobs:
           MAKE_LATEST: ${{ inputs.make_latest }}
         run: |
           set -euo pipefail
-          if [[ "${OPERATION}" == "publish" ]]; then
-            arguments=("${SOURCE_REF}" --make-latest "${MAKE_LATEST}")
-            if [[ -n "${REQUESTED_VERSION}" ]]; then
-              arguments+=(--version "${REQUESTED_VERSION}")
-            fi
-            version="$(uv run --project user-docs --locked --no-build python user-docs/scripts/versions.py validate-publish "${arguments[@]}")"
-            echo "version=${version}" >> "${GITHUB_OUTPUT}"
-          else
-            version="$(uv run --project user-docs --locked --no-build python user-docs/scripts/versions.py validate-delete "${REQUESTED_VERSION}")"
-            echo "version=${version}" >> "${GITHUB_OUTPUT}"
-          fi
+          case "${OPERATION}" in
+            publish)
+              arguments=("${SOURCE_REF}" --make-latest "${MAKE_LATEST}")
+              if [[ -n "${REQUESTED_VERSION}" ]]; then
+                arguments+=(--version "${REQUESTED_VERSION}")
+              fi
+              version="$(uv run --project user-docs --locked --no-build python user-docs/scripts/versions.py validate-publish "${arguments[@]}")"
+              ;;
+            delete)
+              version="$(uv run --project user-docs --locked --no-build python user-docs/scripts/versions.py validate-delete "${REQUESTED_VERSION}")"
+              ;;
+            *)
+              echo "::error::operation must be 'publish' or 'delete'"
+              exit 1
+              ;;
+          esac
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
 
       - name: Validate documentation
         if: inputs.operation == 'publish'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing release tag to publish (e.g. v2.1.0 or v2.1.0-rc1). Create and push it first (admins only). A hyphen marks it as a pre-release."
+        description: "Existing release tag to publish (e.g. v2.1.0 or v2.1.0-rc1). Create and push it first (admins only). A pre-release version suffix such as -rc1 marks it as a pre-release."
         required: true
       previous_tag:
         description: "Previous tag for the changelog base (e.g. v2.0.0). Leave blank to auto-detect the last stable release."
@@ -14,7 +14,46 @@ on:
 permissions: {}
 
 jobs:
+  validate-docs:
+    name: Validate release documentation
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.request.outputs.version }}
+      stability: ${{ steps.request.outputs.stability }}
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          ref: refs/tags/${{ inputs.tag }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          version: "0.11.21"
+          python-version: "3.13"
+          enable-cache: true
+          cache-dependency-glob: user-docs/uv.lock
+
+      - name: Validate publication request
+        id: request
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          version="$(uv run --project user-docs --locked --no-build python user-docs/scripts/versions.py validate-publish "refs/tags/${TAG}")"
+          stability="$(uv run --project user-docs --locked --no-build python user-docs/scripts/versions.py stability "${version}")"
+          echo "Documentation version for this release: ${version} (${stability})"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "stability=${stability}" >> "${GITHUB_OUTPUT}"
+
+      - name: Validate documentation
+        run: uv run --project user-docs --locked --no-build mkdocs build --strict --config-file user-docs/mkdocs.yml
+
   goreleaser:
+    needs: validate-docs
     runs-on: ubuntu-latest
     environment:
       name: release
@@ -92,3 +131,19 @@ jobs:
           SSLCOM_PASSWORD: ${{ secrets.ESIGN_PASSWORD }}
           SSLCOM_CREDENTIAL_ID: ${{ secrets.ESIGN_CREDENTIAL_ID }}
           SSLCOM_TOTP_SECRET: ${{ secrets.ESIGN_TOTP_SECRET }}
+
+  publish-docs:
+    name: Publish release documentation
+    needs:
+      - validate-docs
+      - goreleaser
+    if: needs.validate-docs.outputs.stability == 'stable'
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/docs.yml
+    with:
+      operation: publish
+      source_ref: refs/tags/${{ inputs.tag }}
+      make_latest: auto

--- a/doc/ci.md
+++ b/doc/ci.md
@@ -8,7 +8,8 @@ Security policy for public-repo CI is defined in [Repository Security and Automa
 
 ### CI Pipeline (`ci.yml`)
 
-Runs automatically on every push to `main` and on pull requests targeting `main`:
+Runs automatically on every push to `main` and on pull requests targeting `main` or a release
+line under `release/`:
 
 - **Go Linting** - Runs `golangci-lint` and `tflint`
 - **Python Linting** - Runs `ruff` and `mypy` on test code
@@ -39,16 +40,6 @@ Dependabot version updates use built-in cooldown periods before PR creation:
 The merge delay is separate from Dependabot cooldown: cooldown delays routine PR creation, while the workflow delay defers approval and auto-merge for ungrouped (security) PRs after they exist.
 Auto-merge does not itself rebase Dependabot PRs; branch protection and Dependabot's own update behavior determine whether stale branches are refreshed before merging.
 
-### Release Pipeline (`release.yml`)
-
-Triggered automatically when a version tag is pushed (e.g., `v1.2.3`):
-
-- Builds binaries for all platforms (Linux, macOS, Windows)
-- Runs tests
-- Creates GitHub release with artifacts
-- Uses a protected `release` environment for release/signing approval gates
-- See [Release Process](release.md) for details
-
 ### Merge Workflow (`merge.yml`)
 
 Runs automatically on every push to `main`:
@@ -70,10 +61,34 @@ Splitting by region also keeps a deployment from matching two search targets at 
 
 ## Manual Workflows
 
+### Release Pipeline (`release.yml`)
+
+Maintainers dispatch this workflow with an existing version tag; pushing a tag does not trigger it.
+It checks out the tag it is given and never inspects branches, so releasing from the default branch
+and releasing a patch from a release line work the same way. Dispatch it with the default branch
+selected, so that documentation publication is accepted by the `github-pages` environment.
+
+Three jobs run in order:
+
+- `validate-docs` builds the tag's user documentation with a strict MkDocs build and rejects a tag
+  whose documentation version cannot be derived. Invalid documentation therefore fails the release
+  before anything is published.
+- `goreleaser` builds and signs binaries for Linux, macOS, and Windows and creates the GitHub
+  release with its artifacts. It runs in the protected `release` environment, which gates
+  publishing and signing behind approval.
+- `publish-docs` calls the documentation workflow for the release tag. It runs only for a stable
+  tag, so a pre-release publishes no documentation version. A failure here leaves the release
+  published, and dispatching the documentation workflow for the same tag republishes the same
+  documentation version.
+
+Tests are not part of this workflow; they run in CI before the commit is tagged. See
+[Release Process](release.md) for the maintainer steps.
+
 ### Documentation Publication (`docs.yml`)
 
-Maintainers publish versioned user documentation with the manually dispatched documentation
-workflow. GitHub Pages must be enabled with **GitHub Actions** as its source, and the existing
+Versioned user documentation is published by this workflow, either by the
+[release pipeline](#release-pipeline-releaseyml) for a stable release or by a manual dispatch.
+GitHub Pages must be enabled with **GitHub Actions** as its source, and the existing
 `github-pages` environment must allow deployments only from `main`.
 
 The workflow accepts four inputs:
@@ -83,18 +98,21 @@ The workflow accepts four inputs:
   required for publication.
 - `version`: the published documentation version, either a release line such as `2.2` or a full
   version such as `2.2.0-rc1`. It is required for deletion and optional for publication when
-  `source_ref` is named `v<version>` or ends in `/v<version>`.
+  `source_ref` is named `v<version>` or ends in `/v<version>`. A stable source version derives its
+  release line, so `v2.2.1` publishes `2.2`, and a pre-release derives its full version.
 - `make_latest`: whether the published version takes the `latest` alias and the site root.
   `auto` grants it when no higher stable version is published, `yes` and `no` decide explicitly.
 
 An explicit version can map historical documentation content to an older release line without
 changing an existing release tag. For example, publish a reviewed snapshot based on a current commit
-as `2.1`, or map its full commit SHA by supplying `2.1` explicitly.
+as `2.1`, or map its full commit SHA by supplying `2.1` explicitly. It is also the way to publish a
+full stable version such as `2.2.0`.
 
-Documentation is published per release line from that line's release branch, such as `release/v2.2`
-published as version `2.2`. Publishing the branch again replaces the line from its current tip, so
-content and styling can change after a release without moving any release tag, and a patch can be
-reviewed together with the documentation it changes. Branches outside `release/` are rejected, which
+Documentation is published per release line. Releasing publishes the line from its release tag, and
+a later correction is published from that line's release branch, such as `release/v2.2` published
+as version `2.2`. Publishing the branch replaces the line from its current tip, so content and
+styling can change after a release without moving any release tag, and a patch can be reviewed
+together with the documentation it changes. Branches outside `release/` are rejected, which
 keeps publication from being requested against development work. A name that exists as both a branch
 and a tag is rejected until `source_ref` is qualified with `refs/heads/` or `refs/tags/`. Protect the
 `release/*` branches with a ruleset, as described in
@@ -120,9 +138,10 @@ each published version, so a version published before that configuration existed
 only after it is republished. Readers may see a stale selector for up to ten minutes after a
 publication, because GitHub Pages caches the version catalog it fetches.
 
-All operations are serialized in request order. If Pages deployment fails after the version
-catalog is updated, rerun the same operation to deploy the complete stored catalog. A repeated
-deletion succeeds when the selected version is already absent and redeploys that catalog.
+All operations are serialized in request order, including a publication requested by a release. If
+Pages deployment fails after the version catalog is updated, rerun the same operation to deploy the
+complete stored catalog. A repeated deletion succeeds when the selected version is already absent
+and redeploys that catalog.
 
 ### Deployment Tests (`tests-deployment.yml`)
 

--- a/doc/release.md
+++ b/doc/release.md
@@ -6,14 +6,27 @@ Security requirements for release automation are defined in [Repository Security
 
 ## Overview
 
-Releases are fully automated using [GoReleaser](https://goreleaser.com/) and GitHub Actions. When a version tag is pushed, the release workflow automatically:
-- Builds binaries for all supported platforms
-- Runs the test suite
-- Creates a GitHub release
-- Uploads release artifacts
+A release is built, signed, and published by GitHub Actions, but it is not triggered by a tag push.
+A maintainer pushes a version tag and dispatches the release workflow for that tag. The
+[CI guide](ci.md#release-pipeline-releaseyml) describes the workflow itself.
+
+The maintainer:
+- Finalizes the changelog and commits it.
+- Creates and pushes the version tag.
+- Dispatches the release workflow for that tag.
+- Creates the release line branch after the first stable release of a minor version.
+
+The release workflow:
+- Validates the user documentation at the release tag.
+- Builds, signs, and notarizes binaries for all supported platforms with [GoReleaser](https://goreleaser.com/).
+- Creates the GitHub release with its artifacts, checksums, and generated notes.
+- Publishes the user documentation of a stable release as that release's line version.
+
+Tests are not part of the release workflow. They run in CI on the commit before it is tagged.
 
 Release safety gates:
 - Version tags must follow `v*`.
+- Invalid user documentation at the release tag fails the release before it is published.
 - Publishing and signing run in a protected release environment.
 - Third-party release actions are pinned to immutable commit SHAs.
 - Downloaded signing tooling is version-pinned and checksum-verified in CI.
@@ -23,15 +36,17 @@ Tag governance controls (for example restricting who can create `v*` tags and wh
 ## Release Lines
 
 Each minor version has a release line branch named `release/v<major>.<minor>`, created from that
-line's first stable release tag. The line carries the user documentation published for that
-version, so content and styling can be corrected after the release without moving a release tag,
-and a fix can be reviewed together with the documentation it changes. Publishing documentation
-from a release line is described in the [CI guide](ci.md#documentation-publication-docsyml).
+line's first stable release tag. A release publishes its documentation from the release tag, so the
+branch is not needed in order to release. It exists to carry later corrections: content and styling
+can be fixed after the release without moving a release tag, and a fix is reviewed together with the
+documentation it changes. Republishing a corrected line is described in the
+[CI guide](ci.md#documentation-publication-docsyml).
 
 Tagging is unchanged on a release line: the release workflow checks out the tag it is given and
 does not inspect branches, so a patch is tagged on its release branch exactly as a release is
-tagged on the default branch. Protect `release/*` with a ruleset, as described in
-[CI security best practices](ci_security_best_practices.md).
+tagged on the default branch. Dispatch the release workflow with the default branch selected, so
+that documentation publication is accepted by the `github-pages` environment. Protect `release/*`
+with a ruleset, as described in [CI security best practices](ci_security_best_practices.md).
 
 Which changes reach a release line is decided per line and is not automated.
 
@@ -64,27 +79,34 @@ git commit -m "docs: finalize changelog for v1.2.3"
 ```bash
 # Create an annotated tag with semantic versioning
 git tag -a v1.2.3 -m "Release v1.2.3"
-
-# Push the tag to trigger the release workflow
 git push origin v1.2.3
 ```
 
-### 3. Automated Build
+### 3. Publish the Release
 
-GitHub Actions will automatically:
-1. Checkout the tagged commit
-2. Run tests to ensure quality
-3. Build binaries for all target platforms
-4. Create checksums and archives
-5. Generate release notes
-6. Publish the release on GitHub
+Dispatch [Create GH release (from existing tag)](https://github.com/exasol/exasol-personal/actions/workflows/release.yml)
+with the default branch selected and the tag as its input. Leave the previous tag blank unless the
+changelog base has to be something other than the last stable release.
 
-### 4. Monitor the Release
+Watch the run to completion. It validates the tag's documentation, waits for the release
+environment's approval, publishes the release, and then publishes the documentation of a stable
+release as version `<major>.<minor>`. A pre-release validates its documentation and publishes no
+documentation version.
 
-Watch the GitHub Actions workflow to ensure it completes successfully:
-- Navigate to the [Actions tab](https://github.com/exasol/exasol-personal/actions)
-- Find the workflow run for your tag
-- Verify all jobs complete successfully
+If documentation publication fails after the release is published, the release stays published.
+Republish the documentation by dispatching the
+[documentation workflow](ci.md#documentation-publication-docsyml) for the same tag, which resolves
+the same version.
+
+### 4. Create the Release Line Branch
+
+After the first stable release of a minor version, create that line's branch so later corrections
+have a home:
+
+```bash
+git branch release/v1.2 v1.2.0
+git push origin release/v1.2
+```
 
 ## Release Configuration
 
@@ -102,7 +124,7 @@ The release process is configured in `.goreleaser.yaml`, which defines:
 Releases are built for:
 - **Linux**: amd64, arm64
 - **macOS**: amd64 (Intel), arm64 (Apple Silicon)
-- **Windows**: amd64, arm64
+- **Windows**: amd64
 
 ## Testing Releases Locally
 
@@ -126,10 +148,14 @@ Follow [Semantic Versioning](https://semver.org/):
 
 Before creating a stable release:
 
-- [ ] All tests pass locally (`task all`)
+- [ ] All changes merged to `main`, or to the release line for a patch release
+- [ ] CI passed on the commit to be tagged
+- [ ] User documentation under `user-docs/` describes this release
 - [ ] Changelog is finalized for this version and committed before the tag
-- [ ] Documentation is up to date
 - [ ] Version number follows semantic versioning
-- [ ] All changes merged to main branch, or to the release line for a patch release
 - [ ] Tag created with proper version format (`v1.2.3`)
-- [ ] Release line branch exists for the version, and its published documentation is current
+
+After the release workflow completes:
+
+- [ ] Published documentation shows the released version
+- [ ] Release line branch exists for the version

--- a/doc/repository_security_spec.md
+++ b/doc/repository_security_spec.md
@@ -24,9 +24,11 @@ General guidance is in [CI Security Best Practices](ci_security_best_practices.m
 
 ### Trusted Privileged Lane
 
-- Privileged workflows run only on trusted events (`push` or `workflow_dispatch`):
+- Privileged workflows run only on trusted events (`push`, `workflow_dispatch`, or a
+  `workflow_call` from a workflow that itself runs on a trusted event):
   - [`merge.yml`](../.github/workflows/merge.yml)
   - [`release.yml`](../.github/workflows/release.yml)
+  - [`docs.yml`](../.github/workflows/docs.yml)
   - [`tests-deployment.yml`](../.github/workflows/tests-deployment.yml)
 - Privileged workflows do not run on `pull_request`.
 - Workflows declare explicit `permissions` and only request write scopes where required.
@@ -82,10 +84,11 @@ This is the administrative control for release ref governance and merge governan
 ### 3) Protected Environments
 
 - Create protected `release` environment with required reviewers.
-- Restrict `release` environment deployment refs to intended release refs (version tags).
+- Restrict `release` environment deployment refs to the default branch. The release workflow is dispatched from the default branch and takes the released tag as an input, so the tag is not the run's ref; the `v*` tag ruleset is what governs which tags may exist.
+- Create protected `github-pages` environment for documentation publication with `main`-only restrictions, since a release publishes documentation from the same dispatch.
 - Create protected `deployment-tests` environment for manual cloud tests with required reviewers and `main`-only restrictions.
 
-This enforces approval and ref-gating for privileged jobs in [`release.yml`](../.github/workflows/release.yml) and [`tests-deployment.yml`](../.github/workflows/tests-deployment.yml).
+This enforces approval and ref-gating for privileged jobs in [`release.yml`](../.github/workflows/release.yml), [`docs.yml`](../.github/workflows/docs.yml), and [`tests-deployment.yml`](../.github/workflows/tests-deployment.yml).
 
 ### 4) Ownership and Review Governance
 

--- a/openspec/changes/archive/2026-09-04-publish-docs-with-releases/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-04-publish-docs-with-releases/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/archive/2026-09-04-publish-docs-with-releases/design.md
+++ b/openspec/changes/archive/2026-09-04-publish-docs-with-releases/design.md
@@ -1,0 +1,75 @@
+## Context
+
+Two manual workflows exist. The release workflow is dispatched with an existing tag and runs
+GoReleaser against it. The documentation workflow is dispatched with a source revision and
+publishes one documentation version to GitHub Pages. Nothing connects them, so documentation
+alignment depends on a maintainer remembering a second dispatch.
+
+The release line model established for documentation sources publishes one version per minor
+line, such as `2.2` from `release/v2.2`. A release line branch is created from the first stable
+tag of its line, which means it does not exist while that release is being published.
+
+## Decisions
+
+### Release line versions derive from stable tags
+
+A stable tag derives the release line it belongs to, so `v2.3.0` and `v2.3.1` both derive `2.3`.
+Pre-release tags keep their full version, because a pre-release documents one candidate rather
+than a line. An explicit version still overrides derivation, which retains mapping historical
+content onto an older line.
+
+The alternative is a release workflow that computes the line and passes it as an explicit version.
+That leaves two rules for one question: manually publishing the same tag would derive a full
+version and produce a different published version than the release did. Since the manual workflow
+is the recovery path for the automated one, recovery has to reproduce what it recovers, so the
+rule belongs in the shared version helper rather than in the release workflow.
+
+Deriving from the tag also removes the ordering problem. The release publishes its line from the
+released commit, so no release line branch is required while releasing, and the branch is needed
+only for later corrections.
+
+### Documentation validation gates the release
+
+Validation runs as a separate job before GoReleaser, using the content, configuration, scripts,
+and locked dependencies of the tag being released. It performs the same strict build the
+publication path performs and rejects a request whose version cannot be derived, so a release
+cannot reach a state where its documentation cannot be published afterwards.
+
+Publication runs after the release is published. A failure there leaves the release in place,
+because withdrawing a signed and notarized release to correct a documentation link is a worse
+outcome than a short gap in published documentation. The maintainer recovers by dispatching the
+documentation workflow for the same tag, which derives the same version.
+
+Pre-releases are validated and publish nothing. Publishing every candidate would add versions that
+only an explicit deletion removes, while validating them keeps a documentation break from reaching
+the stable release unnoticed.
+
+### One publication implementation, two entry points
+
+The documentation workflow accepts a workflow call in addition to its manual dispatch, and the
+release workflow calls it. A second implementation would drift from the recovery path it is meant
+to mirror. The shared workflow keeps one serialized concurrency group, so a release publication
+and a manual publication cannot interleave.
+
+A called workflow runs under the calling run's ref, so the release workflow has to be dispatched
+from the default branch for the `github-pages` environment to accept the deployment. That is
+already how releases are dispatched, since the workflow checks out the tag it is given and does
+not inspect the selected branch.
+
+### Release lines are validated but created manually
+
+Continuous integration accepts pull requests targeting `release/*`, so a documentation correction
+or a patch on a release line is validated before that line is published again. Creating the line
+branch stays a maintainer step, because it is a release-process decision about which commits a
+line carries and it is not on the critical path for publication.
+
+## Risks / Trade-offs
+
+- A tag without a complete documentation setup blocks its release. Mitigation: continuous
+  integration validates the same setup on every pull request to `main` and to a release line, so
+  the gate fails only for a tag that was never validated.
+- Documentation publication and the release are no longer independent, so a Pages outage delays
+  documentation for a published release. Mitigation: the release is unaffected and the manual
+  workflow republishes the same tag to the same version.
+- Stable tags no longer derive a full version. Mitigation: an explicit version input still
+  publishes one, and no published version depends on the previous derivation.

--- a/openspec/changes/archive/2026-09-04-publish-docs-with-releases/proposal.md
+++ b/openspec/changes/archive/2026-09-04-publish-docs-with-releases/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+Releasing a version and publishing its documentation are two unconnected manual workflows, so a
+release can ship with documentation that is missing, stale, or invalid. The documented release
+process also still describes a tag push as the release trigger, which stopped being true when
+releases moved to an explicit manual dispatch.
+
+## What Changes
+
+- Publish documentation for a stable release from the release workflow, using the release tag as
+  the source and requiring no version input.
+- **BREAKING** Derive a release line such as `2.3` from a stable release tag, instead of the full
+  version `2.3.0`. Pre-release tags keep their full version, and an explicit version still
+  overrides derivation.
+- Complete documentation validation before a release is published, so invalid documentation
+  prevents the release.
+- Validate the documentation of a pre-release without publishing a documentation version.
+- Validate changes proposed to a release line, so a release line is publishable when its
+  documentation changes.
+- Describe in the release and CI guides which release steps a maintainer performs and which the
+  release workflow performs.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `versioned-documentation-publishing`: Releasing a stable version publishes its release line
+  documentation, and a stable tag derives a release line version.
+
+## Impact
+
+The release workflow, the documentation workflow, the version helper script and its tests, the CI
+pull request triggers, the release guide, the CI guide, and the versioned documentation publishing
+specification change. Releasing gains a documentation validation gate. No product behavior and no
+additional dependency is introduced.

--- a/openspec/changes/archive/2026-09-04-publish-docs-with-releases/specs/versioned-documentation-publishing/spec.md
+++ b/openspec/changes/archive/2026-09-04-publish-docs-with-releases/specs/versioned-documentation-publishing/spec.md
@@ -1,0 +1,120 @@
+## ADDED Requirements
+
+### Requirement: Releasing a stable version publishes its documentation
+
+Publishing a release SHALL complete documentation validation for the released tag before the
+release is published, and SHALL publish documentation for a stable release from that tag without a
+supplied version.
+
+#### Scenario: Publish a stable release
+
+- **WHEN** a maintainer publishes a stable release from tag `v2.3.1`
+- **THEN** the release SHALL be published and documentation from that tag SHALL be published as
+  version `2.3`
+
+#### Scenario: Invalid documentation blocks the release
+
+- **WHEN** the documentation at the selected release tag fails validation
+- **THEN** publishing SHALL fail before the release is created and before any published
+  documentation version changes
+
+#### Scenario: Publish a pre-release
+
+- **WHEN** a maintainer publishes a release from a pre-release tag
+- **THEN** the documentation at that tag SHALL be validated and the published documentation
+  versions SHALL remain unchanged
+
+#### Scenario: Recover a failed documentation deployment
+
+- **WHEN** GitHub Pages deployment fails after the release is published
+- **THEN** the release SHALL remain published and publishing the same tag through the
+  documentation workflow SHALL produce the same documentation version
+
+### Requirement: Release line changes are validated before publication
+
+Documentation validation SHALL run for a proposed change that targets a release line, so that the
+documentation of a release line is publishable when it changes.
+
+#### Scenario: Validate a release line correction
+
+- **WHEN** a pull request targets a branch under `release/`
+- **THEN** the repository's user documentation validation SHALL run for that pull request
+
+## MODIFIED Requirements
+
+### Requirement: Maintainers can manually publish documentation from a selected source
+
+The documentation workflow SHALL allow a maintainer to select an existing Git tag, an existing
+branch whose name begins with `release/`, or a full 40-character commit SHA as the documentation
+source, and publish it under an independently selected documentation version. A documentation
+version SHALL be a release line such as `2.2` or a full version such as `2.2.0-rc1`. When the
+version is omitted, the workflow SHALL derive it from a source name that is `v<version>` or ends
+in `/v<version>`, deriving the release line of a stable version and the full version of a
+pre-release.
+
+#### Scenario: Publish a release line from its release branch
+
+- **WHEN** a maintainer publishes documentation from a branch such as `release/v2.3` without
+  supplying a version
+- **THEN** version `2.3` SHALL be published from the current tip of that branch
+
+#### Scenario: Revise a published release line
+
+- **WHEN** a maintainer adds commits to the release branch of an already published release line
+  and publishes that branch again
+- **THEN** that version SHALL be replaced from the new branch tip while every other published
+  version and every release tag SHALL remain unchanged
+
+#### Scenario: Publish a release line derived from a stable tag
+
+- **WHEN** a maintainer publishes documentation from a stable tag such as `v2.3.1` without
+  supplying a version
+- **THEN** version `2.3` SHALL be published
+
+#### Scenario: Publish a release-candidate version derived from a namespaced tag
+
+- **WHEN** a maintainer publishes documentation from a tag such as `docs/v2.3.0-rc1` without
+  supplying a version
+- **THEN** version `2.3.0-rc1` SHALL be published
+
+#### Scenario: Publish an explicitly mapped version
+
+- **WHEN** a maintainer publishes a source revision and supplies version `2.2`
+- **THEN** the selected source content SHALL be published as version `2.2` regardless of the
+  source name
+
+#### Scenario: Publish a full stable version
+
+- **WHEN** a maintainer publishes a stable tag such as `v2.3.0` and supplies version `2.3.0`
+- **THEN** version `2.3.0` SHALL be published
+
+#### Scenario: Require an explicit version for an underivable source
+
+- **WHEN** a maintainer publishes a full commit SHA or a source name that does not end in
+  `v<version>` without supplying a version
+- **THEN** publication SHALL fail before changing any published version and explain that a version
+  is required
+
+#### Scenario: Reject a branch outside the release namespace
+
+- **WHEN** a maintainer selects a branch whose name does not begin with `release/`
+- **THEN** publication SHALL fail before changing any published version and explain that a branch
+  source must be a release branch
+
+#### Scenario: Reject an ambiguous source name
+
+- **WHEN** a maintainer selects a source name that exists as both a branch and a tag
+- **THEN** publication SHALL fail before changing any published version and explain that the
+  source must be selected as either a branch or a tag
+
+#### Scenario: Reject an unknown source
+
+- **WHEN** a maintainer selects a source name that is neither an existing tag, an existing branch,
+  nor the checked-out commit
+- **THEN** publication SHALL fail before changing any published version
+
+#### Scenario: Republish one version
+
+- **WHEN** a maintainer publishes a documentation version that already exists
+- **THEN** that version SHALL be replaced from the selected source and every other published
+  version SHALL remain unchanged

--- a/openspec/changes/archive/2026-09-04-publish-docs-with-releases/tasks.md
+++ b/openspec/changes/archive/2026-09-04-publish-docs-with-releases/tasks.md
@@ -1,0 +1,18 @@
+## 1. Derive Release Line Versions
+
+- [x] 1.1 Derive the release line of a stable source version, keep the full version of a
+      pre-release, and test both alongside explicit versions.
+
+## 2. Publish Documentation With Releases
+
+- [x] 2.1 Accept a workflow call in the documentation workflow, and validate the release tag's
+      documentation before the release and publish it afterwards for a stable release.
+
+## 3. Validate Release Lines
+
+- [x] 3.1 Run continuous integration for pull requests targeting a release line.
+
+## 4. Document the Release Process
+
+- [x] 4.1 Update the release and CI guides to describe the maintainer steps and the automated
+      steps of a release.

--- a/openspec/specs/versioned-documentation-publishing/spec.md
+++ b/openspec/specs/versioned-documentation-publishing/spec.md
@@ -2,8 +2,9 @@
 
 ## Purpose
 
-Define how maintainers safely validate and manually publish, replace, or delete versioned user
-documentation through GitHub Pages.
+Define how versioned user documentation is safely validated and published through GitHub Pages,
+both as part of releasing a version and when a maintainer publishes, replaces, or deletes one
+version.
 ## Requirements
 ### Requirement: Maintainers can manually delete one published version
 
@@ -132,7 +133,8 @@ branch whose name begins with `release/`, or a full 40-character commit SHA as t
 source, and publish it under an independently selected documentation version. A documentation
 version SHALL be a release line such as `2.2` or a full version such as `2.2.0-rc1`. When the
 version is omitted, the workflow SHALL derive it from a source name that is `v<version>` or ends
-in `/v<version>`.
+in `/v<version>`, deriving the release line of a stable version and the full version of a
+pre-release.
 
 #### Scenario: Publish a release line from its release branch
 
@@ -147,11 +149,11 @@ in `/v<version>`.
 - **THEN** that version SHALL be replaced from the new branch tip while every other published
   version and every release tag SHALL remain unchanged
 
-#### Scenario: Publish a full version derived from a tag
+#### Scenario: Publish a release line derived from a stable tag
 
-- **WHEN** a maintainer publishes documentation from a tag such as `v2.3.0` without supplying a
-  version
-- **THEN** version `2.3.0` SHALL be published
+- **WHEN** a maintainer publishes documentation from a stable tag such as `v2.3.1` without
+  supplying a version
+- **THEN** version `2.3` SHALL be published
 
 #### Scenario: Publish a release-candidate version derived from a namespaced tag
 
@@ -164,6 +166,11 @@ in `/v<version>`.
 - **WHEN** a maintainer publishes a source revision and supplies version `2.2`
 - **THEN** the selected source content SHALL be published as version `2.2` regardless of the
   source name
+
+#### Scenario: Publish a full stable version
+
+- **WHEN** a maintainer publishes a stable tag such as `v2.3.0` and supplies version `2.3.0`
+- **THEN** version `2.3.0` SHALL be published
 
 #### Scenario: Require an explicit version for an underivable source
 
@@ -195,4 +202,44 @@ in `/v<version>`.
 - **WHEN** a maintainer publishes a documentation version that already exists
 - **THEN** that version SHALL be replaced from the selected source and every other published
   version SHALL remain unchanged
+
+### Requirement: Releasing a stable version publishes its documentation
+
+Publishing a release SHALL complete documentation validation for the released tag before the
+release is published, and SHALL publish documentation for a stable release from that tag without a
+supplied version.
+
+#### Scenario: Publish a stable release
+
+- **WHEN** a maintainer publishes a stable release from tag `v2.3.1`
+- **THEN** the release SHALL be published and documentation from that tag SHALL be published as
+  version `2.3`
+
+#### Scenario: Invalid documentation blocks the release
+
+- **WHEN** the documentation at the selected release tag fails validation
+- **THEN** publishing SHALL fail before the release is created and before any published
+  documentation version changes
+
+#### Scenario: Publish a pre-release
+
+- **WHEN** a maintainer publishes a release from a pre-release tag
+- **THEN** the documentation at that tag SHALL be validated and the published documentation
+  versions SHALL remain unchanged
+
+#### Scenario: Recover a failed documentation deployment
+
+- **WHEN** GitHub Pages deployment fails after the release is published
+- **THEN** the release SHALL remain published and publishing the same tag through the
+  documentation workflow SHALL produce the same documentation version
+
+### Requirement: Release line changes are validated before publication
+
+Documentation validation SHALL run for a proposed change that targets a release line, so that the
+documentation of a release line is publishable when it changes.
+
+#### Scenario: Validate a release line correction
+
+- **WHEN** a pull request targets a branch under `release/`
+- **THEN** the repository's user documentation validation SHALL run for that pull request
 

--- a/user-docs/scripts/versions.py
+++ b/user-docs/scripts/versions.py
@@ -91,11 +91,21 @@ def resolve_version(source_ref: str, version: str | None) -> str:
     derived = match.group("version") if match else ""
     if not DOCUMENTATION_VERSION.fullmatch(derived):
         raise VersionError(PUBLISH_VERSION_ERROR)
-    return derived
+    return release_line(derived) if is_stable(derived) else derived
 
 
 def is_stable(version: str) -> bool:
     return "-" not in version.partition("+")[0]
+
+
+def release_line(version: str) -> str:
+    major, minor, *_ = version.partition("+")[0].split(".")
+    return f"{major}.{minor}"
+
+
+def stability(version: str) -> str:
+    require_version(version)
+    return "stable" if is_stable(version) else "prerelease"
 
 
 def require_version(version: str) -> None:
@@ -193,6 +203,11 @@ def parse_args() -> argparse.Namespace:
     )
     delete_parser.add_argument("version")
 
+    stability_parser = commands.add_parser(
+        "stability", help="Report whether a version is stable or a prerelease"
+    )
+    stability_parser.add_argument("version")
+
     return parser.parse_args()
 
 
@@ -207,6 +222,8 @@ def main() -> int:
             )
         elif args.command == "publish":
             publish(args.version, args.make_latest)
+        elif args.command == "stability":
+            sys.stdout.write(f"{stability(args.version)}\n")
         else:
             delete(args.version)
     except VersionError as error:

--- a/user-docs/tests/test_versions.py
+++ b/user-docs/tests/test_versions.py
@@ -50,15 +50,17 @@ def test_validate_delete_rejects_invalid_versions(target: str) -> None:
 @pytest.mark.parametrize(
     ("source_ref", "expected"),
     [
-        ("v2.3.0", "2.3.0"),
-        ("docs/v2.2.0-rc.1", "2.2.0-rc.1"),
-        ("refs/tags/docs/v2.1.0", "2.1.0"),
+        ("v2.3.0", "2.3"),
+        ("v2.3.1", "2.3"),
+        ("refs/tags/v2.3.1", "2.3"),
+        ("refs/tags/docs/v2.1.0", "2.1"),
         ("release/v2.4", "2.4"),
         ("refs/heads/release/v2.4", "2.4"),
-        ("refs/heads/release/v2.5.0-rc.1", "2.5.0-rc.1"),
+        ("v2.3.0+build.1", "2.3"),
+        ("v2.3+build.1", "2.3"),
     ],
 )
-def test_validate_publish_derives_version_from_conventional_sources(
+def test_validate_publish_derives_the_release_line_of_a_stable_source(
     source_ref: str, expected: str
 ) -> None:
     # Given / When
@@ -66,6 +68,56 @@ def test_validate_publish_derives_version_from_conventional_sources(
 
     # Then
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ("source_ref", "expected"),
+    [
+        ("v2.2.0-rc.1", "2.2.0-rc.1"),
+        ("docs/v2.2.0-rc.1", "2.2.0-rc.1"),
+        ("refs/heads/release/v2.5.0-rc.1", "2.5.0-rc.1"),
+    ],
+)
+def test_validate_publish_derives_the_full_version_of_a_prerelease_source(
+    source_ref: str, expected: str
+) -> None:
+    # Given / When
+    actual = versions.validate_publish(source_ref, None)
+
+    # Then
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("2.3", "stable"),
+        ("2.3.0", "stable"),
+        ("2.3.0+build-1", "stable"),
+        ("2.3.0-rc.1", "prerelease"),
+        ("2.3.0-rc.1+build", "prerelease"),
+    ],
+)
+def test_stability_classifies_a_version(version: str, expected: str) -> None:
+    # Given / When
+    actual = versions.stability(version)
+
+    # Then
+    assert actual == expected
+
+
+def test_stability_rejects_an_invalid_version() -> None:
+    # Given / When / Then
+    with pytest.raises(versions.VersionError, match="must be a release line"):
+        versions.stability("v2.3.0")
+
+
+def test_validate_publish_accepts_an_explicit_full_stable_version() -> None:
+    # Given / When
+    actual = versions.validate_publish("v2.3.0", "2.3.0")
+
+    # Then
+    assert actual == "2.3.0"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Releasing a version and publishing its documentation were two unconnected manual workflows, so a release could ship with documentation that was missing, stale, or invalid. Releasing now validates and publishes the documentation of the tag being released, and the release guide states which steps a maintainer performs and which the workflow performs.

## Related Issue

SPOT-32458

## Type of Change

- [x] `feat`: New feature
- [x] `docs`: Documentation update

## Changes Made

- A stable release tag derives its release line as the documentation version, so `v2.3.1` publishes `2.3`. A pre-release keeps its full version, and an explicit `version` input still overrides derivation. **This changes an existing input:** publishing `v2.1.0` manually now yields `2.1` rather than `2.1.0`; supply `version: 2.1.0` for the previous result. The rule lives in the shared version helper rather than in the release workflow, because the manual workflow is the recovery path and has to reproduce what it recovers.
- `release.yml` runs three jobs in order. `validate-docs` builds the tag's documentation strictly and rejects a tag whose documentation version cannot be derived, so invalid documentation fails the release before anything is published. `goreleaser` publishes the release. `publish-docs` publishes the documentation.
- `publish-docs` runs only for a stable tag and calls `docs.yml` as a reusable workflow, so releasing and the manual recovery path share one implementation and one serialized concurrency group. A Pages failure leaves the release published, and dispatching `docs.yml` for the same tag republishes the same version.
- `ci.yml` runs for pull requests targeting `release/**`, so a documentation correction or a patch on a release line is validated before that line is republished.
- `doc/release.md` and `doc/ci.md` describe the actual flow. The release workflow moved to the manual-workflow section of the CI guide, because a tag push has not triggered it since 0475771.

## Testing

- [ ] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

### Test Details

`task lint` passes, which includes `task docs-check` (ruff, the documentation tests, and a strict MkDocs build). The 45 documentation tests cover the new derivation for stable tags, pre-releases, and explicit versions. `openspec validate --specs --strict` passes 31 of 31.

`task all` was not run because no Go code changed; the Go suites cover nothing touched here.

`actionlint` is clean on `release.yml` and `ci.yml`. Its only finding is the pre-existing `concurrency.queue` key in `docs.yml`, which is a newer GitHub feature than actionlint 1.7.7 knows about.

The workflow wiring can only be exercised by a real release, so it stays unverified until the next one. One detail worth a reviewer's eye: `publish-docs` declares `contents: write`, `pages: write`, and `id-token: write` on the calling job, because `release.yml` sets `permissions: {}` and a called workflow can only narrow the caller's grant.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [ ] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [ ] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

No CHANGELOG entry: this is release and CI tooling with no user-visible product behavior, consistent with de5d1b5.

Dispatch `release.yml` with the default branch selected so the `github-pages` environment accepts the documentation deployment. That is already how releases are dispatched, since the workflow checks out the tag it is given and never inspects branches.

Three stale documentation claims were corrected along the way, all caused by the same earlier move to a dispatched release:

- Both guides said the release workflow runs tests. It does not; `.goreleaser.yaml` only has generate and signing hooks.
- `doc/release.md` listed Windows arm64 as a release target, but `windows_arm64` is commented out in `.goreleaser.yaml`.
- `doc/repository_security_spec.md` told admins to restrict the `release` environment to version tags, which would block every release, because the workflow is dispatched from the default branch and takes the tag as an input. `docs.yml` and `workflow_call` were added to the privileged lane, and the `github-pages` environment was added, because it is now load-bearing for releases.
