### PR TITLE
feat: Standardize launcher paths to platform-specific locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ Notable user-facing changes to Exasol Personal are documented here.
 
 ### Changed
 
+- Launcher-managed files now live under platform-conventional locations instead of one flat `~/.exasol/personal` directory on every platform. Managed deployments and SQL history move to `~/.exasol/launcher/{deployments,history}` on Linux, `~/Library/Application Support/exasol/launcher/{deployments,history}` on macOS, and `%APPDATA%\exasol\launcher\{deployments,history}` on Windows. The resource cache configuration moves from `runtime-artifacts.yaml` in the deployments root to `resources.yaml` at `${XDG_CONFIG_HOME:-~/.config}/exasol/launcher/resources.yaml` (Linux), `~/Library/Application Support/exasol/launcher/resources.yaml` (macOS), or `%APPDATA%\exasol\launcher\resources.yaml` (Windows). The resource cache moves to each platform's cache directory under an `exasol/launcher/resources` namespace.
+
+  Existing deployments, SQL history, and the cache's retention setting migrate automatically the first time a command runs after upgrading; the legacy resource cache is deleted rather than migrated, since it is rebuilt on demand. Cross-filesystem migration preserves deployment permissions and resumes safely if interrupted after publishing its staged copy. The launcher reports every completed change to standard error before the requested command's own output or a later migration error, for example `Migrated managed deployments to ~/.exasol/launcher/deployments`.
+
 - macOS local deployments now store Nano data in host-visible deployment
   storage, making persistent `/exa` files available to host tools.
 

--- a/cmd/exasol/cache_test.go
+++ b/cmd/exasol/cache_test.go
@@ -7,13 +7,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/exasol/exasol-personal/internal/config"
 	"github.com/exasol/exasol-personal/internal/runtimeartifacts"
 	"github.com/spf13/cobra"
 )
@@ -77,14 +75,10 @@ func TestCacheListCommandInitializesConfig(t *testing.T) {
 	if _, err := os.Stat(expectedConfig); err != nil {
 		t.Fatalf("expected cache config to be created, got %v", err)
 	}
-	userCacheDir, err := os.UserCacheDir()
+	expectedCacheRoot, err := runtimeartifacts.DefaultCacheRoot()
 	if err != nil {
-		t.Fatalf("failed to resolve user cache dir: %v", err)
+		t.Fatalf("failed to resolve expected cache root: %v", err)
 	}
-	expectedCacheRoot := filepath.Join(
-		config.LauncherDirPath(userCacheDir),
-		"runtime-artifacts",
-	)
 	if !strings.Contains(buf.String(), "Runtime artifact cache: "+expectedCacheRoot) {
 		t.Fatalf("expected cache root in output, got %q", buf.String())
 	}

--- a/cmd/exasol/cache_test.go
+++ b/cmd/exasol/cache_test.go
@@ -70,7 +70,10 @@ func TestCacheListCommandInitializesConfig(t *testing.T) {
 		t.Fatalf("expected no stderr output, got %q", stderr.String())
 	}
 
-	expectedConfig := filepath.Join(config.LauncherDirPath(home), "runtime-artifacts.yaml")
+	expectedConfig, err := runtimeartifacts.DefaultConfigPath()
+	if err != nil {
+		t.Fatalf("failed to resolve expected config path: %v", err)
+	}
 	if _, err := os.Stat(expectedConfig); err != nil {
 		t.Fatalf("expected cache config to be created, got %v", err)
 	}

--- a/cmd/exasol/deployment_dir_resolution_test.go
+++ b/cmd/exasol/deployment_dir_resolution_test.go
@@ -77,7 +77,11 @@ func TestResolveDeploymentDir_DefaultWinsWhenFlagOmittedOutsideDeploymentDir(t *
 	if source != deploymentDirSourceDefault {
 		t.Fatalf("expected default source, got %v", source)
 	}
-	expected := filepath.Join(config.LauncherDirPath(home), "deployments", "default")
+	deploymentsRoot, err := config.DeploymentsRootPath()
+	if err != nil {
+		t.Fatalf("failed to resolve deployments root: %v", err)
+	}
+	expected := filepath.Join(deploymentsRoot, "default")
 	if deployment.Root() != expected {
 		t.Fatalf("expected %q, got %q", expected, deployment.Root())
 	}
@@ -101,7 +105,11 @@ func TestResolveDeploymentDir_NamedFlagWins(t *testing.T) {
 	if source != deploymentDirSourceNamed {
 		t.Fatalf("expected named source, got %v", source)
 	}
-	expected := filepath.Join(config.LauncherDirPath(home), "deployments", "staging")
+	deploymentsRoot, err := config.DeploymentsRootPath()
+	if err != nil {
+		t.Fatalf("failed to resolve deployments root: %v", err)
+	}
+	expected := filepath.Join(deploymentsRoot, "staging")
 	if deployment.Root() != expected {
 		t.Fatalf("expected %q, got %q", expected, deployment.Root())
 	}
@@ -126,7 +134,11 @@ func TestResolveDeploymentDir_NamedFlagWinsOverCurrentDeploymentDir(t *testing.T
 	if source != deploymentDirSourceNamed {
 		t.Fatalf("expected named source, got %v", source)
 	}
-	expected := filepath.Join(config.LauncherDirPath(home), "deployments", "staging")
+	deploymentsRoot, err := config.DeploymentsRootPath()
+	if err != nil {
+		t.Fatalf("failed to resolve deployments root: %v", err)
+	}
+	expected := filepath.Join(deploymentsRoot, "staging")
 	if deployment.Root() != expected {
 		t.Fatalf("expected %q, got %q", expected, deployment.Root())
 	}

--- a/cmd/exasol/deployments_test.go
+++ b/cmd/exasol/deployments_test.go
@@ -34,7 +34,10 @@ func TestListDeploymentDirectories_SortsAlphabeticallyAndIgnoresNonDirectories(t
 	home := t.TempDir()
 	setTestHome(t, home)
 	t.Chdir(t.TempDir())
-	deploymentsRoot := filepath.Join(config.LauncherDirPath(home), "deployments")
+	deploymentsRoot, err := config.DeploymentsRootPath()
+	if err != nil {
+		t.Fatalf("failed to resolve deployments root: %v", err)
+	}
 	mkdirTest(t, filepath.Join(deploymentsRoot, "staging"))
 	mkdirTest(t, filepath.Join(deploymentsRoot, "prod-aws"))
 	writeTestMarker(t, filepath.Join(deploymentsRoot, "not-a-directory"))
@@ -56,7 +59,10 @@ func TestListDeploymentDirectories_ReportsNotInitializedForUnrecognizedDirectory
 	home := t.TempDir()
 	setTestHome(t, home)
 	t.Chdir(t.TempDir())
-	deploymentsRoot := filepath.Join(config.LauncherDirPath(home), "deployments")
+	deploymentsRoot, err := config.DeploymentsRootPath()
+	if err != nil {
+		t.Fatalf("failed to resolve deployments root: %v", err)
+	}
 	mkdirTest(t, filepath.Join(deploymentsRoot, "empty"))
 
 	entries, err := listDeploymentDirectories(context.Background())
@@ -73,7 +79,10 @@ func TestListDeploymentDirectories_ReportsNotInitializedForLegacyMarkerOnlyDirec
 	home := t.TempDir()
 	setTestHome(t, home)
 	t.Chdir(t.TempDir())
-	deploymentsRoot := filepath.Join(config.LauncherDirPath(home), "deployments")
+	deploymentsRoot, err := config.DeploymentsRootPath()
+	if err != nil {
+		t.Fatalf("failed to resolve deployments root: %v", err)
+	}
 	legacyDir := filepath.Join(deploymentsRoot, "legacy")
 	mkdirTest(t, legacyDir)
 	writeTestMarker(t, filepath.Join(legacyDir, legacyWorkflowStateMarker))
@@ -95,7 +104,10 @@ func TestListDeploymentDirectories_ReportsUnparseableStateFileAsNotInitialized(t
 	home := t.TempDir()
 	setTestHome(t, home)
 	t.Chdir(t.TempDir())
-	deploymentsRoot := filepath.Join(config.LauncherDirPath(home), "deployments")
+	deploymentsRoot, err := config.DeploymentsRootPath()
+	if err != nil {
+		t.Fatalf("failed to resolve deployments root: %v", err)
+	}
 	corruptDir := filepath.Join(deploymentsRoot, "corrupt")
 	mkdirTest(t, corruptDir)
 	writeTestMarker(t, filepath.Join(corruptDir, config.ExasolPersonalStateFileName))
@@ -117,7 +129,10 @@ func TestListDeploymentDirectories_ReportsCanonicalStatusAndPresetIdentity(t *te
 	home := t.TempDir()
 	setTestHome(t, home)
 	t.Chdir(t.TempDir())
-	deploymentsRoot := filepath.Join(config.LauncherDirPath(home), "deployments")
+	deploymentsRoot, err := config.DeploymentsRootPath()
+	if err != nil {
+		t.Fatalf("failed to resolve deployments root: %v", err)
+	}
 	runningDir := filepath.Join(deploymentsRoot, "running")
 	mkdirTest(t, runningDir)
 	writeRunningStateWithPresetIdentity(t, runningDir, "name:aws", "name:standard")
@@ -153,7 +168,10 @@ func TestListDeploymentDirectories_ResolvesStatusesConcurrently(t *testing.T) {
 	home := t.TempDir()
 	setTestHome(t, home)
 	t.Chdir(t.TempDir())
-	deploymentsRoot := filepath.Join(config.LauncherDirPath(home), "deployments")
+	deploymentsRoot, err := config.DeploymentsRootPath()
+	if err != nil {
+		t.Fatalf("failed to resolve deployments root: %v", err)
+	}
 	mkdirTest(t, filepath.Join(deploymentsRoot, "alpha"))
 	mkdirTest(t, filepath.Join(deploymentsRoot, "beta"))
 
@@ -195,7 +213,10 @@ func TestListDeploymentDirectories_StopsWaitingAtParentDeadline(t *testing.T) {
 	home := t.TempDir()
 	setTestHome(t, home)
 	t.Chdir(t.TempDir())
-	deploymentsRoot := filepath.Join(config.LauncherDirPath(home), "deployments")
+	deploymentsRoot, err := config.DeploymentsRootPath()
+	if err != nil {
+		t.Fatalf("failed to resolve deployments root: %v", err)
+	}
 	mkdirTest(t, filepath.Join(deploymentsRoot, "alpha"))
 	mkdirTest(t, filepath.Join(deploymentsRoot, "beta"))
 	stubDeploymentStatus(t, func(

--- a/cmd/exasol/root.go
+++ b/cmd/exasol/root.go
@@ -208,6 +208,16 @@ func Execute() error {
 	}
 	ctx := runtimeartifacts.NewContext(context.Background(), manager)
 
+	// Flag pre-registration below reads an existing deployment's manifest, so
+	// migration has to finish first or the first run after upgrading resolves
+	// the new, still-empty location and fails before migrating anything.
+	// Help renders without touching any launcher-owned path.
+	if !rawArgsRequestHelp(os.Args[1:]) {
+		if err := runStartupMigration(rootCmd.ErrOrStderr()); err != nil {
+			return err
+		}
+	}
+
 	// Register infrastructure variable flags only for commands that need them.
 	// This must happen before Cobra parses arguments.
 	if err := prepareInfrastructureVariableFlags(ctx, os.Args[1:]); err != nil {

--- a/cmd/exasol/root_preregister_test.go
+++ b/cmd/exasol/root_preregister_test.go
@@ -266,7 +266,11 @@ func TestDeploymentDirFromRawArgs_DeploymentFlag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	expected := filepath.Join(config.LauncherDirPath(home), "deployments", "staging")
+	deploymentsRoot, err := config.DeploymentsRootPath()
+	if err != nil {
+		t.Fatalf("failed to resolve deployments root: %v", err)
+	}
+	expected := filepath.Join(deploymentsRoot, "staging")
 	if deployment.Root() != expected {
 		t.Fatalf("expected deployment dir %q, got %q", expected, deployment.Root())
 	}
@@ -285,7 +289,11 @@ func TestDeploymentDirFromRawArgs_DeploymentShorthandFlag(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	expected := filepath.Join(config.LauncherDirPath(home), "deployments", "staging")
+	deploymentsRoot, err := config.DeploymentsRootPath()
+	if err != nil {
+		t.Fatalf("failed to resolve deployments root: %v", err)
+	}
+	expected := filepath.Join(deploymentsRoot, "staging")
 	if deployment.Root() != expected {
 		t.Fatalf("expected deployment dir %q, got %q", expected, deployment.Root())
 	}

--- a/cmd/exasol/startup_migration.go
+++ b/cmd/exasol/startup_migration.go
@@ -1,0 +1,191 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/connect"
+	"github.com/exasol/exasol-personal/internal/launchermigration"
+	"github.com/exasol/exasol-personal/internal/launcherpaths"
+	"github.com/exasol/exasol-personal/internal/runtimeartifacts"
+)
+
+// runStartupMigration runs once, gated by a completion marker; a failure
+// leaves the marker unset so the next invocation retries.
+func runStartupMigration(out io.Writer) error {
+	markerPath, err := launcherpaths.MigrationMarkerPath()
+	if err != nil {
+		return err
+	}
+	marker := launchermigration.NewMarker(markerPath)
+
+	done, err := marker.Done()
+	if err != nil {
+		return err
+	}
+	if done {
+		return nil
+	}
+
+	messages, err := migrateLegacyLocations()
+
+	for _, message := range messages {
+		if _, reportErr := fmt.Fprintln(out, message); reportErr != nil {
+			return errors.Join(err, fmt.Errorf("report migration result: %w", reportErr))
+		}
+	}
+	if err != nil {
+		return err
+	}
+
+	return marker.Write()
+}
+
+func migrateLegacyLocations() ([]string, error) {
+	var messages []string
+
+	message, err := migrateLegacyCacheConfig()
+	if err != nil {
+		return messages, err
+	}
+	if message != "" {
+		messages = append(messages, message)
+	}
+
+	message, err = deleteLegacyCache()
+	if err != nil {
+		return messages, err
+	}
+	if message != "" {
+		messages = append(messages, message)
+	}
+
+	message, err = migrateLegacyHistory()
+	if err != nil {
+		return messages, err
+	}
+	if message != "" {
+		messages = append(messages, message)
+	}
+
+	message, err = migrateLegacyDeployments()
+	if message != "" {
+		messages = append(messages, message)
+	}
+	if err != nil {
+		return messages, err
+	}
+
+	return messages, nil
+}
+
+func migrateLegacyCacheConfig() (string, error) {
+	legacyPath, err := runtimeartifacts.LegacyConfigPath()
+	if err != nil {
+		return "", err
+	}
+	newPath, err := runtimeartifacts.DefaultConfigPath()
+	if err != nil {
+		return "", err
+	}
+
+	hadLegacy, err := pathExists(legacyPath)
+	if err != nil {
+		return "", err
+	}
+
+	if err := runtimeartifacts.MigrateLegacyConfig(legacyPath, newPath); err != nil {
+		return "", fmt.Errorf("migrate cache configuration: %w", err)
+	}
+	if !hadLegacy {
+		return "", nil
+	}
+
+	return "Migrated cache configuration to " + newPath, nil
+}
+
+func deleteLegacyCache() (string, error) {
+	legacyRoot, err := runtimeartifacts.LegacyCacheRoot()
+	if err != nil {
+		return "", err
+	}
+
+	hadLegacy, err := pathExists(legacyRoot)
+	if err != nil {
+		return "", err
+	}
+
+	if err := runtimeartifacts.DeleteLegacyCache(legacyRoot); err != nil {
+		return "", fmt.Errorf("delete legacy resource cache: %w", err)
+	}
+	if !hadLegacy {
+		return "", nil
+	}
+
+	return "Deleted legacy resource cache at " + legacyRoot, nil
+}
+
+func migrateLegacyHistory() (string, error) {
+	legacyPath, err := connect.LegacyHistoryFilePath()
+	if err != nil {
+		return "", err
+	}
+	newPath, err := connect.HistoryFilePath()
+	if err != nil {
+		return "", err
+	}
+
+	hadLegacy, err := pathExists(legacyPath)
+	if err != nil {
+		return "", err
+	}
+	newAlreadyExists, err := pathExists(newPath)
+	if err != nil {
+		return "", err
+	}
+
+	if err := connect.MigrateLegacyHistoryFile(legacyPath, newPath); err != nil {
+		return "", fmt.Errorf("migrate SQL history: %w", err)
+	}
+	if !hadLegacy || newAlreadyExists {
+		return "", nil
+	}
+
+	return "Migrated SQL history to " + newPath, nil
+}
+
+func migrateLegacyDeployments() (string, error) {
+	legacyRoot, err := config.LegacyDeploymentsRootPath()
+	if err != nil {
+		return "", err
+	}
+	newRoot, err := config.DeploymentsRootPath()
+	if err != nil {
+		return "", err
+	}
+
+	hadLegacy, err := pathExists(legacyRoot)
+	if err != nil {
+		return "", err
+	}
+
+	migrated, err := config.MigrateLegacyDeployments(legacyRoot, newRoot)
+	if err != nil && !migrated {
+		return "", fmt.Errorf("migrate managed deployments: %w", err)
+	}
+	if !hadLegacy || !migrated {
+		return "", nil
+	}
+
+	message := "Migrated managed deployments to " + newRoot
+	if err != nil {
+		return message, fmt.Errorf("migrate managed deployments: %w", err)
+	}
+
+	return message, nil
+}

--- a/cmd/exasol/startup_migration_test.go
+++ b/cmd/exasol/startup_migration_test.go
@@ -1,0 +1,250 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/exasol/exasol-personal/internal/config"
+	"github.com/exasol/exasol-personal/internal/connect"
+	"github.com/exasol/exasol-personal/internal/launcherpaths"
+	"github.com/exasol/exasol-personal/internal/runtimeartifacts"
+	"github.com/stretchr/testify/require"
+)
+
+func setStartupMigrationTestHome(t *testing.T, home string) {
+	t.Helper()
+
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HOMEDRIVE", "")
+	t.Setenv("HOMEPATH", "")
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(home, ".cache"))
+	if runtime.GOOS == "windows" {
+		t.Setenv("LOCALAPPDATA", home)
+		t.Setenv("APPDATA", home)
+	}
+}
+
+func seedLegacyDeployment(t *testing.T) {
+	t.Helper()
+
+	legacyRoot, err := config.LegacyDeploymentsRootPath()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Join(legacyRoot, "default"), 0o700))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(legacyRoot, "default", "deployment.json"), []byte("{}"), 0o600,
+	))
+}
+
+//nolint:paralleltest // home-directory environment is process-global.
+func TestRunStartupMigration_AppliesChangesAutomaticallyWithoutPrompting(t *testing.T) {
+	// Given
+	home := t.TempDir()
+	setStartupMigrationTestHome(t, home)
+	seedLegacyDeployment(t)
+
+	// When: nothing supplies interactive input.
+	var out strings.Builder
+	err := runStartupMigration(&out)
+
+	// Then
+	require.NoError(t, err)
+	newDeploymentsRoot, rootErr := config.DeploymentsRootPath()
+	require.NoError(t, rootErr)
+	_, statErr := os.Stat(filepath.Join(newDeploymentsRoot, "default", "deployment.json"))
+	require.NoError(t, statErr)
+}
+
+//nolint:paralleltest // home-directory environment is process-global.
+func TestRunStartupMigration_ReportsWhatItChanged(t *testing.T) {
+	// Given
+	home := t.TempDir()
+	setStartupMigrationTestHome(t, home)
+	seedLegacyDeployment(t)
+
+	// When
+	var out strings.Builder
+	require.NoError(t, runStartupMigration(&out))
+
+	// Then
+	require.Contains(t, out.String(), "Migrated managed deployments")
+}
+
+//nolint:paralleltest // home-directory environment is process-global.
+func TestRunStartupMigration_StaysQuietWhenNothingToMigrate(t *testing.T) {
+	// Given
+	home := t.TempDir()
+	setStartupMigrationTestHome(t, home)
+
+	// When
+	var out strings.Builder
+	require.NoError(t, runStartupMigration(&out))
+
+	// Then
+	require.Empty(t, out.String())
+}
+
+//nolint:paralleltest // home-directory environment is process-global.
+func TestRunStartupMigration_SucceedsWhenNothingToMigrate(t *testing.T) {
+	// Given
+	home := t.TempDir()
+	setStartupMigrationTestHome(t, home)
+
+	// When
+	err := runStartupMigration(&strings.Builder{})
+
+	// Then
+	require.NoError(t, err)
+}
+
+//nolint:paralleltest // home-directory environment is process-global.
+func TestRunStartupMigration_FailsAndDoesNotWriteMarkerOnCollision(t *testing.T) {
+	// Given: a deployment named "default" exists at both the legacy and the
+	// new location.
+	home := t.TempDir()
+	setStartupMigrationTestHome(t, home)
+	seedLegacyDeployment(t)
+	newDeploymentsRoot, err := config.DeploymentsRootPath()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Join(newDeploymentsRoot, "default"), 0o700))
+
+	// When
+	migrationErr := runStartupMigration(&strings.Builder{})
+
+	// Then
+	require.Error(t, migrationErr)
+	markerPath, markerPathErr := launcherpaths.MigrationMarkerPath()
+	require.NoError(t, markerPathErr)
+	_, statErr := os.Stat(markerPath)
+	require.True(t, os.IsNotExist(statErr))
+}
+
+//nolint:paralleltest // home-directory environment is process-global.
+func TestRunStartupMigration_ReportsCompletedChangesBeforeLaterCollision(t *testing.T) {
+	// Given
+	home := t.TempDir()
+	setStartupMigrationTestHome(t, home)
+	seedLegacyDeployment(t)
+
+	legacyDeploymentsRoot, err := config.LegacyDeploymentsRootPath()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Join(legacyDeploymentsRoot, "staging"), 0o700))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(legacyDeploymentsRoot, "staging", "deployment.json"), []byte("{}"), 0o600,
+	))
+	newDeploymentsRoot, err := config.DeploymentsRootPath()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Join(newDeploymentsRoot, "default"), 0o700))
+
+	legacyHistoryPath, err := connect.LegacyHistoryFilePath()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(legacyHistoryPath), 0o700))
+	require.NoError(t, os.WriteFile(legacyHistoryPath, []byte("SELECT 1;\n"), 0o600))
+
+	legacyConfigPath, err := runtimeartifacts.LegacyConfigPath()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(legacyConfigPath), 0o700))
+	require.NoError(t, os.WriteFile(legacyConfigPath, []byte("retention_days: 45\n"), 0o600))
+
+	legacyCacheRoot, err := runtimeartifacts.LegacyCacheRoot()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Join(legacyCacheRoot, "artifacts"), 0o700))
+
+	// When
+	var out strings.Builder
+	migrationErr := runStartupMigration(&out)
+
+	// Then
+	require.Error(t, migrationErr)
+	require.ErrorIs(t, migrationErr, config.ErrDeploymentNameCollision)
+	report := out.String()
+	require.Contains(t, report, "Migrated cache configuration")
+	require.Contains(t, report, "Deleted legacy resource cache")
+	require.Contains(t, report, "Migrated SQL history")
+	require.Contains(t, report, "Migrated managed deployments")
+	_, err = os.Stat(filepath.Join(newDeploymentsRoot, "staging", "deployment.json"))
+	require.NoError(t, err)
+}
+
+//nolint:paralleltest // home-directory environment is process-global.
+func TestRunStartupMigration_SkipsAlreadyCompletedLocation(t *testing.T) {
+	// Given: migration has already completed once.
+	home := t.TempDir()
+	setStartupMigrationTestHome(t, home)
+	seedLegacyDeployment(t)
+	require.NoError(t, runStartupMigration(&strings.Builder{}))
+
+	// When
+	var out strings.Builder
+	err := runStartupMigration(&out)
+
+	// Then
+	require.NoError(t, err)
+	require.Empty(t, out.String())
+}
+
+// Beyond the per-scenario tests above: a real upgrade hits all four
+// locations at once, so this exercises them together rather than in
+// isolation.
+//
+//nolint:paralleltest // home-directory environment is process-global.
+func TestRunStartupMigration_MigratesEveryLocation(t *testing.T) {
+	// Given
+	home := t.TempDir()
+	setStartupMigrationTestHome(t, home)
+	seedLegacyDeployment(t)
+
+	legacyHistoryPath, err := connect.LegacyHistoryFilePath()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(legacyHistoryPath), 0o700))
+	require.NoError(t, os.WriteFile(legacyHistoryPath, []byte("SELECT 1;\n"), 0o600))
+
+	legacyConfigPath, err := runtimeartifacts.LegacyConfigPath()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(legacyConfigPath), 0o700))
+	require.NoError(t, os.WriteFile(legacyConfigPath, []byte("retention_days: 45\n"), 0o600))
+
+	legacyCacheRoot, err := runtimeartifacts.LegacyCacheRoot()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Join(legacyCacheRoot, "artifacts"), 0o700))
+
+	// When
+	var out strings.Builder
+	require.NoError(t, runStartupMigration(&out))
+
+	// Then
+	newDeploymentsRoot, err := config.DeploymentsRootPath()
+	require.NoError(t, err)
+	content, err := os.ReadFile(filepath.Join(newDeploymentsRoot, "default", "deployment.json"))
+	require.NoError(t, err)
+	require.Equal(t, "{}", string(content))
+
+	newHistoryPath, err := connect.HistoryFilePath()
+	require.NoError(t, err)
+	historyContent, err := os.ReadFile(newHistoryPath)
+	require.NoError(t, err)
+	require.Equal(t, "SELECT 1;\n", string(historyContent))
+
+	newConfigPath, err := runtimeartifacts.DefaultConfigPath()
+	require.NoError(t, err)
+	cfg, present, err := runtimeartifacts.LoadCacheConfig(newConfigPath)
+	require.NoError(t, err)
+	require.True(t, present)
+	require.Equal(t, 45, cfg.RetentionDays)
+
+	_, err = os.Stat(legacyCacheRoot)
+	require.True(t, os.IsNotExist(err))
+
+	report := out.String()
+	require.Contains(t, report, "Migrated managed deployments")
+	require.Contains(t, report, "Migrated SQL history")
+	require.Contains(t, report, "Migrated cache configuration")
+	require.Contains(t, report, "Deleted legacy resource cache")
+}

