### PR TITLE
feat: preset backend specific cli options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ Notable user-facing changes to Exasol Personal are documented here.
 
   Example: `exasol install local --help` reports "Infrastructure preset `local`" with `Compatible installation presets: local`, and suggests `exasol install local local`.
 
+- `--tofu-update-lockfile` is now offered only by deployments whose infrastructure preset uses the OpenTofu backend. It stays available for OpenTofu-backed `exasol install` and `exasol deploy`, where help lists it under its own heading, is no longer listed in the help of a local preset or deployment, and is rejected with an error naming the preset when passed to one. On `exasol install` it must follow the preset argument, which is what selects the backend.
+- `--tofu-update-lockfile` is now offered only by deployments whose infrastructure preset uses the OpenTofu backend. It stays available for OpenTofu-backed `exasol install` and `exasol deploy`, is no longer listed in the help of a local preset or deployment, and is rejected with an error naming the preset when passed to one.
+
+  Example: `exasol install local --tofu-update-lockfile` reports `unsupported deployment option: infrastructure preset "local" does not support --tofu-update-lockfile`.
+
 - Local deployments now select and persist a concrete database port during initialization, keep it stable across restarts, allow port changes while stopped, and provide actionable recovery commands when the configured port is unavailable.
 - Documented named deployments, the `exasol slc` command group, and `exasol diag local` in the README, and made clear which features apply to local versus cloud deployments. Named deployments now have their own README section (they apply to both deployment types, not just cloud), a new section covers UDFs and script language containers, and the Limitations section no longer states that UDFs are unavailable on local deployments.
 - macOS local deployments now run the same Podman installation used on Linux inside a managed VM. The VM launcher is responsible only for VM lifecycle, port forwarding, shared files, and command execution; deployment state no longer exposes its SSH transport.

