### PR TITLE
fix: UDF doesn't work on linux with selinux enabled SPOT-32585

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ Notable user-facing changes to Exasol Personal are documented here.
 
 ### Fixed
 
+- Local UDFs and Virtual Schemas now work on Linux hosts with SELinux enforcing.
+
 - `exasol slc install` and `exasol slc update` now accept the flavors shown by
   `exasol slc list`, in addition to aliases. The list displays aliases first and recommends them
   as the stable identifiers for commands.

--- a/internal/localinstall/podman_install.go
+++ b/internal/localinstall/podman_install.go
@@ -30,6 +30,7 @@ const (
 	nanoShmSize               = "512mb"
 	nanoPIDsLimit             = "-1"
 	nanoSecurityOpt           = "unmask=ALL"
+	nanoSELinuxSecurityOpt    = "label=disable"
 	nanoRestartPolicy         = "always"
 	// nanoDataMountPath is where Nano expects its persistent data inside the
 	// container; the target adds SELinux relabelling for the bind mount.
@@ -207,6 +208,7 @@ func (install *PodmanInstall) Start(
 		"--shm-size=" + nanoShmSize,
 		"--pids-limit=" + nanoPIDsLimit,
 		"--security-opt", nanoSecurityOpt,
+		"--security-opt", nanoSELinuxSecurityOpt,
 		"--restart", nanoRestartPolicy,
 		"-p", podmanDBPortMapping(startConfig),
 		"-v", startConfig.DataDir + ":" + nanoDataMountTarget,

--- a/internal/localinstall/podman_install.go
+++ b/internal/localinstall/podman_install.go
@@ -29,9 +29,11 @@ const (
 	nanoInternalDBPort        = 8563
 	nanoShmSize               = "512mb"
 	nanoPIDsLimit             = "-1"
-	nanoSecurityOpt           = "unmask=ALL"
-	nanoSELinuxSecurityOpt    = "label=disable"
-	nanoRestartPolicy         = "always"
+	// `unmask=ALL` and `label=disable` are required for UDFs to work, which need
+	// nested namespaces (at least user, mount and pid).
+	nanoSecurityOpt        = "unmask=ALL"
+	nanoSELinuxSecurityOpt = "label=disable"
+	nanoRestartPolicy      = "always"
 	// nanoDataMountPath is where Nano expects its persistent data inside the
 	// container; the target adds SELinux relabelling for the bind mount.
 	nanoDataMountPath        = "/exa"

--- a/internal/localinstall/podman_install_test.go
+++ b/internal/localinstall/podman_install_test.go
@@ -50,6 +50,7 @@ func TestPodmanInstallStart_StartsFreshPersistentDatabase(t *testing.T) {
 		"<sync>",
 		"<podman><run><-d><--replace><--name><" + testContainerName + ">" +
 			"<--shm-size=512mb><--pids-limit=-1><--security-opt><unmask=ALL>" +
+			"<--security-opt><label=disable>" +
 			"<--restart><always><-p><127.0.0.1:28563:8563>" +
 			"<-v><" + startConfig.DataDir + ":/exa:Z>" +
 			"<" + testLoadedImage + "><init><params=maxConnectionsLicenseLimit=20>" +

--- a/openspec/changes/archive/2026-09-09-support-local-udfs-with-selinux/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-09-support-local-udfs-with-selinux/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-09

--- a/openspec/changes/archive/2026-09-09-support-local-udfs-with-selinux/design.md
+++ b/openspec/changes/archive/2026-09-09-support-local-udfs-with-selinux/design.md
@@ -1,0 +1,33 @@
+## Context
+
+The local installer starts Nano through one shared Podman command for Linux hosts and VM-backed platforms. That command currently uses `unmask=ALL`, but Nano remains assigned an SELinux container process label on enforcing Linux hosts. Nano can start and accept SQL connections, while its namespaced UDF launcher exits immediately and the database reports only `VM crashed`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Apply the narrowest container-scoped SELinux compatibility setting proven to allow Nano UDF subprocesses to run.
+- Keep the shared Podman launch behavior portable across Linux and VM-backed runtimes.
+
+**Non-Goals:**
+
+- Changing host-wide SELinux policy or documenting permissive mode as a prerequisite.
+- Granting the Nano container unrestricted privileged access.
+- Changing the PostgreSQL Virtual Schema deployment test or its sidecar networking model.
+
+## Decisions
+
+### Add `label=disable` to the shared Nano Podman command
+
+The installer will pass `--security-opt label=disable` alongside the existing `--security-opt unmask=ALL`. Disabling labeling only for Nano is sufficient in the reproduced enforcing-SELinux environment and leaves host-wide enforcement active. Keeping the option in the shared Podman command avoids host capability detection and gives all supported Podman environments one deterministic command; runtimes without active SELinux labeling accept the option without changing their effective isolation.
+
+The alternatives are broader or less reliable. Running Nano with `--privileged` grants capabilities unrelated to the failure. Detecting SELinux before constructing the command introduces platform branching and can misclassify remote or VM-backed Podman engines. Requiring permissive host SELinux weakens the host globally and conflicts with the local deployment experience.
+
+## Risks / Trade-offs
+
+- [Disabling Nano's SELinux process label reduces one layer of container isolation] → Scope the setting to the Nano container, preserve the existing namespace and Podman security configuration, and avoid broader privileged mode.
+- [An unconditional security option could behave differently in a future Podman implementation] → Cover exact command construction in unit tests and exercise the existing Linux and macOS deployment jobs.
+
+## Migration Plan
+
+The change affects newly started Nano containers only; there is no persistent-data migration. Existing deployments receive the setting on their next container recreation. Rollback consists of removing the additional Podman security option; deployment data remains unchanged.

--- a/openspec/changes/archive/2026-09-09-support-local-udfs-with-selinux/proposal.md
+++ b/openspec/changes/archive/2026-09-09-support-local-udfs-with-selinux/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+On Linux hosts with enforcing SELinux, the local Nano container's UDF subprocess is killed before a Java adapter can start, so Virtual Schema creation fails with an opaque `VM crashed` error. Ubuntu CI does not expose this host-dependent failure because its host does not enforce SELinux.
+
+## What Changes
+
+- Make local Podman deployments support UDF and Virtual Schema execution on SELinux-enforcing hosts without requiring users to weaken host-wide SELinux enforcement.
+- Preserve the existing Nano sandbox configuration while disabling SELinux process labeling for that container only.
+- Document the repaired Linux behavior in the changelog.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `linux-host-podman-install`: A local Nano deployment supports UDF execution when the Linux host enforces SELinux.
+
+## Impact
+
+The shared local Podman Nano launch command and its unit tests will change. The existing PostgreSQL Virtual Schema deployment test will verify the repaired behavior. There are no public CLI, configuration, storage, or network contract changes and no new dependencies.

--- a/openspec/changes/archive/2026-09-09-support-local-udfs-with-selinux/specs/linux-host-podman-install/spec.md
+++ b/openspec/changes/archive/2026-09-09-support-local-udfs-with-selinux/specs/linux-host-podman-install/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Linux host runtime supports Nano UDF execution under SELinux
+The system SHALL start Nano with container-scoped security settings that allow UDF subprocesses to execute when the Linux host enforces SELinux, without requiring host-wide SELinux enforcement to be disabled.
+
+#### Scenario: Execute a UDF with enforcing SELinux
+- **WHEN** a local deployment runs on a Linux host with SELinux enforcing and invokes a configured script language container
+- **THEN** the UDF subprocess starts and can complete its database operation
+
+#### Scenario: Start Nano on a host without SELinux enforcement
+- **WHEN** a local deployment runs on a host where SELinux labeling is unavailable or not enforced
+- **THEN** Nano starts with the same container-scoped security configuration and database behavior remains available

--- a/openspec/changes/archive/2026-09-09-support-local-udfs-with-selinux/tasks.md
+++ b/openspec/changes/archive/2026-09-09-support-local-udfs-with-selinux/tasks.md
@@ -1,0 +1,11 @@
+## 1. Nano SELinux Compatibility
+
+- [x] 1.1 Add the container-scoped `label=disable` security option to the shared Nano Podman launch command and verify the existing command-construction unit test exercises it.
+- [x] 1.2 Update the Podman installer unit-test expectation for both security options and verify `go test -tags=containers_image_openpgp ./internal/localinstall` passes.
+
+## 2. Integration and Release Note
+
+- [x] 2.1 Add a Fixed changelog entry describing restored local UDF and Virtual Schema execution on SELinux-enforcing Linux hosts and verify the changelog format check passes.
+- [x] 2.2 Run the unchanged PostgreSQL Virtual Schema deployment test on an enforcing-SELinux host and verify both the pre-refresh and post-refresh rows are returned while host SELinux remains enforcing.
+- [x] 2.3 Run `task fmt`, `task lint`, and `task all`, and verify the repository's complete local checks pass.
+- [ ] 2.4 Re-run the manual Linux deployment workflow and verify the unchanged PostgreSQL Virtual Schema test remains green on Ubuntu.

--- a/openspec/specs/linux-host-podman-install/spec.md
+++ b/openspec/specs/linux-host-podman-install/spec.md
@@ -113,6 +113,17 @@ The system SHALL reuse available SLC images, pull missing official images, impor
 - **WHEN** configured SLC materialization completes
 - **THEN** the complete new report atomically replaces the previous report without exposing a partial report
 
+### Requirement: Linux host runtime supports Nano UDF execution under SELinux
+The system SHALL start Nano with container-scoped security settings that allow UDF subprocesses to execute when the Linux host enforces SELinux, without requiring host-wide SELinux enforcement to be disabled.
+
+#### Scenario: Execute a UDF with enforcing SELinux
+- **WHEN** a local deployment runs on a Linux host with SELinux enforcing and invokes a configured script language container
+- **THEN** the UDF subprocess starts and can complete its database operation
+
+#### Scenario: Start Nano on a host without SELinux enforcement
+- **WHEN** a local deployment runs on a host where SELinux labeling is unavailable or not enforced
+- **THEN** Nano starts with the same container-scoped security configuration and database behavior remains available
+
 ### Requirement: Unreferenced managed SLC images are pruned safely
 The system SHALL prune only unreferenced tagged images from the exact official SLC repository and labeled custom imports, and SHALL treat equivalent registry prefixes and implicit `latest` tags as the same reference.
 


### PR DESCRIPTION
## Description

Fixes UDF on Linux with selinux enabled (e.g. our Fedora laptops).
Confirmed with `tests/tests/deployment/test_virtual_schema.py`

## Related Issue

- SPOT-32585

Fixes #

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Added a `podman run` option that disables some isolation which is needed for nested namespaces to work (at least for our implementation of UDFs

## Testing

<!-- Describe how you tested your changes -->

- [x] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

<!-- Describe your testing approach -->

## Checklist

<!-- Mark completed items with an "x" -->

- [ ] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [ ] Updated documentation (if applicable) - `user-docs/` for user-facing changes, `doc/` for contributor-facing changes
- [x] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [ ] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

## Additional Notes

<!-- Any additional information, screenshots, or context -->
