### PR TITLE
fix: Leave failed local deployments able to retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,9 +65,13 @@ Notable user-facing changes to Exasol Personal are documented here.
 
 ### Fixed
 
-- Local port-conflict recovery now uses the actual runtime bind diagnostic instead of a later socket
-  probe, and macOS retains normal failure recovery when a partially started VM cannot be stopped
-  safely.
+- Fixed a failed local `start` or `stop` leaving the deployment in a state that rejected the
+  commands needed to recover. `exasol status` reported `interrupted` and `exasol config set` was
+  refused, so a deployment that failed to start could not be reconfigured and started again. Such
+  a deployment now reports `stopped` on every supported platform, and the failure explains what to
+  do next whether or not the launcher can identify the cause.
+
+  Example: `exasol config set --ports auto` followed by `exasol start`
 
 - Fixed documentation publication failing during validation because the GitHub Actions runner does
   not provide the Task command.

--- a/cmd/exasol/deploymentControl_test.go
+++ b/cmd/exasol/deploymentControl_test.go
@@ -100,6 +100,32 @@ func TestAddLocalPortRecoveryCallToActionQueuesStructuredRecovery(t *testing.T) 
 	}
 }
 
+// An unidentified local failure still has to leave the user with something to
+// do next, and with the same commands on every platform.
+//
+//nolint:paralleltest // mutates shared terminal message queues
+func TestAddLocalPortRecoveryCallToActionQueuesRetryGuidance(t *testing.T) {
+	resetTerminalMessages()
+	defer resetTerminalMessages()
+
+	addLocalPortRecoveryCallToAction(&deploy.LocalRetryableFailureError{
+		Operation: "start",
+		Cause:     errors.New("runtime reported an unrecognized diagnostic"),
+	})
+	var stderr bytes.Buffer
+	writeTerminalCallsToAction(&stderr, true, false)
+
+	for _, expected := range []string{
+		"exasol start",
+		"exasol config set --ports db:<available-port>",
+		"exasol config set --ports auto",
+	} {
+		if !strings.Contains(stderr.String(), expected) {
+			t.Fatalf("expected retry guidance %q, got %q", expected, stderr.String())
+		}
+	}
+}
+
 func TestLifecycleCommandsRegisterJSONFlag(t *testing.T) {
 	t.Parallel()
 

--- a/cmd/exasol/local_port_recovery.go
+++ b/cmd/exasol/local_port_recovery.go
@@ -10,17 +10,32 @@ import (
 	"github.com/exasol/exasol-personal/internal/deploy"
 )
 
+// localRetryGuidance is offered whenever a local lifecycle operation fails and
+// leaves a deployment that can be retried, on every platform and whether or not
+// the launcher identified the cause. It names the port commands without
+// claiming a port caused the failure, because an unavailable port is both the
+// most common fixable cause and the one the launcher cannot always recognize.
+const localRetryGuidance = "The deployment is stopped, so you can fix the reported problem " +
+	"and retry:\n" +
+	"  exasol start\n" +
+	"If the database could not claim its configured port, select another one first:\n" +
+	"  exasol config set --ports db:<available-port>\n" +
+	"  exasol config set --ports auto"
+
 func addLocalPortRecoveryCallToAction(err error) {
-	var recovery *deploy.LocalPortRecoveryError
-	if !errors.As(err, &recovery) {
+	if recovery, ok := errors.AsType[*deploy.LocalPortRecoveryError](err); ok {
+		addTerminalCallToAction(fmt.Sprintf(
+			"Select a replacement port for local service %q, then retry:\n"+
+				"  exasol config set --ports %s:<available-port>\n"+
+				"  exasol config set --ports auto",
+			recovery.Service,
+			recovery.Service,
+		))
+
 		return
 	}
 
-	addTerminalCallToAction(fmt.Sprintf(
-		"Select a replacement port for local service %q, then retry:\n"+
-			"  exasol config set --ports %s:<available-port>\n"+
-			"  exasol config set --ports auto",
-		recovery.Service,
-		recovery.Service,
-	))
+	if _, ok := errors.AsType[*deploy.LocalRetryableFailureError](err); ok {
+		addTerminalCallToAction(localRetryGuidance)
+	}
 }

--- a/cmd/exasol/status.go
+++ b/cmd/exasol/status.go
@@ -32,6 +32,8 @@ Display the status of the current deployment.
 	- ` + deploy.StatusInitialized + `
 	- ` + deploy.StatusOperationInProgress + `
 	- ` + deploy.StatusInterrupted + `
+	- ` + deploy.StatusStopped + `
+	- ` + deploy.StatusRunning + `
 	- ` + deploy.StatusDeploymentFailed + `
 	- ` + deploy.StatusDatabaseConnectionFailed + `
 	- ` + deploy.StatusDatabaseReady + `

--- a/internal/deploy/deploymentControl.go
+++ b/internal/deploy/deploymentControl.go
@@ -171,6 +171,95 @@ func markOperationInterrupted(
 	return operationErr
 }
 
+// LocalRetryableFailureError reports a local lifecycle failure after the
+// deployment has been returned to a state it can be retried from. It makes no
+// claim about the cause: the launcher reports whatever the runtime said and
+// offers the same recovery commands on every platform.
+type LocalRetryableFailureError struct {
+	Operation string
+	Cause     error
+}
+
+func (err *LocalRetryableFailureError) Error() string { return err.Cause.Error() }
+
+func (err *LocalRetryableFailureError) Unwrap() error { return err.Cause }
+
+// recordLifecycleFailure persists the workflow state that a failed lifecycle
+// operation should leave behind, and returns the failure to report.
+//
+// A local deployment always ends up in a state it can retry from, on every
+// platform and whether or not the cause could be identified: stopped is the
+// only post-deploy state that permits `exasol config set`, so anything else
+// blocks the very recovery the failure calls for. Interrupted is left to the
+// signal handlers, which is the only situation that name describes.
+func recordLifecycleFailure(
+	ctx context.Context,
+	exasolState *config.ExasolPersonalState,
+	deployment config.DeploymentDir,
+	operation string,
+	priorState any,
+	operationErr error,
+) error {
+	if _, unavailable := localports.AsUnavailable(operationErr); unavailable {
+		return restoreStateAfterUnavailableLocalPort(
+			exasolState,
+			deployment,
+			priorState,
+			operationErr,
+		)
+	}
+
+	if !isLocalDeployment(deployment) {
+		return markOperationInterrupted(exasolState, deployment, operation, operationErr)
+	}
+
+	return restoreLocalStateAfterFailure(
+		ctx,
+		exasolState,
+		deployment,
+		operation,
+		priorState,
+		operationErr,
+	)
+}
+
+// restoreLocalStateAfterFailure returns a failed local deployment to priorState.
+// A runtime still running after the failure is stopped first, so the recorded
+// state and the machine agree before the user retries. Only a runtime that
+// cannot be brought to a known state stays interrupted.
+func restoreLocalStateAfterFailure(
+	ctx context.Context,
+	exasolState *config.ExasolPersonalState,
+	deployment config.DeploymentDir,
+	operation string,
+	priorState any,
+	operationErr error,
+) error {
+	if probeLocalRuntimeLiveness(ctx, deployment) == localRuntimeRunning {
+		if err := stopLocalRuntimeAfterFailure(ctx, deployment); err != nil {
+			slog.Warn("could not stop the local runtime after a failed operation",
+				"operation", operation, "error", err)
+
+			return markOperationInterrupted(exasolState, deployment, operation, operationErr)
+		}
+	}
+
+	// Logged at error level so a runtime diagnostic the launcher could not
+	// identify stays visible in deployment.log rather than only on stderr.
+	slog.Error("local operation failed; returning the deployment to a retryable state",
+		"operation", operation, "error", operationErr.Error())
+
+	if err := exasolState.SetWorkflowStateAndWrite(priorState, deployment); err != nil {
+		return errors.Join(
+			operationErr,
+			fmt.Errorf("failed to restore workflow state after a failed %s: %w",
+				operation, err),
+		)
+	}
+
+	return &LocalRetryableFailureError{Operation: operation, Cause: operationErr}
+}
+
 // LocalPortRecoveryError reports an unavailable local service port after the
 // deployment's prior workflow state has been restored successfully.
 type LocalPortRecoveryError struct {
@@ -332,17 +421,15 @@ func runStartBackend(
 		waitTimeoutSeconds,
 	); err != nil {
 		unregister()
-		_, unavailable := localports.AsUnavailable(err)
-		if unavailable {
-			return restoreStateAfterUnavailableLocalPort(
-				exasolState,
-				deployment,
-				&config.WorkflowStateStopped{},
-				err,
-			)
-		}
 
-		return markOperationInterrupted(exasolState, deployment, config.StartOperation, err)
+		return recordLifecycleFailure(
+			ctx,
+			exasolState,
+			deployment,
+			config.StartOperation,
+			&config.WorkflowStateStopped{},
+			err,
+		)
 	}
 
 	// Stop handling interrupts before committing final running state
@@ -522,7 +609,14 @@ func runStopBackend(
 	); err != nil {
 		unregister()
 
-		return markOperationInterrupted(exasolState, deployment, config.StopOperation, err)
+		return recordLifecycleFailure(
+			ctx,
+			exasolState,
+			deployment,
+			config.StopOperation,
+			&config.WorkflowStateStopped{},
+			err,
+		)
 	}
 
 	// Stop handling interrupts before committing final stopped state

--- a/internal/deploy/deploymentControl_test.go
+++ b/internal/deploy/deploymentControl_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/exasol/exasol-personal/internal/config"
 	"github.com/exasol/exasol-personal/internal/localports"
+	"github.com/exasol/exasol-personal/internal/runtimeartifacts"
 )
 
 type unavailablePortBackend struct {
@@ -441,5 +442,105 @@ func TestWorkflowStatePermitsStop_GuidesForInitializedDeployment(t *testing.T) {
 		if !strings.Contains(decision.guidance, expected) {
 			t.Fatalf("expected guidance to contain %q, got %q", expected, decision.guidance)
 		}
+	}
+}
+
+// writeFakeStoppedRunner builds a Manager whose runner reports a runtime that
+// is not running, both directly and through the Podman container probe the
+// host runtimes use.
+func writeFakeStoppedRunner(t *testing.T) *runtimeartifacts.Manager {
+	t.Helper()
+
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = status ]; then echo '{\"running\":false}'; exit 0; fi\n" +
+		"if [ \"$1\" = run ]; then\n" +
+		"  shift; [ \"$1\" = -- ]; shift\n" +
+		"  if [ \"$1 $2 $3\" = 'podman container exists' ]; then exit 1; fi\n" +
+		"fi\n" +
+		"exit 1\n"
+
+	return newTestManagerForRunner(t, []byte(script))
+}
+
+func TestRecordLifecycleFailureRestoresPriorStateWhenRuntimeStopped(t *testing.T) {
+	t.Parallel()
+	skipOnWindows(t)
+
+	deployment := newLocalTestDeployment(t)
+	ensureLocalRuntimeWorkDir(t, deployment)
+	state, err := config.ReadExasolPersonalState(deployment)
+	if err != nil {
+		t.Fatalf("read state failed: %v", err)
+	}
+	if err := state.SetWorkflowStateAndWrite(
+		&config.WorkflowStateOperationInProgress{Operation: config.StartOperation},
+		deployment,
+	); err != nil {
+		t.Fatalf("write workflow state failed: %v", err)
+	}
+	ctx := runtimeartifacts.NewContext(context.Background(), writeFakeStoppedRunner(t))
+	cause := errors.New("runtime reported an unrecognized diagnostic")
+
+	failure := recordLifecycleFailure(
+		ctx,
+		state,
+		deployment,
+		config.StartOperation,
+		&config.WorkflowStateStopped{},
+		cause,
+	)
+
+	if !errors.Is(failure, cause) {
+		t.Fatalf("expected the original cause to be preserved, got %v", failure)
+	}
+	if _, retryable := errors.AsType[*LocalRetryableFailureError](failure); !retryable {
+		t.Fatalf("expected a retryable local failure so the recovery guidance is offered, "+
+			"got %T", failure)
+	}
+	persisted, readErr := config.ReadExasolPersonalState(deployment)
+	if readErr != nil {
+		t.Fatalf("read restored state failed: %v", readErr)
+	}
+	workflowState := mustWorkflowState(t, persisted)
+	if _, stopped := workflowState.(*config.WorkflowStateStopped); !stopped {
+		t.Fatalf("expected stopped state, got %T", workflowState)
+	}
+}
+
+// A cloud deployment keeps the interrupted state: only local deployments have a
+// runtime the launcher can bring to a known state and retry against.
+func TestRecordLifecycleFailureMarksCloudDeploymentInterrupted(t *testing.T) {
+	t.Parallel()
+
+	deployment, state := deploymentInState(
+		t,
+		&config.WorkflowStateOperationInProgress{Operation: config.StartOperation},
+	)
+	cause := errors.New("backend failed for an unrelated reason")
+
+	failure := recordLifecycleFailure(
+		context.Background(),
+		state,
+		deployment,
+		config.StartOperation,
+		&config.WorkflowStateStopped{},
+		cause,
+	)
+
+	if !errors.Is(failure, cause) {
+		t.Fatalf("expected the original cause to be preserved, got %v", failure)
+	}
+	persisted, readErr := config.ReadExasolPersonalState(deployment)
+	if readErr != nil {
+		t.Fatalf("read persisted state failed: %v", readErr)
+	}
+	workflowState := mustWorkflowState(t, persisted)
+	interrupted, isInterrupted := workflowState.(*config.WorkflowStateInterrupted)
+	if !isInterrupted {
+		t.Fatalf("expected interrupted state, got %T", workflowState)
+	}
+	if interrupted.InterruptedDuringOperation != config.StartOperation {
+		t.Fatalf("expected the start operation to be recorded, got %q",
+			interrupted.InterruptedDuringOperation)
 	}
 }

--- a/internal/deploy/local_runtime.go
+++ b/internal/deploy/local_runtime.go
@@ -63,6 +63,73 @@ func reconcileCustomSLCsAfterStart(ctx context.Context, deployment config.Deploy
 	}
 }
 
