### PR TITLE
fix: Add preflight check and retrial on fetching bootstrapping scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ Notable user-facing changes to Exasol Personal are documented here.
 
 ### Fixed
 
+- Fixed cloud deployments intermittently failing when a bootstrap asset could not be fetched during early boot. Bootstrap files are now fetched after network setup, validated before launcher startup, and reported with actionable rerun guidance (#298).
+
 - Fixed documentation publication failing during validation because the GitHub Actions runner does
   not provide the Task command.
 

--- a/assets/infrastructure/aws/cloudinit.tf
+++ b/assets/infrastructure/aws/cloudinit.tf
@@ -55,6 +55,27 @@ locals {
     trimsuffix(trimprefix(f.dest_path, "/"), "/") => f
   }
 
+  bootstrap_required_files = join("\n", [
+    for path in keys(local.bootstrap_node_files_by_key) : "  ${jsonencode("/${path}")}"
+  ])
+
+  bootstrap_preflight_script = <<-SCRIPT
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    required_files=(
+    ${local.bootstrap_required_files}
+    )
+
+    for file in "$${required_files[@]}"; do
+      if [[ ! -f "$file" ]]; then
+        echo "Bootstrap asset missing: $file" >&2
+        echo "S3 bootstrap fetch failed; rerun install." >&2
+        exit 1
+      fi
+    done
+  SCRIPT
+
   # Cluster addressing helpers (also used for JSON payload values).
   node_ips           = [for n in local.nodes : n.ip]
   node_ips_space_sep = join(" ", local.node_ips)
@@ -156,6 +177,11 @@ data "cloudinit_config" "cloud_config" {
       write_files = concat(
         [
           {
+            path        = "/usr/local/sbin/exasol-bootstrap-preflight"
+            permissions = "0755"
+            content     = local.bootstrap_preflight_script
+          },
+          {
             path        = local.infrastructure_json_target_path
             permissions = "0644"
             content     = jsonencode(local.infrastructure_payload)
@@ -170,6 +196,7 @@ data "cloudinit_config" "cloud_config" {
           for f in local.installation_node_files : {
             path        = f.dest_path
             permissions = f.permissions
+            defer       = true
             source = {
               uri = "https://${aws_s3_bucket.bootstrap_assets.bucket_regional_domain_name}/${aws_s3_object.bootstrap_assets[trimsuffix(trimprefix(f.dest_path, "/"), "/")].key}"
             }
@@ -179,6 +206,7 @@ data "cloudinit_config" "cloud_config" {
           for f in local.infrastructure_node_files : {
             path        = f.dest_path
             permissions = f.permissions
+            defer       = true
             source = {
               uri = "https://${aws_s3_bucket.bootstrap_assets.bucket_regional_domain_name}/${aws_s3_object.bootstrap_assets[trimsuffix(trimprefix(f.dest_path, "/"), "/")].key}"
             }
@@ -186,5 +214,17 @@ data "cloudinit_config" "cloud_config" {
         ]
       )
     })
+  }
+
+  part {
+    content_type = "text/x-shellscript"
+    filename     = "99-start-launcher.sh"
+    content      = <<-SCRIPT
+      #!/usr/bin/env bash
+      set -Eeuo pipefail
+      /usr/local/sbin/exasol-bootstrap-preflight
+      systemctl daemon-reload
+      systemctl enable --now --no-block exasol_launcher.target
+    SCRIPT
   }
 }

--- a/assets/infrastructure/azure/cloudinit.tf
+++ b/assets/infrastructure/azure/cloudinit.tf
@@ -55,6 +55,27 @@ locals {
     trimsuffix(trimprefix(f.dest_path, "/"), "/") => f
   }
 
+  bootstrap_required_files = join("\n", [
+    for path in keys(local.bootstrap_node_files_by_key) : "  ${jsonencode("/${path}")}"
+  ])
+
+  bootstrap_preflight_script = <<-SCRIPT
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    required_files=(
+    ${local.bootstrap_required_files}
+    )
+
+    for file in "$${required_files[@]}"; do
+      if [[ ! -f "$file" ]]; then
+        echo "Bootstrap asset missing: $file" >&2
+        echo "Bootstrap fetch failed; rerun install." >&2
+        exit 1
+      fi
+    done
+  SCRIPT
+
   # Cluster addressing helpers (also used for JSON payload values).
   node_ips           = [for n in local.nodes : n.ip]
   node_ips_space_sep = join(" ", local.node_ips)
@@ -196,6 +217,11 @@ data "cloudinit_config" "cloud_config" {
       write_files = concat(
         [
           {
+            path        = "/usr/local/sbin/exasol-bootstrap-preflight"
+            permissions = "0755"
+            content     = local.bootstrap_preflight_script
+          },
+          {
             path        = local.infrastructure_json_target_path
             permissions = "0644"
             content     = jsonencode(local.infrastructure_payload)
@@ -210,6 +236,7 @@ data "cloudinit_config" "cloud_config" {
           for f in local.installation_node_files : {
             path        = f.dest_path
             permissions = f.permissions
+            defer       = true
             source = {
               uri = "${azurerm_storage_blob.bootstrap_assets[trimsuffix(trimprefix(f.dest_path, "/"), "/")].url}?${data.azurerm_storage_account_sas.bootstrap_assets.sas}"
             }
@@ -219,6 +246,7 @@ data "cloudinit_config" "cloud_config" {
           for f in local.infrastructure_node_files : {
             path        = f.dest_path
             permissions = f.permissions
+            defer       = true
             source = {
               uri = "${azurerm_storage_blob.bootstrap_assets[trimsuffix(trimprefix(f.dest_path, "/"), "/")].url}?${data.azurerm_storage_account_sas.bootstrap_assets.sas}"
             }
@@ -226,5 +254,17 @@ data "cloudinit_config" "cloud_config" {
         ]
       )
     })
+  }
+
+  part {
+    content_type = "text/x-shellscript"
+    filename     = "99-start-launcher.sh"
+    content      = <<-SCRIPT
+      #!/usr/bin/env bash
+      set -Eeuo pipefail
+      /usr/local/sbin/exasol-bootstrap-preflight
+      systemctl daemon-reload
+      systemctl enable --now --no-block exasol_launcher.target
+    SCRIPT
   }
 }

--- a/assets/infrastructure/exoscale/cloudinit.tf
+++ b/assets/infrastructure/exoscale/cloudinit.tf
@@ -55,6 +55,27 @@ locals {
     trimsuffix(trimprefix(f.dest_path, "/"), "/") => f
   }
 
+  bootstrap_required_files = join("\n", [
+    for path in keys(local.bootstrap_node_files_by_key) : "  ${jsonencode("/${path}")}"
+  ])
+
+  bootstrap_preflight_script = <<-SCRIPT
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    required_files=(
+    ${local.bootstrap_required_files}
+    )
+
+    for file in "$${required_files[@]}"; do
+      if [[ ! -f "$file" ]]; then
+        echo "Bootstrap asset missing: $file" >&2
+        echo "Bootstrap fetch failed; rerun install." >&2
+        exit 1
+      fi
+    done
+  SCRIPT
+
   # Cluster addressing helpers (also used for JSON payload values).
   node_ips           = [for n in local.nodes : n.ip]
   node_ips_space_sep = join(" ", local.node_ips)
@@ -158,6 +179,11 @@ data "cloudinit_config" "cloud_config" {
       write_files = concat(
         [
           {
+            path        = "/usr/local/sbin/exasol-bootstrap-preflight"
+            permissions = "0755"
+            content     = local.bootstrap_preflight_script
+          },
+          {
             path        = local.infrastructure_json_target_path
             permissions = "0644"
             content     = jsonencode(local.infrastructure_payload)
@@ -172,6 +198,7 @@ data "cloudinit_config" "cloud_config" {
           for f in local.installation_node_files : {
             path        = f.dest_path
             permissions = f.permissions
+            defer       = true
             source = {
               uri = "https://${aws_s3_bucket.bootstrap_assets.bucket}.sos-${var.zone}.exo.io/${aws_s3_object.bootstrap_assets[trimsuffix(trimprefix(f.dest_path, "/"), "/")].key}"
             }
@@ -181,6 +208,7 @@ data "cloudinit_config" "cloud_config" {
           for f in local.infrastructure_node_files : {
             path        = f.dest_path
             permissions = f.permissions
+            defer       = true
             source = {
               uri = "https://${aws_s3_bucket.bootstrap_assets.bucket}.sos-${var.zone}.exo.io/${aws_s3_object.bootstrap_assets[trimsuffix(trimprefix(f.dest_path, "/"), "/")].key}"
             }
@@ -213,5 +241,17 @@ data "cloudinit_config" "cloud_config" {
         "netplan apply"
       ]
     })
+  }
+
+  part {
+    content_type = "text/x-shellscript"
+    filename     = "99-start-launcher.sh"
+    content      = <<-SCRIPT
+      #!/usr/bin/env bash
+      set -Eeuo pipefail
+      /usr/local/sbin/exasol-bootstrap-preflight
+      systemctl daemon-reload
+      systemctl enable --now --no-block exasol_launcher.target
+    SCRIPT
   }
 }

--- a/assets/infrastructure/stackit/cloudinit.tf
+++ b/assets/infrastructure/stackit/cloudinit.tf
@@ -55,6 +55,27 @@ locals {
     trimsuffix(trimprefix(f.dest_path, "/"), "/") => f
   }
 
+  bootstrap_required_files = join("\n", [
+    for path in keys(local.bootstrap_node_files_by_key) : "  ${jsonencode("/${path}")}"
+  ])
+
+  bootstrap_preflight_script = <<-SCRIPT
+    #!/usr/bin/env bash
+    set -Eeuo pipefail
+
+    required_files=(
+    ${local.bootstrap_required_files}
+    )
+
+    for file in "$${required_files[@]}"; do
+      if [[ ! -f "$file" ]]; then
+        echo "Bootstrap asset missing: $file" >&2
+        echo "Bootstrap fetch failed; rerun install." >&2
+        exit 1
+      fi
+    done
+  SCRIPT
+
   # Cluster addressing helpers (also used for JSON payload values).
   node_ips_space_sep = join(" ", local.node_ips)
   n11_ip             = one([for n in local.nodes : n.ip if n.name == "n11"])
@@ -156,6 +177,11 @@ data "cloudinit_config" "cloud_config" {
       write_files = concat(
         [
           {
+            path        = "/usr/local/sbin/exasol-bootstrap-preflight"
+            permissions = "0755"
+            content     = local.bootstrap_preflight_script
+          },
+          {
             path        = local.infrastructure_json_target_path
             permissions = "0644"
             content     = jsonencode(local.infrastructure_payload)
@@ -170,6 +196,7 @@ data "cloudinit_config" "cloud_config" {
           for f in local.installation_node_files : {
             path        = f.dest_path
             permissions = f.permissions
+            defer       = true
             source = {
               uri = "https://${minio_s3_bucket.bootstrap_assets.bucket}.object.storage.${var.region}.onstackit.cloud/${minio_s3_object.bootstrap_assets[trimsuffix(trimprefix(f.dest_path, "/"), "/")].object_name}"
             }
@@ -179,6 +206,7 @@ data "cloudinit_config" "cloud_config" {
           for f in local.infrastructure_node_files : {
             path        = f.dest_path
             permissions = f.permissions
+            defer       = true
             source = {
               uri = "https://${minio_s3_bucket.bootstrap_assets.bucket}.object.storage.${var.region}.onstackit.cloud/${minio_s3_object.bootstrap_assets[trimsuffix(trimprefix(f.dest_path, "/"), "/")].object_name}"
             }
@@ -186,5 +214,17 @@ data "cloudinit_config" "cloud_config" {
         ]
       )
     })
+  }
+
+  part {
+    content_type = "text/x-shellscript"
+    filename     = "99-start-launcher.sh"
+    content      = <<-SCRIPT
+      #!/usr/bin/env bash
+      set -Eeuo pipefail
+      /usr/local/sbin/exasol-bootstrap-preflight
+      systemctl daemon-reload
+      systemctl enable --now --no-block exasol_launcher.target
+    SCRIPT
   }
 }

--- a/assets/installation/ubuntu/cloudconf/static.yaml
+++ b/assets/installation/ubuntu/cloudconf/static.yaml
@@ -21,8 +21,6 @@ runcmd:
   - "chown -R ubuntu: /var/lib/exasol_launcher"
   - "touch /var/lib/exasol_launcher/state/cloud-init.complete"
   - "echo 'EXASOL-INSTALL-SUBSTEP: Configuring systemd services...'"
-  - "systemctl daemon-reload"
-  - "systemctl enable --now --no-block exasol_launcher.target"
-  - "echo 'EXASOL-INSTALL-SUBSTEP: Installation started in background'"
+  - "echo 'EXASOL-INSTALL-SUBSTEP: Cloud-init bootstrap preparation completed'"
 
 final_message: "EXASOL-INSTALL-SUBSTEP: Cloud-init preparation complete after $UPTIME seconds"

--- a/openspec/changes/fix-bootstrap-asset-fetch-race/.openspec.yaml
+++ b/openspec/changes/fix-bootstrap-asset-fetch-race/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/fix-bootstrap-asset-fetch-race/design.md
+++ b/openspec/changes/fix-bootstrap-asset-fetch-race/design.md
@@ -1,0 +1,48 @@
+## Context
+
+Provider presets upload launcher files to deployment-scoped object storage and reference them from cloud-init `write_files` entries. The current entries are processed before the launcher starts, but a transient early-boot network failure can leave a required file absent while cloud-init continues with a warning.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Move remote bootstrap asset retrieval to cloud-init's final stage.
+- Keep bootstrap files in provider object storage rather than increasing user-data with inline file contents.
+- Validate the complete provider-specific asset set before launcher startup.
+- Preserve the existing launcher workflow and provider access controls.
+
+**Non-Goals:**
+
+- Adding a second asset transport or changing object-store permissions.
+- Retrying installation automatically after a bootstrap failure.
+- Changing launcher scripts, service dependencies, or asset contents.
+
+## Decisions
+
+### Defer remote file writes
+
+Mark every object-storage-backed `write_files` entry with `defer: true`. Cloud-init's native deferred-write module runs after package setup and before user scripts in the final stage, reducing exposure to early network initialization without adding payload content.
+
+An inline fallback is rejected because the launcher asset set is large and the existing design intentionally avoids the provider user-data limit.
+
+### Start the launcher from a final-stage shell part
+
+Remove the shared `runcmd` launcher start and add a provider cloud-init shell part that runs after deferred writes. This preserves the required ordering explicitly instead of depending on cloud-init list merging or systemd startup races.
+
+### Generate a preflight manifest from uploaded assets
+
+Render the expected destination paths from the same Terraform file map used for uploads. The final-stage shell part runs the inline preflight script before enabling the launcher and exits with an actionable message if any expected asset is missing.
+
+## Risks / Trade-offs
+
+- [An older cloud-init image may not support deferred writes] → Validate the supported Ubuntu image cloud-init version in provider deployment tests.
+- [A failed fetch still requires a new installation attempt] → Fail before launcher startup with the missing path and rerun guidance.
+- [The preflight list could drift from the uploaded files] → Generate it from the same `bootstrap_node_files_by_key` map as the object resources.
+
+## Migration Plan
+
+Deploy the Terraform/cloud-init changes with the normal provider update. Existing deployments are unaffected; a new deployment receives the deferred-fetch sequence. Rollback is a code rollback that restores the original early launcher start and non-deferred entries.
+
+## Open Questions
+
+None.

--- a/openspec/changes/fix-bootstrap-asset-fetch-race/proposal.md
+++ b/openspec/changes/fix-bootstrap-asset-fetch-race/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Bootstrap assets fetched from provider object storage can be unavailable during early cloud-init networking. Cloud-init may then skip a required launcher file, causing installation to fail later with an opaque missing-executable error.
+
+## What Changes
+
+- Defer provider bootstrap asset fetches until cloud-init's final stage.
+- Validate that every expected bootstrap asset was written before starting the launcher.
+- Report a clear, retryable bootstrap failure when an asset is missing.
+- Start the launcher only after deferred bootstrap assets and validation complete.
+- Apply the behavior consistently to AWS, Azure, Exoscale, and STACKIT.
+
+## Capabilities
+
+### New Capabilities
+
+- `reliable-bootstrap-asset-delivery`: Ensure provider bootstrap assets are available and validated before launcher startup.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Changes provider cloud-init rendering and the shared Ubuntu bootstrap sequence.
+- Adds no runtime dependencies or changes to provider storage access controls.
+- A failed bootstrap is surfaced during cloud-init and requires rerunning the installation.

--- a/openspec/changes/fix-bootstrap-asset-fetch-race/specs/reliable-bootstrap-asset-delivery/spec.md
+++ b/openspec/changes/fix-bootstrap-asset-fetch-race/specs/reliable-bootstrap-asset-delivery/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Bootstrap assets are available before launcher startup
+
+Each provider preset SHALL retrieve all uploaded installation and provider bootstrap files before starting `exasol_launcher.target`.
+
+#### Scenario: Successful bootstrap asset delivery
+
+- **WHEN** a new node completes cloud-init final-stage processing
+- **THEN** every expected bootstrap asset exists at its configured host destination
+- **AND** `exasol_launcher.target` is enabled and started only after those files are available
+
+#### Scenario: Bootstrap retrieval occurs after initial network setup
+
+- **WHEN** cloud-init processes a provider bootstrap file configured with a remote source
+- **THEN** the file retrieval occurs during the final stage after package and network setup
+
+### Requirement: Missing bootstrap assets fail with actionable diagnostics
+
+The provider bootstrap sequence SHALL verify every expected bootstrap asset before starting the launcher and SHALL stop startup when any expected file is missing.
+
+#### Scenario: Required asset is unavailable after source retries
+
+- **WHEN** a bootstrap source remains unreachable after cloud-init's configured retries
+- **THEN** the bootstrap sequence reports the missing destination path
+- **AND** it reports that the installation must be rerun
+- **AND** it does not start `exasol_launcher.target`
+
+### Requirement: Bootstrap delivery remains within user-data limits
+
+The provider presets SHALL keep launcher file contents in deployment object storage and SHALL add only the deferred-write metadata and validation commands to cloud-init user data.
+
+#### Scenario: Bootstrap reliability is added without embedding launcher files
+
+- **WHEN** cloud-init user data is rendered for any supported provider
+- **THEN** uploaded launcher files remain referenced by HTTPS source URIs
+- **AND** the rendered user data does not inline those launcher file contents

--- a/openspec/changes/fix-bootstrap-asset-fetch-race/tasks.md
+++ b/openspec/changes/fix-bootstrap-asset-fetch-race/tasks.md
@@ -1,0 +1,11 @@
+## 1. Deferred bootstrap delivery
+
+- [x] 1.1 Mark installation and provider bootstrap object-storage files for deferred cloud-init writing in AWS, Azure, Exoscale, and STACKIT.
+- [x] 1.2 Generate an inline preflight manifest from the provider bootstrap asset map and report missing destination paths before launcher startup.
+- [x] 1.3 Move launcher startup from the shared early `runcmd` sequence to a final-stage shell part after deferred writes complete.
+
+## 2. Validation
+
+- [x] 2.1 Apply the deferred bootstrap sequence consistently across all supported providers.
+- [x] 2.2 Run Terraform formatting, Terraform linting, and whitespace validation.
+- [ ] 2.3 Verify successful and failed bootstrap paths in provider deployment tests.


### PR DESCRIPTION
## Description

Fix intermittent cloud deployment failures caused by bootstrap assets being unavailable during early cloud-init networking.

## Related Issue

Fixes #298 

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Deferred bootstrap asset downloads until cloud-init’s final stage.
- Added preflight validation for every expected bootstrap asset.
- Prevented launcher startup when assets are missing.
- Added actionable retry guidance for failed installations.

## Testing

<!-- Describe how you tested your changes -->

- [ ] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [ ] Manually tested the changes

### Test Details

<!-- Describe your testing approach -->

## Checklist

<!-- Mark completed items with an "x" -->

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable) - `user-docs/` for user-facing changes, `doc/` for contributor-facing changes
- [x] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

<!-- Any additional information, screenshots, or context -->
