### PR TITLE
Gb.root command auto approve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,9 @@ Notable user-facing changes to Exasol Personal are documented here.
 
   Example: `exasol install local --auto-approve`
 
-- Added `--auto-approve` to `exasol deploy`, `exasol install`, and `exasol start` to approve local runtime host preparation without prompting.
+- Added a global `--auto-approve` flag, accepted by every command like `--log-level`, which approves confirmation prompts without asking. It covers local runtime host preparation for `exasol deploy`, `exasol install`, and `exasol start`.
 
-  Example: `exasol start --auto-approve`
+  Example: `exasol --auto-approve install local`
 
 ### Changed
 
@@ -66,7 +66,7 @@ Notable user-facing changes to Exasol Personal are documented here.
 
 - Fixed documentation publication failing during validation because the GitHub Actions runner does
   not provide the Task command.
-
+- `exasol destroy` and `exasol remove` no longer report success without doing anything when no terminal is attached. Such a run now proceeds as though `--auto-approve` had been passed. Detection of an attached terminal was also corrected, so a command redirected from the null device is treated as unattended rather than interactive.
 - Corrected the local Virtual Schema setup guide to use the active deployment's shared directory on
   macOS instead of obsolete SSH paths, and added the required deployment selection and PostgreSQL
   timezone configuration steps.
@@ -82,6 +82,7 @@ Notable user-facing changes to Exasol Personal are documented here.
 
 ### Breaking Changes
 
+- Commands that ask for confirmation now proceed without asking when no terminal is attached, as though `--auto-approve` had been passed. This covers `exasol destroy`, `exasol remove`, and the database-restarting `exasol slc` operations, and it applies however standard input is redirected, so a piped answer no longer declines them. Local runtime host preparation is the exception and still requires an answer or `--auto-approve`. Scripts that relied on a redirected `exasol destroy` declining must stop invoking it.
 - Local runtime host preparation in a non-interactive invocation now fails instead of proceeding without approval. Scripts that relied on the previous behavior must pass `--auto-approve` to `exasol deploy`, `exasol install`, or `exasol start`.
 - Local deployments now publish the database port on `127.0.0.1` instead of on all addresses, so it is no longer reachable from other hosts. The documented connection endpoint is unchanged; use a cloud deployment if the database must be reachable over the network.
 

--- a/cmd/exasol/auto_approve_flag_test.go
+++ b/cmd/exasol/auto_approve_flag_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestAutoApproveFlagReachesNestedSubcommands(t *testing.T) {
+	t.Parallel()
+
+	for name, args := range map[string][]string{
+		"before the subcommands": {"--auto-approve", "child", "grandchild"},
+		"after the subcommands":  {"child", "grandchild", "--auto-approve"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// Given
+			state := &RootFlags{}
+			root := &cobra.Command{Use: "exasol"}
+			child := &cobra.Command{Use: "child"}
+			grandchild := &cobra.Command{
+				Use:  "grandchild",
+				RunE: func(*cobra.Command, []string) error { return nil },
+			}
+			child.AddCommand(grandchild)
+			root.AddCommand(child)
+			registerAutoApproveFlag(root, state)
+
+			// When
+			root.SetArgs(args)
+			if err := root.Execute(); err != nil {
+				t.Fatalf("expected the command to accept --auto-approve: %v", err)
+			}
+
+			// Then
+			if !state.AutoApprove {
+				t.Error("expected --auto-approve to set the root flag state")
+			}
+		})
+	}
+}
+
+func TestAutoApproveFlagDefaultsToRequiringApproval(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	state := &RootFlags{}
+	root := &cobra.Command{Use: "exasol"}
+	child := &cobra.Command{
+		Use:  "child",
+		RunE: func(*cobra.Command, []string) error { return nil },
+	}
+	root.AddCommand(child)
+	registerAutoApproveFlag(root, state)
+
+	// When
+	root.SetArgs([]string{"child"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("expected the command to run: %v", err)
+	}
+
+	// Then
+	if state.AutoApprove {
+		t.Error("expected approval to be required when --auto-approve is absent")
+	}
+}
+
+// A command declaring its own --auto-approve shadows the global flag, so the
+// global one would silently stop applying to exactly the commands that ask
+// for confirmation.
+//
+// Walking the shared command tree mutates it: cobra sorts and caches a
+// command's children on first access, and reading local flag sets merges
+// persistent flags into them. This test therefore stays sequential.
+//
+//nolint:paralleltest // Mutates the shared command tree, see above.
+func TestCommandsDoNotShadowGlobalAutoApproveFlag(t *testing.T) {
+	// Given
+	var shadowing []string
+
+	// When
+	var walk func(cmd *cobra.Command)
+	walk = func(cmd *cobra.Command) {
+		if cmd.LocalNonPersistentFlags().Lookup("auto-approve") != nil {
+			shadowing = append(shadowing, cmd.CommandPath())
+		}
+		for _, child := range cmd.Commands() {
+			walk(child)
+		}
+	}
+	walk(rootCmd)
+
+	// Then
+	if len(shadowing) > 0 {
+		t.Fatalf("commands declare their own --auto-approve instead of using the "+
+			"global flag: %v", shadowing)
+	}
+}

--- a/cmd/exasol/commonFlags.go
+++ b/cmd/exasol/commonFlags.go
@@ -33,7 +33,6 @@ type CommonFlags struct {
 	// Common flags for deploy-like commands (deploy + install).
 	DeployVerbose            bool
 	DeployTofuUpdateLockfile bool
-	LocalRuntimeAutoApprove  bool
 }
 
 // commonFlags is the default runtime instance used by the actual CLI commands.
@@ -89,18 +88,6 @@ func registerDeployFlags(cmd *cobra.Command, state *CommonFlags) {
 		"tofu-update-lockfile",
 		false,
 		"Allow OpenTofu to update .terraform.lock.hcl during init",
-	)
-	registerRuntimePreparationFlag(cmd, state)
-}
-
-// registerRuntimePreparationFlag is shared by the deploy-like commands and
-// start, all of which may need to prepare the local runtime's host.
-func registerRuntimePreparationFlag(cmd *cobra.Command, state *CommonFlags) {
-	cmd.Flags().BoolVar(
-		&state.LocalRuntimeAutoApprove,
-		"auto-approve",
-		false,
-		"Approve required local runtime host preparation without prompting",
 	)
 }
 

