### PR TITLE
docs: Use the direct Exasol Personal installer and link the Starter Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ does not impose an artificial data-size limit.
 
 On macOS, Linux, and Windows (WSL), install the launcher with:
 ```bash
-curl https://www.exasol.com/install/ | sh
+curl https://downloads.exasol.com/exasol-personal/installer.sh | sh
 ```
 
 For a quick start and a general overview of the available commands, type:
@@ -50,9 +50,16 @@ For next steps, read the [user documentation](https://exasol.github.io/exasol-pe
 It also covers the system requirements and supported deployment targets, as well as tutorials,
 command guidance, and troubleshooting information.
 
-AI coding agents can use
-[agent skills](https://github.com/exasol-labs/exasol-agent-skills) to install Exasol Personal,
-connect to it, load data, and write Exasol SQL.
+If you work with AI coding agents, the
+[Exasol Personal Local Starter Kit](https://github.com/exasol-labs/exasol-personal-local-starterkit)
+bundles an MCP server, agent skills, and other components that let your agent work with Exasol
+directly.
+
+Install it with:
+
+```bash
+curl https://www.exasol.com/install/ | sh
+```
 
 ## 🛠️ Development and contributions
 

--- a/user-docs/content/getting-started.md
+++ b/user-docs/content/getting-started.md
@@ -19,7 +19,7 @@ Choose where the database will run:
 Run:
 
 ```bash
-curl https://www.exasol.com/install/ | sh
+curl https://downloads.exasol.com/exasol-personal/installer.sh | sh
 ```
 
 The installer places the `exasol` binary in `~/.local/bin`. If that directory is not in `PATH`,

--- a/user-docs/content/index.md
+++ b/user-docs/content/index.md
@@ -17,7 +17,7 @@ To install and run Exasol Personal locally on macOS, Linux, or Windows, follow t
 Install the launcher:
 
 ```bash
-curl https://www.exasol.com/install/ | sh
+curl https://downloads.exasol.com/exasol-personal/installer.sh | sh
 ```
 
 The installer places the `exasol` binary in `~/.local/bin`. If that directory is not in `PATH`,


### PR DESCRIPTION
## Description

Switches the documented install command to the direct `downloads.exasol.com` installer path and
replaces the agent-skills paragraph with a pointer to the Exasol Personal Local Starter Kit, which
supersedes it.

## Related Issue

None.

## Type of Change

- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [x] `docs`: Documentation update
- [ ] `test`: Test additions or changes
- [ ] `refactor`: Code refactoring
- [ ] `chore`: Maintenance tasks

## Changes Made

- `README.md`, `user-docs/content/getting-started.md`, `user-docs/content/index.md`: install the
  launcher from `https://downloads.exasol.com/exasol-personal/installer.sh` instead of the
  `www.exasol.com/install/` alias, so the documented command names the artifact it downloads.
- `README.md`: replaced the agent-skills paragraph with the Exasol Personal Local Starter Kit, which
  bundles an MCP server, agent skills, and further components, and added its install command.

## Testing

- [ ] All existing tests pass (`task all`)
- [ ] Added new tests for new functionality
- [x] Manually tested the changes

### Test Details

Verified that the installer URL returns the launcher install script over HTTPS. Built the site with
`task docs-build` (`mkdocs build --strict`), which completed with no warnings, and confirmed that the
changed install command renders on both the Getting started and landing pages.

`task all` was not run because this change touches only Markdown; no Go, Terraform, or Python code is
affected.

## Checklist

- [x] Code follows the project's [coding guidelines](doc/best_practices.md)
- [ ] Ran `task fmt` and `task lint`
- [x] Updated documentation (if applicable) - `user-docs/` for user-facing changes, `doc/` for contributor-facing changes
- [ ] Updated `CHANGELOG.md` for user-facing changes, including examples for new features when useful
- [ ] Added/updated tests
- [ ] All tests pass locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format

`task fmt` and `task lint` cover Go, Terraform, and Python; neither applies to a Markdown-only
change. No `CHANGELOG.md` entry was added because the install command's underlying behavior is
unchanged and the Starter Kit is a separate product.