--- a/go.mod
+++ b/go.mod
@@ -200,6 +200,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.3.0 // indirect
 	github.com/otiai10/copy v1.14.1 // indirect
 	github.com/owenrumney/go-sarif/v2 v2.3.3 // indirect
+	github.com/pelletier/go-toml/v2 v2.4.3 // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
@@ -363,7 +364,6 @@ require (
 	github.com/nishanths/predeclared v0.2.2 // indirect
 	github.com/nunnatsa/ginkgolinter v0.23.1 // indirect
 	github.com/olekukonko/tablewriter v1.1.4
-	github.com/pelletier/go-toml/v2 v2.4.3 // indirect
 	github.com/prometheus/client_golang v1.24.1 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect

--- a/internal/config/deployment_dir.go
+++ b/internal/config/deployment_dir.go
@@ -37,17 +37,21 @@ func NewDeploymentDir(path string) DeploymentDir {
 }
 
 func DefaultDeploymentDirPath() (string, error) {
-	rootDir, err := LauncherRootDirPath()
+	rootDir, err := DeploymentsRootPath()
 	if err != nil {
 		return "", err
 	}
 
-	return filepath.Join(rootDir, deploymentsDirName, defaultDeploymentDirName), nil
+	return filepath.Join(rootDir, defaultDeploymentDirName), nil
 }
 
-// DeploymentsRootPath returns the launcher-managed directory that contains
-// the default deployment directory and every named deployment directory.
 func DeploymentsRootPath() (string, error) {
+	return launcherpaths.DeploymentsRootPath()
+}
+
+// LegacyDeploymentsRootPath exists only so deployments there can be
+// migrated to DeploymentsRootPath.
+func LegacyDeploymentsRootPath() (string, error) {
 	rootDir, err := LauncherRootDirPath()
 	if err != nil {
 		return "", err
@@ -61,12 +65,12 @@ func DeploymentsRootPath() (string, error) {
 // directory. Callers are responsible for validating name is safe to use as a
 // literal directory name (see DeploymentNameVar in cmd/exasol).
 func NamedDeploymentDirPath(name string) (string, error) {
-	rootDir, err := LauncherRootDirPath()
+	rootDir, err := DeploymentsRootPath()
 	if err != nil {
 		return "", err
 	}
 
-	return filepath.Join(rootDir, deploymentsDirName, name), nil
+	return filepath.Join(rootDir, name), nil
 }
 
 func LauncherRootDirPath() (string, error) {

--- a/internal/config/deployment_dir_test.go
+++ b/internal/config/deployment_dir_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/exasol/exasol-personal/internal/launcherpaths"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,6 +33,36 @@ func TestDeploymentDir_LayoutPaths(t *testing.T) {
 		filepath.Join(root, ConnectionInstruction),
 		deployment.ConnectionInstructionsPath(),
 	)
+}
+
+func TestDeploymentsRootPath_UsesSharedLauncherDeploymentsRoot(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	want, err := launcherpaths.DeploymentsRootPath()
+	require.NoError(t, err)
+
+	// When
+	got, err := DeploymentsRootPath()
+
+	// Then
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+func TestLegacyDeploymentsRootPath_UsesLauncherRootDirectory(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	rootDir, err := LauncherRootDirPath()
+	require.NoError(t, err)
+
+	// When
+	got, err := LegacyDeploymentsRootPath()
+
+	// Then
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(rootDir, deploymentsDirName), got)
 }
 
 func TestNamedDeploymentDirPath_SameParentAsDefault(t *testing.T) {

--- a/internal/config/deployments_migration.go
+++ b/internal/config/deployments_migration.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/exasol/exasol-personal/internal/launchermigration"
+)
+
+// ErrDeploymentNameCollision is returned by MigrateLegacyDeployments when a
+// deployment name exists at both the legacy and the new managed-deployments
+// root. The colliding name is left untouched at both locations.
+var ErrDeploymentNameCollision = errors.New(
+	"deployment name exists at both the legacy and new managed-deployments root",
+)
+
+// MigrateLegacyDeployments joins one error per name collision but still
+// migrates every other, non-colliding deployment in the same run. It reports
+// whether at least one deployment was migrated, including when it returns an
+// error for another deployment.
+func MigrateLegacyDeployments(legacyRoot, newRoot string) (bool, error) {
+	entries, err := os.ReadDir(legacyRoot)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("list legacy deployments root %s: %w", legacyRoot, err)
+	}
+
+	migrated := false
+	var collisions []error
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		if err := migrateOneLegacyDeployment(legacyRoot, newRoot, entry.Name()); err != nil {
+			if errors.Is(err, ErrDeploymentNameCollision) {
+				collisions = append(collisions, err)
+
+				continue
+			}
+
+			return migrated, err
+		}
+		migrated = true
+	}
+
+	if len(collisions) > 0 {
+		return migrated, errors.Join(collisions...)
+	}
+
+	return migrated, nil
+}
+
+// migrateOneLegacyDeployment wraps ErrDeploymentNameCollision when name
+// already exists under newRoot.
+func migrateOneLegacyDeployment(legacyRoot, newRoot, name string) error {
+	legacyPath := filepath.Join(legacyRoot, name)
+	newPath := filepath.Join(newRoot, name)
+
+	err := launchermigration.Migrate(legacyPath, newPath)
+	if errors.Is(err, launchermigration.ErrDestinationExists) {
+		return fmt.Errorf(
+			"%w: %q (legacy: %s, new: %s)", ErrDeploymentNameCollision, name, legacyPath, newPath,
+		)
+	} else if err != nil {
+		return fmt.Errorf("migrate deployment %q: %w", name, err)
+	}
+
+	return nil
+}

--- a/internal/config/deployments_migration_test.go
+++ b/internal/config/deployments_migration_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrateLegacyDeployments_IsNoOpWhenLegacyRootDoesNotExist(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	dir := t.TempDir()
+	legacyRoot := filepath.Join(dir, "legacy")
+	newRoot := filepath.Join(dir, "new")
+
+	// When
+	migrated, err := MigrateLegacyDeployments(legacyRoot, newRoot)
+
+	// Then
+	require.NoError(t, err)
+	require.False(t, migrated)
+	_, err = os.Stat(newRoot)
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestMigrateLegacyDeployments_MigratesEachLegacyDeployment(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	dir := t.TempDir()
+	legacyRoot := filepath.Join(dir, "legacy")
+	newRoot := filepath.Join(dir, "new")
+	writeTestFile(t, filepath.Join(legacyRoot, "default", "deployment.json"), "{}")
+	writeTestFile(t, filepath.Join(legacyRoot, "staging", "deployment.json"), "{}")
+
+	// When
+	migrated, migrationErr := MigrateLegacyDeployments(legacyRoot, newRoot)
+
+	// Then
+	require.NoError(t, migrationErr)
+	require.True(t, migrated)
+	requireFileContent(t, filepath.Join(newRoot, "default", "deployment.json"), "{}")
+	requireFileContent(t, filepath.Join(newRoot, "staging", "deployment.json"), "{}")
+	_, err := os.Stat(filepath.Join(legacyRoot, "default"))
+	require.True(t, os.IsNotExist(err))
+	_, err = os.Stat(filepath.Join(legacyRoot, "staging"))
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestMigrateLegacyDeployments_CollisionIsReportedButOthersStillMigrate(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	dir := t.TempDir()
+	legacyRoot := filepath.Join(dir, "legacy")
+	newRoot := filepath.Join(dir, "new")
+	writeTestFile(t, filepath.Join(legacyRoot, "default", "deployment.json"), "legacy default")
+	writeTestFile(t, filepath.Join(legacyRoot, "staging", "deployment.json"), "legacy staging")
+	writeTestFile(t, filepath.Join(newRoot, "default", "deployment.json"), "new default")
+
+	// When
+	migrated, err := MigrateLegacyDeployments(legacyRoot, newRoot)
+
+	// Then
+	require.True(t, migrated)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrDeploymentNameCollision)
+	require.Contains(t, err.Error(), legacyRoot)
+	require.Contains(t, err.Error(), newRoot)
+	requireFileContent(t, filepath.Join(legacyRoot, "default", "deployment.json"), "legacy default")
+	requireFileContent(t, filepath.Join(newRoot, "default", "deployment.json"), "new default")
+	requireFileContent(t, filepath.Join(newRoot, "staging", "deployment.json"), "legacy staging")
+	_, statErr := os.Stat(filepath.Join(legacyRoot, "staging"))
+	require.True(t, os.IsNotExist(statErr))
+}
+
+func writeTestFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+}
+
+func requireFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, want, string(got))
+}

--- a/internal/connect/history_migration.go
+++ b/internal/connect/history_migration.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package connect
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/exasol/exasol-personal/internal/launchermigration"
+)
+
+// LegacyHistoryFilePath exists only so an existing file there can be
+// migrated into the new history location.
+func LegacyHistoryFilePath() (string, error) {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(cacheDir, historyFileName), nil
+}
+
+// MigrateLegacyHistoryFile is a no-op if legacyPath is missing or newPath
+// already exists.
+func MigrateLegacyHistoryFile(legacyPath, newPath string) error {
+	if _, err := os.Lstat(legacyPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+
+		return fmt.Errorf("inspect legacy history file %s: %w", legacyPath, err)
+	}
+
+	if _, err := os.Lstat(newPath); err == nil {
+		return nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect history file %s: %w", newPath, err)
+	}
+
+	if err := launchermigration.Migrate(legacyPath, newPath); err != nil {
+		return fmt.Errorf("migrate legacy history file %s to %s: %w", legacyPath, newPath, err)
+	}
+
+	return nil
+}