--- a/cmd/exasol/backend_options.go
+++ b/cmd/exasol/backend_options.go
@@ -1,0 +1,252 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/exasol/exasol-personal/internal/deploy"
+	"github.com/spf13/cobra"
+)
+
+// Recorded per command, so one command's backend options stay out of another's.
+const (
+	backendOptionFlagsAnnotationKey       = "exasol.backendOptionFlags"
+	backendOptionPresetLabelAnnotationKey = "exasol.backendOptionPresetLabel"
+)
+
+var errBackendOptionFlagConflict = errors.New("backend option flag name conflict")
+
+// Runs before Cobra parses, which is what keeps an option out of the help and the
+// accepted flags of a deployment whose backend cannot act on it.
+func prepareBackendOptionFlags(ctx context.Context, args []string) error {
+	cmd, _ := preregisteredCommand(args)
+
+	switch cmd {
+	case installCmd:
+		return prepareInstallBackendOptionFlags(ctx, installCmd, args)
+	case deployCmd:
+		return prepareDeployBackendOptionFlags(deployCmd, args)
+	default:
+		return nil
+	}
+}
+
+func prepareInstallBackendOptionFlags(
+	ctx context.Context,
+	cmd *cobra.Command,
+	args []string,
+) error {
+	resolution, ok := resolveInstallBackendOptions(ctx, args)
+	if !ok {
+		// The command itself reports an unusable preset, and can list the valid ones.
+		return nil
+	}
+
+	return applyBackendOptionFlags(cmd, args, resolution)
+}
+
+func resolveInstallBackendOptions(
+	ctx context.Context,
+	args []string,
+) (deploy.DeployOptionResolution, bool) {
+	preset, err := scanInfrastructurePresetSelection(ctx, args)
+	if err != nil || preset == nil {
+		return deploy.DeployOptionResolution{}, false
+	}
+
+	resolution, err := deploy.ResolveDeployOptions(ctx, *preset)
+	if err != nil {
+		return deploy.DeployOptionResolution{}, false
+	}
+
+	return resolution, true
+}
+
+func prepareDeployBackendOptionFlags(cmd *cobra.Command, args []string) error {
+	resolution, ok := resolveDeploymentBackendOptions(args)
+	if ok {
+		return applyBackendOptionFlags(cmd, args, resolution)
+	}
+
+	// No backend to consult. Registering every known option lets parsing succeed so
+	// the initialized-deployment gate reports the real problem instead of an unknown
+	// flag; hiding them keeps help offering only what a known backend supports.
+	if err := registerBackendOptionFlags(cmd, deploy.AllDeployOptions()); err != nil {
+		return err
+	}
+	hideBackendOptionFlags(cmd)
+
+	return nil
+}
+
+func hideBackendOptionFlags(cmd *cobra.Command) {
+	for _, name := range backendOptionFlagNames(cmd) {
+		if flag := cmd.Flags().Lookup(name); flag != nil {
+			flag.Hidden = true
+		}
+	}
+}
+
+func resolveDeploymentBackendOptions(
+	args []string,
+) (deploy.DeployOptionResolution, bool) {
+	deployment, err := deploymentDirFromRawArgs(args)
+	if err != nil {
+		return deploy.DeployOptionResolution{}, false
+	}
+
+	resolution, err := deploy.ResolveDeployOptionsFromDeployment(deployment)
+	if err != nil {
+		return deploy.DeployOptionResolution{}, false
+	}
+
+	return resolution, true
+}
+
+func applyBackendOptionFlags(
+	cmd *cobra.Command,
+	args []string,
+	resolution deploy.DeployOptionResolution,
+) error {
+	if err := rejectUnsupportedBackendOptions(args, resolution); err != nil {
+		return err
+	}
+	if err := registerBackendOptionFlags(cmd, resolution.Options); err != nil {
+		return err
+	}
+	if len(resolution.Options) > 0 {
+		recordBackendOptionPresetLabel(cmd, resolution.PresetLabel)
+	}
+
+	return nil
+}
+
+// rejectUnsupportedBackendOptions names the preset, where Cobra would report an
+// unknown flag and read like a typo.
+func rejectUnsupportedBackendOptions(
+	args []string,
+	resolution deploy.DeployOptionResolution,
+) error {
+	if rawArgsRequestHelp(args) {
+		return nil
+	}
+
+	supported := map[string]struct{}{}
+	for _, option := range resolution.Options {
+		supported[option.Name] = struct{}{}
+	}
+
+	for _, option := range deploy.AllDeployOptions() {
+		if _, ok := supported[option.Name]; ok {
+			continue
+		}
+		if !rawArgsContainFlag(args, option.Name) {
+			continue
+		}
+
+		return fmt.Errorf(
+			"%w: infrastructure preset %q does not support --%s",
+			deploy.ErrUnsupportedDeployOption, resolution.PresetLabel, option.Name,
+		)
+	}
+
+	return nil
+}
+
+func rawArgsContainFlag(args []string, name string) bool {
+	for _, arg := range args {
+		if arg == "--"+name || strings.HasPrefix(arg, "--"+name+"=") {
+			return true
+		}
+	}
+
+	return false
+}
+
+func registerBackendOptionFlags(
+	cmd *cobra.Command,
+	options []deploy.DeployOptionDefinition,
+) error {
+	for _, option := range options {
+		if err := registerBackendOptionFlag(cmd, option); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func registerBackendOptionFlag(
+	cmd *cobra.Command,
+	option deploy.DeployOptionDefinition,
+) error {
+	if cmd.Flags().Lookup(option.Name) != nil || cmd.InheritedFlags().Lookup(option.Name) != nil {
+		return fmt.Errorf(
+			"%w: --%s is already defined", errBackendOptionFlagConflict, option.Name,
+		)
+	}
+
+	switch option.Type {
+	case deploy.ConfigVariableTypeBool:
+		cmd.Flags().Bool(option.Name, false, option.Description)
+	case deploy.ConfigVariableTypeNumber:
+		cmd.Flags().Var(&numberFlag{}, option.Name, option.Description)
+	case deploy.ConfigVariableTypeString:
+		cmd.Flags().String(option.Name, "", option.Description)
+	default:
+		cmd.Flags().String(option.Name, "", option.Description)
+	}
+	recordBackendOptionFlag(cmd, option.Name)
+
+	return nil
+}
+
+func recordBackendOptionPresetLabel(cmd *cobra.Command, label string) {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations[backendOptionPresetLabelAnnotationKey] = label
+}
+
+func recordBackendOptionFlag(cmd *cobra.Command, name string) {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+
+	registered := backendOptionFlagNames(cmd)
+	cmd.Annotations[backendOptionFlagsAnnotationKey] = strings.Join(
+		append(registered, name), ",",
+	)
+}
+
+func backendOptionFlagNames(cmd *cobra.Command) []string {
+	recorded := strings.TrimSpace(cmd.Annotations[backendOptionFlagsAnnotationKey])
+	if recorded == "" {
+		return nil
+	}
+
+	return strings.Split(recorded, ",")
+}
+
+func isBackendOptionFlagName(cmd *cobra.Command, flagName string) bool {
+	return slices.Contains(backendOptionFlagNames(cmd), flagName)
+}
+
+func collectBackendOptions(cmd *cobra.Command) map[string]string {
+	options := map[string]string{}
+	for _, name := range backendOptionFlagNames(cmd) {
+		flag := cmd.Flags().Lookup(name)
+		if flag == nil || !flag.Changed {
+			continue
+		}
+		options[name] = flag.Value.String()
+	}
+
+	return options
+}

--- a/cmd/exasol/backend_options_test.go
+++ b/cmd/exasol/backend_options_test.go
@@ -1,0 +1,357 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/deploy"
+	"github.com/spf13/cobra"
+)
+
+const testTofuPresetName = "aws"
+
+const tofuInfrastructureManifestForDeployment = `name: Exasol in Test Cloud
+description: Exasol on a tofu-managed test cloud.
+backend: tofu
+
+tofu:
+  variablesFile: variables.tf
+`
+
+const localInfrastructureManifestForDeployment = `name: Exasol Local for backend options
+description: Exasol Local deployment used to check backend option ownership.
+backend: local
+
+local:
+  cpuCount: 2
+`
+
+// Stands in for `install` or `deploy`, so registration leaves the real commands
+// alone. The tests still reach the package-global rootCmd, whose lookup mutates
+// shared Cobra state, so they run sequentially.
+func newBackendOptionTestCommand() *cobra.Command {
+	return &cobra.Command{Use: "test", RunE: func(*cobra.Command, []string) error {
+		return nil
+	}}
+}
+
+//nolint:paralleltest
+func TestInstallBackendOptions_TofuPresetOffersLockfileOption(t *testing.T) {
+	cmd := newBackendOptionTestCommand()
+
+	err := prepareInstallBackendOptionFlags(
+		testManagerContext(t),
+		cmd,
+		[]string{"install", testTofuPresetName, "--tofu-update-lockfile"},
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	flag := cmd.Flags().Lookup("tofu-update-lockfile")
+	if flag == nil {
+		t.Fatal("expected --tofu-update-lockfile to be registered for a tofu preset")
+	}
+	if flag.Value.Type() != "bool" {
+		t.Fatalf("expected a boolean flag, got %q", flag.Value.Type())
+	}
+	if flag.Usage == "" {
+		t.Error("expected the option's description to be rendered as flag usage")
+	}
+}
+
+// Help must not list an option the preset's backend cannot act on.
+//
+//nolint:paralleltest
+func TestInstallBackendOptions_LocalPresetOffersNoLockfileOption(t *testing.T) {
+	cmd := newBackendOptionTestCommand()
+
+	err := prepareInstallBackendOptionFlags(
+		testManagerContext(t),
+		cmd,
+		[]string{"install", testLocalPresetName},
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if cmd.Flags().Lookup("tofu-update-lockfile") != nil {
+		t.Error("expected --tofu-update-lockfile to be absent for a local preset")
+	}
+}
+
+//nolint:paralleltest
+func TestInstallBackendOptions_LocalPresetRejectsLockfileOption(t *testing.T) {
+	err := prepareInstallBackendOptionFlags(
+		testManagerContext(t),
+		newBackendOptionTestCommand(),
+		[]string{"install", testLocalPresetName, "--tofu-update-lockfile"},
+	)
+	if err == nil {
+		t.Fatal("expected a clear error, got nil")
+	}
+	if !errors.Is(err, deploy.ErrUnsupportedDeployOption) {
+		t.Fatalf("expected ErrUnsupportedDeployOption, got %v", err)
+	}
+	for _, want := range []string{"--tofu-update-lockfile", testLocalPresetName} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention %q, got: %v", want, err)
+		}
+	}
+}
+
+// Help must render even for an unsupported option, as it does for preset variables.
+//
+//nolint:paralleltest
+func TestInstallBackendOptions_HelpRendersDespiteUnsupportedOption(t *testing.T) {
+	cmd := newBackendOptionTestCommand()
+
+	err := prepareInstallBackendOptionFlags(
+		testManagerContext(t),
+		cmd,
+		[]string{"install", testLocalPresetName, "--tofu-update-lockfile", "--help"},
+	)
+	if err != nil {
+		t.Fatalf("expected help to render (nil error), got %v", err)
+	}
+	if cmd.Flags().Lookup("tofu-update-lockfile") != nil {
+		t.Error("expected --tofu-update-lockfile to stay absent for a local preset")
+	}
+}
+
+// Written before the preset, the pre-parser consumes the preset as the option's
+// value, leaving no backend to resolve.
+//
+//nolint:paralleltest
+func TestInstallBackendOptions_OptionBeforePresetOffersNothing(t *testing.T) {
+	cmd := newBackendOptionTestCommand()
+
+	err := prepareInstallBackendOptionFlags(
+		testManagerContext(t),
+		cmd,
+		[]string{"install", "--tofu-update-lockfile", testTofuPresetName},
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if cmd.Flags().Lookup("tofu-update-lockfile") != nil {
+		t.Error("expected no option to be registered before the preset is known")
+	}
+}
+
+// Options render under their own heading, not among the generic flags.
+//
+//nolint:paralleltest
+func TestInstallBackendOptions_RenderUnderTheirOwnHelpHeading(t *testing.T) {
+	cmd := newBackendOptionTestCommand()
+
+	if err := prepareInstallBackendOptionFlags(
+		testManagerContext(t),
+		cmd,
+		[]string{"install", testTofuPresetName},
+	); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !hasBackendOptionFlags(cmd) {
+		t.Fatal("expected the backend option section to be rendered")
+	}
+	if title := backendOptionFlagsTitle(cmd); !strings.Contains(title, testTofuPresetName) {
+		t.Errorf("expected the title to name the preset, got %q", title)
+	}
+	if usages := backendOptionFlagUsages(cmd); !strings.Contains(usages, "--tofu-update-lockfile") {
+		t.Errorf("expected the option in its own section, got %q", usages)
+	}
+	for _, flag := range otherLocalFlags(cmd) {
+		if flag.Name == "tofu-update-lockfile" {
+			t.Error("expected the option to be excluded from the generic flag section")
+		}
+	}
+}
+
+// A backend declaring no options renders no heading at all.
+//
+//nolint:paralleltest
+func TestInstallBackendOptions_LocalPresetRendersNoHelpHeading(t *testing.T) {
+	cmd := newBackendOptionTestCommand()
+
+	if err := prepareInstallBackendOptionFlags(
+		testManagerContext(t),
+		cmd,
+		[]string{"install", testLocalPresetName},
+	); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if hasBackendOptionFlags(cmd) {
+		t.Error("expected no backend option section for a preset that declares none")
+	}
+}
+
+// The command itself reports an unresolvable preset, so pre-registration stays silent.
+//
+//nolint:paralleltest
+func TestInstallBackendOptions_UnknownPresetStaysSilent(t *testing.T) {
+	cmd := newBackendOptionTestCommand()
+
+	if err := prepareInstallBackendOptionFlags(
+		testManagerContext(t),
+		cmd,
+		[]string{"install", "no-such-preset"},
+	); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if cmd.Flags().Lookup("tofu-update-lockfile") != nil {
+		t.Error("expected no options to be registered for an unknown preset")
+	}
+}
+
+//nolint:paralleltest
+func TestDeployBackendOptions_TofuDeploymentOffersLockfileOption(t *testing.T) {
+	cmd := newBackendOptionTestCommand()
+	dir := writeInitializedDeployment(t, tofuInfrastructureManifestForDeployment)
+
+	err := prepareDeployBackendOptionFlags(
+		cmd,
+		[]string{"deploy", "--deployment-dir", dir, "--tofu-update-lockfile"},
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if cmd.Flags().Lookup("tofu-update-lockfile") == nil {
+		t.Error("expected --tofu-update-lockfile to be registered for a tofu deployment")
+	}
+}
+
+//nolint:paralleltest
+func TestDeployBackendOptions_LocalDeploymentRejectsLockfileOption(t *testing.T) {
+	dir := writeInitializedDeployment(t, localInfrastructureManifestForDeployment)
+
+	err := prepareDeployBackendOptionFlags(
+		newBackendOptionTestCommand(),
+		[]string{"deploy", "--deployment-dir", dir, "--tofu-update-lockfile"},
+	)
+	if err == nil {
+		t.Fatal("expected a clear error, got nil")
+	}
+	if !errors.Is(err, deploy.ErrUnsupportedDeployOption) {
+		t.Fatalf("expected ErrUnsupportedDeployOption, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "Exasol Local for backend options") {
+		t.Errorf("error should name the deployment's preset, got: %v", err)
+	}
+}
+
+//nolint:paralleltest
+func TestDeployBackendOptions_LocalDeploymentOffersNoLockfileOption(t *testing.T) {
+	cmd := newBackendOptionTestCommand()
+	dir := writeInitializedDeployment(t, localInfrastructureManifestForDeployment)
+
+	if err := prepareDeployBackendOptionFlags(
+		cmd,
+		[]string{"deploy", "--deployment-dir", dir},
+	); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if cmd.Flags().Lookup("tofu-update-lockfile") != nil {
+		t.Error("expected --tofu-update-lockfile to be absent for a local deployment")
+	}
+}
+
+// Parsing must still succeed without a backend, so the initialized-deployment gate
+// reports the real problem instead of an unknown flag.
+//
+//nolint:paralleltest
+func TestDeployBackendOptions_UninitializedDeploymentKeepsOptionsParseable(t *testing.T) {
+	cmd := newBackendOptionTestCommand()
+	dir := filepath.Join(t.TempDir(), "not-a-deployment")
+
+	if err := prepareDeployBackendOptionFlags(
+		cmd,
+		[]string{"deploy", "--deployment-dir", dir, "--tofu-update-lockfile"},
+	); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	flag := cmd.Flags().Lookup("tofu-update-lockfile")
+	if flag == nil {
+		t.Fatal("expected every known option to stay parseable")
+	}
+	if !flag.Hidden {
+		t.Error("expected the option to stay out of help while no backend is known")
+	}
+	if hasBackendOptionFlags(cmd) {
+		t.Error("expected no backend option section while no backend is known")
+	}
+}
+
+//nolint:paralleltest
+func TestCollectBackendOptions_ReturnsSuppliedValues(t *testing.T) {
+	cmd := newBackendOptionTestCommand()
+
+	if err := registerBackendOptionFlags(cmd, deploy.AllDeployOptions()); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if err := cmd.Flags().Parse([]string{"--tofu-update-lockfile"}); err != nil {
+		t.Fatalf("expected the option to parse, got %v", err)
+	}
+
+	options := collectBackendOptions(cmd)
+	if options["tofu-update-lockfile"] != "true" {
+		t.Fatalf("expected the supplied value, got %v", options)
+	}
+}
+
+// An unsupplied option stays absent, so the backend keeps its own default.
+//
+//nolint:paralleltest
+func TestCollectBackendOptions_OmitsUnsuppliedOptions(t *testing.T) {
+	cmd := newBackendOptionTestCommand()
+
+	if err := registerBackendOptionFlags(cmd, deploy.AllDeployOptions()); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if err := cmd.Flags().Parse(nil); err != nil {
+		t.Fatalf("expected parsing to succeed, got %v", err)
+	}
+
+	if options := collectBackendOptions(cmd); len(options) != 0 {
+		t.Fatalf("expected no options, got %v", options)
+	}
+}
+
+//nolint:paralleltest
+func TestRegisterBackendOptionFlag_ReportsNameConflict(t *testing.T) {
+	cmd := newBackendOptionTestCommand()
+	cmd.Flags().Bool("tofu-update-lockfile", false, "")
+
+	err := registerBackendOptionFlags(cmd, deploy.AllDeployOptions())
+	if !errors.Is(err, errBackendOptionFlagConflict) {
+		t.Fatalf("expected a flag name conflict, got %v", err)
+	}
+}
+
+//nolint:paralleltest
+func TestRawArgsContainFlag(t *testing.T) {
+	testCases := []struct {
+		name     string
+		args     []string
+		expected bool
+	}{
+		{name: "absent", args: []string{"install", "local"}},
+		{name: "bare", args: []string{"--tofu-update-lockfile"}, expected: true},
+		{name: "with value", args: []string{"--tofu-update-lockfile=true"}, expected: true},
+		{name: "other flag", args: []string{"--tofu-update-lockfile-x"}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			actual := rawArgsContainFlag(testCase.args, "tofu-update-lockfile")
+			if actual != testCase.expected {
+				t.Fatalf("expected %v, got %v", testCase.expected, actual)
+			}
+		})
+	}
+}

--- a/cmd/exasol/commonFlags.go
+++ b/cmd/exasol/commonFlags.go
@@ -31,8 +31,7 @@ type CommonFlags struct {
 	OutputJson bool
 
 	// Common flags for deploy-like commands (deploy + install).
-	DeployVerbose            bool
-	DeployTofuUpdateLockfile bool
+	DeployVerbose bool
 }
 
 // commonFlags is the default runtime instance used by the actual CLI commands.
@@ -80,15 +79,6 @@ func registerDeploymentDirFlag(cmd *cobra.Command, state *CommonFlags) {
 		),
 	)
 	cmd.MarkFlagsMutuallyExclusive(deploymentDirFlagName, deploymentNameFlagName)
-}
-
-func registerDeployFlags(cmd *cobra.Command, state *CommonFlags) {
-	cmd.Flags().BoolVar(
-		&state.DeployTofuUpdateLockfile,
-		"tofu-update-lockfile",
-		false,
-		"Allow OpenTofu to update .terraform.lock.hcl during init",
-	)
 }
 
 func registerOutputFlags(cmd *cobra.Command, state *CommonFlags) {

--- a/cmd/exasol/config_set_options_error_test.go
+++ b/cmd/exasol/config_set_options_error_test.go
@@ -7,12 +7,9 @@
 package main
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-
-	"github.com/exasol/exasol-personal/internal/config"
 )
 
 const localInfrastructureManifestForConfigSet = `name: Exasol Local on macOS
@@ -24,34 +21,10 @@ local:
   dataSizeGB: 100
 `
 
-// writeInitializedLocalDeployment creates a deployment directory that looks like a
-// local deployment in the initialized state (the state a deployment returns to after
-// `exasol destroy`), so `config set` can resolve its infrastructure options.
 func writeInitializedLocalDeployment(t *testing.T) string {
 	t.Helper()
-	dir := t.TempDir()
-	dep := config.NewDeploymentDir(dir)
 
-	if err := os.MkdirAll(filepath.Dir(dep.InfrastructureManifestPath()), 0o750); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	if err := os.WriteFile(
-		dep.InfrastructureManifestPath(),
-		[]byte(localInfrastructureManifestForConfigSet),
-		0o600,
-	); err != nil {
-		t.Fatalf("write manifest: %v", err)
-	}
-
-	state := &config.ExasolPersonalState{DeploymentId: "local", ClusterIdentity: "local"}
-	if err := state.SetWorkflowState(&config.WorkflowStateInitialized{}); err != nil {
-		t.Fatalf("set state: %v", err)
-	}
-	if err := config.WriteExasolPersonalState(state, dep); err != nil {
-		t.Fatalf("write state: %v", err)
-	}
-
-	return dir
+	return writeInitializedDeployment(t, localInfrastructureManifestForConfigSet)
 }
 
 // A non-help `config set` against a directory that is not an initialized deployment must

--- a/cmd/exasol/deploy.go
+++ b/cmd/exasol/deploy.go
@@ -31,7 +31,7 @@ var deployCmd = &cobra.Command{
 			deployment,
 			commonFlags.DeployVerbose,
 			deploy.DeployOptions{
-				UpdateDependencyLockfile: commonFlags.DeployTofuUpdateLockfile,
+				BackendOptions: collectBackendOptions(cmd),
 				RuntimePreparation: hostRuntimePreparationOptions(
 					cmd, rootOpts.ApprovalMode(),
 				),
@@ -53,6 +53,5 @@ func init() {
 	requireDeploymentFileLogging(deployCmd)
 	registerDeploymentDirFlag(deployCmd, commonFlags)
 	registerVerboseFlag(deployCmd, commonFlags)
-	registerDeployFlags(deployCmd, commonFlags)
 	rootCmd.AddCommand(deployCmd)
 }

--- a/cmd/exasol/install.go
+++ b/cmd/exasol/install.go
@@ -57,7 +57,6 @@ func init() {
 	registerInitFlags(installCmd, commonFlags)
 	registerDeploymentDirFlag(installCmd, commonFlags)
 	registerVerboseFlag(installCmd, commonFlags)
-	registerDeployFlags(installCmd, commonFlags)
 	rootCmd.AddCommand(installCmd)
 }
 
@@ -164,7 +163,7 @@ func runInstallPersistentPostRun(cmd *cobra.Command, _ []string) error {
 		deployment,
 		commonFlags.DeployVerbose,
 		deploy.DeployOptions{
-			UpdateDependencyLockfile: commonFlags.DeployTofuUpdateLockfile,
+			BackendOptions: collectBackendOptions(cmd),
 			RuntimePreparation: hostRuntimePreparationOptions(
 				cmd, rootOpts.ApprovalMode(),
 			),

--- a/cmd/exasol/root.go
+++ b/cmd/exasol/root.go
@@ -217,6 +217,10 @@ func Execute() error {
 		return err
 	}
 
+	if err := prepareBackendOptionFlags(ctx, os.Args[1:]); err != nil {
+		return err
+	}
+
 	// Record the preset selection that preset-specific help describes; scans only when
 	// help is requested.
 	preparePresetHelpSelection(ctx, os.Args[1:])

--- a/cmd/exasol/root_preregister_test.go
+++ b/cmd/exasol/root_preregister_test.go
@@ -108,7 +108,6 @@ func TestScanPresetFromArgs_BooleanFlagsBeforeInfrastructurePreset(t *testing.T)
 	}{
 		{name: "verbose", flag: "--verbose"},
 		{name: "verbose shorthand", flag: "-v"},
-		{name: "tofu lockfile update", flag: "--tofu-update-lockfile"},
 		{name: "launcher version check", flag: "--no-launcher-version-check"},
 	}
 

--- a/cmd/exasol/testhelpers_test.go
+++ b/cmd/exasol/testhelpers_test.go
@@ -5,8 +5,11 @@ package main
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/exasol/exasol-personal/internal/config"
 	"github.com/exasol/exasol-personal/internal/runtimeartifacts/runtimeartifactstest"
 )
 
@@ -17,4 +20,32 @@ func testManagerContext(t *testing.T) context.Context {
 	t.Helper()
 
 	return runtimeartifactstest.NewContext(t)
+}
+
+// Initialized is the state a deployment returns to after `exasol destroy`.
+func writeInitializedDeployment(t *testing.T, infrastructureManifest string) string {
+	t.Helper()
+	dir := t.TempDir()
+	dep := config.NewDeploymentDir(dir)
+
+	if err := os.MkdirAll(filepath.Dir(dep.InfrastructureManifestPath()), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(
+		dep.InfrastructureManifestPath(),
+		[]byte(infrastructureManifest),
+		0o600,
+	); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	state := &config.ExasolPersonalState{DeploymentId: "local", ClusterIdentity: "local"}
+	if err := state.SetWorkflowState(&config.WorkflowStateInitialized{}); err != nil {
+		t.Fatalf("set state: %v", err)
+	}
+	if err := config.WriteExasolPersonalState(state, dep); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+
+	return dir
 }

--- a/cmd/exasol/usage_template.go
+++ b/cmd/exasol/usage_template.go
@@ -19,6 +19,9 @@ func init() {
 	cobra.AddTemplateFunc("hasInstallationVariableFlags", hasInstallationVariableFlags)
 	cobra.AddTemplateFunc("installationVariableFlagsTitle", installationVariableFlagsTitle)
 	cobra.AddTemplateFunc("installationVariableFlagUsages", installationVariableFlagUsages)
+	cobra.AddTemplateFunc("hasBackendOptionFlags", hasBackendOptionFlags)
+	cobra.AddTemplateFunc("backendOptionFlagsTitle", backendOptionFlagsTitle)
+	cobra.AddTemplateFunc("backendOptionFlagUsages", backendOptionFlagUsages)
 	cobra.AddTemplateFunc("hasGlobalFlags", hasGlobalFlags)
 	cobra.AddTemplateFunc("globalFlagUsages", globalFlagUsages)
 	cobra.AddTemplateFunc("commandsInGroup", commandsInGroup)
@@ -155,6 +158,43 @@ func installationVariableFlagUsages(cmd *cobra.Command) string {
 	return strings.TrimRight(flagset.FlagUsages(), "\n")
 }
 
+func hasBackendOptionFlags(cmd *cobra.Command) bool {
+	if cmd == nil {
+		return false
+	}
+
+	for _, flagName := range backendOptionFlagNames(cmd) {
+		if flag := cmd.LocalNonPersistentFlags().Lookup(flagName); flag != nil && !flag.Hidden {
+			return true
+		}
+	}
+
+	return false
+}
+
+func backendOptionFlagsTitle(cmd *cobra.Command) string {
+	label := ""
+	if cmd != nil && cmd.Annotations != nil {
+		label = strings.TrimSpace(cmd.Annotations[backendOptionPresetLabelAnnotationKey])
+	}
+	if label == "" {
+		return "Backend option flags:"
+	}
+
+	return fmt.Sprintf("Backend option flags of preset `%s`:", label)
+}
+
+func backendOptionFlagUsages(cmd *cobra.Command) string {
+	flagset := pflag.NewFlagSet("backend-options", pflag.ContinueOnError)
+	for _, flagName := range backendOptionFlagNames(cmd) {
+		if f := cmd.LocalNonPersistentFlags().Lookup(flagName); f != nil {
+			flagset.AddFlag(f)
+		}
+	}
+
+	return strings.TrimRight(flagset.FlagUsages(), "\n")
+}
+
 func commandsInGroup(cmd *cobra.Command, groupID string) []*cobra.Command {
 	if cmd == nil {
 		return nil
@@ -236,6 +276,9 @@ func otherLocalFlags(cmd *cobra.Command) []*pflag.Flag {
 		if isInstallationVariableFlagName(flag.Name) {
 			return
 		}
+		if isBackendOptionFlagName(cmd, flag.Name) {
+			return
+		}
 		flags = append(flags, flag)
 	})
 
@@ -279,6 +322,9 @@ const customUsageTemplate = `Usage:
 
 {{end}}{{if hasInstallationVariableFlags .}}{{installationVariableFlagsTitle .}}
 {{installationVariableFlagUsages . | trimTrailingWhitespaces}}
+
+{{end}}{{if hasBackendOptionFlags .}}{{backendOptionFlagsTitle .}}
+{{backendOptionFlagUsages . | trimTrailingWhitespaces}}
 
 {{end}}{{if hasOtherLocalFlags .}}Flags:
 {{otherLocalFlagUsages . | trimTrailingWhitespaces}}

--- a/internal/deploy/backend.go
+++ b/internal/deploy/backend.go
@@ -21,14 +21,11 @@ const (
 	backendTypeLocal = "local"
 )
 
-// DeployOptions carries backend-agnostic options for a single deploy invocation.
-// Individual backends interpret the options they understand and ignore the rest.
+// DeployOptions carries the options for a single deploy invocation.
 type DeployOptions struct {
-	// UpdateDependencyLockfile signals that the backend may update any
-	// dependency lockfile during initialization (e.g. OpenTofu's
-	// .terraform.lock.hcl). When false, the backend must treat any such
-	// lockfile as read-only.
-	UpdateDependencyLockfile bool
+	// Keyed by option name. Validated against the backend's declaration before
+	// the backend runs, so a backend only receives options it declared.
+	BackendOptions map[string]string
 
 	// RuntimePreparation carries the approval and progress policy applied
 	// before the deployment records an operation in progress.
@@ -85,17 +82,17 @@ func resolveBackendKind(manifest *presets.InfrastructureManifest) (string, error
 		backend = backendTypeTofu
 	}
 
-	switch backend {
-	case backendTypeTofu, backendTypeLocal:
-		return backend, nil
-	case "":
+	if backend == "" {
 		return "", fmt.Errorf(
 			"%w: infrastructure manifest does not declare a supported backend",
 			ErrUnknownDeploymentType,
 		)
-	default:
-		return "", fmt.Errorf("%w: %q", ErrUnknownDeploymentType, backend)
 	}
+	if _, err := backendDescriptorForKind(backend); err != nil {
+		return "", err
+	}
+
+	return backend, nil
 }
 
 func newDeploymentBackendForDeployment(
@@ -115,26 +112,12 @@ func newDeploymentBackend(
 	deployment config.DeploymentDir,
 	manifest *presets.InfrastructureManifest,
 ) (deploymentBackend, error) {
-	kind, err := resolveBackendKind(manifest)
+	descriptor, err := backendDescriptorForManifest(manifest)
 	if err != nil {
 		return nil, err
 	}
 
-	manager := runtimeartifacts.FromContext(ctx)
-
-	switch kind {
-	case backendTypeTofu:
-		return newTofuBackend(deployment, manifest, manager), nil
-	case backendTypeLocal:
-		localRuntime, err := newLocalRuntime(deployment, manager)
-		if err != nil {
-			return nil, err
-		}
-
-		return newLocalBackend(deployment, manifest, localRuntime), nil
-	default:
-		return nil, fmt.Errorf("%w: %q", ErrUnknownDeploymentType, kind)
-	}
+	return descriptor.newBackend(deployment, manifest, runtimeartifacts.FromContext(ctx))
 }
 
 // readInfrastructurePresetConfigVariables exposes a preset's configurable
@@ -147,23 +130,12 @@ func readInfrastructurePresetConfigVariables(
 	preset PresetRef,
 	manifest *presets.InfrastructureManifest,
 ) (map[string]ConfigVariableDefinition, error) {
-	kind, err := resolveBackendKind(manifest)
+	descriptor, err := backendDescriptorForManifest(manifest)
 	if err != nil {
 		return nil, err
 	}
 
-	switch kind {
-	case backendTypeTofu:
-		if manifest.Tofu == nil {
-			return map[string]ConfigVariableDefinition{}, nil
-		}
-
-		return readTofuPresetConfigVariables(ctx, preset, *manifest.Tofu)
-	case backendTypeLocal:
-		return localConfigVariableDefinitions(ctx, manifest), nil
-	default:
-		return nil, fmt.Errorf("%w: %q", ErrUnknownDeploymentType, kind)
-	}
+	return descriptor.presetConfigVariables(ctx, preset, manifest)
 }
 
 func newLocalRuntime(

--- a/internal/deploy/backend_options.go
+++ b/internal/deploy/backend_options.go
@@ -1,0 +1,148 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/presets"
+)
+
+var (
+	ErrUnsupportedDeployOption = errors.New("unsupported deployment option")
+	ErrInvalidDeployOption     = errors.New("invalid deployment option")
+)
+
+// DeployOptionDefinition declares one option a backend accepts for a deploy
+// operation. Name is the option as written on the command line.
+type DeployOptionDefinition struct {
+	Name        string
+	Description string
+	Type        ConfigVariableType
+}
+
+// DeployOptionResolution pairs a backend's options with the label identifying the
+// preset they came from: an embedded preset name, a preset path, or a manifest name.
+type DeployOptionResolution struct {
+	Options     []DeployOptionDefinition
+	PresetLabel string
+}
+
+// ResolveDeployOptions reads the preset's manifest only, so `install` can offer a
+// backend's options before a deployment directory exists.
+func ResolveDeployOptions(
+	ctx context.Context,
+	preset PresetRef,
+) (DeployOptionResolution, error) {
+	manifest, label, err := readInfrastructureManifestForPreset(ctx, preset)
+	if err != nil {
+		return DeployOptionResolution{PresetLabel: label}, err
+	}
+
+	options, err := deployOptionsForManifest(manifest)
+	if err != nil {
+		return DeployOptionResolution{PresetLabel: label}, err
+	}
+
+	return DeployOptionResolution{Options: options, PresetLabel: label}, nil
+}
+
+func ResolveDeployOptionsFromDeployment(
+	deployment config.DeploymentDir,
+) (DeployOptionResolution, error) {
+	manifest, err := config.ReadInfrastructureManifest(deployment)
+	if err != nil {
+		return DeployOptionResolution{}, err
+	}
+
+	options, err := deployOptionsForManifest(manifest)
+	if err != nil {
+		return DeployOptionResolution{PresetLabel: manifest.Name}, err
+	}
+
+	return DeployOptionResolution{Options: options, PresetLabel: manifest.Name}, nil
+}
+
+// AllDeployOptions lets the CLI tell an option no backend knows from one the
+// selected backend does not support.
+func AllDeployOptions() []DeployOptionDefinition {
+	options := make([]DeployOptionDefinition, 0)
+	for _, descriptor := range backendDescriptors {
+		options = append(options, descriptor.deployOptions...)
+	}
+
+	slices.SortFunc(options, func(left, right DeployOptionDefinition) int {
+		return strings.Compare(left.Name, right.Name)
+	})
+
+	return options
+}
+
+func deployOptionsForManifest(
+	manifest *presets.InfrastructureManifest,
+) ([]DeployOptionDefinition, error) {
+	descriptor, err := backendDescriptorForManifest(manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	return descriptor.deployOptions, nil
+}
+
+// validateDeployOptionsForManifest rejects options the manifest's backend never
+// declared, so a backend cannot silently drop one that reaches it.
+func validateDeployOptionsForManifest(
+	manifest *presets.InfrastructureManifest,
+	options DeployOptions,
+) error {
+	descriptor, err := backendDescriptorForManifest(manifest)
+	if err != nil {
+		return err
+	}
+
+	declared := make(map[string]struct{}, len(descriptor.deployOptions))
+	for _, option := range descriptor.deployOptions {
+		declared[option.Name] = struct{}{}
+	}
+
+	supplied := make([]string, 0, len(options.BackendOptions))
+	for name := range options.BackendOptions {
+		supplied = append(supplied, name)
+	}
+	slices.Sort(supplied)
+
+	for _, name := range supplied {
+		if _, ok := declared[name]; !ok {
+			return fmt.Errorf(
+				"%w: the %s backend does not support --%s",
+				ErrUnsupportedDeployOption, descriptor.kind, name,
+			)
+		}
+	}
+
+	return nil
+}
+
+// boolOption reads false for an option the user did not supply.
+func (options DeployOptions) boolOption(name string) (bool, error) {
+	raw := strings.TrimSpace(options.BackendOptions[name])
+	if raw == "" {
+		return false, nil
+	}
+
+	value, err := strconv.ParseBool(raw)
+	if err != nil {
+		return false, fmt.Errorf(
+			"%w: --%s expects a boolean, got %q", ErrInvalidDeployOption, name, raw,
+		)
+	}
+
+	return value, nil
+}

--- a/internal/deploy/backend_options_test.go
+++ b/internal/deploy/backend_options_test.go
@@ -1,0 +1,270 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/presets"
+)
+
+const tofuInfrastructureManifest = `name: Test Cloud
+description: Test cloud infrastructure.
+backend: tofu
+
+tofu:
+  variablesFile: variables.tf
+`
+
+const localInfrastructureManifest = `name: Test Local
+description: Test local infrastructure.
+backend: local
+
+local:
+  cpuCount: 2
+`
+
+// The manifest is all that resolving a deployment's backend needs.
+func writeDeploymentWithInfrastructureManifest(
+	t *testing.T, manifest string,
+) config.DeploymentDir {
+	t.Helper()
+
+	deployment := config.NewDeploymentDir(t.TempDir())
+	path := deployment.InfrastructureManifestPath()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(manifest), 0o600); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	return deployment
+}
+
+func TestAllDeployOptions_DeclaresTofuLockfileOptionAsBoolean(t *testing.T) {
+	t.Parallel()
+
+	options := AllDeployOptions()
+
+	var found *DeployOptionDefinition
+	for index, option := range options {
+		if option.Name == tofuUpdateLockfileOption {
+			found = &options[index]
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected %q among %v", tofuUpdateLockfileOption, options)
+	}
+	if found.Type != ConfigVariableTypeBool {
+		t.Fatalf("expected a boolean option, got %q", found.Type)
+	}
+	if found.Description == "" {
+		t.Fatal("expected a description the CLI can render as flag usage")
+	}
+}
+
+func TestAllDeployOptions_IsOrderedByName(t *testing.T) {
+	t.Parallel()
+
+	options := AllDeployOptions()
+	for index := 1; index < len(options); index++ {
+		if options[index-1].Name > options[index].Name {
+			t.Fatalf("expected options ordered by name, got %v", options)
+		}
+	}
+}
+
+func TestResolveDeployOptions_TofuPresetDeclaresLockfileOption(t *testing.T) {
+	t.Parallel()
+
+	presetDir := t.TempDir()
+	writePresetInfrastructureManifest(t, presetDir, tofuInfrastructureManifest)
+
+	resolution, err := ResolveDeployOptions(
+		context.Background(), PresetRef{Path: presetDir},
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(resolution.Options) != 1 ||
+		resolution.Options[0].Name != tofuUpdateLockfileOption {
+		t.Fatalf("expected the tofu lockfile option, got %v", resolution.Options)
+	}
+	if resolution.PresetLabel != presetDir {
+		t.Fatalf("expected label %q, got %q", presetDir, resolution.PresetLabel)
+	}
+}
+
+func TestResolveDeployOptions_LocalPresetDeclaresNoOptions(t *testing.T) {
+	t.Parallel()
+
+	presetDir := t.TempDir()
+	writePresetInfrastructureManifest(t, presetDir, localInfrastructureManifest)
+
+	resolution, err := ResolveDeployOptions(
+		context.Background(), PresetRef{Path: presetDir},
+	)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(resolution.Options) != 0 {
+		t.Fatalf("expected no options, got %v", resolution.Options)
+	}
+}
+
+func writePresetInfrastructureManifest(t *testing.T, dir, manifest string) {
+	t.Helper()
+
+	path := filepath.Join(dir, presets.InfrastructureManifestFilename)
+	if err := os.WriteFile(path, []byte(manifest), 0o600); err != nil {
+		t.Fatalf("write preset manifest: %v", err)
+	}
+}
+
+func TestResolveDeployOptionsFromDeployment_UsesTheDeploymentsBackend(t *testing.T) {
+	t.Parallel()
+
+	deployment := writeDeploymentWithInfrastructureManifest(t, tofuInfrastructureManifest)
+
+	resolution, err := ResolveDeployOptionsFromDeployment(deployment)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(resolution.Options) != 1 ||
+		resolution.Options[0].Name != tofuUpdateLockfileOption {
+		t.Fatalf("expected the tofu lockfile option, got %v", resolution.Options)
+	}
+	if resolution.PresetLabel != "Test Cloud" {
+		t.Fatalf("expected the manifest name as label, got %q", resolution.PresetLabel)
+	}
+}
+
+func TestResolveDeployOptionsFromDeployment_LocalDeploymentDeclaresNoOptions(t *testing.T) {
+	t.Parallel()
+
+	deployment := writeDeploymentWithInfrastructureManifest(t, localInfrastructureManifest)
+
+	resolution, err := ResolveDeployOptionsFromDeployment(deployment)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(resolution.Options) != 0 {
+		t.Fatalf("expected no options, got %v", resolution.Options)
+	}
+}
+
+func TestResolveDeployOptionsFromDeployment_ReportsMissingManifest(t *testing.T) {
+	t.Parallel()
+
+	_, err := ResolveDeployOptionsFromDeployment(config.NewDeploymentDir(t.TempDir()))
+	if err == nil {
+		t.Fatal("expected an error for a directory without an infrastructure manifest")
+	}
+}
+
+func TestValidateDeployOptionsForManifest_AcceptsDeclaredOption(t *testing.T) {
+	t.Parallel()
+
+	manifest := &presets.InfrastructureManifest{
+		Backend: backendTypeTofu,
+		Tofu:    &presets.InfrastructureTofu{},
+	}
+	options := DeployOptions{
+		BackendOptions: map[string]string{tofuUpdateLockfileOption: "true"},
+	}
+
+	if err := validateDeployOptionsForManifest(manifest, options); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidateDeployOptionsForManifest_RejectsOptionOfAnotherBackend(t *testing.T) {
+	t.Parallel()
+
+	manifest := &presets.InfrastructureManifest{Backend: backendTypeLocal}
+	options := DeployOptions{
+		BackendOptions: map[string]string{tofuUpdateLockfileOption: "true"},
+	}
+
+	err := validateDeployOptionsForManifest(manifest, options)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if !errors.Is(err, ErrUnsupportedDeployOption) {
+		t.Fatalf("expected ErrUnsupportedDeployOption, got %v", err)
+	}
+	if !strings.Contains(err.Error(), tofuUpdateLockfileOption) ||
+		!strings.Contains(err.Error(), backendTypeLocal) {
+		t.Fatalf("expected the option and the backend to be named, got %q", err.Error())
+	}
+}
+
+func TestValidateDeployOptionsForManifest_AcceptsNoOptions(t *testing.T) {
+	t.Parallel()
+
+	manifest := &presets.InfrastructureManifest{Backend: backendTypeLocal}
+
+	if err := validateDeployOptionsForManifest(manifest, DeployOptions{}); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestValidateDeployOptionsForManifest_ReportsUnknownBackend(t *testing.T) {
+	t.Parallel()
+
+	manifest := &presets.InfrastructureManifest{Backend: "unknown"}
+
+	err := validateDeployOptionsForManifest(manifest, DeployOptions{})
+	if !errors.Is(err, ErrUnknownDeploymentType) {
+		t.Fatalf("expected ErrUnknownDeploymentType, got %v", err)
+	}
+}
+
+func TestDeployOptionsBoolOption(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		raw       map[string]string
+		expected  bool
+		expectErr bool
+	}{
+		{name: "not supplied", raw: nil},
+		{name: "empty value", raw: map[string]string{"option": ""}},
+		{name: "true", raw: map[string]string{"option": "true"}, expected: true},
+		{name: "false", raw: map[string]string{"option": "false"}},
+		{name: "invalid", raw: map[string]string{"option": "maybe"}, expectErr: true},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			options := DeployOptions{BackendOptions: testCase.raw}
+
+			value, err := options.boolOption("option")
+			if testCase.expectErr {
+				if !errors.Is(err, ErrInvalidDeployOption) {
+					t.Fatalf("expected ErrInvalidDeployOption, got %v", err)
+				}
+
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if value != testCase.expected {
+				t.Fatalf("expected %v, got %v", testCase.expected, value)
+			}
+		})
+	}
+}

--- a/internal/deploy/backend_registry.go
+++ b/internal/deploy/backend_registry.go
@@ -1,0 +1,60 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/presets"
+	"github.com/exasol/exasol-personal/internal/runtimeartifacts"
+)
+
+// backendDescriptor declares one infrastructure backend. Everything in it is
+// reachable from a manifest alone, so the CLI can offer a backend's options before
+// a deployment directory exists to construct that backend from.
+type backendDescriptor struct {
+	kind string
+
+	// A backend that declares no options accepts none.
+	deployOptions []DeployOptionDefinition
+
+	newBackend func(
+		deployment config.DeploymentDir,
+		manifest *presets.InfrastructureManifest,
+		manager *runtimeartifacts.Manager,
+	) (deploymentBackend, error)
+
+	presetConfigVariables func(
+		ctx context.Context,
+		preset PresetRef,
+		manifest *presets.InfrastructureManifest,
+	) (map[string]ConfigVariableDefinition, error)
+}
+
+var backendDescriptors = map[string]backendDescriptor{
+	backendTypeTofu:  tofuBackendDescriptor,
+	backendTypeLocal: localBackendDescriptor,
+}
+
+func backendDescriptorForKind(kind string) (backendDescriptor, error) {
+	descriptor, ok := backendDescriptors[kind]
+	if !ok {
+		return backendDescriptor{}, fmt.Errorf("%w: %q", ErrUnknownDeploymentType, kind)
+	}
+
+	return descriptor, nil
+}
+
+func backendDescriptorForManifest(
+	manifest *presets.InfrastructureManifest,
+) (backendDescriptor, error) {
+	kind, err := resolveBackendKind(manifest)
+	if err != nil {
+		return backendDescriptor{}, err
+	}
+
+	return backendDescriptorForKind(kind)
+}

--- a/internal/deploy/backend_registry_test.go
+++ b/internal/deploy/backend_registry_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package deploy
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/presets"
+)
+
+// Registering a descriptor must be enough to make a new backend usable.
+func TestBackendDescriptors_AreComplete(t *testing.T) {
+	t.Parallel()
+
+	for kind, descriptor := range backendDescriptors {
+		if descriptor.kind != kind {
+			t.Errorf("descriptor registered as %q reports kind %q", kind, descriptor.kind)
+		}
+		if descriptor.newBackend == nil {
+			t.Errorf("backend %q cannot be constructed", kind)
+		}
+		if descriptor.presetConfigVariables == nil {
+			t.Errorf("backend %q declares no preset configuration variables", kind)
+		}
+		for _, option := range descriptor.deployOptions {
+			if option.Name == "" || option.Description == "" {
+				t.Errorf("backend %q declares an unusable option %+v", kind, option)
+			}
+		}
+	}
+}
+
+// Otherwise the CLI cannot tell which backend interprets a supplied value.
+func TestBackendDescriptors_DeclareDistinctDeployOptions(t *testing.T) {
+	t.Parallel()
+
+	owners := map[string]string{}
+	for kind, descriptor := range backendDescriptors {
+		for _, option := range descriptor.deployOptions {
+			if owner, ok := owners[option.Name]; ok {
+				t.Errorf(
+					"option %q is declared by both %q and %q", option.Name, owner, kind,
+				)
+			}
+			owners[option.Name] = kind
+		}
+	}
+}
+
+func TestBackendDescriptorForKind_RejectsUnregisteredKind(t *testing.T) {
+	t.Parallel()
+
+	_, err := backendDescriptorForKind("unregistered")
+	if !errors.Is(err, ErrUnknownDeploymentType) {
+		t.Fatalf("expected ErrUnknownDeploymentType, got %v", err)
+	}
+}
+
+func TestBackendDescriptorForManifest_ResolvesLegacyTofuManifest(t *testing.T) {
+	t.Parallel()
+
+	manifest := &presets.InfrastructureManifest{Tofu: &presets.InfrastructureTofu{}}
+
+	descriptor, err := backendDescriptorForManifest(manifest)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if descriptor.kind != backendTypeTofu {
+		t.Fatalf("expected the tofu backend, got %q", descriptor.kind)
+	}
+}

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -155,6 +155,13 @@ func deployLocked(
 	if err != nil {
 		return err
 	}
+
+	// Runs before anything is recorded as in progress, so a rejected invocation
+	// leaves the deployment untouched.
+	if err := validateDeployOptionsForManifest(infrastructureManifest, options); err != nil {
+		return err
+	}
+
 	backend, err := newDeploymentBackend(ctx, deployment, infrastructureManifest)
 	if err != nil {
 		return err

--- a/internal/deploy/local_backend.go
+++ b/internal/deploy/local_backend.go
@@ -17,6 +17,7 @@ import (
 	"github.com/exasol/exasol-personal/internal/config"
 	"github.com/exasol/exasol-personal/internal/localruntime"
 	"github.com/exasol/exasol-personal/internal/presets"
+	"github.com/exasol/exasol-personal/internal/runtimeartifacts"
 	"github.com/exasol/exasol-personal/internal/util"
 	"gopkg.in/yaml.v3"
 )
@@ -52,6 +53,31 @@ var errUnsupportedLocalPlatform = errors.New(
 	"local deployments are only supported on macOS Apple Silicon, " +
 		"Linux amd64/arm64, and Windows amd64",
 )
+
+// The local backend needs nothing per invocation: its settings are fixed by the
+// host platform or persisted as deployment configuration.
+var localBackendDescriptor = backendDescriptor{
+	kind: backendTypeLocal,
+	newBackend: func(
+		deployment config.DeploymentDir,
+		manifest *presets.InfrastructureManifest,
+		manager *runtimeartifacts.Manager,
+	) (deploymentBackend, error) {
+		localRuntime, err := newLocalRuntime(deployment, manager)
+		if err != nil {
+			return nil, err
+		}
+
+		return newLocalBackend(deployment, manifest, localRuntime), nil
+	},
+	presetConfigVariables: func(
+		ctx context.Context,
+		_ PresetRef,
+		manifest *presets.InfrastructureManifest,
+	) (map[string]ConfigVariableDefinition, error) {
+		return localConfigVariableDefinitions(ctx, manifest), nil
+	},
+}
 
 func newLocalBackend(
 	deployment config.DeploymentDir,

--- a/internal/deploy/tofu_backend.go
+++ b/internal/deploy/tofu_backend.go
@@ -57,6 +57,39 @@ type tofuBackend struct {
 	defaultsErr    error
 }
 
+const tofuUpdateLockfileOption = "tofu-update-lockfile"
+
+var tofuBackendDescriptor = backendDescriptor{
+	kind: backendTypeTofu,
+	deployOptions: []DeployOptionDefinition{
+		{
+			Name:        tofuUpdateLockfileOption,
+			Description: "Allow OpenTofu to update .terraform.lock.hcl during init",
+			Type:        ConfigVariableTypeBool,
+		},
+	},
+	newBackend: func(
+		deployment config.DeploymentDir,
+		manifest *presets.InfrastructureManifest,
+		manager *runtimeartifacts.Manager,
+	) (deploymentBackend, error) {
+		return newTofuBackend(deployment, manifest, manager), nil
+	},
+	presetConfigVariables: tofuPresetConfigVariables,
+}
+
+func tofuPresetConfigVariables(
+	ctx context.Context,
+	preset PresetRef,
+	manifest *presets.InfrastructureManifest,
+) (map[string]ConfigVariableDefinition, error) {
+	if manifest == nil || manifest.Tofu == nil {
+		return map[string]ConfigVariableDefinition{}, nil
+	}
+
+	return readTofuPresetConfigVariables(ctx, preset, *manifest.Tofu)
+}
+
 func newTofuBackend(
 	deployment config.DeploymentDir,
 	manifest *presets.InfrastructureManifest,
@@ -381,8 +414,13 @@ func (b *tofuBackend) Deploy(
 	stdOutWriter := util.CombineWriters(logBuffer, out)
 	stdErrWriter := util.CombineWriters(logBuffer, outErr)
 
+	updateLockfile, err := options.boolOption(tofuUpdateLockfileOption)
+	if err != nil {
+		return err
+	}
+
 	lockfileMode := tofu.LockfileReadonly
-	if options.UpdateDependencyLockfile {
+	if updateLockfile {
 		lockfileMode = tofu.LockfileUpdate
 	}
 

--- a/tests/tests/integration/test_backend.py
+++ b/tests/tests/integration/test_backend.py
@@ -19,12 +19,12 @@ from tests.testcase_helpers import (
 )
 
 
-@pytest.mark.launcher_tests
-def test_unknown_backend_is_rejected(exasol_path: str, tmp_path: Path) -> None:
-    # Given an exported infrastructure preset whose manifest declares an
-    # unknown backend
+def exported_preset_with_backend(
+    exasol_path: str, base_dir: Path, backend: str
+) -> Path:
+    """Export the first infrastructure preset, declaring the given backend in it."""
     infra_id = first_infrastructure_preset_id_or_skip(exasol_path)
-    infra_dir = tmp_path / "infra_export"
+    infra_dir = base_dir / f"infra_export_{backend}"
     infra_dir.mkdir()
     export_preset(exasol_path, infra_id, "infrastructure", str(infra_dir))
 
@@ -32,12 +32,21 @@ def test_unknown_backend_is_rejected(exasol_path: str, tmp_path: Path) -> None:
     original = manifest.read_text()
     if "backend:" in original:
         patched = "\n".join(
-            "backend: unknown" if line.strip().startswith("backend:") else line
+            f"backend: {backend}" if line.strip().startswith("backend:") else line
             for line in original.splitlines()
         )
     else:
-        patched = "backend: unknown\n" + original
+        patched = f"backend: {backend}\n" + original
     manifest.write_text(patched)
+
+    return infra_dir
+
+
+@pytest.mark.launcher_tests
+def test_unknown_backend_is_rejected(exasol_path: str, tmp_path: Path) -> None:
+    # Given an exported infrastructure preset whose manifest declares an
+    # unknown backend
+    infra_dir = exported_preset_with_backend(exasol_path, tmp_path, "unknown")
 
     install_dir = tmp_path / "install_export"
     install_dir.mkdir()
@@ -173,3 +182,51 @@ def test_debug_build_is_larger_than_release_build() -> None:
 
     # Restore the default release build for the rest of the suite.
     build(debug=False)
+
+
+@pytest.mark.launcher_tests
+def test_backend_option_is_offered_only_by_the_supporting_backend(
+    exasol_path: str, tmp_path: Path
+) -> None:
+    # Given the same infrastructure preset declared once per backend
+    tofu_preset = exported_preset_with_backend(exasol_path, tmp_path, "tofu")
+    local_preset = exported_preset_with_backend(exasol_path, tmp_path, "local")
+
+    # When help is requested for each of them
+    tofu_help = run_command([exasol_path, "install", str(tofu_preset), "--help"]).stdout
+    local_help = run_command(
+        [exasol_path, "install", str(local_preset), "--help"]
+    ).stdout
+
+    # Then only the OpenTofu-backed preset offers the OpenTofu option
+    assert "--tofu-update-lockfile" in tofu_help
+    assert "--tofu-update-lockfile" not in local_help
+
+
+@pytest.mark.launcher_tests
+def test_backend_option_of_another_backend_is_rejected(
+    exasol_path: str, tmp_path: Path
+) -> None:
+    # Given a local-backed infrastructure preset
+    local_preset = exported_preset_with_backend(exasol_path, tmp_path, "local")
+    deployment_dir = tmp_path / "deployment"
+    deployment_dir.mkdir()
+
+    # When an option only the OpenTofu backend supports is passed
+    command = [
+        exasol_path,
+        "install",
+        str(local_preset),
+        "--tofu-update-lockfile",
+        "--deployment-dir",
+        str(deployment_dir),
+        "--no-launcher-version-check",
+    ]
+    with pytest.raises(CalledProcessError) as exc:
+        run_command(command)
+
+    # Then the option is rejected by name and nothing is initialized
+    stderr = exc.value.stderr or ""
+    assert "--tofu-update-lockfile" in stderr
+    assert "does not support" in stderr
+    assert not (deployment_dir / ".exasolLauncherState.json").exists()


### PR DESCRIPTION
## Description

`--tofu-update-lockfile` was registered as a common deploy flag, so it was offered and accepted for local deployments even though only the OpenTofu backend can act on it. Backend-specific options are now declared and interpreted by the backend that supports them, and the CLI offers only the options of the backend behind the selected deployment.

Behaviour for OpenTofu-backed deployments is unchanged. Local presets and local deployments no longer list the option in their help and reject it with an error naming the preset.

```
$ exasol install aws --help
      --tofu-update-lockfile       Allow OpenTofu to update .terraform.lock.hcl during init

$ exasol install local --help
(no --tofu-update-lockfile)

$ exasol install local --tofu-update-lockfile
Error: unsupported deployment option: infrastructure preset "local" does not support --tofu-update-lockfile

$ exasol deploy --deployment-dir ./local-deployment --tofu-update-lockfile
Error: unsupported deployment option: infrastructure preset "Exasol Local" does not support --tofu-update-lockfile
```

## Related Issue

SPOT-32434

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [x] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Added a backend descriptor registry to `internal/deploy`. Each backend declares, next to its own implementation, how it is constructed, which preset configuration variables it exposes, and which deploy options it accepts. Backend kind resolution, backend construction, and preset variable reading became registry lookups instead of three separate switches, so registering one descriptor is enough to add a backend.
- Replaced `DeployOptions.UpdateDependencyLockfile` with `DeployOptions.BackendOptions`, a name-keyed map. The OpenTofu backend declares `tofu-update-lockfile` and reads it in `Deploy`; the local backend declares no options. The option name and its help text now exist in one place, beside the code that acts on it.
- Deploy operations validate every supplied option against the selected backend's declaration before recording an operation in progress, so an option a backend never declared cannot reach it and be dropped.
- Added CLI pre-registration for backend options, alongside the existing preset variable flag registration. The backend comes from the preset argument for `install` and from the deployment directory for `deploy`. An option only another backend declares is rejected with an error naming the preset, instead of Cobra's `unknown flag`, which reads like a typo.
- Taught the tolerant pre-parser which backend options are boolean, so `exasol install --tofu-update-lockfile aws` still finds its preset argument now that the flag is registered after the preset scan.
- Removed `registerDeployFlags` and `CommonFlags.DeployTofuUpdateLockfile`.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

`task all` passes: lint, docs, build, unit tests (race detector enabled) and integration tests (132 passed, 6 skipped). The deployment suites (`task tests-deployment`) were not run, since they provision real infrastructure.

New unit tests in `internal/deploy`:

- Option resolution from a preset reference and from a deployment directory, for both backends.
- Rejection of an option belonging to another backend, acceptance of a declared one, and boolean value parsing including an invalid value.
- Registry invariants that a future backend must satisfy: every descriptor is complete, and each option name is declared by exactly one backend.

New unit tests in `cmd/exasol`:

- A tofu-backed preset registers the option as a boolean flag with its description as usage; a local preset registers nothing.
- A local preset and a local deployment reject the option, naming both the option and the preset.
- Help still renders when an unsupported option is present, and an unresolvable preset leaves pre-registration silent so the command reports it.
- An uninitialized deployment directory keeps the known options parseable, so the initialized-deployment gate reports the real problem.
- Collection returns supplied values and omits unsupplied ones.

New offline integration tests in `tests/tests/integration/test_backend.py` export one infrastructure preset per backend from the same source preset, assert the option appears only in the OpenTofu-backed preset's help, and assert the local-backed preset rejects it by name and initializes nothing. The existing unknown-backend test now shares the manifest fixture they introduced.

Manual verification against a built binary covered the help of `install local`, `install aws`, `init aws` and `deploy` for both backends, the option supplied before and after the preset argument, `--flag` and `--flag=value` forms, and `deploy` against an uninitialized directory.
## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable) - `user-docs/` for user-facing changes, `doc/` for contributor-facing changes
- [x] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

No documentation update was needed: no document in `user-docs/` or `doc/` mentions the option.

## Additional Notes

Three deliberate decisions worth a reviewer's attention:

- `exasol install --help` without a preset argument no longer mentions the option, because no backend can be consulted yet. This matches how the preset variable flags already behave, and preset-specific help is one argument away.
- The error for a `deploy` invocation names the deployment manifest's display name rather than a preset id, which is the only label an initialized deployment carries. `config set` reports preset labels the same way.
- Option declarations are resolved from a manifest alone rather than from a constructed backend. Constructing the local backend resolves a platform runtime and can fail, and help must render on any platform.

The new `cmd/exasol` tests run sequentially, like the other pre-registration tests: recognizing the invoked command goes through the package-global `rootCmd`, and Cobra's lookup mutates shared state that the race detector rightly reports when two tests do it at once.

Option ownership is intentionally scoped to deploy options. The four local-specific behavioural checks in `internal/deploy` are deployment policy rather than option ownership, and were left unchanged. `StartOptions` has no backend-specific options today and can adopt the same mechanism without redesign.