--- a/cmd/exasol/deploy.go
+++ b/cmd/exasol/deploy.go
@@ -33,7 +33,7 @@ var deployCmd = &cobra.Command{
 			deploy.DeployOptions{
 				UpdateDependencyLockfile: commonFlags.DeployTofuUpdateLockfile,
 				RuntimePreparation: hostRuntimePreparationOptions(
-					cmd, commonFlags.LocalRuntimeAutoApprove,
+					cmd, rootOpts.ApprovalMode(),
 				),
 			},
 		); err != nil {

--- a/cmd/exasol/deploymentControl.go
+++ b/cmd/exasol/deploymentControl.go
@@ -62,7 +62,7 @@ var startCmd = &cobra.Command{
 			deploy.StartOptions{
 				WaitTimeoutSeconds: waitTimeoutSeconds,
 				RuntimePreparation: hostRuntimePreparationOptions(
-					cmd, commonFlags.LocalRuntimeAutoApprove,
+					cmd, rootOpts.ApprovalMode(),
 				),
 			},
 		); err != nil {
@@ -124,7 +124,6 @@ func registerStartFlags() {
 		deploy.StartedDefaultTimeoutInMinutes,
 		"Maximum minutes to wait for the database to become ready",
 	)
-	registerRuntimePreparationFlag(startCmd, commonFlags)
 }
 
 // nolint: gochecknoinits

--- a/cmd/exasol/destroy.go
+++ b/cmd/exasol/destroy.go
@@ -20,16 +20,11 @@ Pass --remove to remove the local deployment directory after deployment resource
 `
 
 var destroyOpts = struct {
-	AutoApprove bool
-	Remove      bool
+	Remove bool
 }{}
 
 func registerDestroyFlags(cmd *cobra.Command) {
 	registerVerboseFlag(cmd, commonFlags)
-	cmd.Flags().BoolVar(&destroyOpts.AutoApprove,
-		"auto-approve",
-		false,
-		"Force destroy without confirmation prompt")
 	// nolint: revive
 	cmd.Flags().BoolVar(&destroyOpts.Remove,
 		"remove",
@@ -48,15 +43,21 @@ var destroyCmd = &cobra.Command{
 
 		deployment := commonFlags.Deployment()
 
-		response := destroyOpts.AutoApprove
-		if !response {
-			removalTarget := ""
-			if destroyOpts.Remove {
-				removalTarget = deployment.Root()
-			}
-			response = askForUserConfirmation(destroyConfirmationPrompt(removalTarget))
+		proceed, err := confirmAction(
+			rootOpts.ApprovalMode(),
+			func() bool {
+				removalTarget := ""
+				if destroyOpts.Remove {
+					removalTarget = deployment.Root()
+				}
+
+				return askForUserConfirmation(destroyConfirmationPrompt(removalTarget))
+			},
+		)
+		if err != nil {
+			return err
 		}
-		if !response {
+		if !proceed {
 			return nil
 		}
 

--- a/cmd/exasol/host_runtime_preparation.go
+++ b/cmd/exasol/host_runtime_preparation.go
@@ -10,8 +10,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/exasol/exasol-personal/internal/approval"
 	"github.com/exasol/exasol-personal/internal/localruntime"
-	"github.com/exasol/exasol-personal/internal/util"
 	"github.com/spf13/cobra"
 )
 
@@ -21,10 +21,10 @@ import (
 // detection) in the command layer.
 func hostRuntimePreparationOptions(
 	cmd *cobra.Command,
-	autoApprove bool,
+	mode approval.Mode,
 ) localruntime.PrepareOptions {
 	return localruntime.PrepareOptions{
-		ApproveHostChange: hostChangeApprover(cmd, autoApprove, util.IsInteractiveStdin()),
+		ApproveHostChange: hostChangeApprover(cmd, mode),
 		// Preparation progress goes to stderr unconditionally: it reports
 		// multi-minute steps the user needs to see, and is not the
 		// --verbose-gated subprocess output.
@@ -35,21 +35,22 @@ func hostRuntimePreparationOptions(
 // hostChangeApprover refuses rather than assumes when it cannot ask. A
 // non-interactive run without --auto-approve fails with instructions instead
 // of silently mutating the host.
-//
-//nolint:revive // autoApprove and interactive describe command presentation policy.
 func hostChangeApprover(
 	cmd *cobra.Command,
-	autoApprove, interactive bool,
+	mode approval.Mode,
 ) localruntime.HostChangeApprover {
 	return func(_ context.Context, request localruntime.HostChangeRequest) (bool, error) {
-		if autoApprove {
+		switch mode {
+		case approval.ModeApprove:
 			return true, nil
-		}
-		if !interactive {
+		case approval.ModeNonInteractive:
 			return false, errors.New(
 				"local runtime host preparation requires approval; " +
 					"re-run with --auto-approve or run the displayed setup manually",
 			)
+		case approval.ModePrompt:
+		default:
+			return false, fmt.Errorf("unrecognised approval mode %q", mode)
 		}
 
 		writer := cmd.ErrOrStderr()

--- a/cmd/exasol/host_runtime_preparation_test.go
+++ b/cmd/exasol/host_runtime_preparation_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/exasol/exasol-personal/internal/approval"
 	"github.com/exasol/exasol-personal/internal/localruntime"
 	"github.com/spf13/cobra"
 )
@@ -33,7 +34,7 @@ func TestHostChangeApprover_AutoApproveSkipsPrompt(t *testing.T) {
 	t.Parallel()
 
 	cmd, errOut := newApproverTestCommand("")
-	approver := hostChangeApprover(cmd, true, false)
+	approver := hostChangeApprover(cmd, approval.ModeApprove)
 
 	approved, err := approver(context.Background(), testHostChangeRequest)
 	if err != nil {
@@ -54,7 +55,7 @@ func TestHostChangeApprover_NonInteractiveRefusesWithoutAutoApprove(t *testing.T
 	t.Parallel()
 
 	cmd, _ := newApproverTestCommand("")
-	approver := hostChangeApprover(cmd, false, false)
+	approver := hostChangeApprover(cmd, approval.ModeNonInteractive)
 
 	approved, err := approver(context.Background(), testHostChangeRequest)
 	if err == nil {
@@ -72,7 +73,7 @@ func TestHostChangeApprover_InteractiveShowsCommandsAndAcceptsYes(t *testing.T) 
 	t.Parallel()
 
 	cmd, errOut := newApproverTestCommand("y\n")
-	approver := hostChangeApprover(cmd, false, true)
+	approver := hostChangeApprover(cmd, approval.ModePrompt)
 
 	approved, err := approver(context.Background(), testHostChangeRequest)
 	if err != nil {
@@ -95,7 +96,7 @@ func TestHostChangeApprover_InteractiveDefaultsToNo(t *testing.T) {
 
 	for _, input := range []string{"\n", "n\n", "no\n", ""} {
 		cmd, _ := newApproverTestCommand(input)
-		approver := hostChangeApprover(cmd, false, true)
+		approver := hostChangeApprover(cmd, approval.ModePrompt)
 
 		approved, err := approver(context.Background(), testHostChangeRequest)
 		if err != nil {
@@ -111,7 +112,7 @@ func TestHostRuntimePreparationOptions_AlwaysSuppliesApproverAndProgress(t *test
 	t.Parallel()
 
 	cmd, errOut := newApproverTestCommand("")
-	options := hostRuntimePreparationOptions(cmd, true)
+	options := hostRuntimePreparationOptions(cmd, approval.ModeApprove)
 
 	if options.ApproveHostChange == nil {
 		t.Error("expected an approver to always be supplied")

--- a/cmd/exasol/install.go
+++ b/cmd/exasol/install.go
@@ -166,7 +166,7 @@ func runInstallPersistentPostRun(cmd *cobra.Command, _ []string) error {
 		deploy.DeployOptions{
 			UpdateDependencyLockfile: commonFlags.DeployTofuUpdateLockfile,
 			RuntimePreparation: hostRuntimePreparationOptions(
-				cmd, commonFlags.LocalRuntimeAutoApprove,
+				cmd, rootOpts.ApprovalMode(),
 			),
 		},
 	); err != nil {

--- a/cmd/exasol/remove.go
+++ b/cmd/exasol/remove.go
@@ -19,19 +19,6 @@ WARNING: This command removes the local deployment directory. It does not destro
 deployment resources and can make launcher-based cleanup impossible if resources still exist.
 `
 
-var removeOpts = struct {
-	AutoApprove bool
-}{}
-
-func registerRemoveFlags(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(
-		&removeOpts.AutoApprove,
-		"auto-approve",
-		false,
-		"Force local removal without confirmation prompt",
-	)
-}
-
 var removeCmd = &cobra.Command{
 	Use:     "remove",
 	Short:   removeCmdShortDesc,
@@ -41,12 +28,18 @@ var removeCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		cmd.SilenceUsage = true
 
-		response := removeOpts.AutoApprove
-		if !response {
-			deployment := commonFlags.Deployment()
-			response = askForUserConfirmation(removeConfirmationPrompt(deployment.Root()))
+		proceed, err := confirmAction(
+			rootOpts.ApprovalMode(),
+			func() bool {
+				deployment := commonFlags.Deployment()
+
+				return askForUserConfirmation(removeConfirmationPrompt(deployment.Root()))
+			},
+		)
+		if err != nil {
+			return err
 		}
-		if !response {
+		if !proceed {
 			return nil
 		}
 
@@ -67,6 +60,5 @@ func removeConfirmationPrompt(deploymentDir string) string {
 // nolint: gochecknoinits
 func init() {
 	registerDeploymentDirFlag(removeCmd, commonFlags)
-	registerRemoveFlags(removeCmd)
 	rootCmd.AddCommand(removeCmd)
 }

--- a/cmd/exasol/root.go
+++ b/cmd/exasol/root.go
@@ -12,9 +12,11 @@ import (
 	"time"
 
 	"github.com/exasol/exasol-personal/assets/resources"
+	"github.com/exasol/exasol-personal/internal/approval"
 	"github.com/exasol/exasol-personal/internal/config"
 	"github.com/exasol/exasol-personal/internal/deploy"
 	"github.com/exasol/exasol-personal/internal/runtimeartifacts"
+	"github.com/exasol/exasol-personal/internal/util"
 	"github.com/lmittmann/tint"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -68,6 +70,37 @@ var logLevelMap = map[string]slog.Level{
 }
 
 var ErrInvalidLogLevel = errors.New("invalid log level")
+
+// RootFlags contains flag values that apply to every command.
+//
+// State is kept separate from registration, like CommonFlags, so tests can
+// register against a throwaway command tree instead of the shared globals.
+type RootFlags struct {
+	AutoApprove bool
+}
+
+var rootOpts = &RootFlags{}
+
+// ApprovalMode resolves the flag together with terminal availability, so each
+// command can respond to "nobody can be asked" on its own terms rather than
+// having it collapsed into a plain refusal here.
+func (flags *RootFlags) ApprovalMode() approval.Mode {
+	return approval.Resolve(flags.AutoApprove, util.IsInteractiveStdin())
+}
+
+// registerAutoApproveFlag makes approval a single cross-cutting choice rather
+// than a per-command one. Commands read rootOpts.ApprovalMode() instead of
+// declaring their own flag, which would shadow this one where it matters.
+func registerAutoApproveFlag(root *cobra.Command, state *RootFlags) {
+	root.PersistentFlags().BoolVar(
+		&state.AutoApprove,
+		"auto-approve",
+		false,
+		"Approve confirmation prompts, which a run with no terminal also does "+
+			"automatically except for local runtime host preparation. Input "+
+			"validation and other safety checks still apply",
+	)
+}
 
 var rootCmd = &cobra.Command{
 	Use:           "exasol",
@@ -164,6 +197,7 @@ func addHelpFlag(cmd *cobra.Command) {
 func Execute() error {
 	resetTerminalMessages()
 	registerLogLevelFlag(rootCmd, commonFlags)
+	registerAutoApproveFlag(rootCmd, rootOpts)
 
 	// One resource manager for the whole process, attached to the root
 	// context so every command reaches it via cmd.Context() instead of each

--- a/cmd/exasol/slc.go
+++ b/cmd/exasol/slc.go
@@ -12,31 +12,24 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"github.com/exasol/exasol-personal/internal/approval"
 	"github.com/exasol/exasol-personal/internal/deploy"
-	"github.com/exasol/exasol-personal/internal/util"
 	"github.com/spf13/cobra"
 )
 
 var slcInstallOpts = struct {
-	AutoApprove bool
-	NoRestart   bool
+	NoRestart bool
 }{}
 
 var slcUpdateOpts = struct {
-	AutoApprove bool
-	NoRestart   bool
+	NoRestart bool
 }{}
 
 var slcRemoveOpts = struct {
-	AutoApprove bool
-	NoRestart   bool
+	NoRestart bool
 }{}
 
 const slcOperationAbortedMessage = "Aborted; no changes were made."
-
-const slcAutoApproveFlagName = "auto-approve"
-
-const slcAutoApproveFlagDesc = "Do not prompt for confirmation before restarting the database"
 
 const slcNoRestartFlagName = "no-restart"
 
@@ -44,19 +37,17 @@ const slcNoRestartFlagName = "no-restart"
 const slcInstalledVerb = "Installed"
 
 var slcCustomInstallOpts = struct {
-	AutoApprove bool
-	NoRestart   bool
-	Source      string
-	Alias       string
-	Language    string
+	NoRestart bool
+	Source    string
+	Alias     string
+	Language  string
 }{}
 
 var slcCustomUpdateOpts = struct {
-	AutoApprove bool
-	NoRestart   bool
-	Source      string
-	Alias       string
-	Language    string
+	NoRestart bool
+	Source    string
+	Alias     string
+	Language  string
 }{}
 
 const slcCustomSourceFlagName = "source"
@@ -104,7 +95,7 @@ var slcInstallCmd = &cobra.Command{
 			alias,
 			commonFlags.DeployVerbose,
 			!slcInstallOpts.NoRestart,
-			slcConfirmFunc(cmd, slcInstallOpts.AutoApprove, fmt.Sprintf("Installing %q", alias)),
+			slcConfirmFunc(cmd, rootOpts.ApprovalMode(), fmt.Sprintf("Installing %q", alias)),
 		)
 		if errors.Is(err, deploy.ErrSLCOperationCancelled) {
 			addTerminalNotice(slcOperationAbortedMessage)
@@ -159,7 +150,7 @@ var slcUpdateCmd = &cobra.Command{
 			alias,
 			commonFlags.DeployVerbose,
 			!slcUpdateOpts.NoRestart,
-			slcConfirmFunc(cmd, slcUpdateOpts.AutoApprove, fmt.Sprintf("Updating %q", alias)),
+			slcConfirmFunc(cmd, rootOpts.ApprovalMode(), fmt.Sprintf("Updating %q", alias)),
 		)
 		if errors.Is(err, deploy.ErrSLCOperationCancelled) {
 			addTerminalNotice(slcOperationAbortedMessage)
@@ -225,7 +216,7 @@ var slcRemoveCmd = &cobra.Command{
 			alias,
 			commonFlags.DeployVerbose,
 			!slcRemoveOpts.NoRestart,
-			slcConfirmFunc(cmd, slcRemoveOpts.AutoApprove, fmt.Sprintf("Removing %q", alias)),
+			slcConfirmFunc(cmd, rootOpts.ApprovalMode(), fmt.Sprintf("Removing %q", alias)),
 		)
 		if errors.Is(err, deploy.ErrSLCOperationCancelled) {
 			addTerminalNotice(slcOperationAbortedMessage)
@@ -311,7 +302,7 @@ func runSLCCustomInstall(cmd *cobra.Command) error {
 		},
 		commonFlags.DeployVerbose,
 		!slcCustomInstallOpts.NoRestart,
-		customSLCConfirmFunc(cmd, slcCustomInstallOpts.AutoApprove),
+		customSLCConfirmFunc(cmd, rootOpts.ApprovalMode()),
 	)
 	if errors.Is(err, deploy.ErrSLCOperationCancelled) {
 		addTerminalNotice(slcOperationAbortedMessage)
@@ -357,7 +348,7 @@ func runSLCCustomUpdate(cmd *cobra.Command) error {
 		},
 		commonFlags.DeployVerbose,
 		!slcCustomUpdateOpts.NoRestart,
-		customSLCConfirmFunc(cmd, slcCustomUpdateOpts.AutoApprove),
+		customSLCConfirmFunc(cmd, rootOpts.ApprovalMode()),
 	)
 	if errors.Is(err, deploy.ErrSLCOperationCancelled) {
 		addTerminalNotice(slcOperationAbortedMessage)
@@ -398,7 +389,6 @@ func runSLCCustomUpdate(cmd *cobra.Command) error {
 func runSLCInstallRust(cmd *cobra.Command) error {
 	return runSLCRust(
 		cmd,
-		slcInstallOpts.AutoApprove,
 		!slcInstallOpts.NoRestart,
 		"The Rust SLC is already installed with this container. Nothing to do.",
 		"Replaced",
@@ -411,7 +401,6 @@ func runSLCInstallRust(cmd *cobra.Command) error {
 func runSLCUpdateRust(cmd *cobra.Command) error {
 	return runSLCRust(
 		cmd,
-		slcUpdateOpts.AutoApprove,
 		!slcUpdateOpts.NoRestart,
 		"The Rust SLC is already up to date. Nothing to do.",
 		"Updated",
@@ -427,7 +416,6 @@ var installRustSLCFn = deploy.InstallRustSLC
 // wording for an unchanged container and for a replaced one.
 func runSLCRust(
 	cmd *cobra.Command,
-	autoApprove bool,
 	restart bool,
 	unchangedMessage string,
 	replacedVerb string,
@@ -438,7 +426,7 @@ func runSLCRust(
 		deploy.RustSLCInstallOpts{},
 		commonFlags.DeployVerbose,
 		restart,
-		customSLCConfirmFunc(cmd, autoApprove),
+		customSLCConfirmFunc(cmd, rootOpts.ApprovalMode()),
 	)
 
 	return reportRustSLCResult(result, err, unchangedMessage, replacedVerb)
@@ -524,19 +512,21 @@ func runSLCCustomRemove(cmd *cobra.Command, alias string) error {
 	return nil
 }
 
-// Refuses non-interactively so scripts never override an SLC silently.
-//
-//nolint:revive // autoApprove reflects the user's flag, not internal control coupling.
-func customSLCConfirmFunc(cmd *cobra.Command, autoApprove bool) deploy.CustomSLCConfirm {
-	if autoApprove {
+// A run with no terminal proceeds without asking rather than blocking on a
+// prompt nobody can answer. A nil callback means "already confirmed", so an
+// unrecognised mode must not return one.
+func customSLCConfirmFunc(cmd *cobra.Command, mode approval.Mode) deploy.CustomSLCConfirm {
+	switch mode {
+	case approval.ModeApprove, approval.ModeNonInteractive:
 		return nil
+	case approval.ModePrompt:
+	default:
+		return func(string) (bool, error) {
+			return false, fmt.Errorf("unrecognised approval mode %q", mode)
+		}
 	}
 
 	return func(prompt string) (bool, error) {
-		if !util.IsInteractiveStdin() {
-			return false, errors.New(prompt + "; re-run with --auto-approve to proceed")
-		}
-
 		// stderr, so an interactive prompt never lands in the middle of --json output.
 		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "%s.\nContinue? [y/N]: ", prompt)
 
@@ -550,24 +540,21 @@ func customSLCConfirmFunc(cmd *cobra.Command, autoApprove bool) deploy.CustomSLC
 }
 
 // slcConfirmFunc returns a confirmation callback for a database-restarting SLC operation.
-// It returns nil when the user passed --auto-approve (pre-approved). Otherwise it warns and
-// prompts interactively, and refuses non-interactively so scripts never trigger a silent
-// restart.
-//
-//nolint:revive // autoApprove reflects the user's flag, not internal control coupling.
-func slcConfirmFunc(cmd *cobra.Command, autoApprove bool, action string) deploy.ConfirmFunc {
-	if autoApprove {
+// It returns nil when the restart needs no confirmation, either because approval was
+// granted or because there is no terminal to ask. Otherwise it warns and prompts. A nil
+// callback means "already confirmed", so an unrecognised mode must not return one.
+func slcConfirmFunc(cmd *cobra.Command, mode approval.Mode, action string) deploy.ConfirmFunc {
+	switch mode {
+	case approval.ModeApprove, approval.ModeNonInteractive:
 		return nil
+	case approval.ModePrompt:
+	default:
+		return func() (bool, error) {
+			return false, fmt.Errorf("unrecognised approval mode %q", mode)
+		}
 	}
 
 	return func() (bool, error) {
-		if !util.IsInteractiveStdin() {
-			return false, errors.New(
-				"this restarts the database; re-run with --auto-approve to confirm, " +
-					"or --no-restart to apply on the next start",
-			)
-		}
-
 		_, _ = fmt.Fprintf(
 			cmd.ErrOrStderr(),
 			"%s will restart the database. Open connections will be dropped and running "+
@@ -827,8 +814,6 @@ func init() {
 	registerDeploymentDirFlag(slcInstallCmd, commonFlags)
 	registerOutputFlags(slcInstallCmd, commonFlags)
 	registerVerboseFlag(slcInstallCmd, commonFlags)
-	slcInstallCmd.Flags().BoolVar(&slcInstallOpts.AutoApprove, slcAutoApproveFlagName, false,
-		slcAutoApproveFlagDesc)
 	slcInstallCmd.Flags().BoolVar(&slcInstallOpts.NoRestart, slcNoRestartFlagName, false,
 		"Record the SLC without restarting; it activates on the next start")
 
@@ -837,8 +822,6 @@ func init() {
 	registerDeploymentDirFlag(slcUpdateCmd, commonFlags)
 	registerOutputFlags(slcUpdateCmd, commonFlags)
 	registerVerboseFlag(slcUpdateCmd, commonFlags)
-	slcUpdateCmd.Flags().BoolVar(&slcUpdateOpts.AutoApprove, slcAutoApproveFlagName, false,
-		slcAutoApproveFlagDesc)
 	slcUpdateCmd.Flags().BoolVar(&slcUpdateOpts.NoRestart, slcNoRestartFlagName, false,
 		"Record the update without restarting; it applies on the next start")
 
@@ -847,8 +830,6 @@ func init() {
 	registerDeploymentDirFlag(slcRemoveCmd, commonFlags)
 	registerOutputFlags(slcRemoveCmd, commonFlags)
 	registerVerboseFlag(slcRemoveCmd, commonFlags)
-	slcRemoveCmd.Flags().BoolVar(&slcRemoveOpts.AutoApprove, slcAutoApproveFlagName, false,
-		slcAutoApproveFlagDesc)
 	slcRemoveCmd.Flags().BoolVar(&slcRemoveOpts.NoRestart, slcNoRestartFlagName, false,
 		"Record the removal without restarting; it applies on the next start")
 
@@ -860,10 +841,6 @@ func init() {
 	registerDeploymentDirFlag(slcCustomInstallCmd, commonFlags)
 	registerOutputFlags(slcCustomInstallCmd, commonFlags)
 	registerVerboseFlag(slcCustomInstallCmd, commonFlags)
-	slcCustomInstallCmd.Flags().BoolVar(&slcCustomInstallOpts.AutoApprove,
-		slcAutoApproveFlagName, false,
-		"Do not prompt before restarting the database, overriding a built-in alias, "+
-			"or replacing a custom SLC")
 	slcCustomInstallCmd.Flags().BoolVar(&slcCustomInstallOpts.NoRestart,
 		slcNoRestartFlagName, false,
 		"Record the custom SLC without restarting; it activates on the next start")
@@ -880,8 +857,6 @@ func init() {
 	registerDeploymentDirFlag(slcCustomUpdateCmd, commonFlags)
 	registerOutputFlags(slcCustomUpdateCmd, commonFlags)
 	registerVerboseFlag(slcCustomUpdateCmd, commonFlags)
-	slcCustomUpdateCmd.Flags().BoolVar(&slcCustomUpdateOpts.AutoApprove,
-		slcAutoApproveFlagName, false, slcAutoApproveFlagDesc)
 	slcCustomUpdateCmd.Flags().BoolVar(&slcCustomUpdateOpts.NoRestart,
 		slcNoRestartFlagName, false,
 		"Record the update without restarting; it applies on the next start")

--- a/cmd/exasol/slc_test.go
+++ b/cmd/exasol/slc_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/exasol/exasol-personal/internal/approval"
 	"github.com/exasol/exasol-personal/internal/config"
 	"github.com/exasol/exasol-personal/internal/deploy"
 	"github.com/spf13/cobra"
@@ -70,10 +71,12 @@ func TestSLCCustomInstallAndUpdateCarryRestartFlags(t *testing.T) {
 
 	// When / Then
 	for name, cmd := range commands {
-		for _, flag := range []string{"no-restart", "auto-approve"} {
-			if cmd.Flags().Lookup(flag) == nil {
-				t.Fatalf("slc custom %s is missing --%s", name, flag)
-			}
+		if cmd.Flags().Lookup("no-restart") == nil {
+			t.Fatalf("slc custom %s is missing --no-restart", name)
+		}
+		// Approval is a global flag, so the command must not declare its own.
+		if cmd.Flags().Lookup("auto-approve") != nil {
+			t.Fatalf("slc custom %s declares its own --auto-approve", name)
 		}
 	}
 	if slcInstallCmd.Flags().Lookup("no-restart") == nil {
@@ -86,9 +89,9 @@ func TestSLCCustomInstallAndUpdateCarryRestartFlags(t *testing.T) {
 func TestSLCInstallAndUpdateFlagSurfaceIsUnchangedByRustSupport(t *testing.T) {
 	t.Parallel()
 
-	// Given
+	// Given: --auto-approve is global, so it must not appear in the local surface.
 	want := []string{
-		"auto-approve", "no-restart", "deployment", "deployment-dir", "json", "verbose",
+		"no-restart", "deployment", "deployment-dir", "json", "verbose",
 	}
 
 	// When / Then
@@ -315,9 +318,12 @@ func TestSLCInstallDispatchesRustWithoutNetworkOrLiveDeployment(t *testing.T) {
 
 		return &deploy.CustomSLCInstallResult{Alias: "RUST", Language: "rust"}, nil
 	})
-	slcInstallOpts.AutoApprove = true
+	rootOpts.AutoApprove = true
 	slcInstallOpts.NoRestart = false
-	defer func() { slcInstallOpts = struct{ AutoApprove, NoRestart bool }{} }()
+	defer func() {
+		rootOpts.AutoApprove = false
+		slcInstallOpts = struct{ NoRestart bool }{}
+	}()
 
 	// When
 	if err := slcInstallCmd.RunE(slcInstallCmd, []string{"rust"}); err != nil {
@@ -354,9 +360,12 @@ func TestSLCUpdateDispatchesRustWithoutNetworkOrLiveDeployment(t *testing.T) {
 			Alias: "RUST", Language: "rust", AlreadyInstalled: true,
 		}, nil
 	})
-	slcUpdateOpts.AutoApprove = true
+	rootOpts.AutoApprove = true
 	slcUpdateOpts.NoRestart = true
-	defer func() { slcUpdateOpts = struct{ AutoApprove, NoRestart bool }{} }()
+	defer func() {
+		rootOpts.AutoApprove = false
+		slcUpdateOpts = struct{ NoRestart bool }{}
+	}()
 
 	// When
 	if err := slcUpdateCmd.RunE(slcUpdateCmd, []string{"RUST"}); err != nil {
@@ -593,12 +602,12 @@ func TestSLCConfirmPromptsGoToStderr(t *testing.T) {
 
 	for name, prompt := range map[string]func(*cobra.Command) error{
 		"custom": func(cmd *cobra.Command) error {
-			_, err := customSLCConfirmFunc(cmd, false)("overriding a built-in alias")
+			_, err := customSLCConfirmFunc(cmd, approval.ModePrompt)("overriding a built-in alias")
 
 			return err
 		},
 		"official": func(cmd *cobra.Command) error {
-			_, err := slcConfirmFunc(cmd, false, "Installing")()
+			_, err := slcConfirmFunc(cmd, approval.ModePrompt, "Installing")()
 
 			return err
 		},
@@ -617,6 +626,9 @@ func TestSLCConfirmPromptsGoToStderr(t *testing.T) {
 		// Then
 		if stdout.Len() != 0 {
 			t.Fatalf("%s: prompt must not write to stdout, got %q", name, stdout.String())
+		}
+		if stderr.Len() == 0 {
+			t.Fatalf("%s: expected the prompt on stderr", name)
 		}
 	}
 }
@@ -645,5 +657,55 @@ func TestFormatSLCListTextSeparatesOfficialFromCustom(t *testing.T) {
 	// And: a custom-only listing must not start with a blank line.
 	if got := formatSLCListText(nil, custom); strings.HasPrefix(got, "\n") {
 		t.Fatalf("a custom-only listing must not be preceded by a blank line, got %q", got)
+	}
+}
+
+// A restart needs confirming only when someone can answer. Both an approved
+// run and one with no terminal hand over no callback at all, which is how the
+// SLC operations proceed without asking.
+func TestSLCConfirmFuncsRespondPerApprovalMode(t *testing.T) {
+	t.Parallel()
+
+	for name, mode := range map[string]approval.Mode{
+		"approved":    approval.ModeApprove,
+		"no terminal": approval.ModeNonInteractive,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if slcConfirmFunc(&cobra.Command{}, mode, "Installing") != nil {
+				t.Errorf("expected no confirmation callback when %s", name)
+			}
+			if customSLCConfirmFunc(&cobra.Command{}, mode) != nil {
+				t.Errorf("expected no custom confirmation callback when %s", name)
+			}
+		})
+	}
+
+	if slcConfirmFunc(&cobra.Command{}, approval.ModePrompt, "Installing") == nil {
+		t.Error("expected a confirmation callback when a user can be asked")
+	}
+	if customSLCConfirmFunc(&cobra.Command{}, approval.ModePrompt) == nil {
+		t.Error("expected a custom confirmation callback when a user can be asked")
+	}
+
+	// A nil callback grants the restart, so an unrecognised mode must refuse
+	// rather than hand one back.
+	bogus := approval.Mode("bogus")
+	confirm := slcConfirmFunc(&cobra.Command{}, bogus, "Installing")
+	if confirm == nil {
+		t.Fatal("expected an unrecognised mode to withhold pre-approval")
+	}
+	if approved, err := confirm(); err == nil || approved {
+		t.Errorf("expected an unrecognised mode to refuse, got approved=%v err=%v", approved, err)
+	}
+
+	customConfirm := customSLCConfirmFunc(&cobra.Command{}, bogus)
+	if customConfirm == nil {
+		t.Fatal("expected an unrecognised mode to withhold custom pre-approval")
+	}
+	if approved, err := customConfirm("overriding"); err == nil || approved {
+		t.Errorf("expected an unrecognised custom mode to refuse, got approved=%v err=%v",
+			approved, err)
 	}
 }

--- a/cmd/exasol/util.go
+++ b/cmd/exasol/util.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/exasol/exasol-personal/internal/approval"
 	"github.com/exasol/exasol-personal/internal/deploy"
 	"github.com/exasol/exasol-personal/internal/presets"
 	"github.com/exasol/exasol-personal/internal/runtimeartifacts"
@@ -25,6 +26,22 @@ type UserConfirmationValidator func(input string) bool
 func confirmYes(input string) bool {
 	input = strings.ToLower(strings.TrimSpace(input))
 	return input == "y" || input == "yes"
+}
+
+// confirmAction applies the approval mode to an action that needs confirmation.
+// A run with no terminal proceeds as though approval had been granted, so it
+// never blocks on a prompt nobody can answer. Host preparation is the
+// exception and refuses instead, because it mutates state shared beyond the
+// deployment.
+func confirmAction(mode approval.Mode, ask func() bool) (bool, error) {
+	switch mode {
+	case approval.ModeApprove, approval.ModeNonInteractive:
+		return true, nil
+	case approval.ModePrompt:
+		return ask(), nil
+	default:
+		return false, fmt.Errorf("unrecognised approval mode %q", mode)
+	}
 }
 
 // askForUserConfirmation asks the user for confirmation via stderr, and uses validators

--- a/cmd/exasol/util_test.go
+++ b/cmd/exasol/util_test.go
@@ -4,8 +4,10 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/exasol/exasol-personal/internal/approval"
 	"github.com/exasol/exasol-personal/internal/deploy"
 )
 
@@ -54,5 +56,71 @@ func TestLooksLikeExternalPresetURI(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("IsExternalPresetURI(%q) = %v, want %v", tc.arg, got, tc.want)
 		}
+	}
+}
+
+// A run with no terminal proceeds without asking, so an unattended caller is
+// never blocked on a prompt nobody can answer. Only a reachable user can
+// decline.
+func TestConfirmActionPerApprovalMode(t *testing.T) {
+	t.Parallel()
+
+	for name, testCase := range map[string]struct {
+		mode         approval.Mode
+		answer       bool
+		expectAsked  bool
+		expectGo     bool
+		expectErrMsg string
+	}{
+		"pre-approved does not ask": {
+			mode: approval.ModeApprove, expectGo: true,
+		},
+		"reachable user accepts": {
+			mode: approval.ModePrompt, answer: true, expectAsked: true, expectGo: true,
+		},
+		"reachable user declines without an error": {
+			mode: approval.ModePrompt, answer: false, expectAsked: true,
+		},
+		"no terminal proceeds without asking": {
+			mode: approval.ModeNonInteractive, expectGo: true,
+		},
+		"unrecognised mode is an error": {
+			mode: approval.Mode("bogus"), expectErrMsg: "unrecognised approval mode",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// Given
+			asked := false
+			ask := func() bool {
+				asked = true
+
+				return testCase.answer
+			}
+
+			// When
+			proceed, err := confirmAction(testCase.mode, ask)
+
+			// Then
+			if testCase.expectErrMsg == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("expected an error mentioning %q", testCase.expectErrMsg)
+				}
+				if !strings.Contains(err.Error(), testCase.expectErrMsg) {
+					t.Fatalf("expected %q in error, got %v", testCase.expectErrMsg, err)
+				}
+			}
+			if proceed != testCase.expectGo {
+				t.Errorf("expected proceed=%v, got %v", testCase.expectGo, proceed)
+			}
+			if asked != testCase.expectAsked {
+				t.Errorf("expected asked=%v, got %v", testCase.expectAsked, asked)
+			}
+		})
 	}
 }

--- a/internal/approval/approval.go
+++ b/internal/approval/approval.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+// Package approval describes how a command may obtain approval for an action
+// that requires it, so each command decides its own response instead of
+// receiving a single pre-collapsed yes or no.
+package approval
+
+// Mode reports the approval channel available for the current invocation.
+type Mode string
+
+const (
+	// ModeApprove means approval was granted up front and nothing is asked.
+	ModeApprove Mode = "approve"
+	// ModePrompt means the user is reachable and can be asked.
+	ModePrompt Mode = "prompt"
+	// ModeNonInteractive means approval was not granted and cannot be requested.
+	// Callers decide what that means for their action; treating it as consent
+	// lets a scripted run mutate state its author never approved.
+	ModeNonInteractive Mode = "non-interactive"
+)
+
+// Resolve maps the state of the --auto-approve flag and the availability of an
+// interactive terminal onto a Mode. Terminal detection stays with the caller so
+// this stays a pure decision.
+func Resolve(autoApprove, interactive bool) Mode {
+	if autoApprove {
+		return ModeApprove
+	}
+	if interactive {
+		return ModePrompt
+	}
+
+	return ModeNonInteractive
+}

--- a/internal/approval/approval_test.go
+++ b/internal/approval/approval_test.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package approval
+
+import "testing"
+
+func TestResolve(t *testing.T) {
+	t.Parallel()
+
+	for name, testCase := range map[string]struct {
+		autoApprove bool
+		interactive bool
+		expected    Mode
+	}{
+		"flag set with a terminal": {
+			autoApprove: true, interactive: true, expected: ModeApprove,
+		},
+		"flag set without a terminal": {
+			autoApprove: true, interactive: false, expected: ModeApprove,
+		},
+		"no flag with a terminal": {
+			autoApprove: false, interactive: true, expected: ModePrompt,
+		},
+		"no flag and no terminal": {
+			autoApprove: false, interactive: false, expected: ModeNonInteractive,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// When
+			mode := Resolve(testCase.autoApprove, testCase.interactive)
+
+			// Then
+			if mode != testCase.expected {
+				t.Fatalf("expected %q, got %q", testCase.expected, mode)
+			}
+		})
+	}
+}

--- a/internal/util/terminal_test.go
+++ b/internal/util/terminal_test.go
@@ -1,0 +1,46 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The null device is a character device but not a terminal, and a run
+// redirected from it is unattended.
+func TestIsTerminalRejectsNonTerminals(t *testing.T) {
+	t.Parallel()
+
+	nullDevice, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("could not open the null device: %v", err)
+	}
+	t.Cleanup(func() { _ = nullDevice.Close() })
+
+	regularPath := filepath.Join(t.TempDir(), "input.sql")
+	if err := os.WriteFile(regularPath, []byte("y\n"), 0o600); err != nil {
+		t.Fatalf("could not write the temporary file: %v", err)
+	}
+	regularFile, err := os.Open(regularPath)
+	if err != nil {
+		t.Fatalf("could not open the temporary file: %v", err)
+	}
+	t.Cleanup(func() { _ = regularFile.Close() })
+
+	for name, file := range map[string]*os.File{
+		"null device":  nullDevice,
+		"regular file": regularFile,
+		"nil file":     nil,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if isTerminal(file) {
+				t.Errorf("expected %s not to be reported as a terminal", name)
+			}
+		})
+	}
+}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -142,12 +142,18 @@ func GetTerminalWidth() (int, bool) {
 
 // IsInteractiveStdin returns true when stdin is attached to a terminal.
 func IsInteractiveStdin() bool {
-	stat, err := os.Stdin.Stat()
-	if err != nil {
+	return isTerminal(os.Stdin)
+}
+
+// isTerminal asks whether the file is a terminal rather than whether it is a
+// character device: /dev/null is a character device, so the weaker test
+// reports a redirected, unattended run as interactive.
+func isTerminal(file *os.File) bool {
+	if file == nil {
 		return false
 	}
 
-	return (stat.Mode() & os.ModeCharDevice) != 0
+	return term.IsTerminal(int(file.Fd()))
 }
 
 var (

--- a/user-docs/content/local-deployment.md
+++ b/user-docs/content/local-deployment.md
@@ -30,9 +30,10 @@ default machine when necessary, without changing the configuration of an existin
 installing Podman changes shared host state, the launcher displays the exact command and asks for
 approval.
 
-Use `--auto-approve` with `install`, `deploy`, or `start` for unattended preparation. A command that
-cannot prompt refuses the host change unless this option is present. Stopping or destroying an
-Exasol deployment leaves the shared Podman machine running.
+Use `--auto-approve` for unattended preparation. A command that cannot prompt refuses this host
+change unless the option is present, unlike other confirmations, which an unattended run approves
+automatically. Stopping or destroying an Exasol deployment leaves the shared Podman machine
+running.
 
 ## Open a shell
 

--- a/user-docs/content/manage-deployments.md
+++ b/user-docs/content/manage-deployments.md
@@ -97,6 +97,10 @@ Destroying removes the deployment resources and their data:
 exasol destroy
 ```
 
+The launcher asks for confirmation first. Pass `--auto-approve` to skip the prompt; a command with
+no terminal attached proceeds without asking, so a script that reaches `exasol destroy` or
+`exasol remove` destroys the deployment.
+
 By default, the launcher retains the deployment directory for inspection or recreation. Remove it
 after successful destruction with:
 

--- a/user-docs/content/udfs.md
+++ b/user-docs/content/udfs.md
@@ -34,7 +34,8 @@ state.
 Installing, updating, or removing an SLC normally restarts the local database. This drops open
 connections and aborts running statements. The command asks for confirmation first:
 
-- Use `--auto-approve` to skip the prompt. This is required for non-interactive use.
+- Use `--auto-approve` to skip the prompt. A command with no terminal attached also skips it and
+  restarts without asking.
 - Use `--no-restart` to record the change and activate it the next time the deployment starts.
 
 Official `install`, `update`, and `remove` operations and custom SLC management apply only to local


### PR DESCRIPTION
## Description

`--auto-approve` was declared eight times across six commands and a shared helper, in three variants with three different descriptions, and each one collapsed the user's flag and the terminal's availability into a single boolean before the command could see them. Approval is one cross-cutting choice, so it is now one flag on the root command, available everywhere `--log-level` is.

Commands no longer receive a pre-decided yes or no. They receive an approval mode, and decide their own response:

| Mode | Meaning |
| --- | --- |
| `approve` | `--auto-approve` was passed |
| `prompt` | no flag, and a terminal is attached |
| `non-interactive` | no flag, and there is no terminal to ask |

That third case is the one the old boolean threw away. "The user declined" and "there is nobody to ask" are different situations, and a command that cannot tell them apart either blocks on a prompt no one will answer or reports success for work it never did. Both happened: an unattended `exasol destroy` printed its confirmation question, read nothing, and exited 0 with the deployment intact.

An unattended run now proceeds as though `--auto-approve` had been passed:

| Prompt | `approve` | `prompt` | `non-interactive` |
| --- | --- | --- | --- |
| `destroy`, `remove` | proceeds | asks | proceeds |
| `slc` install, update, remove, custom install, custom update | proceeds | warns about the restart and asks | proceeds |
| Local runtime host preparation | proceeds | shows the exact commands and asks | refuses, naming `--auto-approve` |

Host preparation keeps requiring an answer because it is the one approval-gated host change in the launcher: installing Podman through winget on Windows, which mutates state shared well beyond the deployment and can raise a UAC prompt. Treating a missing terminal as consent there is the silent-consent bug removed in #302.

Detection of an attached terminal was wrong and is corrected. `util.IsInteractiveStdin` tested for a character device, and the null device is one, so `exasol destroy < /dev/null` counted as interactive: it prompted, read end of input, and declined. It now uses `term.IsTerminal`, which is what the function's own documentation already claimed.

For users the flag keeps its name and meaning, and is now also accepted before the subcommand:

```
exasol --auto-approve install local
exasol install local --auto-approve
exasol slc install --alias PYTHON3 --auto-approve
```

Commands that ask nothing accept and ignore it, exactly as they accept `--log-level`. Input validation and non-prompt safety checks are unaffected in every mode: an approved `exasol remove` pointed at a directory that is not a deployment still fails with `not an Exasol Personal deployment directory`.

## Related Issue

Fixes #

## Type of Change

- [x] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Register `--auto-approve` as a persistent flag on the root command, beside `--log-level`, bound to a `RootFlags` struct that keeps state separate from registration so tests can register against a throwaway command tree.
- Remove the eight per-command registrations it replaces, along with `CommonFlags.LocalRuntimeAutoApprove`, `registerRemoveFlags`, and two `slc` flag constants that had no remaining users. A local flag of the same name shadows an inherited persistent one, so leaving any of them would have made the global flag a no-op on exactly the commands that ask for confirmation.
- Add `internal/approval`, holding the `Mode` enum and a pure `Resolve(autoApprove, interactive bool)`. Terminal detection stays in the command layer, so the decision itself is directly testable.
- Resolve the mode once, in `RootFlags.ApprovalMode()`, and have each prompt site apply its own policy to it. Destructive and SLC restart prompts proceed when unattended; host preparation refuses. An unrecognised mode refuses rather than assuming consent.
- Fix `util.IsInteractiveStdin` to test for a terminal rather than a character device.
- Describe the behavior in the flag's own help text, covering both the implicit approval and the fact that it does not bypass validation or other safety checks.
- Update `CHANGELOG.md` and the `README.md` sentences that named the commands the flag applied to or promised a refusal when unattended.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

- 36 packages under `go test -tags=containers_image_openpgp -race`, all passing, and `golangci-lint` reports 0 issues across them.
- New tests: `internal/approval` covers the full input matrix of `Resolve`; `internal/util/terminal_test.go` asserts that the null device, a regular file, and a nil file are not terminals, which is the misdetection above; `cmd/exasol/auto_approve_flag_test.go` covers inheritance by a nested subcommand with the flag in both positions, the default when absent, and a guard that walks the command tree and fails if any command declares its own `--auto-approve`; `util_test.go` and `slc_test.go` cover the per-mode response of each prompt family.
- Manually verified with built binaries, comparing this branch against its merge base. `--auto-approve` appears under `Global Flags` for `destroy`, `remove`, `slc install`, `slc custom install`, `deploy`, `install`, and `status`, exactly once each, confirming nothing shadows it, and parses in both positions. An unattended `remove` reached its safety check under a pipe, under a redirect from a file, and under `< /dev/null`, where it previously prompted and declined. `status --auto-approve` and `--auto-approve` before the subcommand were `unknown flag` errors before this change.
- `TestSLCConfirmPromptsGoToStderr` previously reached the refusal path in CI, because the test process has no terminal, so its claim about prompts going to stderr was never exercised. The mode is now injectable, so the test selects the prompt path and asserts the prompt lands on stderr.
- `task all` was not run to completion. Module-wide Go commands fail on files under `internal/executor` that are unrelated to this change, see Additional Notes. `task lint-ruff-check` passes.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable)
- [x] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

Acceptance criteria are all met. Four needed work beyond the first commit: the help text now states that the option does not bypass validation or other non-prompt safety checks; an unattended run proceeds as if the option were set; that implicit behavior covers the same prompts as the option, with host preparation as the agreed exception; and the help text and changelog describe it.

Scope of the host-preparation exception, since "host preparation" sounds broader than it is. `HostChangeInstallContainerRuntime` is the only approval-gated change in the launcher, requested from one place, and only when `deploy`, `install`, or `start` runs on Windows and `podman` is not resolvable. macOS discards the approver entirely, Linux only checks that `podman` is on `PATH`, and a Windows host that already has Podman returns before anything is asked. Creating or starting Podman's default machine is deliberately not gated, per the change's design, so an unattended run will still do that.

Breaking change for scripts. An unattended `exasol destroy` or `exasol remove` now proceeds, where a redirected run previously declined, and a piped answer is ignored in both directions, so `echo n | exasol destroy` no longer prevents the destroy. Callers that relied on a redirected invocation being a safe no-op must stop invoking it. The changelog records this.

The terminal-detection fix reaches beyond this flag. `util.IsInteractiveStdin` also decides whether `exasol connect` runs an interactive shell and how it resolves non-interactive SQL, so `exasol connect < /dev/null` is now treated as unattended there too. That is the more correct reading, and it is worth a reviewer's attention because it was not the motivation for the change.