### PR TITLE
fix(slc): reject duplicate custom package aliases - SPOT-32593

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@ Notable user-facing changes to Exasol Personal are documented here.
 
 - Local UDFs and Virtual Schemas now work on Linux hosts with SELinux enforcing.
 
+- Custom SLC installation now rejects duplicate aliases declared by another installed custom SLC
+  before the database is restarted. Updating an existing custom SLC alias remains supported,
+  including replacing it with a different package.
+
 - `exasol slc install` and `exasol slc update` now accept the flavors shown by
   `exasol slc list`, in addition to aliases. The list displays aliases first and recommends them
   as the stable identifiers for commands.

--- a/internal/config/exasol_launcher_state.go
+++ b/internal/config/exasol_launcher_state.go
@@ -103,15 +103,16 @@ type InstalledSLC struct {
 }
 
 type InstalledCustomSLC struct {
-	Alias        string `json:"alias"`
-	Language     string `json:"language"`
-	Image        string `json:"image"`
-	Target       string `json:"target"`
-	Package      string `json:"package"`
-	Sha256       string `json:"sha256"`
-	Source       string `json:"source"`
-	Activated    bool   `json:"activated"`
-	DisplacedURI string `json:"displacedUri,omitempty"`
+	Alias          string   `json:"alias"`
+	PackageAliases []string `json:"packageAliases,omitempty"`
+	Language       string   `json:"language"`
+	Image          string   `json:"image"`
+	Target         string   `json:"target"`
+	Package        string   `json:"package"`
+	Sha256         string   `json:"sha256"`
+	Source         string   `json:"source"`
+	Activated      bool     `json:"activated"`
+	DisplacedURI   string   `json:"displacedUri,omitempty"`
 }
 
 // HasExasolPersonalStateFile reports whether the deployment state file exists.

--- a/internal/customslc/archive.go
+++ b/internal/customslc/archive.go
@@ -8,10 +8,12 @@ import (
 	"bufio"
 	"bytes"
 	"compress/gzip"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"path"
+	"slices"
 )
 
 var gzipMagic = []byte{0x1f, 0x8b}
@@ -44,38 +46,99 @@ func openTar(reader io.Reader) (*tar.Reader, func() error, error) {
 	return tar.NewReader(gzipReader), finish, nil
 }
 
