### PR TITLE
test: Fix deployment readiness races

### DIFF
--- a/tests/tests/conftest.py
+++ b/tests/tests/conftest.py
@@ -2,21 +2,15 @@
 # SPDX-License-Identifier: MIT
 
 import logging
-import platform
 import re
 import shlex
 import subprocess
-import time
 from collections.abc import Generator, Sequence
 from typing import Any
 
 import pytest
 
-from framework.deployment import (
-    Deployment,
-    StatusDatabaseReady,
-    StatusOperationInProgress,
-)
+from framework.deployment import Deployment, StatusDatabaseReady
 from framework.launcher import DeploymentConfig, Launcher
 
 _PROVIDER_MARKERS = {
@@ -95,26 +89,6 @@ def reusable_deployment(
     deployment = Deployment(Launcher(exasol_path), config=config)
     try:
         deployment_proc = deployment.deploy_no_block()
-
-        # Sleep after Popen to allow the child process to start
-        # and update status (needed for Windows).
-        if platform.system() == "Windows":
-            time.sleep(3)
-
-        logging.info("Check status deployment in progress")
-        timeout = 10
-        start_time = time.time()
-        while True:
-            if deployment.has_status(StatusOperationInProgress):
-                break
-
-            if time.time() - start_time > timeout:
-                logging.info("Timeout expired. Status incorrect")
-                msg = f"Expected status `{StatusOperationInProgress}` after `deploy`"
-                raise RuntimeError(msg)
-
-            logging.info("Status incorrect. Retrying in 5 seconds")
-            time.sleep(5)
 
         logging.info("Waiting for deploy to complete")
         deploy_timeout = 40 * 60

--- a/tests/tests/deployment/test_virtual_schema.py
+++ b/tests/tests/deployment/test_virtual_schema.py
@@ -218,18 +218,7 @@ def _container_runtime(deployment: Deployment) -> PodmanRunner:
 def _wait_for_postgres(source: PostgresSource) -> None:
     for _ in range(60):
         try:
-            source.podman(
-                [
-                    "exec",
-                    source.container,
-                    "pg_isready",
-                    "--username",
-                    source.user,
-                    "--dbname",
-                    source.database,
-                ],
-                None,
-            )
+            _run_postgres(source, "SELECT 1;", "--file", "-")
         except subprocess.CalledProcessError:
             pass
         else:


### PR DESCRIPTION
## Description

Fixes two timing races in deployment tests. The shared deployment fixture no longer requires observing the short-lived `operation_in_progress` status, and the Virtual Schema setup now waits until PostgreSQL accepts an actual query instead of relying on `pg_isready`.

## Related Issue

None.

## Type of Change

- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [x] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Remove the assertion that deployments expose the transient `operation_in_progress` status.
- Retain process-exit validation, deployment log reporting, and the final `database_ready` assertion.
- Probe PostgreSQL readiness with `SELECT 1` through `psql`, ensuring the database accepts connections before test setup continues.

## Testing

- [x] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [ ] Manually tested the changes

### Test Details

`task fmt`, `task lint`, and `task all` pass locally.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [ ] Updated documentation (not applicable)
- [ ] Updated `CHANGELOG.md` for user-facing changes (not applicable)
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

The removed Windows-specific sleep only gave the child process time to publish its intermediate status. Waiting on the process handle remains synchronous on Windows, and the fixture still validates successful completion and the final ready state.