+// localRuntimeLiveness answers "is the local runtime running?", including the
+// case where the probe cannot answer at all. That case must stay distinct from
+// stopped: treating an unanswerable probe as stopped leaves a deployment in a
+// state that blocks its own recovery.
+type localRuntimeLiveness int
+
+const (
+	localRuntimeLivenessUnknown localRuntimeLiveness = iota
+	localRuntimeStopped
+	localRuntimeRunning
+)
+
+// probeLocalRuntimeLiveness asks the selected local runtime whether it is
+// running. It reports the same answer on every platform, so callers need no
+// per-runtime knowledge to tell a clean failure from an indeterminate one.
+func probeLocalRuntimeLiveness(
+	ctx context.Context,
+	deployment config.DeploymentDir,
+) localRuntimeLiveness {
+	if !isLocalDeployment(deployment) {
+		return localRuntimeLivenessUnknown
+	}
+
+	manager := runtimeartifacts.FromContext(ctx)
+
+	selectedRuntime, err := newLocalRuntime(deployment, manager)
+	if err != nil {
+		slog.Warn("could not select local runtime to probe its status", "error", err)
+		return localRuntimeLivenessUnknown
+	}
+	// Make the runtime observable first. A Podman machine stopped outside the
+	// launcher leaves Status unable to answer, and a swallowed status error
+	// used to leave the stale "running" state in place - which then blocked
+	// the very start that would have restarted the machine. Best-effort: if
+	// this fails, Status is still worth attempting.
+	if err := selectedRuntime.EnsureQueryable(ctx, os.Stderr, os.Stderr); err != nil {
+		slog.Warn("could not make local runtime queryable", "error", err)
+	}
+
+	runtimeStatus, err := selectedRuntime.Status(ctx)
+	if err != nil {
+		slog.Warn("could not determine local runtime status", "error", err)
+		return localRuntimeLivenessUnknown
+	}
+
+	if runtimeStatus.Running {
+		return localRuntimeRunning
+	}
+
+	return localRuntimeStopped
+}
+
+// stopLocalRuntimeAfterFailure stops a local runtime left running by a failed
+// lifecycle operation, so the state the launcher records and the machine the
+// user retries against agree.
+func stopLocalRuntimeAfterFailure(
+	ctx context.Context,
+	deployment config.DeploymentDir,
+) error {
+	selectedRuntime, err := newLocalRuntime(deployment, runtimeartifacts.FromContext(ctx))
+	if err != nil {
+		return err
+	}
+
+	return selectedRuntime.Stop(ctx, os.Stderr, os.Stderr)
+}
+
 // reconcileLocalVMState corrects stale workflow state after an unclean local
 // runtime shutdown. The historical name is retained for compatibility with callers.
 //
