### PR TITLE
fix: Accept SLC flavors for install and update - SPOT-32524

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ Notable user-facing changes to Exasol Personal are documented here.
 
 ### Fixed
 
+- `exasol slc install` and `exasol slc update` now accept the flavors shown by
+  `exasol slc list`, in addition to aliases. The list displays aliases first and recommends them
+  as the stable identifiers for commands.
+
 - Fixed a failed local `start` or `stop` leaving the deployment in a state that rejected the
   commands needed to recover. `exasol status` reported `interrupted` and `exasol config set` was
   refused, so a deployment that failed to start could not be reconfigured and started again. Such

--- a/cmd/exasol/slc.go
+++ b/cmd/exasol/slc.go
@@ -82,9 +82,10 @@ var slcCmd = &cobra.Command{
 }
 
 var slcInstallCmd = &cobra.Command{
-	Use:   "install <alias>",
+	Use:   "install <alias-or-flavor>",
 	Short: "Install an official script language container",
-	Long: "Install an official script language container by alias.\n\n" +
+	Long: "Install an official script language container by alias or flavor.\n" +
+		"Prefer aliases because they remain stable when the catalog flavor changes.\n\n" +
 		"The alias `rust` is special: it is not part of the official catalogue. It installs\n" +
 		"the latest release of exasol-labs/language-container-rs that matches this machine's\n" +
 		"CPU architecture. To install a specific Rust build instead, use\n" +
@@ -137,9 +138,10 @@ var slcInstallCmd = &cobra.Command{
 }
 
 var slcUpdateCmd = &cobra.Command{
-	Use:   "update <alias>",
+	Use:   "update <alias-or-flavor>",
 	Short: "Update an installed official script language container",
-	Long: "Update an installed official script language container by alias.\n\n" +
+	Long: "Update an installed official script language container by alias or flavor.\n" +
+		"Prefer aliases because they remain stable when the catalog flavor changes.\n\n" +
 		"The alias `rust` is special: it re-resolves the latest release of\n" +
 		"exasol-labs/language-container-rs for this machine's CPU architecture and applies it\n" +
 		"if it differs from the installed container. To pin a specific Rust build, use\n" +
@@ -604,6 +606,11 @@ var slcListCmd = &cobra.Command{
 		}
 
 		renderSLCListText(statuses, customs)
+		if len(statuses) > 0 {
+			addTerminalCallToAction(
+				"Prefer an alias from the ALIASES column when installing an SLC.",
+			)
+		}
 
 		return nil
 	},
@@ -704,7 +711,7 @@ func writeOfficialSLCRows(writer io.Writer, statuses []deploy.SLCStatus) {
 		return
 	}
 
-	_, _ = fmt.Fprintln(writer, "FLAVOR\tALIASES\tVERSION\tINSTALLED")
+	_, _ = fmt.Fprintln(writer, "ALIASES\tFLAVOR\tVERSION\tINSTALLED")
 	for _, status := range statuses {
 		installed := "no"
 		if status.Installed {
@@ -713,8 +720,8 @@ func writeOfficialSLCRows(writer io.Writer, statuses []deploy.SLCStatus) {
 		_, _ = fmt.Fprintf(
 			writer,
 			"%s\t%s\t%s\t%s\n",
-			status.Flavor,
 			strings.Join(status.Aliases, ", "),
+			status.Flavor,
 			status.Version,
 			installed,
 		)

--- a/cmd/exasol/slc_test.go
+++ b/cmd/exasol/slc_test.go
@@ -131,6 +131,25 @@ func TestSLCInstallAndUpdateDocumentTheRustAlias(t *testing.T) {
 	}
 }
 
+func TestSLCInstallAndUpdateDocumentAliasesAndFlavors(t *testing.T) {
+	t.Parallel()
+
+	// When / Then
+	for name, cmd := range map[string]*cobra.Command{
+		"install": slcInstallCmd,
+		"update":  slcUpdateCmd,
+	} {
+		if !strings.Contains(cmd.Use, "<alias-or-flavor>") {
+			t.Errorf("slc %s usage does not accept aliases or flavors: %q", name, cmd.Use)
+		}
+		for _, want := range []string{"by alias or flavor", "Prefer aliases"} {
+			if !strings.Contains(cmd.Long, want) {
+				t.Errorf("slc %s help does not mention %q", name, want)
+			}
+		}
+	}
+}
+
 // The alias dispatch is the only thing wiring the Rust SLC into the shared commands; keep both
 // entry points at the signature the RunE handlers call them with.
 func TestSLCRustDispatchFunctionsAreWired(t *testing.T) {
@@ -637,6 +656,10 @@ func TestFormatSLCListTextSeparatesOfficialFromCustom(t *testing.T) {
 	// Then
 	if !strings.Contains(output, "FLAVOR") || !strings.Contains(output, "CUSTOM ALIAS") {
 		t.Fatalf("expected both tables, got %q", output)
+	}
+	header := strings.Fields(strings.SplitN(output, "\n", 2)[0])
+	if !slices.Equal(header, []string{"ALIASES", "FLAVOR", "VERSION", "INSTALLED"}) {
+		t.Fatalf("expected aliases before flavor, got %q", output)
 	}
 	if !strings.Contains(output, "\n\n") {
 		t.Fatalf("expected a blank line between the two tables, got %q", output)

--- a/internal/deploy/slc.go
+++ b/internal/deploy/slc.go
@@ -378,7 +378,7 @@ func UpdateSLC(
 		return nil, err
 	}
 
-	index := findInstalledSLC(state.InstalledSLCs, alias)
+	index := findInstalledSLC(state.InstalledSLCs, entry.Language)
 	if index < 0 {
 		return &SLCUpdateResult{Operation: SLCOperationUpdate, Found: false}, nil
 	}

--- a/internal/deploy/slc_test.go
+++ b/internal/deploy/slc_test.go
@@ -4,11 +4,15 @@
 package deploy
 
 import (
+	"context"
 	"errors"
 	"os"
+	"runtime"
 	"testing"
 
+	"github.com/exasol/exasol-personal/assets/resources"
 	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/slc"
 )
 
 func TestInstalledFlavors(t *testing.T) {
@@ -147,6 +151,57 @@ func TestFindInstalledSLCMatchesAliasLanguageAndFlavor(t *testing.T) {
 		if got := findInstalledSLC(installed, needle); got != want {
 			t.Errorf("findInstalledSLC(%q) = %d, want %d", needle, got, want)
 		}
+	}
+}
+
+func TestUpdateSLCFindsInstalledEntryAfterFlavorChange(t *testing.T) {
+	t.Parallel()
+
+	// Given: a stopped local deployment with the previous flavor of the current Python SLC.
+	catalog, err := slc.Load(resources.SLCCatalogYAML)
+	if err != nil {
+		t.Fatalf("load catalog: %v", err)
+	}
+	current, err := catalog.Resolve("PYTHON3", runtime.GOARCH)
+	if err != nil {
+		t.Fatalf("resolve Python SLC: %v", err)
+	}
+	previous := toInstalledSLC(current)
+	previous.Flavor += "-previous"
+	previous.Image += "-previous"
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	if err := os.MkdirAll(deployment.InfrastructureDir(), 0o750); err != nil {
+		t.Fatalf("create infrastructure directory: %v", err)
+	}
+	if err := os.WriteFile(
+		deployment.InfrastructureManifestPath(), []byte("backend: local\n"), 0o600,
+	); err != nil {
+		t.Fatalf("write infrastructure manifest: %v", err)
+	}
+	state := &config.ExasolPersonalState{
+		DeploymentVersion: "0.0.0",
+		InstalledSLCs:     []config.InstalledSLC{previous},
+	}
+	if err := state.SetWorkflowStateAndWrite(
+		&config.WorkflowStateStopped{}, deployment,
+	); err != nil {
+		t.Fatalf("write deployment state: %v", err)
+	}
+
+	// When: updating by the new flavor advertised by the catalog.
+	result, err := UpdateSLC(
+		context.Background(), deployment, current.Flavor, false, false, nil,
+	)
+	// Then: the previous flavor is found and replaced by the current entry.
+	if err != nil {
+		t.Fatalf("UpdateSLC returned an error: %v", err)
+	}
+	if !result.Found || !result.Changed {
+		t.Fatalf("expected an installed SLC update, got %#v", result)
+	}
+	if result.FromFlavor != previous.Flavor || result.Entry.Flavor != current.Flavor {
+		t.Fatalf("unexpected flavor transition: %#v", result)
 	}
 }
 

--- a/internal/slc/catalog.go
+++ b/internal/slc/catalog.go
@@ -65,7 +65,7 @@ type Entry struct {
 // with errors.Is; operations that require a concrete SLC (install/update) let it surface.
 var ErrArchitectureUnsupported = errors.New("architecture is not supported")
 
-// UnknownAliasError reports an alias that matches no catalog entry.
+// UnknownAliasError reports an identifier that matches no catalog entry.
 type UnknownAliasError struct {
 	Alias        string
 	ValidAliases []string
@@ -73,11 +73,11 @@ type UnknownAliasError struct {
 
 func (e *UnknownAliasError) Error() string {
 	if len(e.ValidAliases) == 0 {
-		return fmt.Sprintf("unknown SLC alias %q", e.Alias)
+		return fmt.Sprintf("unknown SLC identifier %q", e.Alias)
 	}
 
 	return fmt.Sprintf(
-		"unknown SLC alias %q; available aliases: %s",
+		"unknown SLC identifier %q; available aliases: %s",
 		e.Alias,
 		strings.Join(e.ValidAliases, ", "),
 	)
@@ -100,12 +100,12 @@ func Load(data []byte) (*Catalog, error) {
 	return &catalog, nil
 }
 
-// Resolve maps a user-supplied alias (matched case-insensitively) to a concrete SLC in
-// the architecture's default version.
-func (c *Catalog) Resolve(alias, goarch string) (Entry, error) {
-	normalized := strings.TrimSpace(alias)
+// Resolve maps a user-supplied alias or flavor (matched case-insensitively) to a concrete
+// SLC in the architecture's default version.
+func (c *Catalog) Resolve(identifier, goarch string) (Entry, error) {
+	normalized := strings.TrimSpace(identifier)
 	if normalized == "" {
-		return Entry{}, errors.New("no SLC alias provided")
+		return Entry{}, errors.New("no SLC identifier provided")
 	}
 
 	entries, err := c.entries(goarch)
@@ -114,6 +114,9 @@ func (c *Catalog) Resolve(alias, goarch string) (Entry, error) {
 	}
 
 	for _, entry := range entries {
+		if strings.EqualFold(entry.Flavor, normalized) {
+			return entry, nil
+		}
 		for _, candidate := range entry.Aliases {
 			if strings.EqualFold(candidate, normalized) {
 				return entry, nil

--- a/internal/slc/catalog_test.go
+++ b/internal/slc/catalog_test.go
@@ -93,6 +93,20 @@ func TestResolveIsCaseInsensitiveAndMatchesVersionedAlias(t *testing.T) {
 	}
 }
 
+func TestResolveMatchesFlavorCaseInsensitively(t *testing.T) {
+	t.Parallel()
+
+	catalog := mustLoad(t)
+
+	entry, err := catalog.Resolve("JAVA-17", "arm64")
+	if err != nil {
+		t.Fatalf("Resolve(JAVA-17) error: %v", err)
+	}
+	if entry.Flavor != "java-17" {
+		t.Errorf("Flavor = %q, want %q", entry.Flavor, "java-17")
+	}
+}
+
 func TestResolveUnknownAliasListsValidAliases(t *testing.T) {
 	t.Parallel()
 
@@ -106,6 +120,20 @@ func TestResolveUnknownAliasListsValidAliases(t *testing.T) {
 	}
 	if len(unknown.ValidAliases) == 0 {
 		t.Error("expected UnknownAliasError to list valid aliases")
+	}
+	if !strings.Contains(err.Error(), "unknown SLC identifier") {
+		t.Errorf("expected an identifier error, got %q", err)
+	}
+}
+
+func TestResolveRejectsEmptyIdentifier(t *testing.T) {
+	t.Parallel()
+
+	catalog := mustLoad(t)
+
+	_, err := catalog.Resolve("  ", "arm64")
+	if err == nil || err.Error() != "no SLC identifier provided" {
+		t.Errorf("expected an empty identifier error, got %v", err)
 	}
 }
 

--- a/tests/tests/deployment/test_slc.py
+++ b/tests/tests/deployment/test_slc.py
@@ -132,9 +132,15 @@ def _assert_python_udf_is_unavailable(deployment: Deployment, schema: str) -> No
 def test_slc_list_reports_catalog_containers(slc_deployment: Deployment) -> None:
     """`slc list` reports the catalog in text and JSON, whatever is installed."""
     # When / Then: text listing shows the table and the Python alias.
-    text = _slc(slc_deployment, "list", capture=True).stdout
-    assert "FLAVOR" in text
-    assert PYTHON_ALIAS in text
+    result = _slc(slc_deployment, "list", capture=True)
+    assert result.stdout.splitlines()[0].split() == [
+        "ALIASES",
+        "FLAVOR",
+        "VERSION",
+        "INSTALLED",
+    ]
+    assert PYTHON_ALIAS in result.stdout
+    assert "Prefer an alias from the ALIASES column" in result.stderr
 
     # When / Then: JSON listing carries the documented fields for every entry.
     statuses = _official_statuses(slc_deployment)
@@ -161,7 +167,7 @@ def test_slc_install_rejects_unknown_alias(slc_deployment: Deployment) -> None:
 
     # Then: the error names the failure and valid aliases, and nothing changed.
     stderr = exc_info.value.stderr or ""
-    assert "unknown SLC alias" in stderr
+    assert "unknown SLC identifier" in stderr
     assert PYTHON_ALIAS in stderr
     assert _is_alias_installed(slc_deployment, PYTHON_ALIAS) == was_installed
 
@@ -182,8 +188,11 @@ def test_slc_remove_when_not_installed_is_noop(slc_deployment: Deployment) -> No
 @pytest.mark.local_e2e
 def test_official_slc_install_runs_udf(slc_deployment: Deployment) -> None:
     """Installing an official SLC makes its UDFs runnable; reinstalling is a no-op."""
-    # When / Then: installing marks it installed and a Python UDF runs.
-    _slc(slc_deployment, "install", PYTHON_ALIAS, "--auto-approve")
+    # Given: the flavor advertised by `slc list` for the Python SLC.
+    python_flavor = str(_status_for_alias(slc_deployment, PYTHON_ALIAS)["flavor"])
+
+    # When / Then: installing by flavor marks it installed and a Python UDF runs.
+    _slc(slc_deployment, "install", python_flavor, "--auto-approve")
     assert _is_alias_installed(slc_deployment, PYTHON_ALIAS)
     assert "hi" in _run_scalar_udf(slc_deployment, PYTHON_ALIAS, "slc_e2e_official")
 

--- a/user-docs/content/udfs.md
+++ b/user-docs/content/udfs.md
@@ -16,9 +16,10 @@ exasol slc update python3
 exasol slc remove python3
 ```
 
-The language argument is an alias used by `CREATE ... SCRIPT` and is matched case-insensitively. For
-example, the Python container enables the `PYTHON3` and `PYTHON312` aliases, the Java container
-enables `JAVA` and `JAVA17`, and the R container enables `R` and `R44`.
+Official SLCs can be installed, updated, or removed using either an alias or the flavor shown by
+`exasol slc list`. Matching is case-insensitive. Prefer aliases because they remain stable when the
+catalog flavor changes. For example, the Python container enables the `PYTHON3` and `PYTHON312`
+aliases, the Java container enables `JAVA` and `JAVA17`, and the R container enables `R` and `R44`.
 
 The alias `rust` is reserved and is not part of the official catalog. Instead of resolving a catalog
 entry, it installs the latest release of
@@ -28,8 +29,8 @@ release and applies it if it has changed. To install a specific Rust container i
 `rust` currently resolves to, use `exasol slc custom install --alias RUST --language rust --source
 <path-or-url>`.
 
-`exasol slc list` displays each available container's flavor, aliases, version, and installation
-state.
+`exasol slc list` displays aliases first, followed by each container's flavor, version, and
+installation state.
 
 Installing, updating, or removing an SLC normally restarts the local database. This drops open
 connections and aborts running statements. The command asks for confirmation first:


### PR DESCRIPTION
## Description

This PR allows official SLCs to be installed and updated using either an alias or the flavor displayed by exasol slc list. The text listing now shows aliases first and recommends aliases as the preferred stable identifiers.

## Related Issue

[SPOT-32524](https://exasol.atlassian.net/browse/SPOT-32524)

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Resolve official SLCs by alias or flavor, case-insensitively.
- Display ALIASES before FLAVOR and recommend aliases for installation.
- Add unit and deployment coverage for flavor-based installation.

## Testing

- [ ] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

Manually verified that the Python SLC can be installed using its flavor (python-3.12) with the exasol slc install command.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable) - `user-docs/` for user-facing changes, `doc/` for contributor-facing changes
- [x] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

Dev Testing Logs: [SPOT-32524-Dev-Testing-Logs.txt](https://github.com/user-attachments/files/31950092/SPOT-32524-Dev-Testing-Logs.txt)

[SPOT-32524]: https://exasol.atlassian.net/browse/SPOT-32524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