### PR TITLE
fix(build): Include OpenPGP tag in releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,7 +10,7 @@ builds:
   - env:
       - CGO_ENABLED=0
     flags:
-      - -tags=official_release
+      - -tags=official_release,containers_image_openpgp
       - -trimpath
       - -gcflags=all=-l
     ldflags:


### PR DESCRIPTION
## Description

Make release builds select the pure-Go OpenPGP implementation required for static cross-compilation. Without this tag, GoReleaser selects the CGO-only GPGME implementation and fails while building macOS ARM64.

## Related Issue

[SPOT-32023](https://exasol.atlassian.net/browse/SPOT-32023)

## Type of Change

- [x] `fix`: Bug fix

## Changes Made

- Add `containers_image_openpgp` alongside `official_release` to the GoReleaser build tags.

## Testing

- [x] `task fmt`
- [x] `task all` — 130 integration tests passed, 6 platform-specific tests skipped
- [x] Direct macOS ARM64 release cross-build
- [x] GoReleaser v2.18.1 configuration validation
- [x] Snapshot compiled all five release targets; it stopped afterward at the expected unavailable local Windows-signing credentials

## Checklist

- [x] Code follows the project's coding guidelines
- [x] Commit follows Conventional Commits
- [x] No documentation or changelog update is required


[SPOT-32023]: https://exasol.atlassian.net/browse/SPOT-32023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