@@ -92,35 +159,13 @@ func reconcileLocalVMState(
 		return nil
 	}
 
-	manager := runtimeartifacts.FromContext(ctx)
-
-	selectedRuntime, err := newLocalRuntime(deployment, manager)
-	if err != nil {
-		slog.Warn("could not select local runtime during reconciliation", "error", err)
-		return nil
-	}
-	// Make the runtime observable first. A Podman machine stopped outside the
-	// launcher leaves Status unable to answer, and a swallowed status error
-	// used to leave the stale "running" state in place — which then blocked
-	// the very start that would have restarted the machine. Best-effort: if
-	// this fails, Status is still worth attempting.
-	if err := selectedRuntime.EnsureQueryable(ctx, os.Stderr, os.Stderr); err != nil {
-		slog.Warn("could not make local runtime queryable during reconciliation",
-			"error", err)
-	}
-
-	runtimeStatus, err := selectedRuntime.Status(ctx)
-	if err != nil {
-		slog.Warn("could not determine local runtime status during reconciliation", "error", err)
+	if probeLocalRuntimeLiveness(ctx, deployment) != localRuntimeStopped {
 		return nil
 	}
 
-	if !runtimeStatus.Running {
-		slog.Info("local runtime is not running; correcting workflow state to stopped")
-		return exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateStopped{}, deployment)
-	}
+	slog.Info("local runtime is not running; correcting workflow state to stopped")
 