--- a/internal/connect/history_migration_test.go
+++ b/internal/connect/history_migration_test.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package connect
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrateLegacyHistoryFile_MovesFileAndPreservesContent(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	dir := t.TempDir()
+	legacyPath := filepath.Join(dir, "exasol_history")
+	newPath := filepath.Join(dir, "history", "exasol_history")
+	require.NoError(t, os.WriteFile(legacyPath, []byte("SELECT 1;\n"), 0o600))
+
+	// When
+	require.NoError(t, MigrateLegacyHistoryFile(legacyPath, newPath))
+
+	// Then
+	content, err := os.ReadFile(newPath)
+	require.NoError(t, err)
+	require.Equal(t, "SELECT 1;\n", string(content))
+
+	_, err = os.Stat(legacyPath)
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestMigrateLegacyHistoryFile_IsNoOpWhenLegacyFileDoesNotExist(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	dir := t.TempDir()
+	legacyPath := filepath.Join(dir, "exasol_history")
+	newPath := filepath.Join(dir, "history", "exasol_history")
+
+	// When
+	require.NoError(t, MigrateLegacyHistoryFile(legacyPath, newPath))
+
+	// Then
+	_, err := os.Stat(newPath)
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestMigrateLegacyHistoryFile_IsNoOpWhenNewFileAlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	dir := t.TempDir()
+	legacyPath := filepath.Join(dir, "exasol_history")
+	newPath := filepath.Join(dir, "history", "exasol_history")
+	require.NoError(t, os.WriteFile(legacyPath, []byte("legacy content"), 0o600))
+	require.NoError(t, os.MkdirAll(filepath.Dir(newPath), 0o700))
+	require.NoError(t, os.WriteFile(newPath, []byte("new content"), 0o600))
+
+	// When
+	require.NoError(t, MigrateLegacyHistoryFile(legacyPath, newPath))
+
+	// Then
+	content, err := os.ReadFile(newPath)
+	require.NoError(t, err)
+	require.Equal(t, "new content", string(content))
+
+	legacyContent, err := os.ReadFile(legacyPath)
+	require.NoError(t, err)
+	require.Equal(t, "legacy content", string(legacyContent))
+}

--- a/internal/connect/shell.go
+++ b/internal/connect/shell.go
@@ -15,7 +15,13 @@ import (
 
 	"github.com/exasol/exasol-personal/internal/connect/readline"
 	"github.com/exasol/exasol-personal/internal/connect/types"
+	"github.com/exasol/exasol-personal/internal/launcherpaths"
 	"github.com/exasol/exasol-personal/internal/util"
+)
+
+const (
+	historyFileName = "exasol_history"
+	historyDirPerm  = 0o700
 )
 
 const exitCommand = "exit"
@@ -359,15 +365,13 @@ func isSpaceByte(b byte) bool {
 	return b == ' ' || b == '\t' || b == '\r' || b == '\n'
 }
 
-func getHistoryFilePath() (string, error) {
-	const historyFileName = "exasol_history"
-
-	cacheDir, err := os.UserCacheDir()
+func HistoryFilePath() (string, error) {
+	historyDir, err := launcherpaths.HistoryRootPath()
 	if err != nil {
 		return "", err
 	}
 
-	historyFilePath := filepath.Join(cacheDir, historyFileName)
+	historyFilePath := filepath.Join(historyDir, historyFileName)
 
 	slog.Debug("obtained history file path", "path", historyFilePath)
 
@@ -432,9 +436,9 @@ func RunShellWithOpts(processInput ProcessInputFunc, opts ShellOpts) error {
 }
 
 func newInteractiveLineReader() (types.LineReader, error) {
-	historyFilePath, err := getHistoryFilePath()
+	historyFilePath, err := ensureHistoryFileDir()
 	if err != nil {
-		return nil, fmt.Errorf("couldn't get the history file path: %w", err)
+		return nil, err
 	}
 
 	lineReader, err := readline.New(historyFilePath)
@@ -443,4 +447,21 @@ func newInteractiveLineReader() (types.LineReader, error) {
 	}
 
 	return lineReader, nil
+}
+
+// ensureHistoryFileDir resolves the history file path and creates the
+// directory holding it. readline responds to a history file it cannot open by
+// silently keeping no history at all, so on a fresh install nothing would
+// ever be persisted unless the directory is in place first.
+func ensureHistoryFileDir() (string, error) {
+	historyFilePath, err := HistoryFilePath()
+	if err != nil {
+		return "", fmt.Errorf("couldn't get the history file path: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(historyFilePath), historyDirPerm); err != nil {
+		return "", fmt.Errorf("couldn't create the history directory: %w", err)
+	}
+
+	return historyFilePath, nil
 }

--- a/internal/connect/shell_test.go
+++ b/internal/connect/shell_test.go
@@ -6,12 +6,14 @@ package connect
 import (
 	"errors"
 	"io"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/exasol/exasol-personal/internal/connect/readline"
 	"github.com/exasol/exasol-personal/internal/connect/types"
 	"github.com/exasol/exasol-personal/internal/connect/types/typesfakes"
+	"github.com/exasol/exasol-personal/internal/launcherpaths"
 	"github.com/stretchr/testify/require"
 )
 
@@ -547,4 +549,35 @@ func TestScriptWithoutSlashFlushedWholeAtEOF(t *testing.T) {
 			"class M { double run() { return x * 2.0; } }",
 		processor.inputs[0],
 	)
+}
+
+func TestHistoryFilePath_ResolvesUnderTheLauncherHistoryRoot(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	want, err := launcherpaths.HistoryRootPath()
+	require.NoError(t, err)
+
+	// When
+	got, err := HistoryFilePath()
+
+	// Then
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(want, historyFileName), got)
+}
+
+//nolint:paralleltest // home-directory environment is process-global.
+func TestEnsureHistoryFileDir_CreatesTheDirectoryOnAFreshInstall(t *testing.T) {
+	// Given a home with no history directory, as after a fresh install
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
+
+	// When
+	path, err := ensureHistoryFileDir()
+
+	// Then the file can be created where readline will look for it
+	require.NoError(t, err)
+	require.DirExists(t, filepath.Dir(path))
 }

--- a/internal/launchermigration/marker.go
+++ b/internal/launchermigration/marker.go
@@ -1,0 +1,56 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+// Package launchermigration provides the primitives startup path migration
+// is built from: a completion marker and a staging/resume helper.
+package launchermigration
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	markerDirPerm  = 0o700
+	markerFilePerm = 0o600
+	markerContents = "1\n"
+)
+
+// Marker records completion of a one-time step as a plain file.
+type Marker struct {
+	path string
+}
+
+func NewMarker(path string) Marker {
+	return Marker{path: path}
+}
+
+func (m Marker) Path() string {
+	return m.path
+}
+
+func (m Marker) Done() (bool, error) {
+	data, err := os.ReadFile(m.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+
+		return false, fmt.Errorf("read migration marker %s: %w", m.path, err)
+	}
+
+	return string(data) == markerContents, nil
+}
+
+func (m Marker) Write() error {
+	if err := os.MkdirAll(filepath.Dir(m.path), markerDirPerm); err != nil {
+		return fmt.Errorf("create directory for migration marker %s: %w", m.path, err)
+	}
+	if err := os.WriteFile(m.path, []byte(markerContents), markerFilePerm); err != nil {
+		return fmt.Errorf("write migration marker %s: %w", m.path, err)
+	}
+
+	return nil
+}

--- a/internal/launchermigration/marker_test.go
+++ b/internal/launchermigration/marker_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package launchermigration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMarker_DoneIsFalseWhenFileIsMissing(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	marker := NewMarker(filepath.Join(t.TempDir(), "marker"))
+
+	// When
+	done, err := marker.Done()
+	// Then
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if done {
+		t.Fatal("expected marker to not be done")
+	}
+}
+
+func TestMarker_WriteThenDoneIsTrue(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	marker := NewMarker(filepath.Join(t.TempDir(), "nested", "marker"))
+
+	// When
+	if err := marker.Write(); err != nil {
+		t.Fatalf("expected no error writing marker, got %v", err)
+	}
+	done, err := marker.Done()
+	// Then
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !done {
+		t.Fatal("expected marker to be done after Write")
+	}
+}
+
+func TestMarker_DoneIsFalseWhenFileContentDoesNotMatch(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	path := filepath.Join(t.TempDir(), "marker")
+	if err := os.WriteFile(path, []byte("garbage"), 0o600); err != nil {
+		t.Fatalf("failed to seed marker file: %v", err)
+	}
+	marker := NewMarker(path)
+
+	// When
+	done, err := marker.Done()
+	// Then
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if done {
+		t.Fatal("expected marker with unexpected content to not be done")
+	}
+}

--- a/internal/launchermigration/migrate.go
+++ b/internal/launchermigration/migrate.go
@@ -1,0 +1,221 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package launchermigration
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/exasol/exasol-personal/internal/util"
+)
+
+const stagingSuffix = ".migrating"
+
+// ErrDestinationExists is returned by Migrate when destination already
+// exists; callers own collision handling.
+var ErrDestinationExists = errors.New("migration destination already exists")
+
+// Migrate moves source to destination. A pre-existing destination is accepted
+// only when the staging marker proves this migration already published it.
+// A cross-filesystem move can't be one atomic rename, so it stages the copy
+// and only removes source after a completion marker confirms the copy
+// landed; an interruption before that marker leaves source untouched and
+// gets retried from scratch.
+func Migrate(source, destination string) error {
+	if _, err := os.Lstat(destination); err == nil {
+		resumed, resumeErr := finishPublishedMigration(source, destination)
+		if resumeErr != nil {
+			return resumeErr
+		}
+		if resumed {
+			return nil
+		}
+
+		return fmt.Errorf("%w: %s", ErrDestinationExists, destination)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect migration destination %s: %w", destination, err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(destination), markerDirPerm); err != nil {
+		return fmt.Errorf("create parent directory for %s: %w", destination, err)
+	}
+
+	if err := os.Rename(source, destination); err == nil {
+		return nil
+	}
+
+	return migrateViaStaging(source, destination)
+}
+
+func migrateViaStaging(source, destination string) error {
+	staging := destination + stagingSuffix
+	marker := migrationMarker(destination)
+
+	done, err := marker.Done()
+	if err != nil {
+		return err
+	}
+	if !done {
+		if err := stageDurableCopy(source, staging, marker); err != nil {
+			return err
+		}
+	}
+
+	if err := os.Rename(staging, destination); err != nil {
+		return fmt.Errorf("publish migrated %s to %s: %w", staging, destination, err)
+	}
+	// The publish is a directory-entry change, so it has to be durable before
+	// the source goes; otherwise an interruption here could leave neither
+	// location holding the data.
+	if err := syncFile(filepath.Dir(destination)); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(source); err != nil {
+		return fmt.Errorf("remove migrated source %s: %w", source, err)
+	}
+	if err := os.Remove(marker.Path()); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove migration marker %s: %w", marker.Path(), err)
+	}
+
+	return nil
+}
+
+// stageDurableCopy leaves staging holding a complete copy of source, writing
+// the marker only once the staged bytes and the directory entries recording
+// them are both on disk. The marker means "this copy is durable, safe to
+// publish", so anything it vouches for has to survive a power loss.
+func stageDurableCopy(source, staging string, marker Marker) error {
+	if err := os.RemoveAll(staging); err != nil {
+		return fmt.Errorf("reset incomplete migration staging %s: %w", staging, err)
+	}
+	if err := copyPath(source, staging); err != nil {
+		return fmt.Errorf("copy %s to staging %s: %w", source, staging, err)
+	}
+	if err := syncPath(staging); err != nil {
+		return err
+	}
+	if err := marker.Write(); err != nil {
+		return err
+	}
+
+	return syncFile(filepath.Dir(staging))
+}
+
+func finishPublishedMigration(source, destination string) (bool, error) {
+	marker := migrationMarker(destination)
+	done, err := marker.Done()
+	if err != nil || !done {
+		return false, err
+	}
+
+	staging := destination + stagingSuffix
+	if _, err := os.Lstat(staging); err == nil {
+		return false, nil
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return false, fmt.Errorf("inspect migration staging %s: %w", staging, err)
+	}
+
+	if err := os.RemoveAll(source); err != nil {
+		return true, fmt.Errorf("remove migrated source %s: %w", source, err)
+	}
+	if err := os.Remove(marker.Path()); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return true, fmt.Errorf("remove migration marker %s: %w", marker.Path(), err)
+	}
+
+	return true, nil
+}
+
+func migrationMarker(destination string) Marker {
+	return NewMarker(destination + stagingSuffix + ".complete")
+}
+
+func copyPath(source, destination string) error {
+	info, err := os.Lstat(source)
+	if err != nil {
+		return fmt.Errorf("inspect %s: %w", source, err)
+	}
+	if info.IsDir() {
+		return copyDirectory(source, destination)
+	}
+
+	return copyFile(source, destination, info.Mode())
+}
+
+// The staging directory starts private so a half-copied tree is never
+// world-readable; util.CopyDir restores the source's own modes afterwards.
+func copyDirectory(source, destination string) error {
+	if err := os.Mkdir(destination, markerDirPerm); err != nil {
+		return fmt.Errorf("create private staging directory %s: %w", destination, err)
+	}
+
+	return util.CopyDir(source, destination)
+}
+
+// syncPath flushes a staged file, or every file and directory entry of a
+// staged tree, so the copy survives a system failure and not merely a
+// process exit.
+func syncPath(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("inspect staged %s: %w", path, err)
+	}
+	if !info.IsDir() {
+		return syncFile(path)
+	}
+
+	if err := filepath.Walk(path, func(walked string, walkedInfo os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if walkedInfo.IsDir() || walkedInfo.Mode().IsRegular() {
+			return syncFile(walked)
+		}
+
+		return nil
+	}); err != nil {
+		return fmt.Errorf("flush staged %s: %w", path, err)
+	}
+
+	return nil
+}
+
+func syncFile(path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open staged %s for flushing: %w", path, err)
+	}
+	defer file.Close()
+
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("flush staged %s: %w", path, err)
+	}
+
+	return nil
+}
+
+func copyFile(source, destination string, mode os.FileMode) error {
+	sourceFile, err := os.Open(source)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", source, err)
+	}
+	defer sourceFile.Close()
+
+	destFile, err := os.OpenFile(destination, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode.Perm())
+	if err != nil {
+		return fmt.Errorf("create %s: %w", destination, err)
+	}
+	defer destFile.Close()
+
+	if _, err := io.Copy(destFile, sourceFile); err != nil {
+		return fmt.Errorf("copy %s to %s: %w", source, destination, err)
+	}
+	if err := destFile.Chmod(mode.Perm()); err != nil {
+		return fmt.Errorf("preserve permissions from %s on %s: %w", source, destination, err)
+	}
+
+	return destFile.Sync()
+}

--- a/internal/launchermigration/migrate_test.go
+++ b/internal/launchermigration/migrate_test.go
@@ -1,0 +1,325 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package launchermigration
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestMigrate_FileWithinSameFilesystemMoves(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source", "history")
+	destination := filepath.Join(dir, "destination", "history")
+	writeFile(t, source, "some history")
+
+	// When
+	if err := Migrate(source, destination); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Then
+	assertFileContent(t, destination, "some history")
+	assertGone(t, source)
+}
+
+func TestMigrate_DirectoryWithinSameFilesystemMoves(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source", "deployment")
+	destination := filepath.Join(dir, "destination", "deployment")
+	writeFile(t, filepath.Join(source, "deployment.json"), "{}")
+
+	// When
+	if err := Migrate(source, destination); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Then
+	assertFileContent(t, filepath.Join(destination, "deployment.json"), "{}")
+	assertGone(t, source)
+}
+
+func TestMigrate_DestinationAlreadyExistsIsRefused(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source")
+	destination := filepath.Join(dir, "destination")
+	writeFile(t, source, "content")
+	writeFile(t, destination, "existing content")
+
+	// When
+	err := Migrate(source, destination)
+
+	// Then
+	if !errors.Is(err, ErrDestinationExists) {
+		t.Fatalf("expected ErrDestinationExists, got %v", err)
+	}
+	assertFileContent(t, source, "content")
+	assertFileContent(t, destination, "existing content")
+}
+
+func TestMigrateViaStaging_FileRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source")
+	destination := filepath.Join(dir, "destination")
+	writeFile(t, source, "history contents")
+
+	// When
+	if err := migrateViaStaging(source, destination); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Then
+	assertFileContent(t, destination, "history contents")
+	assertGone(t, source)
+	assertGone(t, destination+stagingSuffix)
+	assertGone(t, destination+stagingSuffix+stagingSuffix+".complete")
+}
+
+func TestMigrateViaStaging_DirectoryRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source")
+	destination := filepath.Join(dir, "destination")
+	writeFile(t, filepath.Join(source, "nested", "file.txt"), "nested content")
+
+	// When
+	if err := migrateViaStaging(source, destination); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Then
+	assertFileContent(t, filepath.Join(destination, "nested", "file.txt"), "nested content")
+	assertGone(t, source)
+}
+
+func TestMigrateViaStaging_PreservesDirectoryAndFilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not expose Unix permission bits")
+	}
+	t.Parallel()
+
+	// Given
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source")
+	destination := filepath.Join(dir, "destination")
+	privateDir := filepath.Join(source, "private")
+	secretFile := filepath.Join(privateDir, "secrets.json")
+	writeFile(t, secretFile, "secret")
+	//nolint:gosec // verifies exact source mode preservation
+	if err := os.Chmod(source, 0o750); err != nil {
+		t.Fatalf("failed to set source permissions: %v", err)
+	}
+	//nolint:gosec // verifies exact source mode preservation
+	if err := os.Chmod(privateDir, 0o710); err != nil {
+		t.Fatalf("failed to set private directory permissions: %v", err)
+	}
+	if err := os.Chmod(secretFile, 0o600); err != nil {
+		t.Fatalf("failed to set secret permissions: %v", err)
+	}
+
+	// When
+	if err := migrateViaStaging(source, destination); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Then
+	assertPermissions(t, destination, 0o750)
+	assertPermissions(t, filepath.Join(destination, "private"), 0o710)
+	assertPermissions(t, filepath.Join(destination, "private", "secrets.json"), 0o600)
+}
+
+func TestMigrateViaStaging_SourceIsPreservedWhenStagingCopyFails(t *testing.T) {
+	t.Parallel()
+
+	// Given: the staging copy cannot be written, so the copy never completes.
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source")
+	destParent := filepath.Join(dir, "readonly")
+	destination := filepath.Join(destParent, "destination")
+	writeFile(t, source, "must survive")
+	if err := os.MkdirAll(destParent, 0o700); err != nil {
+		t.Fatalf("failed to create destination parent: %v", err)
+	}
+	//nolint:gosec // remove write bit to force the staging copy to fail
+	if err := os.Chmod(destParent, 0o500); err != nil {
+		t.Fatalf("failed to make destination parent read-only: %v", err)
+	}
+	t.Cleanup(func() {
+		//nolint:errcheck,gosec,revive // best-effort cleanup
+		os.Chmod(destParent, 0o700)
+	})
+
+	// When
+	err := migrateViaStaging(source, destination)
+
+	// Then
+	if err == nil {
+		t.Fatal("expected an error when the staging copy cannot be written")
+	}
+	assertFileContent(t, source, "must survive")
+	if _, statErr := os.Lstat(destination); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected destination to not exist, stat returned err=%v", statErr)
+	}
+}
+
+func TestMigrateViaStaging_ResetsIncompleteStagingAndRetries(t *testing.T) {
+	t.Parallel()
+
+	// Given: a staging directory left over from a previous attempt, with no
+	// completion marker, so it must not be trusted.
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source")
+	destination := filepath.Join(dir, "destination")
+	writeFile(t, source, "correct content")
+	staging := destination + stagingSuffix
+	writeFile(t, filepath.Join(staging, "leftover"), "stale")
+
+	// When
+	if err := migrateViaStaging(source, destination); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Then
+	assertFileContent(t, destination, "correct content")
+	assertGone(t, source)
+}
+
+func TestMigrateViaStaging_ResumesFromCompletedStagingWithoutRecopying(t *testing.T) {
+	t.Parallel()
+
+	// Given: a process died after finishing the staged copy and writing the
+	// marker, but before publishing and removing the source. The source no
+	// longer needs to exist for a resume to succeed, since the copy step is
+	// skipped once the marker is already done.
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source")
+	destination := filepath.Join(dir, "destination")
+	staging := destination + stagingSuffix
+	writeFile(t, staging, "already staged content")
+	marker := migrationMarker(destination)
+	if err := marker.Write(); err != nil {
+		t.Fatalf("failed to seed marker: %v", err)
+	}
+
+	// When
+	if err := migrateViaStaging(source, destination); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Then
+	assertFileContent(t, destination, "already staged content")
+	assertGone(t, staging)
+	assertGone(t, marker.Path())
+}
+
+func TestMigrate_ResumesAfterCompletedStagingWasPublished(t *testing.T) {
+	t.Parallel()
+
+	// Given: a process died after publishing the staged copy but before removing
+	// the legacy source.
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source")
+	destination := filepath.Join(dir, "destination")
+	writeFile(t, source, "legacy content")
+	writeFile(t, destination, "published content")
+	marker := migrationMarker(destination)
+	if err := marker.Write(); err != nil {
+		t.Fatalf("failed to seed marker: %v", err)
+	}
+
+	// When
+	if err := Migrate(source, destination); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Then
+	assertFileContent(t, destination, "published content")
+	assertGone(t, source)
+	assertGone(t, marker.Path())
+}
+
+func TestMigrate_DoesNotTrustCompletedMarkerWhileStagingStillExists(t *testing.T) {
+	t.Parallel()
+
+	// Given: another destination appeared after staging completed, so the
+	// staged copy was never published.
+	dir := t.TempDir()
+	source := filepath.Join(dir, "source")
+	destination := filepath.Join(dir, "destination")
+	staging := destination + stagingSuffix
+	writeFile(t, source, "legacy content")
+	writeFile(t, destination, "collision content")
+	writeFile(t, staging, "staged content")
+	marker := migrationMarker(destination)
+	if err := marker.Write(); err != nil {
+		t.Fatalf("failed to seed marker: %v", err)
+	}
+
+	// When
+	err := Migrate(source, destination)
+
+	// Then
+	if !errors.Is(err, ErrDestinationExists) {
+		t.Fatalf("expected ErrDestinationExists, got %v", err)
+	}
+	assertFileContent(t, source, "legacy content")
+	assertFileContent(t, destination, "collision content")
+	assertFileContent(t, staging, "staged content")
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("failed to create parent directory for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write %s: %v", path, err)
+	}
+}
+
+func assertFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", path, err)
+	}
+	if string(got) != want {
+		t.Fatalf("expected %s to contain %q, got %q", path, want, string(got))
+	}
+}
+
+func assertGone(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected %s to not exist, stat returned err=%v", path, err)
+	}
+}
+
+func assertPermissions(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("failed to stat %s: %v", path, err)
+	}
+	if got := info.Mode().Perm(); got != want {
+		t.Fatalf("expected %s permissions to be %04o, got %04o", path, want, got)
+	}
+}