-func ValidateArchive(reader io.Reader) error {
+type languageDefinitions struct {
+	//nolint:tagliatelle // Metadata key is defined by the SLC archive format.
+	LanguageDefinitions []languageDefinition `json:"language_definitions"`
+}
+
+type languageDefinition struct {
+	Aliases []string `json:"aliases"`
+}
+
+// ReadAliases validates an SLC archive and returns the database aliases declared by it.
+// The archive is streamed and is not extracted to disk.
+func ReadAliases(reader io.Reader) ([]string, error) {
 	tarReader, finish, err := openTar(reader)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	clientFound := false
+	metadataFound := false
+	var aliases []string
 	for {
 		header, err := tarReader.Next()
 		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if isClientExecutable(header) {
 			clientFound = true
 		}
+		if path.Clean(header.Name) == "build_info/language_definitions.json" {
+			if metadataFound {
+				return nil, errors.New(
+					"container archive contains duplicate " +
+						"build_info/language_definitions.json",
+				)
+			}
+			metadataFound = true
+			parsed, err := readLanguageAliases(tarReader)
+			if err != nil {
+				return nil, err
+			}
+			aliases = append(aliases, parsed...)
+		}
 	}
 
 	if err := finish(); err != nil {
-		return fmt.Errorf("container archive is corrupt: %w", err)
+		return nil, fmt.Errorf("container archive is corrupt: %w", err)
 	}
 	if !clientFound {
-		return fmt.Errorf(
+		return nil, fmt.Errorf(
 			"%s was not found as an executable in the container; Exasol Personal supports "+
 				"standard SLCs built with exaslct",
 			clientRelPath,
 		)
 	}
+	if !metadataFound || len(aliases) == 0 {
+		return nil, errors.New("build_info/language_definitions.json contains no language aliases")
+	}
 
-	return nil
+	return aliases, nil
+}
+
+func readLanguageAliases(reader io.Reader) ([]string, error) {
+	var definitions languageDefinitions
+	if err := json.NewDecoder(reader).Decode(&definitions); err != nil {
+		return nil, fmt.Errorf("failed to parse language definitions: %w", err)
+	}
+
+	var aliases []string
+	for _, definition := range definitions.LanguageDefinitions {
+		for _, alias := range definition.Aliases {
+			normalized := NormalizeAlias(alias)
+			if normalized == "" {
+				return nil, errors.New("language definitions contain an empty alias")
+			}
+			if slices.Contains(aliases, normalized) {
+				return nil, fmt.Errorf(
+					"language definitions contain duplicate alias %q", normalized,
+				)
+			}
+			aliases = append(aliases, normalized)
+		}
+	}
+
+	return aliases, nil
+}
+
+func ValidateArchive(reader io.Reader) error {
+	_, err := ReadAliases(reader)
+
+	return err
 }
 
 func isClientExecutable(header *tar.Header) bool {

--- a/internal/customslc/archive_test.go
+++ b/internal/customslc/archive_test.go
@@ -17,6 +17,11 @@ func TestValidateArchiveAcceptsValidSLC(t *testing.T) {
 	// Given
 	archive := gzipBytes(t, buildTar(t, []archiveEntry{
 		{name: "exaudf/exaudfclient", body: "#!/bin/sh\n", mode: 0o755},
+		{
+			name: "build_info/language_definitions.json",
+			body: `{"language_definitions":[{"aliases":["PYTHON3"]}]}`,
+			mode: 0o644,
+		},
 		{name: "python/runtime", body: "x", mode: 0o644},
 	}))
 
@@ -34,6 +39,11 @@ func TestValidateArchiveAcceptsUncompressedTar(t *testing.T) {
 	// Given
 	archive := buildTar(t, []archiveEntry{
 		{name: "exaudf/exaudfclient", body: "#!/bin/sh\n", mode: 0o755},
+		{
+			name: "build_info/language_definitions.json",
+			body: `{"language_definitions":[{"aliases":["PYTHON3"]}]}`,
+			mode: 0o644,
+		},
 	})
 
 	// When
@@ -41,6 +51,70 @@ func TestValidateArchiveAcceptsUncompressedTar(t *testing.T) {
 	// Then
 	if err != nil {
 		t.Fatalf("expected an uncompressed tar to pass, got %v", err)
+	}
+}
+
+func TestReadAliasesReturnsAllNormalizedAliases(t *testing.T) {
+	t.Parallel()
+
+	archive := gzipBytes(t, buildTar(t, []archiveEntry{
+		{name: "exaudf/exaudfclient", body: "#!/bin/sh\n", mode: 0o755},
+		{
+			name: "build_info/language_definitions.json",
+			body: `{"language_definitions":[{"aliases":["rust", " RUST2 "]},` +
+				`{"aliases":["Rust3"]}]}`,
+			mode: 0o644,
+		},
+	}))
+
+	aliases, err := ReadAliases(bytes.NewReader(archive))
+	if err != nil {
+		t.Fatalf("expected aliases to be read, got %v", err)
+	}
+	if strings.Join(aliases, ",") != "RUST,RUST2,RUST3" {
+		t.Fatalf("unexpected aliases: %v", aliases)
+	}
+}
+
+func TestReadAliasesRejectsMalformedOrMissingMetadata(t *testing.T) {
+	t.Parallel()
+
+	for _, body := range []string{"not json", `{"language_definitions":[]}`} {
+		archive := gzipBytes(t, buildTar(t, []archiveEntry{
+			{name: "exaudf/exaudfclient", body: "#!/bin/sh\n", mode: 0o755},
+			{name: "build_info/language_definitions.json", body: body, mode: 0o644},
+		}))
+		if _, err := ReadAliases(bytes.NewReader(archive)); err == nil {
+			t.Fatalf("expected metadata %q to be rejected", body)
+		}
+	}
+}
+
+func TestReadAliasesRejectsDuplicateMetadata(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	archive := gzipBytes(t, buildTar(t, []archiveEntry{
+		{name: "exaudf/exaudfclient", body: "#!/bin/sh\n", mode: 0o755},
+		{
+			name: "build_info/language_definitions.json",
+			body: `{"language_definitions":[{"aliases":["PYTHON3"]}]}`,
+			mode: 0o644,
+		},
+		{
+			name: "build_info/language_definitions.json",
+			body: `{"language_definitions":[{"aliases":["RUST"]}]}`,
+			mode: 0o644,
+		},
+	}))
+
+	// When
+	_, err := ReadAliases(bytes.NewReader(archive))
+
+	// Then
+	duplicateMetadata := "duplicate build_info/language_definitions.json"
+	if err == nil || !strings.Contains(err.Error(), duplicateMetadata) {
+		t.Fatalf("expected duplicate metadata to be rejected, got %v", err)
 	}
 }
 

--- a/internal/deploy/custom_slc.go
+++ b/internal/deploy/custom_slc.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	neturl "net/url"
 	"os"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"slices"
@@ -177,8 +178,17 @@ func stageCustomSLCInstall(
 			Outcome:          SLCApplyNone,
 		}, nil, nil
 	}
+	aliases, err := readCustomSLCAliases(tarball.path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid custom SLC container: %w", err)
+	}
+	if err := checkCustomSLCInternalAliasConflicts(
+		deployment, state, aliases, idx, "install", request.alias,
+	); err != nil {
+		return nil, nil, err
+	}
 
-	entry, err := recordCustomSLC(deployment, state, request, tarball)
+	entry, err := recordCustomSLC(deployment, state, request, tarball, aliases)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -302,9 +312,18 @@ func stageCustomSLCUpdate(
 			Outcome:   SLCApplyNone,
 		}, nil, nil
 	}
+	aliases, err := readCustomSLCAliases(tarball.path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid custom SLC container: %w", err)
+	}
+	if err := checkCustomSLCInternalAliasConflicts(
+		deployment, state, aliases, idx, "update", alias,
+	); err != nil {
+		return nil, nil, err
+	}
 
 	request := customSLCRequest{alias: alias, language: language, source: source}
-	entry, err := recordCustomSLC(deployment, state, request, tarball)
+	entry, err := recordCustomSLC(deployment, state, request, tarball, aliases)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -333,6 +352,7 @@ func recordCustomSLC(
 	state *config.ExasolPersonalState,
 	request customSLCRequest,
 	tarball acquiredTarball,
+	aliases []string,
 ) (config.InstalledCustomSLC, error) {
 	file, err := os.Open(
 		tarball.path,
@@ -342,22 +362,20 @@ func recordCustomSLC(
 	}
 	defer file.Close()
 
-	if err := customslc.ValidateArchive(file); err != nil {
-		return config.InstalledCustomSLC{}, fmt.Errorf("invalid custom SLC container: %w", err)
-	}
 	if _, err := file.Seek(0, io.SeekStart); err != nil {
 		return config.InstalledCustomSLC{}, err
 	}
 
 	entry := config.InstalledCustomSLC{
-		Alias:        request.alias,
-		Language:     string(request.language),
-		Image:        customSLCImage(request.alias, tarball.sha256),
-		Target:       customSLCTarget(request.alias),
-		Package:      customSLCPackageName(request.alias, tarball.sha256),
-		Sha256:       tarball.sha256,
-		Source:       request.source,
-		DisplacedURI: carriedDisplacedURI(state.InstalledCustomSLCs, request.alias),
+		Alias:          request.alias,
+		PackageAliases: aliases,
+		Language:       string(request.language),
+		Image:          customSLCImage(request.alias, tarball.sha256),
+		Target:         customSLCTarget(request.alias),
+		Package:        customSLCPackageName(request.alias, tarball.sha256),
+		Sha256:         tarball.sha256,
+		Source:         request.source,
+		DisplacedURI:   carriedDisplacedURI(state.InstalledCustomSLCs, request.alias),
 	}
 
 	if err := placeCustomSLCPackage(deployment, entry.Package, tarball, file); err != nil {
@@ -380,6 +398,66 @@ func recordCustomSLC(
 	}
 
 	return entry, nil
+}
+
+func readCustomSLCAliases(packagePath string) ([]string, error) {
+	file, err := os.Open(packagePath) //nolint:gosec // path is launcher-owned
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	return customslc.ReadAliases(file)
+}
+
+func checkCustomSLCInternalAliasConflicts(
+	deployment config.DeploymentDir,
+	state *config.ExasolPersonalState,
+	candidate []string,
+	excludeCustomIndex int,
+	operation string,
+	targetAlias string,
+) error {
+	for _, alias := range candidate {
+		for idx, installed := range state.InstalledCustomSLCs {
+			if idx == excludeCustomIndex {
+				continue
+			}
+			aliases, err := installedCustomSLCAliases(deployment, installed)
+			if err != nil {
+				return fmt.Errorf(
+					"cannot inspect installed custom SLC %q: %w", installed.Alias, err,
+				)
+			}
+			for _, declared := range aliases {
+				if customslc.NormalizeAlias(alias) == customslc.NormalizeAlias(declared) {
+					return fmt.Errorf(
+						"cannot %s custom SLC %q: an alias defined in this package, %q, is "+
+							"already provided by installed custom SLC %q; remove %q before "+
+							"proceeding, or use a package with different aliases",
+						operation,
+						targetAlias,
+						customslc.NormalizeAlias(alias),
+						installed.Alias,
+						installed.Alias,
+					)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func installedCustomSLCAliases(
+	deployment config.DeploymentDir,
+	installed config.InstalledCustomSLC,
+) ([]string, error) {
+	if len(installed.PackageAliases) > 0 {
+		return installed.PackageAliases, nil
+	}
+
+	return readCustomSLCAliases(filepath.Join(customSLCStagingDir(deployment), installed.Package))
 }
 
 func applyStagedCustomSLC(
@@ -1012,17 +1090,47 @@ func acquireCustomTarball(
 	}
 
 	slog.Info("reading the custom script language container", "file", source)
-	sha, err := hashFile(source)
+	tmp, err := newCustomSLCStagingFile(deployment)
 	if err != nil {
 		return acquiredTarball{}, err
 	}
+	tempPath := tmp.Name()
+	remove := func() { _ = os.Remove(tempPath) }
+	removeOnError := true
+	defer func() {
+		if removeOnError {
+			remove()
+		}
+	}()
+
+	input, err := os.Open(source) //nolint:gosec // path is user-supplied by design (--source)
+	if err != nil {
+		_ = tmp.Close()
+
+		return acquiredTarball{}, err
+	}
+	hasher := sha256.New()
+	if _, err := io.Copy(tmp, io.TeeReader(input, hasher)); err != nil {
+		_ = input.Close()
+		_ = tmp.Close()
+
+		return acquiredTarball{}, err
+	}
+	if err := input.Close(); err != nil {
+		_ = tmp.Close()
+
+		return acquiredTarball{}, err
+	}
+	if err := tmp.Close(); err != nil {
+		return acquiredTarball{}, err
+	}
+	removeOnError = false
 
 	return acquiredTarball{
-		path:   source,
-		sha256: sha,
-		cleanup: func() {
-			// A user-supplied file is not ours to delete.
-		},
+		path:    tempPath,
+		sha256:  hex.EncodeToString(hasher.Sum(nil)),
+		staged:  true,
+		cleanup: remove,
 	}, nil
 }
 

--- a/internal/deploy/custom_slc_test.go
+++ b/internal/deploy/custom_slc_test.go
@@ -150,6 +150,56 @@ func TestCheckOfficialAliasNotHeldByCustom(t *testing.T) {
 	}
 }
 
+func TestCheckCustomSLCInternalAliasConflicts(t *testing.T) {
+	t.Parallel()
+
+	// Given
+	state := &config.ExasolPersonalState{
+		InstalledSLCs: []config.InstalledSLC{{Flavor: "python-3.12", Aliases: []string{"PYTHON3"}}},
+		InstalledCustomSLCs: []config.InstalledCustomSLC{
+			{Alias: "FIRST", PackageAliases: []string{"JAVA"}},
+			{Alias: "OTHER", PackageAliases: []string{"RUST"}},
+		},
+	}
+	deployment := config.NewDeploymentDir(t.TempDir())
+
+	// When / Then
+	err := checkCustomSLCInternalAliasConflicts(
+		deployment, state, []string{"rust"}, -1, "install", "NEW",
+	)
+	if err == nil {
+		t.Fatal("expected conflict with another custom SLC")
+	}
+	want := `cannot install custom SLC "NEW": an alias defined in this package, "RUST"`
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("unexpected conflict message %q", err)
+	}
+	if err := checkCustomSLCInternalAliasConflicts(
+		deployment, state, []string{"rust"}, 1, "update", "OTHER",
+	); err != nil {
+		t.Fatalf("expected update to retain its own alias, got %v", err)
+	}
+	err = checkCustomSLCInternalAliasConflicts(
+		deployment, state, []string{"rust"}, 0, "update", "FIRST",
+	)
+	if err == nil {
+		t.Fatal("expected update conflict with another custom SLC")
+	}
+	if want := `cannot update custom SLC "FIRST"`; !strings.Contains(err.Error(), want) {
+		t.Fatalf("unexpected update conflict message %q", err)
+	}
+	if err := checkCustomSLCInternalAliasConflicts(
+		deployment, state, []string{"rust"}, 1, "install", "OTHER",
+	); err != nil {
+		t.Fatalf("expected install replacement to retain its own alias, got %v", err)
+	}
+	if err := checkCustomSLCInternalAliasConflicts(
+		deployment, state, []string{"unique"}, -1, "install", "NEW",
+	); err != nil {
+		t.Fatalf("expected unique alias to pass, got %v", err)
+	}
+}
+
 func TestCustomSLCNamesAreDerivedFromAliasAndDigest(t *testing.T) {
 	t.Parallel()
 
@@ -531,7 +581,7 @@ func TestAcquireCustomTarballURLFailsOnNon200(t *testing.T) {
 	}
 }
 
-func TestAcquireCustomTarballFromFileIsNeverDeleted(t *testing.T) {
+func TestAcquireCustomTarballFromFileSnapshotsAndCleansUp(t *testing.T) {
 	t.Parallel()
 
 	// Given
@@ -549,14 +599,17 @@ func TestAcquireCustomTarballFromFileIsNeverDeleted(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if tarball.path != path {
-		t.Fatalf("expected the file used in place, got %s", tarball.path)
+	if tarball.path == path {
+		t.Fatal("expected the local source to be copied to a snapshot")
 	}
 	if want := fmt.Sprintf("%x", sha256.Sum256(content)); tarball.sha256 != want {
 		t.Fatalf("digest = %s, want %s", tarball.sha256, want)
 	}
 
 	tarball.cleanup()
+	if _, err := os.Stat(tarball.path); !os.IsNotExist(err) {
+		t.Fatalf("expected the snapshot removed after cleanup, got %v", err)
+	}
 	if _, err := os.Stat(path); err != nil {
 		t.Fatalf("cleanup must not delete a user-supplied source: %v", err)
 	}
@@ -655,31 +708,6 @@ func TestAcquireCustomTarballDownloadsIntoTheStagingDirectory(t *testing.T) {
 	)
 	if err != nil || !bytes.Equal(got, body) {
 		t.Fatalf("promoted content mismatch: %q err %v", got, err)
-	}
-}
-
-func TestAcquireCustomTarballFromFileIsNotStaged(t *testing.T) {
-	t.Parallel()
-
-	// Given
-	path := filepath.Join(t.TempDir(), "c.tar.gz")
-	if err := os.WriteFile(path, []byte("file-bytes"), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	// When
-	tarball, err := acquireCustomTarball(
-		context.Background(), config.NewDeploymentDir(t.TempDir()), path,
-	)
-	// Then
-	if err != nil {
-		t.Fatal(err)
-	}
-	if tarball.staged {
-		t.Fatal("a user-supplied file must not be reported as staged")
-	}
-	if tarball.path != path {
-		t.Fatalf("expected the file used in place, got %s", tarball.path)
 	}
 }
 

--- a/openspec/changes/archive/2026-09-10-validate-custom-slc-internal-aliases/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-10-validate-custom-slc-internal-aliases/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-10

--- a/openspec/changes/archive/2026-09-10-validate-custom-slc-internal-aliases/design.md
+++ b/openspec/changes/archive/2026-09-10-validate-custom-slc-internal-aliases/design.md
@@ -1,0 +1,46 @@
+## Context
+
+Custom SLCs are currently identified by the launcher alias supplied on the command line, while
+the database validates aliases declared inside the package metadata. Two packages can therefore
+have different launcher aliases but still declare the same database language alias. The conflict
+is discovered only when the database starts.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Detect internal alias conflicts before staging or applying a custom SLC install/update.
+- Keep the check generic for every custom SLC language.
+- Allow an update to retain the aliases of the SLC it replaces.
+- Avoid extracting the full archive and preserve existing SHA/no-op behaviour.
+
+**Non-Goals:**
+
+- Changing Podman image loading or database startup behaviour.
+- Adding Rust-specific handling.
+- Using the archive SHA as the alias-conflict key.
+- Addressing unrelated SLC VM crashes.
+
+## Decisions
+
+- Read `build_info/language_definitions.json` directly from the gzip/tar stream. This reuses the
+  package bytes already acquired, avoids full extraction, and leaves the original archive and its
+  SHA unchanged for staging and update comparisons.
+- Store the discovered internal aliases with each installed custom SLC. This makes conflict
+  checks possible without reopening every staged package and also supports older state by treating
+  missing metadata as an explicit validation error when it is needed.
+- Compare candidate aliases with aliases from all other installed custom SLCs. For update and
+  install replacement, exclude the existing record being replaced; for a new install, exclude no
+  record. Comparison is case-insensitive, matching database alias semantics.
+- Run validation before recording/staging the candidate and before any restart confirmation that
+  could lead to a state-changing operation. Existing same-alias SHA no-op behaviour remains in
+  place.
+
+## Risks / Trade-offs
+
+- [Older state has no persisted aliases] → Read metadata from the corresponding staged package
+  when possible; otherwise fail with a clear message rather than permitting an unsafe operation.
+- [Malformed or incomplete package metadata] → Reject the package with a validation error before
+  changing deployment state.
+- [Alias comparison differs from database normalisation] → Normalise aliases consistently and add
+  tests for case differences and multiple aliases.

--- a/openspec/changes/archive/2026-09-10-validate-custom-slc-internal-aliases/proposal.md
+++ b/openspec/changes/archive/2026-09-10-validate-custom-slc-internal-aliases/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Installing the same custom SLC package under two launcher aliases can expose the same internal
+language alias twice. The database rejects that configuration only during startup, leaving the
+deployment stopped; the launcher should reject the operation before changing the deployment.
+
+## What Changes
+
+- Read the internal language aliases from a custom SLC package before staging it.
+- Reject custom install/update when those aliases conflict with another installed custom SLC.
+- Allow an update to retain aliases already owned by the SLC being updated.
+- Persist the discovered aliases in deployment state for later comparisons.
+- Keep package SHA handling for existing no-op/update behaviour; do not use SHA as the conflict key.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `local-slc-management`: custom SLC install and update validate package alias uniqueness before applying changes.
+
+## Impact
+
+The custom-SLC archive reader, local deployment state, and custom SLC install/update paths are
+affected. Existing official/custom launcher-alias handling, the database, Podman image loading,
+and Rust-specific behaviour are unchanged.

--- a/openspec/changes/archive/2026-09-10-validate-custom-slc-internal-aliases/specs/local-slc-management/spec.md
+++ b/openspec/changes/archive/2026-09-10-validate-custom-slc-internal-aliases/specs/local-slc-management/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Custom SLC internal aliases are unique
+
+Before applying a custom SLC install or update, the launcher SHALL read the aliases declared by
+the package and reject any alias that is already declared by another installed custom SLC. The
+check SHALL be independent of the launcher-supplied external alias and package SHA. Existing
+official/custom launcher-alias validation remains unchanged.
+
+#### Scenario: Custom install with a conflicting internal alias is rejected
+
+- **WHEN** a custom SLC is installed under a new launcher alias
+- **AND** its package declares an alias already declared by an installed custom SLC
+- **THEN** the command fails before staging or restarting
+- **AND** the existing deployment state remains unchanged
+- **AND** the error identifies the conflicting internal alias
+
+#### Scenario: Custom install with unique internal aliases succeeds
+
+- **WHEN** a custom SLC package declares no internal alias used by an installed SLC
+- **THEN** the custom SLC is staged and installed normally
+
+#### Scenario: Custom update may retain its own aliases
+
+- **WHEN** an installed custom SLC is updated using the same launcher alias
+- **AND** the replacement package declares an alias already owned by the custom SLC being replaced
+- **THEN** the update is allowed to proceed
+- **AND** aliases owned by other installed custom SLCs remain conflicts
+
+#### Scenario: Internal alias comparison is case-insensitive
+
+- **WHEN** a candidate package declares an internal alias differing only in letter case from an
+  alias declared by another installed SLC
+- **THEN** the candidate is rejected as a duplicate

--- a/openspec/changes/archive/2026-09-10-validate-custom-slc-internal-aliases/tasks.md
+++ b/openspec/changes/archive/2026-09-10-validate-custom-slc-internal-aliases/tasks.md
@@ -1,0 +1,16 @@
+## 1. Archive metadata and state
+
+- [x] 1.1 Extend custom SLC archive validation to read and return internal aliases from `build_info/language_definitions.json` without extracting the archive.
+- [x] 1.2 Persist internal aliases in installed custom-SLC state and retain compatibility with existing state files.
+
+## 2. Install and update validation
+
+- [x] 2.1 Add generic alias-conflict checking against installed custom SLCs before a custom install is staged.
+- [x] 2.2 Apply the same check to custom update while excluding the SLC record being replaced.
+- [x] 2.3 Return a clear conflict error and leave deployment state and runtime unchanged when validation fails.
+
+## 3. Tests and verification
+
+- [x] 3.1 Add unit tests for archive alias reading, malformed metadata, multiple aliases, and case-insensitive comparison.
+- [x] 3.2 Add install/update tests covering conflicts with official/custom SLCs and an update retaining its own alias.
+- [x] 3.3 Run the focused Go tests and relevant deployment tests, then verify the OpenSpec scenarios.

--- a/openspec/specs/local-slc-management/spec.md
+++ b/openspec/specs/local-slc-management/spec.md
@@ -98,6 +98,39 @@ aliases, guiding the user to remove the custom SLC first.
 - **AND** the user installs an official SLC that also declares `PYTHON3`
 - **THEN** the install is blocked, guiding the user to remove the custom SLC first
 
+### Requirement: Custom SLC internal aliases are unique
+
+Before applying a custom SLC install or update, the launcher SHALL read the aliases declared by
+the package and reject any alias that is already declared by another installed custom SLC. The
+check SHALL be independent of the launcher-supplied external alias and package SHA. Existing
+official/custom launcher-alias validation remains unchanged.
+
+#### Scenario: Custom install with a conflicting internal alias is rejected
+
+- **WHEN** a custom SLC is installed under a new launcher alias
+- **AND** its package declares an alias already declared by an installed custom SLC
+- **THEN** the command fails before staging or restarting
+- **AND** the existing deployment state remains unchanged
+- **AND** the error identifies the conflicting internal alias
+
+#### Scenario: Custom install with unique internal aliases succeeds
+
+- **WHEN** a custom SLC package declares no internal alias used by an installed SLC
+- **THEN** the custom SLC is staged and installed normally
+
+#### Scenario: Custom update may retain its own aliases
+
+- **WHEN** an installed custom SLC is updated using the same launcher alias
+- **AND** the replacement package declares an alias already owned by the custom SLC being replaced
+- **THEN** the update is allowed to proceed
+- **AND** aliases owned by other installed custom SLCs remain conflicts
+
+#### Scenario: Internal alias comparison is case-insensitive
+
+- **WHEN** a candidate package declares an internal alias differing only in letter case from an
+  alias declared by another installed SLC
+- **THEN** the candidate is rejected as a duplicate
+
 ### Requirement: Install, update, and remove apply through a verified database restart
 
 An SLC operation that applies through a restart SHALL restart the local database to apply the
@@ -568,4 +601,3 @@ SQL — is not tracked in launcher state and SHALL NOT be expected to be detecte
 - **AND** `exasol slc install rust` is run
 - **THEN** the alias is taken over by the installed container without a warning, because an
   untracked alias is neither an official catalog alias nor recorded launcher state
-

--- a/user-docs/content/udfs.md
+++ b/user-docs/content/udfs.md
@@ -66,6 +66,10 @@ Custom `install` and `update` restart the database and support `--auto-approve` 
 If the container cannot be activated, the database still starts but the command reports that the
 container is recorded as pending.
 
+A custom package can define one or more database aliases. The launcher rejects an installation when
+those aliases are already provided by another installed custom SLC. Updating an existing custom SLC
+replaces that SLC, so its own aliases may remain unchanged.
+
 Removing a custom container takes effect immediately and does not accept the restart options. The
 deployment must be running to remove an active alias through the database. A container recorded but
 never activated can be removed while the deployment is stopped.


### PR DESCRIPTION
## Description

This PR prevents custom SLC installation/update conflicts caused by duplicate package aliases.

## Related Issue

[SPOT-32593](https://exasol.atlassian.net/browse/SPOT-32593)

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- Read and store package aliases from SLC metadata.
- Reject duplicate aliases between custom SLCs.
- Allow valid same-alias updates and no-op unchanged updates.
- Improve conflict error messages.

## Testing

- [x] All existing tests pass (`task all`)
- [x] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

Manually validated the changes

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [x] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable) - `user-docs/` for user-facing changes, `doc/` for contributor-facing changes
- [x] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [x] Added/updated tests
- [x] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

[SPOT-32593]: https://exasol.atlassian.net/browse/SPOT-32593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