-	return nil
+	return exasolState.SetWorkflowStateAndWrite(&config.WorkflowStateStopped{}, deployment)
 }
 
 func isLocalDeployment(deployment config.DeploymentDir) bool {

--- a/tests/framework/deployment.py
+++ b/tests/framework/deployment.py
@@ -236,6 +236,10 @@ class Deployment:
     def status(self, *args: str) -> CompletedProcess[str]:
         return self.launcher.status(self.deployment_dir.name, *args)
 
+    def status_value(self) -> str:
+        """Return the launcher-reported deployment status."""
+        return self.launcher.status_value(self.deployment_dir.name)
+
     def has_status(self, expected_status: str) -> bool:
         return self.launcher.has_status(
             self.deployment_dir.name,

--- a/tests/framework/launcher.py
+++ b/tests/framework/launcher.py
@@ -218,11 +218,11 @@ class Launcher:
             capture_output=True,
         )
 
-    def has_status(
+    def status_value(
         self,
         deployment_dir: str,
-        expected_status: str,
-    ) -> bool:
+    ) -> str:
+        """Return the `status` field reported by `exasol status --json`."""
         status_result = self.status(
             deployment_dir=deployment_dir,
         )
@@ -233,13 +233,22 @@ class Launcher:
 
         status_data = json.loads(status_result.stdout)
 
-        if status_data["status"] == expected_status:
+        return str(status_data["status"])
+
+    def has_status(
+        self,
+        deployment_dir: str,
+        expected_status: str,
+    ) -> bool:
+        actual_status = self.status_value(deployment_dir)
+
+        if actual_status == expected_status:
             return True
 
         logging.info(
             "expected status %s, got status %s",
             expected_status,
-            status_data["status"],
+            actual_status,
         )
 
         return False

--- a/tests/tests/deployment/test_local_deployment.py
+++ b/tests/tests/deployment/test_local_deployment.py
@@ -166,19 +166,17 @@ def _verify_occupied_port_recovery(deployment: Deployment) -> None:
                 capture_output=True,
             )
 