--- a/internal/launcherpaths/launcherpaths.go
+++ b/internal/launcherpaths/launcherpaths.go
@@ -13,11 +13,20 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
 const (
 	rootDirName     = ".exasol"
 	personalDirName = "personal"
+
+	namespaceDirName       = "exasol"
+	appDirName             = "launcher"
+	deploymentsDirName     = "deployments"
+	historyDirName         = "history"
+	resourceConfigFileName = "resources.yaml"
+	resourceCacheDirName   = "resources"
+	migrationMarkerName    = ".migrated"
 )
 
 // RootDirPath returns the launcher-owned directory under the current user's
@@ -34,4 +43,82 @@ func RootDirPath() (string, error) {
 // DirPath returns the launcher-owned directory below baseDir.
 func DirPath(baseDir string) string {
 	return filepath.Join(baseDir, rootDirName, personalDirName)
+}
+
+func DeploymentsRootPath() (string, error) {
+	root, err := durableRootPath()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(root, deploymentsDirName), nil
+}
+
+func HistoryRootPath() (string, error) {
+	root, err := durableRootPath()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(root, historyDirName), nil
+}
+
+func ResourceConfigFilePath() (string, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve config directory for resource cache config file: %w", err)
+	}
+
+	return filepath.Join(launcherNamespaceRoot(configDir), resourceConfigFileName), nil
+}
+
+func CacheRootPath() (string, error) {
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve cache directory for launcher cache root: %w", err)
+	}
+
+	return filepath.Join(launcherNamespaceRoot(cacheDir), resourceCacheDirName), nil
+}
+
+func MigrationMarkerPath() (string, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve config directory for launcher migration marker: %w", err)
+	}
+
+	return filepath.Join(launcherNamespaceRoot(configDir), migrationMarkerName), nil
+}
+
+// On Linux this stays a dotfile location separate from config; elsewhere it
+// shares the config base, since os.UserConfigDir() already resolves to the
+// platform's per-app directory.
+func durableRootPath() (string, error) {
+	return durableRootPathForOS(runtime.GOOS)
+}
+
+func durableRootPathForOS(goos string) (string, error) {
+	if goos == "linux" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory for launcher durable root: %w", err)
+		}
+
+		return legacyStyleRoot(home), nil
+	}
+
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve config directory for launcher durable root: %w", err)
+	}
+
+	return launcherNamespaceRoot(configDir), nil
+}
+
+func legacyStyleRoot(home string) string {
+	return filepath.Join(home, rootDirName, appDirName)
+}
+
+func launcherNamespaceRoot(base string) string {
+	return filepath.Join(base, namespaceDirName, appDirName)
 }

--- a/internal/launcherpaths/launcherpaths_test.go
+++ b/internal/launcherpaths/launcherpaths_test.go
@@ -29,3 +29,113 @@ func TestRootDirPath_ResolvesUnderTheCurrentUsersHomeDirectory(t *testing.T) {
 		t.Fatalf("expected a path ending in .exasol/personal, got %q", got)
 	}
 }
