### PR TITLE
docs: Align user documentation with the 2.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,14 @@
 
 ## 📖 About Exasol Personal
 
-Exasol Personal gives individual users a complete Exasol database for development, exploration,
-analytics, and AI-assisted workflows. The Exasol Launcher is a scriptable command-line application
-that installs and manages the database locally or on supported cloud infrastructure.
-
 Exasol is an in-memory, massively parallel analytics database with full SQL support, a vast
-ecosystem, extensive AI capabilities, and flexible extensibility. Exasol Personal is free for
-personal use and does not impose an artificial data-size limit.
+ecosystem, extensive AI capabilities, and flexible extensibility.
+
+Exasol Personal gives individual users a complete Exasol database for development, exploration,
+analytics, and AI-assisted workflows. It runs either locally (on macOS, Linux, or Windows) or on
+one of the supported clouds (AWS, Azure, STACKIT, or Exoscale), managed by the Exasol Launcher, an
+open-source scriptable command-line application. Exasol Personal is free for personal use and
+does not impose an artificial data-size limit.
 
 ## 🚀 Get started
 

--- a/user-docs/content/getting-started.md
+++ b/user-docs/content/getting-started.md
@@ -14,7 +14,7 @@ Choose where the database will run:
   the account setup guide for [AWS](cloud/aws.md), [Azure](cloud/azure.md),
   [Exoscale](cloud/exoscale.md), or [STACKIT](cloud/stackit.md).
 
-## Install on macOS or Linux
+## Install on macOS, Linux or Windows (WSL)
 
 Run:
 
@@ -24,11 +24,6 @@ curl https://www.exasol.com/install/ | sh
 
 The installer places the `exasol` binary in `~/.local/bin`. If that directory is not in `PATH`,
 follow the instructions printed by the installer.
-
-## Install on Windows
-
-Download the launcher from the [Exasol Download Portal](https://downloads.exasol.com/exasol-personal)
-and copy the binary into a directory in `PATH`.
 
 ## Verify the installation
 

--- a/user-docs/content/index.md
+++ b/user-docs/content/index.md
@@ -10,7 +10,36 @@ shell sessions.
 These pages describe the product version selected in the version menu. Choose the version that
 matches your installed launcher when commands or supported capabilities differ between releases.
 
-## Start here
+## Quick start
+
+To install and run Exasol Personal locally on macOS, Linux, or Windows, follow these steps.
+
+Install the launcher:
+
+```bash
+curl https://www.exasol.com/install/ | sh
+```
+
+The installer places the `exasol` binary in `~/.local/bin`. If that directory is not in `PATH`,
+follow the instructions printed by the installer.
+
+Install and start the database:
+
+```bash
+exasol install local
+```
+
+Connect to your database:
+
+```bash
+exasol connect
+```
+
+Type any SQL statement terminated by `;`. For example, test your connection with `SELECT 1;`.
+See the [Exasol SQL reference](https://docs.exasol.com/db/latest/sql_reference.htm) for the
+full syntax.
+
+## Detailed user guides
 
 - [Install the launcher](getting-started.md), then [run Exasol locally](local-deployment.md) or
   [deploy it to the cloud](cloud-deployment.md).

--- a/user-docs/content/load-data.md
+++ b/user-docs/content/load-data.md
@@ -30,16 +30,6 @@ CREATE OR REPLACE TABLE PRODUCT_REVIEWS AS (
 
 Exasol infers the table schemas from the Parquet files.
 
-## Import a local Parquet file
-
-The bundled SQL client can upload one Parquet file per statement from the client computer:
-
-```sql
-CREATE TABLE LOCAL_PRODUCTS AS (
-    IMPORT FROM LOCAL PARQUET FILE '/path/to/products.parquet'
-);
-```
-
 Run the statement through `exasol connect -c` or place it in a file passed to `exasol connect -f`.
 The `LOCAL` form reads the file from the computer running the client. It does not change the
 database engine's object-storage Parquet behavior.


### PR DESCRIPTION
## Description

Aligns the user documentation with the 2.3 release: a Quick start on the documentation landing page,
Windows in the one-line installer instructions, high-level system requirements in the README now
that they are the same across all platforms, and removal of a local Parquet import example that does
not work as documented.

## Related Issue

None.

## Type of Change

- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [x] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- `user-docs/content/index.md`: added a Quick start covering install, `exasol install local`, and
  `exasol connect`, including the `~/.local/bin` PATH caveat, so a new user can reach a working
  database without leaving the landing page.
- `README.md` and `user-docs/content/getting-started.md`: the one-line installer now states that it
  covers Windows as well as macOS and Linux.
- `README.md`: replaced platform-specific system requirements with a high-level summary, because 2.3
  makes them the same on every supported platform.
- `user-docs/content/load-data.md`: removed the `IMPORT FROM LOCAL PARQUET` example. Schema inference
  does not work for LOCAL imports, so the example could not be followed as written.

## Testing

- [ ] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

Built the site with `task docs-build` (`mkdocs build --strict`), which completed with no warnings,
and reviewed the result in `task docs-serve`. Confirmed on the served site that the Quick start and
Detailed user guide sections render with the `exasol install local` step, that the load-data page no
longer contains the LOCAL Parquet example, and that getting-started mentions Windows.

`task all` was not run because this change touches only Markdown; no Go, Terraform, or Python code
is affected.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [ ] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable) - `user-docs/` for user-facing changes, `doc/` for contributor-facing changes
- [ ] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [ ] Added/updated tests
- [ ] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

`task fmt` and `task lint` cover Go, Terraform, and Python; neither applies to a Markdown-only
change. No `CHANGELOG.md` entry was added because the underlying 2.3 behavior is already recorded
there and this PR only documents it; the load-data removal corrects an example rather than changing
tool behavior. No tests were added because the documentation build itself is the check, and it runs
in CI through `task docs-check`.

## Additional Notes

This branch covers the install path and the landing page only. A review of the 2.3 changelog against
the published documentation found further gaps that are deliberately left for follow-up work:

- Local deployments now publish the database port on `127.0.0.1` only. Nothing in `limitations.md`
  or `connect.md` states that the database is no longer reachable from other hosts, which is the
  most likely source of support questions.
- Host-visible Nano data is undocumented, and the macOS section of `virtual-schemas.md` still stages
  files into the former guest path, where the database no longer reads them.
- The one-time macOS VM guest rebuild on the first `exasol start` after upgrading is not explained.
- The new five-second default and `--timeout` option for `exasol status` are undocumented.
- Data Lakehouse Turbo, including the requirement to recreate cloud deployments created before 2.3,
  is not mentioned.
- Recovering a local deployment after a failed `start` or `stop` is not covered in
  `troubleshooting.md`.