-        # Then it stays stopped and reports both replacement commands
-        assert deployment.has_status(StatusStopped)
-        assert _configured_db_port(deployment) == conflict_port
-        expected_error = (
-            f'local service "db" cannot bind configured host port {conflict_port}'
-        )
-        assert expected_error in captured.value.stderr
+        # Then the terminal offers actionable recovery, whether or not the
+        # launcher could identify the cause on this platform
         assert "exasol config set --ports db:<available-port>" in captured.value.stderr
         assert "exasol config set --ports auto" in captured.value.stderr
+        assert _configured_db_port(deployment) == conflict_port
     finally:
         _close_listeners(conflict)
 
-    # When automatic replacement is selected after releasing the conflict
+    # When automatic replacement is selected after releasing the conflict.
+    # This succeeding is also what proves the failed start left the deployment
+    # reconfigurable: `config set` is rejected in every other post-deploy state.
     reset_result = deployment.launcher.run_command(
         "config",
         deployment.deployment_dir.name,
@@ -310,7 +308,7 @@ def test_static_local_port_selection_reconfiguration_and_recovery(
         deployment.deploy()
         assert _reported_db_port(deployment) == EXPECTED_AUTOMATIC_PORT
         deployment.stop()
-        assert deployment.has_status(StatusStopped)
+        assert deployment.status_value() == StatusStopped
         deployment.start()
 
         # Then its runtime endpoint remains stable


### PR DESCRIPTION
## Description

Follow-up to #331. A failed local `start` or `stop` left the deployment in a state that rejected the commands needed to recover, which is what made the deployment tests fail on macOS and Windows in [run 34098858740](https://github.com/exasol/exasol-personal/actions/runs/34098858740).

`exasol status` reported `interrupted`, and `WorkflowStatePermitsConfigure` refuses `exasol config set` in that state, so a deployment that could not claim its configured port could neither be reconfigured nor started again. The recovery commands the error message printed were rejected by the state the same failure had just recorded.

Local lifecycle failures now leave the deployment in `stopped` on every supported platform, which is the only post-deploy state that permits local reconfiguration, and the failure always says what to do next.

## Related Issue

SPOT-32276

## Type of Change

- [x] `fix`: Bug fix
- [x] `test`: Test additions or changes
- [x] `docs`: Documentation update

## Changes Made

- Local `start`/`stop` failures return the deployment to a retryable state on every platform, deciding it from a uniform runtime probe rather than from per-runtime diagnostic strings. A runtime still running after the failure is stopped first so the recorded state and the machine agree. `interrupted` is left to the signal handlers, which is the only situation that name describes.
- The recovery guidance is now offered whether or not the cause could be identified, with the same commands everywhere. The distinction is carried by error types only (`LocalPortRecoveryError` when the unavailable port is known, `LocalRetryableFailureError` otherwise); every CTA string is assembled in `cmd/exasol`.
- Unattributed runtime failures are logged at ERROR so they stay diagnosable from `deployment.log`.
- `exasol status --help` now lists `stopped` and `running`, which it previously omitted.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [ ] Manually tested the changes

### Test Details

Unit tests cover both branches of the state decision and both CTA shapes. The end-to-end assertions in `_verify_occupied_port_recovery` now check what the user sees in the terminal rather than internal state: the recovery commands appear on stderr, and the subsequent `config set --ports auto` plus `start` prove the deployment stayed reconfigurable, since `config set` is rejected in every other post-deploy state.

Deployment tests are `workflow_dispatch` only and are being triggered separately on this branch for all three local platforms.

Not verified locally: macOS and Windows behaviour. On Linux the port conflict is classified, so `AsUnavailable` matches first and none of the new code runs, which is why the Linux job should be unaffected.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable)
- [x] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

Worth a look while reviewing: `internal/deploy/local_reachability.go` holds three hand-written platform-specific guidance blobs, and `diagnoseLocalFailure` wraps every failed local start with one of them. That is platform-divergent user-facing guidance built inside an internal package, and it sits on this exact failure path. Left untouched here.

`exasol status` still reports only "Deployment stopped." after a failed start, without mentioning the failure. Carrying that forward would need `WorkflowStateStopped` to hold an optional last-failure field.