+
+func TestLegacyStyleRoot_JoinsHomeDotExasolLauncher(t *testing.T) {
+	t.Parallel()
+
+	// When
+	got := legacyStyleRoot("/home/user")
+	// Then
+	want := filepath.Join("/home/user", ".exasol", "launcher")
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestLauncherNamespaceRoot_JoinsBaseExasolLauncher(t *testing.T) {
+	t.Parallel()
+
+	// When
+	got := launcherNamespaceRoot("/home/user/Library/Application Support")
+	// Then
+	want := filepath.Join("/home/user/Library/Application Support", "exasol", "launcher")
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestDurableRootPathForOS_LinuxUsesDotExasolLauncherUnderHome(t *testing.T) {
+	t.Parallel()
+
+	// When
+	got, err := durableRootPathForOS("linux")
+	// Then
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if filepath.Base(got) != "launcher" || filepath.Base(filepath.Dir(got)) != ".exasol" {
+		t.Fatalf("expected a path ending in .exasol/launcher, got %q", got)
+	}
+}
+
+func TestDurableRootPathForOS_NonLinuxUsesConfigDirNamespace(t *testing.T) {
+	t.Parallel()
+
+	for _, goos := range []string{"darwin", "windows"} {
+		// When
+		got, err := durableRootPathForOS(goos)
+		// Then
+		if err != nil {
+			t.Fatalf("%s: expected no error, got %v", goos, err)
+		}
+		if filepath.Base(got) != "launcher" || filepath.Base(filepath.Dir(got)) != "exasol" {
+			t.Fatalf("%s: expected a path ending in exasol/launcher, got %q", goos, got)
+		}
+	}
+}
+
+func TestDeploymentsRootPath_ResolvesUnderTheDurableRoot(t *testing.T) {
+	t.Parallel()
+
+	// When
+	got, err := DeploymentsRootPath()
+	// Then
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if filepath.Base(got) != "deployments" || filepath.Base(filepath.Dir(got)) != "launcher" {
+		t.Fatalf("expected a path ending in launcher/deployments, got %q", got)
+	}
+}
+
+func TestHistoryRootPath_ResolvesUnderTheDurableRoot(t *testing.T) {
+	t.Parallel()
+
+	// When
+	got, err := HistoryRootPath()
+	// Then
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if filepath.Base(got) != "history" || filepath.Base(filepath.Dir(got)) != "launcher" {
+		t.Fatalf("expected a path ending in launcher/history, got %q", got)
+	}
+}
+
+func TestResourceConfigFilePath_ResolvesUnderTheNamespaceRoot(t *testing.T) {
+	t.Parallel()
+
+	// When
+	got, err := ResourceConfigFilePath()
+	// Then
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if filepath.Base(got) != "resources.yaml" || filepath.Base(filepath.Dir(got)) != "launcher" {
+		t.Fatalf("expected a path ending in launcher/resources.yaml, got %q", got)
+	}
+}
+
+func TestCacheRootPath_ResolvesUnderTheNamespaceRoot(t *testing.T) {
+	t.Parallel()
+
+	// When
+	got, err := CacheRootPath()
+	// Then
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if filepath.Base(got) != "resources" || filepath.Base(filepath.Dir(got)) != "launcher" {
+		t.Fatalf("expected a path ending in launcher/resources, got %q", got)
+	}
+}

--- a/internal/runtimeartifacts/cache.go
+++ b/internal/runtimeartifacts/cache.go
@@ -137,6 +137,12 @@ func DefaultCacheRoot() (string, error) {
 }
 
 func DefaultConfigPath() (string, error) {
+	return launcherpaths.ResourceConfigFilePath()
+}
+
+// LegacyConfigPath exists only so an existing file there can be migrated
+// to DefaultConfigPath.
+func LegacyConfigPath() (string, error) {
 	rootDir, err := launcherpaths.RootDirPath()
 	if err != nil {
 		return "", err
@@ -184,16 +190,18 @@ func DefaultCacheConfig() CacheConfig {
 
 func LoadCacheConfig(path string) (CacheConfig, bool, error) {
 	cfg := DefaultCacheConfig()
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return cfg, false, nil
 		}
 
-		return cfg, false, err
+		return cfg, false, fmt.Errorf("read cache config %s: %w", path, err)
 	}
+
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return cfg, true, err
+		return cfg, true, fmt.Errorf("parse cache config %s: %w", path, err)
 	}
 	if err := validateCacheConfig(cfg); err != nil {
 		return cfg, true, err
@@ -208,15 +216,23 @@ func EnsureCacheConfig(path string) (CacheConfig, error) {
 		return cfg, err
 	}
 
+	return cfg, writeCacheConfig(path, cfg)
+}
+
+func writeCacheConfig(path string, cfg CacheConfig) error {
 	if err := os.MkdirAll(filepath.Dir(path), dirPerm); err != nil {
-		return cfg, err
-	}
-	data, err := yaml.Marshal(cfg)
-	if err != nil {
-		return cfg, err
+		return fmt.Errorf("create directory for cache config %s: %w", path, err)
 	}
 
-	return cfg, os.WriteFile(path, data, filePerm)
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("encode cache config %s: %w", path, err)
+	}
+	if err := os.WriteFile(path, data, filePerm); err != nil {
+		return fmt.Errorf("write cache config %s: %w", path, err)
+	}
+
+	return nil
 }
 
 func validateCacheConfig(cfg CacheConfig) error {

--- a/internal/runtimeartifacts/cache.go
+++ b/internal/runtimeartifacts/cache.go
@@ -128,12 +128,26 @@ type partialDownloadCandidate struct {
 }
 
 func DefaultCacheRoot() (string, error) {
+	return launcherpaths.CacheRootPath()
+}
+
+// LegacyCacheRoot exists only to be deleted once DefaultCacheRoot is in use;
+// the cache is disposable, so its contents are never migrated.
+func LegacyCacheRoot() (string, error) {
 	cacheDir, err := os.UserCacheDir()
 	if err != nil {
 		return "", fmt.Errorf("resolve user cache directory: %w", err)
 	}
 
 	return filepath.Join(launcherpaths.DirPath(cacheDir), runtimeArtifactsDirName), nil
+}
+
+func DeleteLegacyCache(legacyCacheRoot string) error {
+	if err := os.RemoveAll(legacyCacheRoot); err != nil {
+		return fmt.Errorf("remove legacy cache root %s: %w", legacyCacheRoot, err)
+	}
+
+	return nil
 }
 
 func DefaultConfigPath() (string, error) {

--- a/internal/runtimeartifacts/cache_test.go
+++ b/internal/runtimeartifacts/cache_test.go
@@ -27,22 +27,79 @@ func (c *testClock) Now() time.Time {
 	return c.now
 }
 
-func TestDefaultCacheRootUsesLauncherRuntimeArtifactsNamespace(t *testing.T) {
+func TestDefaultCacheRootUsesSharedLauncherCacheRoot(t *testing.T) {
 	t.Parallel()
 
+	// Given
+	want, err := launcherpaths.CacheRootPath()
+	if err != nil {
+		t.Fatalf("failed to resolve launcher cache root: %v", err)
+	}
+
+	// When
+	got, err := DefaultCacheRoot()
+	// Then
+	if err != nil {
+		t.Fatalf("expected cache root, got error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestLegacyCacheRootUsesLauncherRuntimeArtifactsNamespace(t *testing.T) {
+	t.Parallel()
+
+	// Given
 	cacheDir, err := os.UserCacheDir()
 	if err != nil {
 		t.Fatalf("failed to resolve user cache dir: %v", err)
 	}
 
-	root, err := DefaultCacheRoot()
+	// When
+	root, err := LegacyCacheRoot()
+	// Then
 	if err != nil {
 		t.Fatalf("expected cache root, got error: %v", err)
 	}
-
 	expected := filepath.Join(launcherpaths.DirPath(cacheDir), runtimeArtifactsDirName)
 	if root != expected {
 		t.Fatalf("expected %q, got %q", expected, root)
+	}
+}
+
+func TestDeleteLegacyCache_RemovesExistingRoot(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	dir := t.TempDir()
+	legacyRoot := filepath.Join(dir, "runtime-artifacts")
+	if err := os.MkdirAll(filepath.Join(legacyRoot, "artifacts"), dirPerm); err != nil {
+		t.Fatalf("failed to seed legacy cache root: %v", err)
+	}
+
+	// When
+	if err := DeleteLegacyCache(legacyRoot); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Then
+	if _, err := os.Stat(legacyRoot); !os.IsNotExist(err) {
+		t.Fatalf("expected legacy cache root to be removed, stat returned err=%v", err)
+	}
+}
+
+func TestDeleteLegacyCache_IsNoOpWhenMissing(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	legacyRoot := filepath.Join(t.TempDir(), "runtime-artifacts")
+
+	// When
+	err := DeleteLegacyCache(legacyRoot)
+	// Then
+	if err != nil {
+		t.Fatalf("expected no error when legacy cache root does not exist, got %v", err)
 	}
 }
 

--- a/internal/runtimeartifacts/cache_test.go
+++ b/internal/runtimeartifacts/cache_test.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -47,16 +46,38 @@ func TestDefaultCacheRootUsesLauncherRuntimeArtifactsNamespace(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // home-directory environment is process-global.
-func TestDefaultConfigPathUsesLauncherRootDirectory(t *testing.T) {
-	home := t.TempDir()
-	setRuntimeArtifactsTestHome(t, home)
+func TestDefaultConfigPathUsesResourceConfigFile(t *testing.T) {
+	t.Parallel()
 
-	path, err := DefaultConfigPath()
+	// Given
+	want, err := launcherpaths.ResourceConfigFilePath()
+	if err != nil {
+		t.Fatalf("failed to resolve resource config file path: %v", err)
+	}
+
+	// When
+	got, err := DefaultConfigPath()
+	// Then
 	if err != nil {
 		t.Fatalf("expected config path, got error: %v", err)
 	}
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
 
+//nolint:paralleltest // home-directory environment is process-global.
+func TestLegacyConfigPathUsesLauncherRootDirectory(t *testing.T) {
+	// Given
+	home := t.TempDir()
+	setRuntimeArtifactsTestHome(t, home)
+
+	// When
+	path, err := LegacyConfigPath()
+	// Then
+	if err != nil {
+		t.Fatalf("expected config path, got error: %v", err)
+	}
 	expected := filepath.Join(launcherpaths.DirPath(home), cacheConfigFileName)
 	if path != expected {
 		t.Fatalf("expected %q, got %q", expected, path)
@@ -66,7 +87,7 @@ func TestDefaultConfigPathUsesLauncherRootDirectory(t *testing.T) {
 func TestEnsureCacheConfigCreatesDefaultAndRejectsInvalidRetention(t *testing.T) {
 	t.Parallel()
 
-	configPath := filepath.Join(t.TempDir(), "config", cacheConfigFileName)
+	configPath := filepath.Join(t.TempDir(), "config", "resources.yaml")
 
 	cfg, err := EnsureCacheConfig(configPath)
 	if err != nil {
@@ -83,8 +104,10 @@ func TestEnsureCacheConfigCreatesDefaultAndRejectsInvalidRetention(t *testing.T)
 		t.Fatalf("expected retention_days in config, got: %s", string(content))
 	}
 
-	if err := os.WriteFile(configPath, []byte("retention_days: 0\n"), filePerm); err != nil {
-		t.Fatalf("failed to write invalid config: %v", err)
+	invalidCfg := CacheConfig{RetentionDays: 0}
+	writeErr := writeCacheConfig(configPath, invalidCfg)
+	if writeErr != nil {
+		t.Fatalf("failed to write invalid config: %v", writeErr)
 	}
 	_, _, err = LoadCacheConfig(configPath)
 	if !errors.Is(err, ErrInvalidCacheConfig) {
@@ -553,7 +576,7 @@ func newTestCache(t *testing.T, now time.Time) *Cache {
 
 	clk := &testClock{now: now}
 	root := filepath.Join(t.TempDir(), "cache")
-	configPath := filepath.Join(t.TempDir(), "config", cacheConfigFileName)
+	configPath := filepath.Join(t.TempDir(), "config", "resources.yaml")
 
 	return newCacheWithClock(root, configPath, clk)
 }
@@ -561,11 +584,8 @@ func newTestCache(t *testing.T, now time.Time) *Cache {
 func writeTestCacheConfig(t *testing.T, cache *Cache, retentionDays int) {
 	t.Helper()
 
-	if err := os.MkdirAll(filepath.Dir(cache.configPath), dirPerm); err != nil {
-		t.Fatalf("failed to create config directory: %v", err)
-	}
-	content := "retention_days: " + strconv.Itoa(retentionDays) + "\n"
-	if err := os.WriteFile(cache.configPath, []byte(content), filePerm); err != nil {
+	cfg := CacheConfig{RetentionDays: retentionDays}
+	if err := writeCacheConfig(cache.configPath, cfg); err != nil {
 		t.Fatalf("failed to write cache config: %v", err)
 	}
 }

--- a/internal/runtimeartifacts/config_migration.go
+++ b/internal/runtimeartifacts/config_migration.go
@@ -1,0 +1,41 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package runtimeartifacts
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// MigrateLegacyConfig is a no-op if legacyConfigPath does not exist.
+func MigrateLegacyConfig(legacyConfigPath, newConfigPath string) error {
+	data, err := os.ReadFile(legacyConfigPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+
+		return fmt.Errorf("read legacy cache config %s: %w", legacyConfigPath, err)
+	}
+
+	cfg := DefaultCacheConfig()
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return fmt.Errorf("parse legacy cache config %s: %w", legacyConfigPath, err)
+	}
+	if err := validateCacheConfig(cfg); err != nil {
+		return fmt.Errorf("validate legacy cache config %s: %w", legacyConfigPath, err)
+	}
+
+	if err := writeCacheConfig(newConfigPath, cfg); err != nil {
+		return fmt.Errorf("migrate legacy cache config to %s: %w", newConfigPath, err)
+	}
+	if err := os.Remove(legacyConfigPath); err != nil {
+		return fmt.Errorf("remove legacy cache config %s: %w", legacyConfigPath, err)
+	}
+
+	return nil
+}

--- a/internal/runtimeartifacts/config_migration_test.go
+++ b/internal/runtimeartifacts/config_migration_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package runtimeartifacts
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestMigrateLegacyConfig_MovesRetentionIntoResourceConfigAndRemovesLegacyFile(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	dir := t.TempDir()
+	legacyPath := filepath.Join(dir, "runtime-artifacts.yaml")
+	newPath := filepath.Join(dir, "resources.yaml")
+	if err := os.WriteFile(legacyPath, []byte("retention_days: 45\n"), filePerm); err != nil {
+		t.Fatalf("failed to seed legacy config: %v", err)
+	}
+
+	// When
+	if err := MigrateLegacyConfig(legacyPath, newPath); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Then
+	cfg, present, err := LoadCacheConfig(newPath)
+	if err != nil {
+		t.Fatalf("expected no error loading migrated config, got %v", err)
+	}
+	if !present {
+		t.Fatal("expected migrated config file to be present after migration")
+	}
+	if cfg.RetentionDays != 45 {
+		t.Fatalf("expected retention 45, got %d", cfg.RetentionDays)
+	}
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("expected legacy config file to be removed, stat returned err=%v", err)
+	}
+}
+
+func TestMigrateLegacyConfig_IsNoOpWhenLegacyFileDoesNotExist(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	dir := t.TempDir()
+	legacyPath := filepath.Join(dir, "runtime-artifacts.yaml")
+	newPath := filepath.Join(dir, "resources.yaml")
+
+	// When
+	if err := MigrateLegacyConfig(legacyPath, newPath); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Then
+	if _, err := os.Stat(newPath); !os.IsNotExist(err) {
+		t.Fatalf("expected no config file to be created, stat returned err=%v", err)
+	}
+}
+
+func TestMigrateLegacyConfig_RejectsInvalidLegacyRetention(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	dir := t.TempDir()
+	legacyPath := filepath.Join(dir, "runtime-artifacts.yaml")
+	newPath := filepath.Join(dir, "resources.yaml")
+	if err := os.WriteFile(legacyPath, []byte("retention_days: 0\n"), filePerm); err != nil {
+		t.Fatalf("failed to seed legacy config: %v", err)
+	}
+
+	// When
+	err := MigrateLegacyConfig(legacyPath, newPath)
+
+	// Then
+	if err == nil {
+		t.Fatal("expected an error for invalid legacy retention")
+	}
+	if _, statErr := os.Stat(legacyPath); statErr != nil {
+		t.Fatalf("expected legacy config file to remain after a failed migration: %v", statErr)
+	}
+}

--- a/internal/util/copy_test.go
+++ b/internal/util/copy_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Exasol AG
+// SPDX-License-Identifier: MIT
+
+package util
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestCopyDir_PreservesRestrictivePermissions(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are not meaningful on Windows")
+	}
+
+	// Given a source tree whose file and nested directory are private
+	root := t.TempDir()
+	src := filepath.Join(root, "src")
+	nested := filepath.Join(src, "nested")
+	if err := os.MkdirAll(nested, 0o700); err != nil {
+		t.Fatalf("failed to create source tree: %v", err)
+	}
+	secret := filepath.Join(nested, "secret")
+	if err := os.WriteFile(secret, []byte("token"), 0o600); err != nil {
+		t.Fatalf("failed to write source file: %v", err)
+	}
+
+	// When the tree is copied
+	dst := filepath.Join(root, "dst")
+	if err := CopyDir(src, dst); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Then the copy keeps the source's modes rather than being widened
+	fileInfo, err := os.Stat(filepath.Join(dst, "nested", "secret"))
+	if err != nil {
+		t.Fatalf("expected copied file to exist: %v", err)
+	}
+	if got := fileInfo.Mode().Perm(); got != 0o600 {
+		t.Fatalf("expected copied file mode 0600, got %04o", got)
+	}
+	dirInfo, err := os.Stat(filepath.Join(dst, "nested"))
+	if err != nil {
+		t.Fatalf("expected copied directory to exist: %v", err)
+	}
+	if got := dirInfo.Mode().Perm(); got != 0o700 {
+		t.Fatalf("expected copied directory mode 0700, got %04o", got)
+	}
+}
+
+func TestCopyDir_PreservesExecutableBit(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are not meaningful on Windows")
+	}
+
+	// Given a source tree holding an executable file
+	root := t.TempDir()
+	src := filepath.Join(root, "src")
+	if err := os.MkdirAll(src, 0o750); err != nil {
+		t.Fatalf("failed to create source tree: %v", err)
+	}
+	//nolint:gosec // the executable bit is the property under test.
+	if err := os.WriteFile(filepath.Join(src, "tool"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("failed to write source file: %v", err)
+	}
+
+	// When the tree is copied
+	dst := filepath.Join(root, "dst")
+	if err := CopyDir(src, dst); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// Then the copied file stays executable
+	info, err := os.Stat(filepath.Join(dst, "tool"))
+	if err != nil {
+		t.Fatalf("expected copied file to exist: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o755 {
+		t.Fatalf("expected copied file mode 0755, got %04o", got)
+	}
+}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"golang.org/x/term"
@@ -232,6 +233,61 @@ func CopyDir(src, dst string) error {
 			Src: src,
 			Dst: dst,
 			Err: fmt.Errorf("%w: %w", ErrCopyFailed, err),
+		}
+	}
+
+	return restorePermissions(src, dst)
+}
+
+// restorePermissions reapplies the source tree's permission bits, because
+// os.CopyFS creates files as 0666 and directories as 0777 before umask,
+// widening anything the source kept private. Directories are done last so a
+// restored read-only directory cannot block writes to its own contents.
+func restorePermissions(src, dst string) error {
+	type dirMode struct {
+		path string
+		mode os.FileMode
+	}
+	var dirs []dirMode
+
+	err := filepath.Walk(src, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+
+		relative, err := filepath.Rel(src, path)
+		if err != nil {
+			return fmt.Errorf("resolve copied path for %s: %w", path, err)
+		}
+		copied := filepath.Join(dst, relative)
+
+		if info.IsDir() {
+			dirs = append(dirs, dirMode{path: copied, mode: info.Mode()})
+
+			return nil
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+
+		return os.Chmod(copied, info.Mode().Perm())
+	})
+	if err != nil {
+		return &CopyDirError{
+			Op:  "preserve permissions",
+			Src: src,
+			Dst: dst,
+			Err: err,
+		}
+	}
+
+	for _, dir := range slices.Backward(dirs) {
+		if err := os.Chmod(dir.path, dir.mode.Perm()); err != nil {
+			return &CopyDirError{
+				Op:  "preserve permissions",
+				Dst: dir.path,
+				Err: err,
+			}
 		}
 	}
 

--- a/openspec/changes/archive/2026-09-08-standardize-launcher-paths/design.md
+++ b/openspec/changes/archive/2026-09-08-standardize-launcher-paths/design.md
@@ -1,0 +1,204 @@
+## Context
+
+`internal/launcherpaths` currently resolves one flat root, `<home>/.exasol/personal`,
+identically on every platform. Everything launcher-owned nests under it or, in two
+cases, doesn't nest under anything launcher-owned at all:
+
+- Managed deployments (`internal/config/deployment_dir.go`) and the runtime-artifact
+  cache (`internal/runtimeartifacts/cache.go`) both sit under the flat root.
+- The runtime-artifact cache's own config file, `runtime-artifacts.yaml`, is written
+  directly into the flat root, i.e. into the deployments root, not the cache it
+  configures.
+- SQL history (`internal/connect/shell.go`) is written as `exasol_history` directly
+  into `os.UserCacheDir()`, with no launcher namespace at all.
+
+This is also the change that puts launcher configuration in the platform's
+configuration location for the first time. Nothing in the codebase writes to that
+location today.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Every launcher-owned path lives under one `exasol/launcher` namespace per platform,
+  in the platform-conventional location for its lifecycle (durable data, config, or
+  cache).
+- Existing users keep their deployments, SQL history, and cache retention setting
+  across the upgrade, with no data loss and no silent overwrite on a naming collision.
+- The disposable resource cache is treated as disposable: it is deleted, not migrated.
+- Each subsystem's settings live in their own file at the configuration location, so a
+  later subsystem adds its own file without touching the resource cache's.
+
+**Non-Goals:**
+
+- The broader SPOT-32441 resource-resolution pipeline redesign (unifying HTTP/Git/
+  local/container/embedded sources, preset-scoped resources). This change only moves
+  and renames the resource cache's on-disk location and config file.
+- Renaming the `internal/runtimeartifacts` Go package, its types, or its terminology.
+- Moving deployment-specific configuration out of its deployment directory.
+- Preserving the legacy resource cache's contents.
+
+## Decisions
+
+1. **Platform-specific roots, resolved per purpose, not per flat root.**
+
+   `internal/launcherpaths` currently exposes a single `RootDirPath`/`DirPath` pair.
+   This change replaces it with one function per purpose (deployments root, history
+   root, config file path, cache root), because the four purposes don't share one base
+   directory consistently across platforms:
+
+   | Purpose | Linux | macOS | Windows |
+   | --- | --- | --- | --- |
+   | Managed deployments | `~/.exasol/launcher/deployments` | `~/Library/Application Support/exasol/launcher/deployments` | `%APPDATA%\exasol\launcher\deployments` |
+   | SQL history | `~/.exasol/launcher/history/exasol_history` | `~/Library/Application Support/exasol/launcher/history/exasol_history` | `%APPDATA%\exasol\launcher\history\exasol_history` |
+   | Resource cache configuration | `${XDG_CONFIG_HOME:-~/.config}/exasol/launcher/resources.yaml` | `~/Library/Application Support/exasol/launcher/resources.yaml` | `%APPDATA%\exasol\launcher\resources.yaml` |
+   | Resource cache | `${XDG_CACHE_HOME:-~/.cache}/exasol/launcher/resources` | `~/Library/Caches/exasol/launcher/resources` | `%LOCALAPPDATA%\exasol\launcher\resources` |
+
+   On Linux, deployments and history deliberately do *not* follow `os.UserConfigDir()`
+   or an XDG data-home convention: they keep a stable, discoverable dotfile location
+   analogous to the current `~/.exasol/personal`, distinct from configuration. On
+   macOS and Windows, `os.UserConfigDir()` already resolves to the platform's
+   general-purpose per-app directory (`Application Support`, `%APPDATA%`), so
+   deployments, history, and configuration collapse onto the same base there and are
+   only distinguished by their leaf name. The cache purpose always uses
+   `os.UserCacheDir()` (or its Linux XDG equivalent), on every platform.
+
+2. **Migrate deployments and history; delete, don't migrate, the cache.**
+
+   Deployments and history are user-managed or user-generated data, so losing them is
+   a real regression. The resource cache is rebuilt transparently on next use, so this
+   change deletes the legacy cache directory outright instead of copying it, matching
+   the existing precedent of treating this cache as fully disposable (see
+   `runtime-artifact-cache`).
+
+3. **Collision handling refuses to guess.**
+
+   If a deployment name exists at both the legacy and new managed-deployments root,
+   silently preferring either one risks discarding the other's state. Migration
+   refuses that name with an error naming both paths and asking the user to resolve it
+   (rename or remove one side) before retrying. Every other, non-colliding legacy
+   deployment still migrates normally in the same run.
+
+4. **Migration runs once, at startup, before any operation is recorded in progress,
+   without prompting, and the invocation quits rather than proceeds on failure.**
+
+   Migrating a deployment directory while a command may be mid-operation (e.g.
+   destroying cloud resources) risks a race between the migration and the command's
+   own use of that directory. Startup migration runs before `cmd/exasol` dispatches to
+   any command, so a command never observes a half-migrated deployment tree. A marker
+   in the new root records that migration already ran, so it is not repeated on every
+   invocation.
+
+   Migration does not prompt for confirmation, matching every other automatic
+   migration already in this codebase (`internal/localruntime/mac_data_migration.go`
+   migrates a VM's Nano data with no user prompt). It does, however, tell the user
+   what happened: a clear human-facing message on standard error naming what moved or
+   was deleted and where, emitted before the requested command's own output.
+
+   If migration fails partway (I/O error, a refused collision), the CLI exits with a
+   clear error before dispatching to the requested command. It does not fall back to
+   the legacy paths, and it does not proceed with a mixed old/new state. The marker is
+   only written after migration fully completes, so the next invocation retries from
+   the same state rather than resuming a partially applied one silently.
+
+5. **Migration is resumable, not merely "before any command runs."**
+
+   A rename within the same filesystem is already atomic, but the deployments and
+   history locations are not guaranteed to share a filesystem with their
+   legacy counterparts (e.g. `~/.exasol/launcher` vs. a separately mounted
+   `XDG_CACHE_HOME`), so a cross-filesystem move needs copy-then-delete, which is not
+   atomic and can be interrupted mid-copy. Rather than accept that as a risk to be
+   waved off, this change reuses the stage → mark-complete → atomic-rename → cleanup-
+   source pattern already implemented for macOS Nano data in
+   `internal/localruntime/mac_data_migration.go`: copy into a staging directory next
+   to the destination, write a completion marker once the copy is flushed, atomically
+   rename staging to the final destination, and only then remove the legacy source.
+   An interrupted run leaves the legacy source untouched and an incomplete staging
+   directory that the next invocation resets and retries, never a half-populated
+   destination mistaken for a complete one. Where source and destination share a
+   filesystem, a plain rename is used directly and this staging dance is skipped.
+
+6. **One settings file per subsystem, each owned by the subsystem itself.**
+
+   `resources.yaml` holds only the resource cache's settings, so
+   `internal/runtimeartifacts` reads and writes it directly, depending on
+   `internal/launcherpaths` for path resolution alone. This keeps the ownership
+   boundary the package already needs: `internal/runtimeartifacts` must not depend on
+   `internal/config` (the `launcherpaths` package doc calls this out explicitly, to
+   avoid an import cycle risk if `internal/presets` ever depends on
+   `internal/runtimeartifacts`), and a file read only by its owner never has to. A
+   later subsystem that needs persisted settings adds its own file at the same
+   configuration location.
+
+7. **The cache config file keeps its own identity.**
+
+   `runtime-artifacts.yaml`'s only field, `retention_days`, stays as it is in
+   `resources.yaml` at the configuration location, its name matching the `resources`
+   cache directory leaf. Launcher settings files use YAML, as the rest of the
+   repository does. On first run after upgrade, if the legacy file exists, its value
+   seeds the new file; the legacy file is then removed as part of the same migration
+   that relocates deployments and history. The value is read and rewritten rather than
+   moved, so the file is validated on the way through and the staging primitive from
+   Decision 5 is not involved.
+
+## Risks / Trade-offs
+
+- Running migration at every startup (gated by a marker check) adds a small amount of
+  work to every invocation even after migration is complete; the check is a single
+  marker-file stat, kept cheap deliberately.
+- Startup migration assumes one launcher process runs it at a time, which holds for
+  interactive use. Several first-run invocations started together would each see the
+  marker missing and migrate the same legacy paths, so the losing invocation reports a
+  collision and stops instead of running its command. Serializing them is left out
+  deliberately: the marker keeps the window to the first run on a machine.
+- Collision refusal means a pre-existing name clash blocks that one deployment from
+  migrating until the user acts, rather than the launcher picking a side. This is
+  intentional (see Decision 3) but is a hard stop, not a warning.
+- Migrating without a confirmation prompt means a user's deployments, history file,
+  and cache config move (and the legacy cache is deleted) without them opting in at
+  that exact moment. This matches existing precedent in this codebase (no other
+  migration prompts either) and is mitigated, not eliminated, by the informational
+  message: a user who doesn't read CLI output can still be surprised that legacy
+  paths are gone.
+- Quitting the invocation on a failed migration means every command is unusable until
+  the underlying failure is resolved: there is no "skip migration and proceed with
+  legacy paths for now" fallback. This is intentional (mixed old/new state is worse
+  than a blocked invocation).
+- The stage/mark/rename/cleanup sequence adds real implementation surface (per
+  migrated item: a staging directory, a completion marker, resume-or-reset logic) for
+  a case (cross-filesystem legacy vs. new roots) that will be uncommon in practice;
+  it is justified here because the alternative (accepting non-atomic copy-then-delete
+  as a known gap) is exactly what this design decision exists to avoid.
+
+## Migration Plan
+
+Migration is not a separate rollout step: it runs as part of every CLI invocation's
+startup sequence (see Decision 4), gated by the completion marker, until it has run
+once per location. Shipping the new launcher version is the only rollout action; the
+first invocation of that version against an existing installation is what triggers it.
+
+Order of operations within one CLI startup, once the marker shows work remains:
+
+1. Check the completion marker; if migration is already complete, skip entirely (a
+   single cheap stat).
+2. Migrate the cache configuration into `resources.yaml` and remove the legacy
+   `runtime-artifacts.yaml`.
+3. Relocate the resource cache root and delete the legacy cache directory (no cache
+   content is migrated).
+4. Migrate the SQL history file to its new location.
+5. Migrate each deployment directory, refusing (without aborting the others) any name
+   that collides with an existing new-location deployment.
+6. Report what moved or was deleted in a human-facing message on standard error.
+7. Only once every step above succeeds does the CLI write the completion marker and
+   dispatch to the requested command.
+
+A partial failure at any step leaves the marker unset, so the next invocation retries
+from scratch; steps that already succeeded are safe to repeat because there is nothing
+left at the legacy location to move.
+
+**Rollback: not supported, by design.** Deployments, history, and the cache config are
+moved rather than copied: once migration completes, the legacy locations no longer
+hold that data, so downgrading to a launcher version that only reads legacy paths will
+not find it there. This is accepted deliberately rather than mitigated: a durable
+backup would add ongoing disk usage and cleanup complexity in service of a downgrade
+path this change does not intend to support.

--- a/openspec/changes/archive/2026-09-08-standardize-launcher-paths/proposal.md
+++ b/openspec/changes/archive/2026-09-08-standardize-launcher-paths/proposal.md
@@ -1,0 +1,91 @@
+## Why
+
+Launcher-managed files currently share one flat, Linux-flavored root
+(`~/.exasol/personal`) on every platform, and not everything even lives there: SQL
+history is written straight into the OS cache directory with no launcher-owned
+namespace at all, and the runtime-artifact cache's own configuration file sits in the
+deployments root instead of the platform's configuration location. Users on macOS and
+Windows get a Linux dotfile layout instead of their platform's conventional locations,
+and nothing distinguishes "data I manage on purpose" (deployments) from "state I can
+always reconstruct" (cache) when deciding what to back up, sync, or delete.
+
+## What Changes
+
+- Introduce one `exasol/launcher` namespace per platform, split by lifecycle:
+  managed deployments and SQL history under a durable, platform-conventional root;
+  configuration under the platform's config directory (`XDG_CONFIG_HOME` on Linux,
+  `Application Support` on macOS, `%APPDATA%` on Windows); the resource cache under
+  the platform's cache directory (`XDG_CACHE_HOME` on Linux, `Caches` on macOS,
+  `%LOCALAPPDATA%` on Windows).
+- Move the runtime-artifact cache's configuration to the new configuration location as
+  `resources.yaml`, a standalone file owned by the cache. It is currently
+  `runtime-artifacts.yaml` in the deployments root; this change renames it and moves it
+  to the platform's configuration location.
+- Rename the on-disk resource-cache directory leaf from `runtime-artifacts` to
+  `resources`, matching its config file name. This is a paths/naming change only:
+  the `internal/runtimeartifacts` Go package, its types, and its terminology are left
+  alone; the broader resource-resolution pipeline redesign remains separate, ongoing
+  work (SPOT-32441).
+- Migrate existing deployments, configuration (the cache retention setting), and SQL
+  history from their legacy locations to the new ones. The legacy resource cache is
+  deleted rather than migrated, since it is disposable and rebuilt on demand.
+- Detect a naming collision between a legacy and new-location deployment directory and
+  fail with a clear error identifying both paths, rather than silently preferring or
+  discarding either one.
+- Run this migration once, early at CLI startup and before any command records an
+  operation in progress against a deployment, so a failed or interrupted migration
+  leaves both locations retryable.
+- Migrate without prompting for confirmation, matching every other automatic
+  migration already in this codebase, but always tell the user what happened: a clear
+  message naming what moved or was deleted and where.
+- Quit the invocation before dispatching to the requested command if migration fails,
+  rather than proceeding against a mixed legacy/new-location state.
+- Make cross-filesystem moves (where a plain rename isn't possible) resumable after
+  interruption, by staging into a temporary location and only publishing once the copy
+  is confirmed complete and flushed, reusing the pattern already implemented for
+  macOS Nano data migration.
+- Update command help and user documentation to describe the new locations.
+
+## Capabilities
+
+### New Capabilities
+
+- `sql-history-storage`: define where the interactive shell's SQL history persists and
+  how an existing legacy history file is carried over.
+- `launcher-path-migration`: the cross-cutting migration mechanics shared by every
+  migrated location (deployments, history, cache config), covering user notification,
+  quitting on failure, and resumable, crash-safe execution.
+
+### Modified Capabilities
+
+- `deployment-directory-resolution`: managed deployments (and the default/named
+  deployment directories it resolves) move from the flat legacy root to the new
+  platform-specific managed-deployments root, with one-time migration and collision
+  detection from the legacy location.
+- `runtime-artifact-cache`: the cache root moves to the new platform-specific cache
+  location under the `resources` leaf name, and its retention configuration moves to
+  `resources.yaml` at the new configuration location.
+- `deployment-directory-listing`: the listing enumerates the managed-deployments root
+  defined by `deployment-directory-resolution` instead of restating a path of its own.
+
+## Impact
+
+- `internal/launcherpaths`: resolves four purpose-specific roots per platform instead
+  of one flat root.
+- `internal/config/deployment_dir.go`: deployments root moves to the new managed root;
+  add legacy-deployment migration and collision detection.
+- `internal/runtimeartifacts/cache.go`: cache root moves to the new cache location
+  under the `resources` leaf name; its config file moves to the new configuration
+  location as `resources.yaml`.
+- `internal/connect/shell.go`: SQL history moves from an unnamespaced file directly in
+  the OS cache directory to the new history location.
+- `cmd/exasol`: wire the one-time startup migration before command dispatch,
+  including the human-facing message reporting what moved or was deleted.
+- New staging/resume helper (reusing the pattern in
+  `internal/localruntime/mac_data_migration.go`): stage a cross-filesystem copy, mark
+  it complete, atomically rename it into place, then remove the legacy source.
+- User docs: `user-docs/content/manage-deployments.md` and any other prose or example
+  output naming `~/.exasol/personal`.
+- OpenSpec specs: `deployment-directory-resolution`, `deployment-directory-listing`,
+  and `runtime-artifact-cache` (modified), new `sql-history-storage` and
+  `launcher-path-migration` capabilities.

--- a/openspec/changes/archive/2026-09-08-standardize-launcher-paths/specs/deployment-directory-listing/spec.md
+++ b/openspec/changes/archive/2026-09-08-standardize-launcher-paths/specs/deployment-directory-listing/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: CLI SHALL list known deployment directories
+`exasol deployments list` SHALL enumerate the deployment directories under the managed-deployments root, including the default deployment directory and every named deployment directory. The root's location is specified by `deployment-directory-resolution`.
+
+#### Scenario: Listing shows the default deployment directory
+- **WHEN** a user runs `exasol deployments list`
+- **AND** a `default` deployment directory exists under the managed-deployments root
+- **THEN** the output includes an entry for `default` with its resolved path
+
+#### Scenario: Listing shows named deployment directories
+- **WHEN** a user runs `exasol deployments list`
+- **AND** one or more named deployment directories exist under the managed-deployments root
+- **THEN** the output includes one entry per named deployment directory, with its name and resolved path
+
+#### Scenario: Listing is empty when no deployment directories exist
+- **WHEN** a user runs `exasol deployments list`
+- **AND** the managed-deployments root does not exist or contains no deployment directories
+- **THEN** the command succeeds
+- **AND** the output indicates that no deployment directories exist
+
+#### Scenario: Non-directory entries are ignored
+- **WHEN** a user runs `exasol deployments list`
+- **AND** the managed-deployments root contains a non-directory entry (a file or symlink)
+- **THEN** the output does not include an entry for it
+- **AND** the command does not fail because of it
+
+#### Scenario: Listing is sorted alphabetically by name
+- **WHEN** a user runs `exasol deployments list`
+- **AND** more than one deployment directory exists under the managed-deployments root
+- **THEN** the entries appear in alphabetical order by name, regardless of filesystem iteration order

--- a/openspec/changes/archive/2026-09-08-standardize-launcher-paths/specs/deployment-directory-resolution/spec.md
+++ b/openspec/changes/archive/2026-09-08-standardize-launcher-paths/specs/deployment-directory-resolution/spec.md
@@ -1,8 +1,5 @@
-# deployment-directory-resolution Specification
+## MODIFIED Requirements
 
-## Purpose
-Define how Exasol Personal resolves the active deployment directory so users can run deployment commands without first creating or changing into a directory, while preserving explicit overrides and existing deployment-directory workflows.
-## Requirements
 ### Requirement: CLI SHALL resolve an active deployment directory
 Commands that operate on a deployment directory SHALL resolve exactly one active deployment directory before command-specific execution.
 
@@ -179,14 +176,7 @@ When commands resolve to the default deployment directory or to a named deployme
 - **AND** the command does not deploy the stale preset from the named deployment directory
 - **AND** the command tells the user to run `exasol destroy --remove` before initializing different presets, or `exasol remove` if the cloud resources are already gone
 
-### Requirement: Commands SHALL log the resolved deployment directory and how it was resolved
-Whenever a command resolves a deployment directory from a flag, the current working directory, or the default location, the launcher SHALL log the resolved path together with the resolution source so log trails are unambiguous about where the launcher is operating.
-
-#### Scenario: Resolved deployment directory and source are logged
-- **WHEN** a command resolves its deployment directory
-- **THEN** the launcher emits a structured log entry containing the resolved deployment directory path
-- **AND** the log entry contains the resolution source (`explicit`, `named`, `current`, or `default`)
-- **AND** the log entry is emitted regardless of whether the directory was supplied explicitly, selected by name, inferred from the current directory, or defaulted
+## ADDED Requirements
 
 ### Requirement: Managed deployments SHALL resolve under a platform-specific root
 The managed-deployments root SHALL be a platform-conventional, launcher-owned directory distinct from the launcher's configuration and cache locations, rather than one flat path shared across platforms.

--- a/openspec/changes/archive/2026-09-08-standardize-launcher-paths/specs/launcher-path-migration/spec.md
+++ b/openspec/changes/archive/2026-09-08-standardize-launcher-paths/specs/launcher-path-migration/spec.md
@@ -1,0 +1,53 @@
+## Purpose
+
+Defines the mechanics shared by every legacy-to-new-location path migration: automatic execution, reporting what changed, quitting on failure, and safe retry after interruption.
+
+## ADDED Requirements
+
+### Requirement: Migration SHALL run automatically
+Startup path migration SHALL apply its changes automatically as part of CLI startup, consistent with every other automatic migration already in the launcher.
+
+#### Scenario: Migration applies changes automatically
+- **WHEN** startup migration has changes to make
+- **THEN** the CLI makes those changes immediately, the same way whether or not stdin is interactive
+
+### Requirement: Migration SHALL report what it changed
+Startup path migration SHALL emit a clear human-facing message identifying what it moved or deleted and where, before any output from the requested command.
+
+#### Scenario: Migration reports its changes
+- **WHEN** startup migration makes any change (moving a deployment, history file, or cache config; deleting the legacy cache)
+- **THEN** the CLI emits a message on standard error naming what changed and its new location, before the requested command produces any output
+
+#### Scenario: Migration stays quiet when there is nothing to do
+- **WHEN** startup migration finds nothing to migrate
+- **THEN** the CLI proceeds straight to the requested command's own output
+
+### Requirement: The invocation SHALL quit before command dispatch on migration failure
+When startup migration fails, the CLI SHALL exit with a clear error before dispatching to the requested command, rather than proceeding against a mixed legacy/new-location state.
+
+#### Scenario: Failed migration blocks the requested command
+- **WHEN** startup migration fails partway (an I/O error, or a refused naming collision)
+- **THEN** the CLI exits with a non-zero status describing the failure before running the requested command
+
+#### Scenario: Successful migration proceeds to the requested command
+- **WHEN** startup migration completes successfully (including when there was nothing to migrate)
+- **THEN** the CLI proceeds to dispatch the requested command normally
+
+### Requirement: Migration SHALL run at most once per completed location
+Once migration for a given location (managed deployments, SQL history, or cache configuration) has completed, later CLI invocations SHALL treat that location as already migrated.
+
+#### Scenario: A completed location is skipped on later invocations
+- **WHEN** startup migration has already completed for a given location
+- **THEN** subsequent CLI invocations skip migrating that location again
+
+### Requirement: An interrupted migration SHALL retry cleanly on the next invocation
+Migration SHALL tolerate being interrupted at any point: the legacy source SHALL remain intact until the new location is confirmed fully and correctly written, and only a new-location copy confirmed fully and correctly written SHALL be treated as valid.
+
+#### Scenario: Legacy source is preserved until the new location is confirmed complete
+- **WHEN** migration is copying data to a new location
+- **THEN** the legacy source remains present and unchanged until the new location is confirmed fully and correctly written
+
+#### Scenario: Interrupted migration retries from scratch
+- **WHEN** a previous migration attempt was interrupted before the new location was confirmed complete
+- **THEN** the next invocation retries that migration from scratch
+- **AND** the legacy source is still present and unmodified when the retry begins

--- a/openspec/changes/archive/2026-09-08-standardize-launcher-paths/specs/runtime-artifact-cache/spec.md
+++ b/openspec/changes/archive/2026-09-08-standardize-launcher-paths/specs/runtime-artifact-cache/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: Cache cleanup SHALL use configured retention
+The launcher SHALL use per-user cache configuration to determine when cached runtime artifacts are old enough to be cleaned. This configuration SHALL be read from a `resources.yaml` file at the platform's conventional configuration location.
+
+#### Scenario: Configured retention identifies stale artifacts
+- **WHEN** cache cleanup evaluates cached runtime artifacts
+- **THEN** artifacts whose last-use timestamp is older than the configured retention are treated as stale
+- **AND** artifacts whose last-use timestamp is within the configured retention are preserved
+
+#### Scenario: Missing retention configuration uses a default
+- **WHEN** cache cleanup runs without an existing user retention configuration
+- **THEN** the launcher uses a default retention value
+
+## ADDED Requirements
+
+### Requirement: The resource cache SHALL live under a platform-specific cache root
+The cache root SHALL be a platform-conventional, launcher-owned cache directory, using the `resources` leaf name.
+
+#### Scenario: Platform-specific cache root
+- **WHEN** the launcher resolves the resource cache root
+- **THEN** it uses `${XDG_CACHE_HOME:-~/.cache}/exasol/launcher/resources` on Linux, `~/Library/Caches/exasol/launcher/resources` on macOS, and `%LOCALAPPDATA%\exasol\launcher\resources` on Windows
+
+### Requirement: The cache configuration file SHALL live at a platform-specific configuration location
+The resource cache's configuration SHALL be one `resources.yaml` file per user, located at the platform's conventional configuration directory.
+
+#### Scenario: Platform-specific cache config file location
+- **WHEN** the launcher resolves the cache configuration file path
+- **THEN** it uses `${XDG_CONFIG_HOME:-~/.config}/exasol/launcher/resources.yaml` on Linux, `~/Library/Application Support/exasol/launcher/resources.yaml` on macOS, and `%APPDATA%\exasol\launcher\resources.yaml` on Windows
+
+### Requirement: An existing legacy cache config file SHALL be migrated to resources.yaml and then removed
+On CLI startup, before any command records an operation in progress, an existing `runtime-artifacts.yaml` cache config file SHALL have its retention setting written to `resources.yaml`, and SHALL then be removed.
+
+#### Scenario: Legacy cache config is migrated once
+- **WHEN** a `runtime-artifacts.yaml` file exists at its legacy location
+- **THEN** its `retention_days` value is written to the `retention_days` field of `resources.yaml`
+- **AND** the legacy `runtime-artifacts.yaml` file is removed
+
+### Requirement: The legacy resource cache directory SHALL be deleted once the new cache location is in use
+The legacy resource cache directory SHALL be deleted outright; the new cache starts empty and repopulates on demand.
+
+#### Scenario: Legacy cache is deleted
+- **WHEN** CLI startup migration runs and a legacy resource cache directory exists
+- **THEN** the legacy directory is deleted
+- **AND** the new cache location contains only entries created after migration

--- a/openspec/changes/archive/2026-09-08-standardize-launcher-paths/specs/sql-history-storage/spec.md
+++ b/openspec/changes/archive/2026-09-08-standardize-launcher-paths/specs/sql-history-storage/spec.md
@@ -1,0 +1,20 @@
+## Purpose
+
+Defines where the interactive shell's SQL history persists and how an existing legacy history file is carried over to the new location.
+
+## ADDED Requirements
+
+### Requirement: SQL history SHALL persist under a platform-specific, launcher-owned location
+The interactive shell's SQL history SHALL be stored under the launcher's own namespace rather than directly in the OS-provided cache directory.
+
+#### Scenario: Platform-specific history location
+- **WHEN** the interactive shell resolves the SQL history file path
+- **THEN** it uses `~/.exasol/launcher/history/exasol_history` on Linux, `~/Library/Application Support/exasol/launcher/history/exasol_history` on macOS, and `%APPDATA%\exasol\launcher\history\exasol_history` on Windows
+
+### Requirement: An existing legacy history file SHALL be migrated with its contents preserved
+On CLI startup, before any command records an operation in progress, an existing history file at the legacy, unnamespaced location SHALL be moved to the new history location.
+
+#### Scenario: Legacy history file is migrated
+- **WHEN** a history file exists at the legacy location (directly in the OS cache directory) and no file exists yet at the new history location
+- **THEN** the CLI moves it to the new history location before dispatching to any command
+- **AND** its contents are preserved

--- a/openspec/changes/archive/2026-09-08-standardize-launcher-paths/tasks.md
+++ b/openspec/changes/archive/2026-09-08-standardize-launcher-paths/tasks.md
@@ -1,0 +1,82 @@
+Each numbered task below maps to exactly one commit. Every commit must pass the full
+check suite (`task all`: unit tests, integration tests, lint, build) on its own, so
+tasks are ordered and scoped so no intermediate commit leaves a location
+half-migrated or a behavior claim untested.
+
+## 1. Path Resolution Foundations
+
+- [x] 1.1 Add one function per purpose (deployments root, history root, config file
+      path, cache root) to `internal/launcherpaths`, implemented per platform per the
+      design's path table, alongside the existing flat-root functions; cover each with
+      unit tests. Purely additive: no existing caller changes yet.
+- [x] 1.2 Add a startup migration marker type so callers can check and record that
+      migration for a given location has completed, with unit tests.
+
+## 2. Resumable Migration Primitive
+
+- [x] 2.1 Add a staging/resume helper, generalized from
+      `internal/localruntime/mac_data_migration.go`'s stage/mark-complete/rename/
+      cleanup pattern, for migrating a directory or file whose source and destination
+      may not share a filesystem, with unit tests covering an interrupted-then-
+      retried migration. Flush the staged copy and the directory entries recording
+      it before marking it complete, keep the published destination durable before
+      removing the source, and preserve the source's permissions by teaching
+      `internal/util`'s directory copy to restore them. Standalone: no caller yet.
+
+## 3. Cache Configuration Relocation
+
+- [x] 3.1 Move the runtime-artifact cache's `RetentionDays` config to `resources.yaml`
+      at the new configuration location, read and written by
+      `internal/runtimeartifacts` itself; on first encounter of an existing
+      standalone `runtime-artifacts.yaml`, migrate its value over and remove the legacy
+      file (a content transform, not a raw move, so this does not use the section-2
+      primitive). Cover with unit tests, including the case where no legacy file
+      exists.
+
+## 4. Cache Root Relocation
+
+- [x] 4.1 Point the runtime-artifact cache root at the new platform-specific cache
+      location under the `resources` leaf name, and delete the legacy cache directory
+      once the new location is in use (no prompt; contents are not migrated). Cover
+      with unit tests.
+
+## 5. SQL History Relocation
+
+- [x] 5.1 Point `internal/connect/shell.go`'s history path at the new history
+      location and migrate an existing legacy history file to it without data loss,
+      using the primitive from section 2. Create the history directory when the
+      interactive shell starts, so a fresh install persists history too. Cover with
+      unit tests.
+
+## 6. Deployments Relocation
+
+- [x] 6.1 Point `internal/config/deployment_dir.go`'s deployments root at the new
+      managed-deployments location; migrate each legacy deployment directory to it
+      using the primitive from section 2; refuse (with a clear error naming both
+      paths) any name that already exists at the new location while still migrating
+      other, non-colliding deployments in the same run. Cover with unit tests,
+      including the collision case. Update the integration tests that assert
+      deployment locations, and point the launcher's platform configuration and
+      cache directories at their temporary home so those tests stay hermetic.
+
+## 7. Startup Wiring
+
+- [x] 7.1 Run the migrations from sections 3-6 once at CLI startup, before
+      deployment-dependent flag pre-registration and before any command records an
+      operation in progress, without prompting for confirmation, exiting before
+      command dispatch on failure, and writing the completion marker only after full
+      success. Report what changed in a human-facing message on
+      standard error before the requested command's own output. Cover the end-to-end
+      sequence with tests: marker-gated no-repeat behavior across all locations, the
+      reported message content, and quitting on failure.
+
+## 8. Documentation
+
+- [x] 8.1 Update command help text that names the legacy path. Already satisfied:
+      help text builds its paths through `defaultDeploymentDirDisplayPath()` /
+      `deploymentsRootDisplayPath()`, which already resolve through the updated
+      `config` functions from section 6. Verified by running `exasol --help` with a
+      fresh HOME. No code change; no commit for this item.
+- [x] 8.2 Update `user-docs/content/manage-deployments.md` and any other user-facing
+      docs naming `~/.exasol/personal`. Verified with `mkdocs build --strict`.
+- [x] 8.3 Add a CHANGELOG entry under `Unreleased`.

--- a/openspec/specs/deployment-directory-listing/spec.md
+++ b/openspec/specs/deployment-directory-listing/spec.md
@@ -4,33 +4,33 @@
 Define how `exasol deployments list` enumerates known deployment directories and reports their deployment status and preset identity, so users can discover and manage multiple named deployment directories.
 ## Requirements
 ### Requirement: CLI SHALL list known deployment directories
-`exasol deployments list` SHALL enumerate the deployment directories under `~/.exasol/personal/deployments/`, including the default deployment directory and every named deployment directory.
+`exasol deployments list` SHALL enumerate the deployment directories under the managed-deployments root, including the default deployment directory and every named deployment directory. The root's location is specified by `deployment-directory-resolution`.
 
 #### Scenario: Listing shows the default deployment directory
 - **WHEN** a user runs `exasol deployments list`
-- **AND** `~/.exasol/personal/deployments/default` exists
+- **AND** a `default` deployment directory exists under the managed-deployments root
 - **THEN** the output includes an entry for `default` with its resolved path
 
 #### Scenario: Listing shows named deployment directories
 - **WHEN** a user runs `exasol deployments list`
-- **AND** one or more named deployment directories exist under `~/.exasol/personal/deployments/`
+- **AND** one or more named deployment directories exist under the managed-deployments root
 - **THEN** the output includes one entry per named deployment directory, with its name and resolved path
 
 #### Scenario: Listing is empty when no deployment directories exist
 - **WHEN** a user runs `exasol deployments list`
-- **AND** `~/.exasol/personal/deployments/` does not exist or contains no deployment directories
+- **AND** the managed-deployments root does not exist or contains no deployment directories
 - **THEN** the command succeeds
 - **AND** the output indicates that no deployment directories exist
 
 #### Scenario: Non-directory entries are ignored
 - **WHEN** a user runs `exasol deployments list`
-- **AND** `~/.exasol/personal/deployments/` contains a non-directory entry (a file or symlink)
+- **AND** the managed-deployments root contains a non-directory entry (a file or symlink)
 - **THEN** the output does not include an entry for it
 - **AND** the command does not fail because of it
 
 #### Scenario: Listing is sorted alphabetically by name
 - **WHEN** a user runs `exasol deployments list`
-- **AND** more than one deployment directory exists under `~/.exasol/personal/deployments/`
+- **AND** more than one deployment directory exists under the managed-deployments root
 - **THEN** the entries appear in alphabetical order by name, regardless of filesystem iteration order
 
 ### Requirement: Listing SHALL report deployment status and preset identity

--- a/openspec/specs/launcher-path-migration/spec.md
+++ b/openspec/specs/launcher-path-migration/spec.md
@@ -1,0 +1,52 @@
+# launcher-path-migration Specification
+
+## Purpose
+Defines the mechanics shared by every legacy-to-new-location path migration: automatic execution, reporting what changed, quitting on failure, and safe retry after interruption.
+## Requirements
+### Requirement: Migration SHALL run automatically
+Startup path migration SHALL apply its changes automatically as part of CLI startup, consistent with every other automatic migration already in the launcher.
+
+#### Scenario: Migration applies changes automatically
+- **WHEN** startup migration has changes to make
+- **THEN** the CLI makes those changes immediately, the same way whether or not stdin is interactive
+
+### Requirement: Migration SHALL report what it changed
+Startup path migration SHALL emit a clear human-facing message identifying what it moved or deleted and where, before any output from the requested command.
+
+#### Scenario: Migration reports its changes
+- **WHEN** startup migration makes any change (moving a deployment, history file, or cache config; deleting the legacy cache)
+- **THEN** the CLI emits a message on standard error naming what changed and its new location, before the requested command produces any output
+
+#### Scenario: Migration stays quiet when there is nothing to do
+- **WHEN** startup migration finds nothing to migrate
+- **THEN** the CLI proceeds straight to the requested command's own output
+
+### Requirement: The invocation SHALL quit before command dispatch on migration failure
+When startup migration fails, the CLI SHALL exit with a clear error before dispatching to the requested command, rather than proceeding against a mixed legacy/new-location state.
+
+#### Scenario: Failed migration blocks the requested command
+- **WHEN** startup migration fails partway (an I/O error, or a refused naming collision)
+- **THEN** the CLI exits with a non-zero status describing the failure before running the requested command
+
+#### Scenario: Successful migration proceeds to the requested command
+- **WHEN** startup migration completes successfully (including when there was nothing to migrate)
+- **THEN** the CLI proceeds to dispatch the requested command normally
+
+### Requirement: Migration SHALL run at most once per completed location
+Once migration for a given location (managed deployments, SQL history, or cache configuration) has completed, later CLI invocations SHALL treat that location as already migrated.
+
+#### Scenario: A completed location is skipped on later invocations
+- **WHEN** startup migration has already completed for a given location
+- **THEN** subsequent CLI invocations skip migrating that location again
+
+### Requirement: An interrupted migration SHALL retry cleanly on the next invocation
+Migration SHALL tolerate being interrupted at any point: the legacy source SHALL remain intact until the new location is confirmed fully and correctly written, and only a new-location copy confirmed fully and correctly written SHALL be treated as valid.
+
+#### Scenario: Legacy source is preserved until the new location is confirmed complete
+- **WHEN** migration is copying data to a new location
+- **THEN** the legacy source remains present and unchanged until the new location is confirmed fully and correctly written
+
+#### Scenario: Interrupted migration retries from scratch
+- **WHEN** a previous migration attempt was interrupted before the new location was confirmed complete
+- **THEN** the next invocation retries that migration from scratch
+- **AND** the legacy source is still present and unmodified when the retry begins

--- a/openspec/specs/runtime-artifact-cache/spec.md
+++ b/openspec/specs/runtime-artifact-cache/spec.md
@@ -51,7 +51,7 @@ The launcher SHALL verify downloaded runtime artifacts before making them availa
 - **AND** the rejected artifact is not recorded as usable in the cache
 
 ### Requirement: Cache cleanup SHALL use configured retention
-The launcher SHALL use per-user cache configuration to determine when cached runtime artifacts are old enough to be cleaned.
+The launcher SHALL use per-user cache configuration to determine when cached runtime artifacts are old enough to be cleaned. This configuration SHALL be read from a `resources.yaml` file at the platform's conventional configuration location.
 
 #### Scenario: Configured retention identifies stale artifacts
 - **WHEN** cache cleanup evaluates cached runtime artifacts
@@ -325,3 +325,32 @@ For resources marked `embed: true`, the resource manager SHALL resolve exclusive
 - **WHEN** a resource is materialized from embedded data
 - **THEN** the resource manager does not re-verify that data against the resource's configured checksum
 
+### Requirement: The resource cache SHALL live under a platform-specific cache root
+The cache root SHALL be a platform-conventional, launcher-owned cache directory, using the `resources` leaf name.
+
+#### Scenario: Platform-specific cache root
+- **WHEN** the launcher resolves the resource cache root
+- **THEN** it uses `${XDG_CACHE_HOME:-~/.cache}/exasol/launcher/resources` on Linux, `~/Library/Caches/exasol/launcher/resources` on macOS, and `%LOCALAPPDATA%\exasol\launcher\resources` on Windows
+
+### Requirement: The cache configuration file SHALL live at a platform-specific configuration location
+The resource cache's configuration SHALL be one `resources.yaml` file per user, located at the platform's conventional configuration directory.
+
+#### Scenario: Platform-specific cache config file location
+- **WHEN** the launcher resolves the cache configuration file path
+- **THEN** it uses `${XDG_CONFIG_HOME:-~/.config}/exasol/launcher/resources.yaml` on Linux, `~/Library/Application Support/exasol/launcher/resources.yaml` on macOS, and `%APPDATA%\exasol\launcher\resources.yaml` on Windows
+
+### Requirement: An existing legacy cache config file SHALL be migrated to resources.yaml and then removed
+On CLI startup, before any command records an operation in progress, an existing `runtime-artifacts.yaml` cache config file SHALL have its retention setting written to `resources.yaml`, and SHALL then be removed.
+
+#### Scenario: Legacy cache config is migrated once
+- **WHEN** a `runtime-artifacts.yaml` file exists at its legacy location
+- **THEN** its `retention_days` value is written to the `retention_days` field of `resources.yaml`
+- **AND** the legacy `runtime-artifacts.yaml` file is removed
+
+### Requirement: The legacy resource cache directory SHALL be deleted once the new cache location is in use
+The legacy resource cache directory SHALL be deleted outright; the new cache starts empty and repopulates on demand.
+
+#### Scenario: Legacy cache is deleted
+- **WHEN** CLI startup migration runs and a legacy resource cache directory exists
+- **THEN** the legacy directory is deleted
+- **AND** the new cache location contains only entries created after migration

--- a/openspec/specs/sql-history-storage/spec.md
+++ b/openspec/specs/sql-history-storage/spec.md
@@ -1,0 +1,19 @@
+# sql-history-storage Specification
+
+## Purpose
+Defines where the interactive shell's SQL history persists and how an existing legacy history file is carried over to the new location.
+## Requirements
+### Requirement: SQL history SHALL persist under a platform-specific, launcher-owned location
+The interactive shell's SQL history SHALL be stored under the launcher's own namespace rather than directly in the OS-provided cache directory.
+
+#### Scenario: Platform-specific history location
+- **WHEN** the interactive shell resolves the SQL history file path
+- **THEN** it uses `~/.exasol/launcher/history/exasol_history` on Linux, `~/Library/Application Support/exasol/launcher/history/exasol_history` on macOS, and `%APPDATA%\exasol\launcher\history\exasol_history` on Windows
+
+### Requirement: An existing legacy history file SHALL be migrated with its contents preserved
+On CLI startup, before any command records an operation in progress, an existing history file at the legacy, unnamespaced location SHALL be moved to the new history location.
+
+#### Scenario: Legacy history file is migrated
+- **WHEN** a history file exists at the legacy location (directly in the OS cache directory) and no file exists yet at the new history location
+- **THEN** the CLI moves it to the new history location before dispatching to any command
+- **AND** its contents are preserved

--- a/tests/tests/integration/conftest.py
+++ b/tests/tests/integration/conftest.py
@@ -11,6 +11,26 @@ from pathlib import Path
 import pytest
 import requests
 
+from .helpers import launcher_home_overrides
+
+
+@pytest.fixture(scope="session", autouse=True)
+def isolated_launcher_home(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]:
+    """Move launcher-owned locations into a throwaway home for the whole suite.
+
+    Every launcher command runs startup path migration, so a suite that
+    inherited the real environment would migrate and delete the developer's
+    own deployments, SQL history, and cache. Tests that build their own
+    environment still override these per command; this only makes the default
+    safe.
+    """
+    home = tmp_path_factory.mktemp("launcher-home")
+    with pytest.MonkeyPatch.context() as patch:
+        for key, value in launcher_home_overrides(home).items():
+            patch.setenv(key, value)
+
+        yield home
+
 
 @pytest.fixture
 def mock_version_server() -> Iterator[str]:

--- a/tests/tests/integration/helpers.py
+++ b/tests/tests/integration/helpers.py
@@ -6,10 +6,56 @@
 import json
 import os
 import subprocess
+import sys
+from pathlib import Path
 from subprocess import CompletedProcess
 from typing import Any
 
 import pytest
+
+
+def launcher_home_overrides(home: Path) -> dict[str, str]:
+    """Environment overrides that move every launcher-owned location into home.
+
+    The launcher resolves its deployments, configuration, and cache locations
+    from platform-specific variables, so overriding the home variables alone
+    would leave a command reading and writing the real user's configuration
+    and cache directories.
+    """
+    return {
+        "HOME": str(home),
+        "USERPROFILE": str(home),
+        "HOMEDRIVE": "",
+        "HOMEPATH": "",
+        "XDG_CONFIG_HOME": str(home / ".config"),
+        "XDG_CACHE_HOME": str(home / ".cache"),
+        "APPDATA": str(home / "AppData" / "Roaming"),
+        "LOCALAPPDATA": str(home / "AppData" / "Local"),
+    }
+
+
+def env_with_home(home: Path) -> dict[str, str]:
+    """Build a full environment whose launcher-owned locations live inside home."""
+    env = os.environ.copy()
+    env.update(launcher_home_overrides(home))
+    return env
+
+
+def deployments_root(home: Path) -> Path:
+    """Where the launcher keeps managed deployments below an isolated home."""
+    if sys.platform == "win32":
+        return home / "AppData" / "Roaming" / "exasol" / "launcher" / "deployments"
+    if sys.platform == "darwin":
+        return (
+            home
+            / "Library"
+            / "Application Support"
+            / "exasol"
+            / "launcher"
+            / "deployments"
+        )
+
+    return home / ".exasol" / "launcher" / "deployments"
 
 
 def run_command(

--- a/tests/tests/integration/test_deployment_directory_resolution.py
+++ b/tests/tests/integration/test_deployment_directory_resolution.py
@@ -2,22 +2,17 @@
 # SPDX-License-Identifier: MIT
 
 import json
-import os
 import subprocess
 from pathlib import Path
 
 import pytest
 
-from .helpers import first_infrastructure_preset_id_or_skip, run_command
-
-
-def _env_with_home(home: Path) -> dict[str, str]:
-    env = os.environ.copy()
-    env["HOME"] = str(home)
-    env["USERPROFILE"] = str(home)
-    env["HOMEDRIVE"] = ""
-    env["HOMEPATH"] = ""
-    return env
+from .helpers import (
+    deployments_root,
+    env_with_home,
+    first_infrastructure_preset_id_or_skip,
+    run_command,
+)
 
 
 def _deployment_dir_logged(stderr: str, deployment_dir: Path, source: str) -> bool:
@@ -74,14 +69,14 @@ def test_status_uses_default_deployment_dir_without_corrupting_json(
     cwd = tmp_path / "work"
     home.mkdir()
     cwd.mkdir()
-    default_dir = home / ".exasol" / "personal" / "deployments" / "default"
+    default_dir = deployments_root(home) / "default"
     launcher = str(Path(exasol_path).resolve())
 
     # When status is invoked outside a deployment directory
     result = subprocess.run(
         [launcher, "--log-level", "debug", "status", "--json"],
         cwd=cwd,
-        env=_env_with_home(home),
+        env=env_with_home(home),
         capture_output=True,
         text=True,
         check=True,
@@ -103,7 +98,7 @@ def test_status_uses_named_deployment_dir_without_corrupting_json(
     cwd = tmp_path / "work"
     home.mkdir()
     cwd.mkdir()
-    named_dir = home / ".exasol" / "personal" / "deployments" / "staging"
+    named_dir = deployments_root(home) / "staging"
     launcher = str(Path(exasol_path).resolve())
 
     # When status is invoked with --deployment and no --deployment-dir
@@ -118,7 +113,7 @@ def test_status_uses_named_deployment_dir_without_corrupting_json(
             "staging",
         ],
         cwd=cwd,
-        env=_env_with_home(home),
+        env=env_with_home(home),
         capture_output=True,
         text=True,
         check=True,
@@ -138,13 +133,13 @@ def test_status_reports_uninitialized_named_deployment_dir(
     # Given a home directory without a named deployment directory
     home = tmp_path / "home"
     home.mkdir()
-    named_dir = home / ".exasol" / "personal" / "deployments" / "staging"
+    named_dir = deployments_root(home) / "staging"
     launcher = str(Path(exasol_path).resolve())
 
     # When status is invoked with --deployment
     result = subprocess.run(
         [launcher, "status", "--json", "--deployment", "staging"],
-        env=_env_with_home(home),
+        env=env_with_home(home),
         capture_output=True,
         text=True,
         check=True,
@@ -174,15 +169,15 @@ def test_named_deployment_dir_wins_over_current_directory(
             str(current_dir),
             "--no-launcher-version-check",
         ],
-        env=_env_with_home(home),
+        env=env_with_home(home),
     )
-    named_dir = home / ".exasol" / "personal" / "deployments" / "staging"
+    named_dir = deployments_root(home) / "staging"
 
     # When status is invoked with --deployment from inside the current deployment
     result = subprocess.run(
         [launcher, "status", "--json", "--deployment", "staging"],
         cwd=current_dir,
-        env=_env_with_home(home),
+        env=env_with_home(home),
         capture_output=True,
         text=True,
         check=True,
@@ -211,7 +206,7 @@ def test_deployment_dir_and_deployment_are_mutually_exclusive_before_any_side_ef
             "--deployment",
             "staging",
         ],
-        env=_env_with_home(home),
+        env=env_with_home(home),
         capture_output=True,
         text=True,
         check=False,
@@ -222,7 +217,7 @@ def test_deployment_dir_and_deployment_are_mutually_exclusive_before_any_side_ef
     assert result.returncode != 0
     assert "deployment-dir" in result.stderr
     assert "were all set" in result.stderr
-    assert not (home / ".exasol").exists()
+    assert not deployments_root(home).exists()
 
 
 def test_deployment_shorthand_wins_over_current_directory(
@@ -243,15 +238,15 @@ def test_deployment_shorthand_wins_over_current_directory(
             str(current_dir),
             "--no-launcher-version-check",
         ],
-        env=_env_with_home(home),
+        env=env_with_home(home),
     )
-    named_dir = home / ".exasol" / "personal" / "deployments" / "staging"
+    named_dir = deployments_root(home) / "staging"
 
     # When status is invoked with -d from inside the current deployment directory
     result = subprocess.run(
         [launcher, "status", "--json", "-d", "staging"],
         cwd=current_dir,
-        env=_env_with_home(home),
+        env=env_with_home(home),
         capture_output=True,
         text=True,
         check=True,
@@ -273,7 +268,7 @@ def test_deployment_flag_rejects_invalid_characters(
     # When --deployment is passed a value with unsafe characters
     result = subprocess.run(
         [launcher, "status", "--deployment", "bad/name"],
-        env=_env_with_home(home),
+        env=env_with_home(home),
         capture_output=True,
         text=True,
         check=False,
@@ -282,7 +277,7 @@ def test_deployment_flag_rejects_invalid_characters(
     # Then the command fails and does not create anything under the deployments tree
     assert result.returncode != 0
     assert "invalid deployment name" in result.stderr
-    assert not (home / ".exasol").exists()
+    assert not deployments_root(home).exists()
 
 
 def test_status_reports_uninitialized_explicit_deployment_dir(
@@ -349,7 +344,7 @@ def test_init_creates_default_deployment_dir(exasol_path: str, tmp_path: Path) -
     cwd = tmp_path / "work"
     home.mkdir()
     cwd.mkdir()
-    default_dir = home / ".exasol" / "personal" / "deployments" / "default"
+    default_dir = deployments_root(home) / "default"
     infra_id = first_infrastructure_preset_id_or_skip(exasol_path)
     launcher = str(Path(exasol_path).resolve())
 
@@ -364,7 +359,7 @@ def test_init_creates_default_deployment_dir(exasol_path: str, tmp_path: Path) -
             "--no-launcher-version-check",
         ],
         cwd=cwd,
-        env=_env_with_home(home),
+        env=env_with_home(home),
         capture_output=True,
         text=True,
         check=True,
@@ -379,7 +374,7 @@ def test_init_creates_named_deployment_dir(exasol_path: str, tmp_path: Path) -> 
     # Given a --deployment flag and no recognized current deployment directory
     home = tmp_path / "home"
     home.mkdir()
-    named_dir = home / ".exasol" / "personal" / "deployments" / "staging"
+    named_dir = deployments_root(home) / "staging"
     infra_id = first_infrastructure_preset_id_or_skip(exasol_path)
     launcher = str(Path(exasol_path).resolve())
 
@@ -395,7 +390,7 @@ def test_init_creates_named_deployment_dir(exasol_path: str, tmp_path: Path) -> 
             "staging",
             "--no-launcher-version-check",
         ],
-        env=_env_with_home(home),
+        env=env_with_home(home),
         capture_output=True,
         text=True,
         check=True,
@@ -412,7 +407,7 @@ def test_init_refuses_different_preset_in_named_deployment_dir(
     # Given a named deployment initialized with one preset
     home = tmp_path / "home"
     home.mkdir()
-    named_dir = home / ".exasol" / "personal" / "deployments" / "staging"
+    named_dir = deployments_root(home) / "staging"
     first_preset, second_preset = _infrastructure_presets_or_skip(exasol_path, 2)
     launcher = str(Path(exasol_path).resolve())
     run_command(
@@ -424,7 +419,7 @@ def test_init_refuses_different_preset_in_named_deployment_dir(
             "staging",
             "--no-launcher-version-check",
         ],
-        env=_env_with_home(home),
+        env=env_with_home(home),
     )
 
     # When init is requested again with a different preset for the same name
@@ -437,7 +432,7 @@ def test_init_refuses_different_preset_in_named_deployment_dir(
             "staging",
             "--no-launcher-version-check",
         ],
-        env=_env_with_home(home),
+        env=env_with_home(home),
         capture_output=True,
         text=True,
         check=False,
@@ -459,14 +454,14 @@ def test_info_reports_uninitialized_resolved_default_dir(
     cwd = tmp_path / "work"
     home.mkdir()
     cwd.mkdir()
-    default_dir = home / ".exasol" / "personal" / "deployments" / "default"
+    default_dir = deployments_root(home) / "default"
     launcher = str(Path(exasol_path).resolve())
 
     # When info is invoked without an explicit deployment directory
     result = subprocess.run(
         [launcher, "info"],
         cwd=cwd,
-        env=_env_with_home(home),
+        env=env_with_home(home),
         capture_output=True,
         text=True,
         check=True,
@@ -486,14 +481,14 @@ def test_status_reports_resolved_default_dir(exasol_path: str, tmp_path: Path) -
     cwd = tmp_path / "work"
     home.mkdir()
     cwd.mkdir()
-    default_dir = home / ".exasol" / "personal" / "deployments" / "default"
+    default_dir = deployments_root(home) / "default"
 
     # When status runs outside any deployment directory
     command = [str(Path(exasol_path).resolve()), "status", "--json"]
     result = subprocess.run(
         command,
         cwd=cwd,
-        env=_env_with_home(home),
+        env=env_with_home(home),
         capture_output=True,
         text=True,
         check=True,
@@ -512,7 +507,7 @@ def test_init_without_flag_uses_default_dir(exasol_path: str, tmp_path: Path) ->
     cwd = tmp_path / "work"
     home.mkdir()
     cwd.mkdir()
-    default_dir = home / ".exasol" / "personal" / "deployments" / "default"
+    default_dir = deployments_root(home) / "default"
 
     # When init runs with no --deployment-dir
     command = [
@@ -524,7 +519,7 @@ def test_init_without_flag_uses_default_dir(exasol_path: str, tmp_path: Path) ->
     subprocess.run(
         command,
         cwd=cwd,
-        env=_env_with_home(home),
+        env=env_with_home(home),
         capture_output=True,
         text=True,
         check=True,

--- a/tests/tests/integration/test_deployments_list.py
+++ b/tests/tests/integration/test_deployments_list.py
@@ -2,20 +2,15 @@
 # SPDX-License-Identifier: MIT
 
 import json
-import os
 import subprocess
 from pathlib import Path
 
-from .helpers import first_infrastructure_preset_id_or_skip, run_command
-
-
-def _env_with_home(home: Path) -> dict[str, str]:
-    env = os.environ.copy()
-    env["HOME"] = str(home)
-    env["USERPROFILE"] = str(home)
-    env["HOMEDRIVE"] = ""
-    env["HOMEPATH"] = ""
-    return env
+from .helpers import (
+    deployments_root,
+    env_with_home,
+    first_infrastructure_preset_id_or_skip,
+    run_command,
+)
 
 
 def test_deployments_list_json_is_empty_array_when_none_exist(
@@ -29,7 +24,7 @@ def test_deployments_list_json_is_empty_array_when_none_exist(
     # When deployments list is invoked
     result = subprocess.run(
         [launcher, "deployments", "list", "--json"],
-        env=_env_with_home(home),
+        env=env_with_home(home),
         capture_output=True,
         text=True,
         check=True,
@@ -56,14 +51,14 @@ def test_deployments_list_reports_named_deployments(
             "staging",
             "--no-launcher-version-check",
         ],
-        env=_env_with_home(home),
+        env=env_with_home(home),
     )
-    (home / ".exasol" / "personal" / "deployments" / "empty-named").mkdir(parents=True)
+    (deployments_root(home) / "empty-named").mkdir(parents=True)
 
     # When deployments list is invoked with --json
     result = subprocess.run(
         [launcher, "deployments", "list", "--json"],
-        env=_env_with_home(home),
+        env=env_with_home(home),
         capture_output=True,
         text=True,
         check=True,
@@ -103,7 +98,7 @@ def test_deployments_list_reports_same_status_as_status_command(
     home.mkdir()
     infra_id = first_infrastructure_preset_id_or_skip(exasol_path)
     launcher = str(Path(exasol_path).resolve())
-    named_dir = home / ".exasol" / "personal" / "deployments" / "staging"
+    named_dir = deployments_root(home) / "staging"
     run_command(
         [
             launcher,
@@ -113,12 +108,12 @@ def test_deployments_list_reports_same_status_as_status_command(
             "staging",
             "--no-launcher-version-check",
         ],
-        env=_env_with_home(home),
+        env=env_with_home(home),
     )
     _set_workflow_state(named_dir, {"running": {}})
     status_result = subprocess.run(
         [launcher, "status", "--deployment", "staging", "--json"],
-        env=_env_with_home(home),
+        env=env_with_home(home),
         capture_output=True,
         text=True,
         check=True,
@@ -127,7 +122,7 @@ def test_deployments_list_reports_same_status_as_status_command(
     # When deployments list is invoked with --json
     result = subprocess.run(
         [launcher, "deployments", "list", "--json"],
-        env=_env_with_home(home),
+        env=env_with_home(home),
         capture_output=True,
         text=True,
         check=True,
@@ -153,14 +148,14 @@ def test_deployments_list_does_not_accept_deployment_dir_or_deployment(
     # When deployments list is invoked with --deployment-dir or --deployment
     dir_result = subprocess.run(
         [launcher, "deployments", "list", "--deployment-dir", str(tmp_path)],
-        env=_env_with_home(home),
+        env=env_with_home(home),
         capture_output=True,
         text=True,
         check=False,
     )
     deployment_result = subprocess.run(
         [launcher, "deployments", "list", "--deployment", "staging"],
-        env=_env_with_home(home),
+        env=env_with_home(home),
         capture_output=True,
         text=True,
         check=False,

--- a/user-docs/content/manage-deployments.md
+++ b/user-docs/content/manage-deployments.md
@@ -5,8 +5,15 @@ directory. Keep this directory until you have destroyed the deployment resources
 
 ## Select a deployment
 
-The default deployment is stored in `~/.exasol/personal/deployments/default`. When you run a command
-from an existing deployment directory, the launcher selects that deployment automatically.
+The default deployment is stored under the launcher's managed deployments directory, in a
+platform-specific location:
+
+- **Linux:** `~/.exasol/launcher/deployments/default`
+- **macOS:** `~/Library/Application Support/exasol/launcher/deployments/default`
+- **Windows:** `%APPDATA%\exasol\launcher\deployments\default`
+
+When you run a command from an existing deployment directory, the launcher selects that deployment
+automatically.
 
 To maintain multiple deployments, give each one a case-sensitive name with `--deployment` or `-d`:
 
@@ -17,8 +24,9 @@ exasol status -d demo
 exasol connect -d demo -c "SELECT 1"
 ```
 
-Named deployments live below `~/.exasol/personal/deployments/<name>`. Names that differ only by case
-may collide on the case-insensitive filesystems commonly used by macOS and Windows.
+Named deployments live in that same managed deployments directory, under `<name>`. Names that
+differ only by case may collide on the case-insensitive filesystems commonly used by macOS and
+Windows.
 
 Alternatively, select an arbitrary path with `--deployment-dir <path>`. You cannot combine
 `--deployment-dir` and `--deployment`.
@@ -32,8 +40,8 @@ exasol deployments list
 Example output:
 
 ```text
-default status=database_ready preset=local/ubuntu path=/Users/me/.exasol/personal/deployments/default
-staging status=stopped preset=aws/ubuntu path=/Users/me/.exasol/personal/deployments/staging
+default status=database_ready preset=local/ubuntu path=/Users/me/Library/Application Support/exasol/launcher/deployments/default
+staging status=stopped preset=aws/ubuntu path=/Users/me/Library/Application Support/exasol/launcher/deployments/staging
 ```
 
 The list does not include deployments selected through an arbitrary `--deployment-dir` path.


### PR DESCRIPTION
## Description

Launcher-managed files share one flat, Linux-flavored root (`~/.exasol/personal`) on every platform. SQL history is written straight into the OS cache directory, and the resource cache's configuration file sits in the deployments root.

### Current locations

| Purpose | Linux | macOS | Windows |
| --- | --- | --- | --- |
| Managed deployments | `~/.exasol/personal/deployments` | `~/.exasol/personal/deployments` | `%USERPROFILE%\.exasol\personal\deployments` |
| SQL history | `${XDG_CACHE_HOME:-~/.cache}/exasol_history` | `~/Library/Caches/exasol_history` | `%LOCALAPPDATA%\exasol_history` |
| Resource cache configuration | `~/.exasol/personal/runtime-artifacts.yaml` | `~/.exasol/personal/runtime-artifacts.yaml` | `%USERPROFILE%\.exasol\personal\runtime-artifacts.yaml` |
| Resource cache | `${XDG_CACHE_HOME:-~/.cache}/.exasol/personal/runtime-artifacts` | `~/Library/Caches/.exasol/personal/runtime-artifacts` | `%LOCALAPPDATA%\.exasol\personal\runtime-artifacts` |

### New locations

This introduces one `exasol/launcher` namespace per platform, split by lifecycle: durable data (deployments, SQL history) in a platform-conventional durable location, configuration in the platform's configuration directory, and the disposable resource cache in the platform's cache directory.

| Purpose | Linux | macOS | Windows |
| --- | --- | --- | --- |
| Managed deployments | `~/.exasol/launcher/deployments` | `~/Library/Application Support/exasol/launcher/deployments` | `%APPDATA%\exasol\launcher\deployments` |
| SQL history | `~/.exasol/launcher/history/exasol_history` | `~/Library/Application Support/exasol/launcher/history/exasol_history` | `%APPDATA%\exasol\launcher\history\exasol_history` |
| Resource cache configuration | `${XDG_CONFIG_HOME:-~/.config}/exasol/launcher/resources.yaml` | `~/Library/Application Support/exasol/launcher/resources.yaml` | `%APPDATA%\exasol\launcher\resources.yaml` |
| Resource cache | `${XDG_CACHE_HOME:-~/.cache}/exasol/launcher/resources` | `~/Library/Caches/exasol/launcher/resources` | `%LOCALAPPDATA%\exasol\launcher\resources` |

Existing deployments, SQL history, and the cache retention setting migrate automatically on the first command after upgrading.

## Related Issue

[SPOT-32510](https://exasol.atlassian.net/browse/SPOT-32510)

## Type of Change

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- `internal/launcherpaths` resolves one path per purpose instead of a single flat root.
- The cache configuration becomes `resources.yaml` in the platform configuration directory.
- The cache directory leaf is renamed from `runtime-artifacts` to `resources`.
- `internal/launchermigration` provides a resumable move: stage, mark complete, atomic rename, remove source.
- CLI startup migrates deployments, SQL history, and the cache configuration once, before command dispatch, and reports each change on standard error.
- A deployment name at both roots fails with both paths named, and the remaining deployments still migrate.
- The legacy resource cache is deleted, since it is rebuilt on demand.
- Integration tests resolve launcher paths per platform.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

Setup, a temporary `HOME` seeded with legacy state:

| Path | Content |
| --- | --- |
| `.exasol/personal/deployments/prod/marker.txt` | `state` |
| `.exasol/personal/runtime-artifacts.yaml` | `retention_days: 45` |
| `.cache/exasol_history` | `SELECT 1;` |

Command: `exasol deployments list`, run twice.

First run output:

```
Migrated cache configuration to $HOME/.config/exasol/launcher/resources.yaml
Migrated SQL history to $HOME/.exasol/launcher/history/exasol_history
Migrated managed deployments to $HOME/.exasol/launcher/deployments
prod status=not_initialized path=$HOME/.exasol/launcher/deployments/prod
```

Resulting state:

| Path | Content |
| --- | --- |
| `.config/exasol/launcher/resources.yaml` | `retention_days: 45` |
| `.config/exasol/launcher/.migrated` | marker present |
| `.exasol/launcher/history/exasol_history` | `SELECT 1;` |
| `.exasol/launcher/deployments/prod/marker.txt` | `state` |

No files remained under `.exasol/personal` or at `.cache/exasol_history`. The second run emitted no migration messages and the same deployment listing.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable) - `user-docs/` for user-facing changes, `doc/` for contributor-facing changes
- [x] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format


[SPOT-32510]: https://exasol.atlassian.net/browse/SPOT-32510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
