### PR TITLE
docs: Amend Virtual Schema docs to reflect /exa path for uploading JAR files and config

### DIFF
--- a/user-docs/content/virtual-schemas.md
+++ b/user-docs/content/virtual-schemas.md
@@ -1,95 +1,91 @@
 # Virtual schemas on local deployments
 
-Virtual schemas let you query another database as if its objects were an Exasol schema. Cloud
-deployments already include the standard script language containers and driver locations, so follow
-the [Exasol virtual schema documentation](https://docs.exasol.com/db/latest/database_concepts/virtual_schemas.htm)
-for those deployments.
+Virtual schemas let you query another database as if its objects were an Exasol schema. The
+[Exasol virtual schema documentation](https://docs.exasol.com/db/latest/database_concepts/virtual_schemas.htm)
+describes the concepts, the available adapters, and the properties each one supports. Follow it for
+the SQL that creates connections, adapter scripts, and virtual schemas.
 
-Local deployments require you to install the adapter runtime and stage its dependencies. This guide
-uses the PostgreSQL JDBC adapter as an example.
+This guide covers only what a local deployment needs before that standard SQL flow works: an adapter
+runtime and the adapter's files staged where the database can read them. Cloud deployments already
+include the script language containers and driver locations, so use the Exasol documentation
+directly for those.
 
-## Install the adapter runtime
+## Where local deployments keep database files
 
-JDBC adapters execute as Java UDFs and JDBC data transfer needs a Java runtime. Install the Java SLC
-without restarting yet:
-
-```bash
-DEPLOY_DIR=$(exasol info --json | jq -r '.deploymentDir')
-exasol slc install java --no-restart --deployment-dir "$DEPLOY_DIR"
-```
-
-This command requires `jq`. Use the same `--deployment` or `--deployment-dir` selector with `info`
-when working with a named or explicitly selected deployment. Skip the installation if the required
-SLC is already present. For an adapter implemented in another language, install that runtime. A
-[custom SLC](udfs.md#install-a-custom-container) can supply packages missing from the official one.
-
-## Understand the required files
-
-A JDBC virtual schema needs the adapter JAR, the source database's JDBC driver JAR, and a
-`settings.cfg` describing the driver.
-
-| Files | Container location | Used by |
-| --- | --- | --- |
-| Adapter and driver JARs | `/exa/bucketfs/<service>/<bucket>/<dir>/` | Adapter script through `/buckets/...` |
-| Driver JAR and `settings.cfg` | `/exa/jdbc/<DRIVERNAME>/` | ETL layer for `IMPORT` and `EXPORT` |
-
-The driver JAR is present in both locations because the adapter reads it for metadata and the ETL
-layer uses the registered copy for data transfer. A BucketFS file stored at
-`/exa/bucketfs/bfsdefault/default/vs/example.jar` is addressed by an adapter script as
-`/buckets/bfsdefault/default/vs/example.jar`.
-
-## Select the deployment and staging directory
-
-Resolve the deployment directory and prepare a staging location:
+Your deployment directory exposes the database's `/exa` directory at `local/runtime/exa` on Linux,
+macOS, and Windows. Stage adapter files by writing them there from your computer.
 
 ```bash
 DEPLOY_DIR=$(exasol info --json | jq -r '.deploymentDir')
-VS_DIR="$DEPLOY_DIR/local/runtime/vm-shared/vs"
-mkdir -p "$VS_DIR"
-```
-
-For another deployment selection:
-
-```bash
-DEPLOY_DIR=$(exasol info --json --deployment demo | jq -r '.deploymentDir')
-# or
-DEPLOY_DIR=$(exasol info --json --deployment-dir /path/to/deployment | jq -r '.deploymentDir')
-```
-
-On Linux, the persistent database data is directly accessible on the host:
-
-```bash
 EXA_DATA="$DEPLOY_DIR/local/runtime/exa"
 ```
 
-On macOS, `local/runtime/vm-shared` is mounted inside the managed virtual machine as `/mnt/host`.
-Use `exasol shell host` to copy staged files into database directories. Do not depend on the virtual
-machine's IP address, SSH key, or SSH port.
+This command requires `jq`. Pass the same `--deployment` or `--deployment-dir` selector to `info`
+when working with a named or explicitly selected deployment.
 
-## PostgreSQL JDBC example
+Two locations below `EXA_DATA` matter for a JDBC virtual schema:
+
+| Files | Path on your computer | Read by |
+| --- | --- | --- |
+| Adapter and driver JARs | `$EXA_DATA/bucketfs/<service>/<bucket>/<dir>/` | the adapter script, through its `%jar` lines |
+| Driver JAR and `settings.cfg` | `$EXA_DATA/jdbc/<DRIVERNAME>/` | the ETL layer, for `IMPORT` and `EXPORT` |
+
+`$EXA_DATA/bucketfs` is the deployment's
+[BucketFS](https://docs.exasol.com/db/latest/database_concepts/bucketfs/bucketfs.htm). Creating a
+directory below it creates the matching bucket, and SQL addresses its contents under `/buckets`. A
+JAR written to `$EXA_DATA/bucketfs/bfsdefault/default/vs/example.jar` is therefore referenced by an
+adapter script as `/buckets/bfsdefault/default/vs/example.jar`.
+
+The driver JAR belongs in both locations because the adapter reads it for metadata while the ETL
+layer uses the registered copy to transfer data. Exasol's
+[Add JDBC Driver](https://docs.exasol.com/db/latest/administration/on-premise/manage_drivers/add_jdbc_driver.htm)
+guide keeps the driver and `settings.cfg` in BucketFS; local deployments use
+`$EXA_DATA/jdbc/<DRIVERNAME>/` instead, with the same `settings.cfg` keys and meanings.
+
+## Install the adapter runtime
+
+JDBC adapters run as Java UDFs, and JDBC data transfer needs a Java runtime. Install the Java SLC
+without restarting yet:
+
+```bash
+exasol slc install java --no-restart --deployment-dir "$DEPLOY_DIR"
+```
+
+`--no-restart` records the container and applies it on the next start. Stage the adapter files
+before that start so the whole setup needs only one restart. Skip this step if the required SLC is
+already installed, and use the matching language for an adapter implemented in another one. A
+[custom SLC](udfs.md#install-a-custom-container) can supply packages missing from the official
+container.
+
+## PostgreSQL example
 
 Check the [PostgreSQL virtual schema releases](https://github.com/exasol/postgresql-virtual-schema)
 and [PostgreSQL JDBC downloads](https://jdbc.postgresql.org/download/) for current versions. The
-versions below are examples and should be updated together when newer compatible artifacts are used.
+versions below are examples; update them together when using newer compatible artifacts, and
+substitute the resulting filenames throughout.
 
-### Download the adapter and driver
+### Stage the adapter and driver
+
+Write both JARs into BucketFS and register the driver for the ETL layer:
 
 ```bash
-DEPLOY_DIR=$(exasol info --json | jq -r '.deploymentDir')
-VS_DIR="$DEPLOY_DIR/local/runtime/vm-shared/vs"
-mkdir -p "$VS_DIR"
-
-ADAPTER_VERSION=4.0.0
-ADAPTER_JAR=virtual-schema-dist-14.0.2-postgresql-4.0.0.jar
+ADAPTER_VERSION=4.0.2
+ADAPTER_JAR=virtual-schema-dist-14.0.5-postgresql-4.0.2.jar
 DRIVER_JAR=postgresql-42.7.13.jar
 
-curl -L -o "$VS_DIR/$ADAPTER_JAR" \
+BUCKET_DIR="$EXA_DATA/bucketfs/bfsdefault/default/vs"
+JDBC_DIR="$EXA_DATA/jdbc/POSTGRESQL"
+mkdir -p "$BUCKET_DIR" "$JDBC_DIR"
+
+curl -L -o "$BUCKET_DIR/$ADAPTER_JAR" \
   "https://github.com/exasol/postgresql-virtual-schema/releases/download/$ADAPTER_VERSION/$ADAPTER_JAR"
-curl -L -o "$VS_DIR/$DRIVER_JAR" \
+curl -L -o "$BUCKET_DIR/$DRIVER_JAR" \
   "https://repo.maven.apache.org/maven2/org/postgresql/postgresql/42.7.13/$DRIVER_JAR"
+
+cp "$BUCKET_DIR/$DRIVER_JAR" "$JDBC_DIR/"
 ```
 
-Create `$VS_DIR/settings.cfg` with an empty final line:
+Create `$JDBC_DIR/settings.cfg` with an empty final line:
 
 ```text
 DRIVERNAME=POSTGRESQL
@@ -101,134 +97,43 @@ JAR=postgresql-42.7.13.jar
 
 ```
 
-### Copy the files on Linux
-
-```bash
-mkdir -p "$EXA_DATA/bucketfs/bfsdefault/default/vs"
-cp "$VS_DIR/$ADAPTER_JAR" "$VS_DIR/$DRIVER_JAR" \
-  "$EXA_DATA/bucketfs/bfsdefault/default/vs/"
-mkdir -p "$EXA_DATA/jdbc/POSTGRESQL"
-cp "$VS_DIR/$DRIVER_JAR" "$VS_DIR/settings.cfg" "$EXA_DATA/jdbc/POSTGRESQL/"
-```
-
-### Copy the files on macOS
-
-Open the virtual-machine shell:
-
-```bash
-exasol shell host --deployment-dir "$DEPLOY_DIR"
-```
-
-Then run inside it:
-
-```bash
-mkdir -p /var/lib/exa/bucketfs/bfsdefault/default/vs /var/lib/exa/jdbc/POSTGRESQL
-cp /mnt/host/vs/virtual-schema-dist-14.0.2-postgresql-4.0.0.jar \
-   /mnt/host/vs/postgresql-42.7.13.jar \
-   /var/lib/exa/bucketfs/bfsdefault/default/vs/
-cp /mnt/host/vs/postgresql-42.7.13.jar \
-   /mnt/host/vs/settings.cfg \
-   /var/lib/exa/jdbc/POSTGRESQL/
-ls -lh /var/lib/exa/bucketfs/bfsdefault/default/vs /var/lib/exa/jdbc/POSTGRESQL
-```
-
-Exit the shell after verifying the files. If you selected other artifact versions, substitute their
-filenames throughout the setup.
+`DRIVERNAME` is the name used in `IMPORT ... DRIVER = '...'`.
 
 ### Restart once
 
-Apply the pending SLC and JDBC driver configuration:
+Apply the pending script language container and the driver registration:
 
 ```bash
 exasol stop --deployment-dir "$DEPLOY_DIR"
 exasol start --deployment-dir "$DEPLOY_DIR"
 ```
 
-### Optional: run PostgreSQL inside the macOS virtual machine
-
-For a self-contained test, run PostgreSQL on a dedicated Podman network inside the managed virtual
-machine and connect the Exasol container to that network.
-
-Open the virtual-machine shell:
-
-```bash
-exasol shell host --deployment-dir "$DEPLOY_DIR"
-```
-
-Then run:
-
-```bash
-EXASOL_CONTAINER=$(podman ps --format '{{.Names}}' | sed -n '/^exasol-db-/p' | head -n 1)
-VS_NETWORK="vs-net-${EXASOL_CONTAINER#exasol-db-}"
-podman network create "$VS_NETWORK"
-podman network connect "$VS_NETWORK" "$EXASOL_CONTAINER"
-podman run -d --rm \
-  --name exasol-vs-postgres \
-  --network "$VS_NETWORK" \
-  --env POSTGRES_DB=vs_test \
-  --env POSTGRES_USER=vs_test \
-  --env POSTGRES_PASSWORD=vs_test \
-  docker.io/library/postgres@sha256:c1b3783309b6499c795eed7c20135a1a4d25cae1b575c3d52c6f536129a1b109 \
-  -c timezone=UTC
-until podman exec exasol-vs-postgres pg_isready --username vs_test --dbname vs_test; do
-  sleep 1
-done
-podman exec exasol-vs-postgres psql --no-password --username vs_test --dbname vs_test \
-  -c "CREATE SCHEMA source_schema"
-podman exec exasol-vs-postgres psql --no-password --username vs_test --dbname vs_test \
-  -c "CREATE TABLE source_schema.source_data (id INTEGER PRIMARY KEY, payload TEXT)"
-podman exec exasol-vs-postgres psql --no-password --username vs_test --dbname vs_test \
-  -c "INSERT INTO source_schema.source_data VALUES (1, 'before-refresh')"
-podman inspect exasol-vs-postgres \
-  --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' \
-  > /mnt/host/vs/postgres-ip
-exit
-```
-
-The dedicated network gives Exasol a route to PostgreSQL while keeping the containers independent.
-Do not use `--network container:<Exasol-container>` because that dependency can prevent
-`exasol destroy` from removing the deployment. The example writes PostgreSQL's address into the
-shared staging directory because Podman DNS aliases are not reliable in every managed environment.
-
-Read the address on the macOS host:
-
-```bash
-PG_HOST=$(tr -d '\r\n' < "$VS_DIR/postgres-ip")
-```
-
-Remove the test container with `podman rm --force exasol-vs-postgres` from `exasol shell host` when
-it is no longer needed. Destroying the virtual machine also removes it.
-
 ### Create the connection and virtual schema
 
-The PostgreSQL host must be reachable from the database container or managed virtual machine.
-`localhost` refers to that environment, not necessarily to the computer running PostgreSQL. For an
-external database, use an address reachable from the Exasol runtime. When PostgreSQL runs on a Mac
-host, do not use `127.0.0.1`; publish it on a reachable host interface and verify connectivity from
-`exasol shell host`.
+The PostgreSQL host must be reachable from the Exasol runtime. `localhost` and `127.0.0.1` refer to
+that runtime, not to the computer running PostgreSQL, so use an address the runtime can reach and
+verify connectivity before creating the virtual schema.
 
-Create `$DEPLOY_DIR/create-vs.sql` and replace the host, credentials, and source schema:
+Create `$DEPLOY_DIR/create-vs.sql`, replacing the host, credentials, and source schema:
 
 ```sql
 CREATE OR REPLACE CONNECTION POSTGRES_CONN
-  TO 'jdbc:postgresql://192.168.1.20:5432/vs_test'
-  USER 'vs_test' IDENTIFIED BY 'vs_test';
+  TO 'jdbc:postgresql://<postgres-host>:5432/<database>'
+  USER '<user>' IDENTIFIED BY '<password>';
 
 CREATE SCHEMA IF NOT EXISTS VS;
 
 CREATE OR REPLACE JAVA ADAPTER SCRIPT VS.POSTGRES_ADAPTER AS
   %scriptclass com.exasol.adapter.RequestDispatcher;
   %jvmoption -Duser.timezone=UTC;
-  %jar /buckets/bfsdefault/default/vs/virtual-schema-dist-14.0.2-postgresql-4.0.0.jar;
+  %jar /buckets/bfsdefault/default/vs/virtual-schema-dist-14.0.5-postgresql-4.0.2.jar;
   %jar /buckets/bfsdefault/default/vs/postgresql-42.7.13.jar;
 /
 
 CREATE VIRTUAL SCHEMA VS_POSTGRES
   USING VS.POSTGRES_ADAPTER
   WITH CONNECTION_NAME = 'POSTGRES_CONN'
-       SCHEMA_NAME = 'source_schema';
-
-SELECT * FROM VS_POSTGRES.source_data;
+       SCHEMA_NAME = '<source-schema>';
 ```
 
 Run it against the selected deployment:
@@ -237,7 +142,7 @@ Run it against the selected deployment:
 exasol connect --deployment-dir "$DEPLOY_DIR" -f "$DEPLOY_DIR/create-vs.sql"
 ```
 
-Refresh the virtual schema after the source schema changes:
+Query the virtual schema like any other schema, and refresh it after the source schema changes:
 
 ```sql
 ALTER VIRTUAL SCHEMA VS_POSTGRES REFRESH;
@@ -253,8 +158,8 @@ lists available adapters and their properties.
 
 ## Troubleshooting
 
-**`ETL-1014: No default DRIVER registered`**: Check that `/exa/jdbc/<DRIVERNAME>/` contains the JAR
-and `settings.cfg`, that the configuration ends with an empty line, and that you restarted the
+**`ETL-1014: No default DRIVER registered`**: Check that `$EXA_DATA/jdbc/<DRIVERNAME>/` contains the
+JAR and `settings.cfg`, that the configuration ends with an empty line, and that you restarted the
 deployment.
 
 **The adapter script cannot find its class**: Check that every `%jar` path resolves below `/buckets`


### PR DESCRIPTION
## Description

Restructures the user-facing virtual schema guide around the host-visible `/exa` path, which is now available on every local platform. The guide previously documented two different procedures, and the macOS one told users to open a VM shell and copy files into `/var/lib/exa`, a location the database no longer reads.

The guide now starts with a platform-neutral explanation of how a deployment exposes database files, including how that path maps to BucketFS, and defers virtual schema concepts and SQL to the Exasol product documentation. The PostgreSQL walkthrough follows as one self-contained section.

## Type of Change

- [x] `docs`: Documentation update

## Changes Made

- Added a high-level section explaining that `local/runtime/exa` in the deployment directory is the database's `/exa` directory on Linux, macOS, and Windows, that `bucketfs` below it is the deployment's BucketFS, and that creating a directory there creates the matching bucket addressed under `/buckets` in SQL. Links to the BucketFS and Add JDBC Driver pages on docs.exasol.com.
- Replaced the separate "Copy the files on Linux" and "Copy the files on macOS" procedures with one set of commands that writes directly into the deployment directory. macOS no longer needs `exasol shell host`, and the obsolete `/var/lib/exa` instructions are gone.
- Removed the "run PostgreSQL inside the macOS virtual machine" section, along with its Podman network setup and container address handoff.
- Removed the `vm-shared/vs` staging directory: files download straight to their destination.
- Reorganized the PostgreSQL example into a single section covering staging, the one required restart, and the connection and virtual schema SQL.
- Updated the example artifacts to the current PostgreSQL virtual schema release (adapter 4.0.2, `virtual-schema-dist-14.0.5`).
- Pointed the troubleshooting entries at the documented `$EXA_DATA` paths.

## Testing

- [x] Manually tested the changes

### Test Details

`task docs-check` passes: docs lint, 53 tooling tests, and a strict MkDocs build with no warnings.

The documented procedure was run end to end against a local macOS deployment before writing it up, using a PostgreSQL source with the adapter and driver staged exactly as described:

- Both JARs written from macOS into `local/runtime/exa/bucketfs/bfsdefault/default/vs/`, with no VM or container shell involved.
- The `bfsdefault/default` bucket appeared automatically in the database's `bucketfs.conf`, confirming the directory-creates-bucket behaviour the guide now describes.
- Driver and `settings.cfg` registered under `local/runtime/exa/jdbc/POSTGRESQL/`.
- After one restart, the virtual schema mirrored all source objects, row counts matched the source exactly across 7 tables, all 3 source views were queryable, and a four-table join returned results identical to the same query run directly against PostgreSQL.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Updated documentation (if applicable) - `user-docs/` for user-facing changes, `doc/` for contributor-facing changes
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

The contributor copy at `doc/virtual_schemas.md` still carries its own macOS VM PostgreSQL section and the older example versions, so the two trees now differ. Aligning it was left out of this PR to keep the change focused on the published guide.

No `CHANGELOG.md` entry is included, by maintainer request.
